### PR TITLE
Build changes for tests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -60,7 +60,6 @@ allprojects {
     hadoopVersion = '2.4.1'
     gemfireXDVersion = '2.0-Beta'
     buildFlags = ''
-    testResultsBase = "${rootProject.buildDir}/tests/snappy"
   }
 
   if (!buildRoot.isEmpty()) {
@@ -68,6 +67,10 @@ allprojects {
   } else {
     // default output directory like in sbt/maven
     buildDir = 'build-artifacts/scala-' + scalaBinaryVersion
+  }
+
+  ext {
+    testResultsBase = "${rootProject.buildDir}/tests/snappy"
   }
 
   dependencies {
@@ -102,6 +105,17 @@ configure(subprojects.findAll {!(it.name ==~ /snappy-spark.*/)}) {
   }
 }
 
+task cleanScalaTest << {
+  def workingDir = "${testResultsBase}/scalatest"
+  delete workingDir
+  file(workingDir).mkdirs()
+}
+task cleanJUnit << {
+  def workingDir = "${testResultsBase}/junit"
+  delete workingDir
+  file(workingDir).mkdirs()
+}
+
 subprojects {
   // the run task for a selected sub-project
   task run(type:JavaExec) {
@@ -119,7 +133,7 @@ subprojects {
 
   task scalaTest(type: Test) {
     actions = [ new com.github.maiflai.ScalaTestAction() ]
-    maxParallelForks = Runtime.getRuntime().availableProcessors()
+    maxParallelForks = (2 * Runtime.getRuntime().availableProcessors())
     maxHeapSize '1g'
     jvmArgs '-XX:+HeapDumpOnOutOfMemoryError', '-XX:MaxPermSize=350M', '-ea'
     testLogging.exceptionFormat = 'full'
@@ -135,28 +149,21 @@ subprojects {
     }
     workingDir = "${testResultsBase}/scalatest"
 
-    binResultsDir = file("${workingDir}/binary")
-    reports.html.destination = file("${workingDir}/html")
+    binResultsDir = file("${workingDir}/binary/${project.name}")
+    reports.html.destination = file("${workingDir}/html/${project.name}")
     reports.junitXml.destination = file(workingDir)
-
-    doFirst {
-      delete workingDir
-      file(workingDir).mkdirs()
-    }
   }
   test {
-    //maxParallelForks = Runtime.getRuntime().availableProcessors()
-    maxParallelForks = 1
+    maxParallelForks = (2 * Runtime.getRuntime().availableProcessors())
     maxHeapSize '1g'
     jvmArgs '-XX:+HeapDumpOnOutOfMemoryError', '-XX:MaxPermSize=350M', '-ea'
     testLogging.exceptionFormat = 'full'
 
     workingDir = "${testResultsBase}/junit"
 
-    binResultsDir = file("${workingDir}/binary")
-    reports.html.destination = file("${workingDir}/html")
+    binResultsDir = file("${workingDir}/binary/${project.name}")
+    reports.html.destination = file("${workingDir}/html/${project.name}")
     reports.junitXml.destination = file(workingDir)
-    reports.junitXml.setOutputPerTestCase true
 
     def eol = System.getProperty('line.separator')
     beforeTest { desc ->
@@ -181,12 +188,8 @@ subprojects {
         output << "${getStackTrace(t)}${eol}"
       }
     }
-    doFirst {
-      delete workingDir
-      file(workingDir).mkdirs()
-    }
   }
-  check.dependsOn ':product', test, scalaTest
+  check.dependsOn test, scalaTest
 
   // apply default manifest
   jar {

--- a/snappy-core/build.gradle
+++ b/snappy-core/build.gradle
@@ -32,3 +32,6 @@ dependencies {
     testRuntime files("${rootDir.getAbsolutePath()}/local-repo/gemfirexd-client-${gemfireXDVersion}.jar")
   }
 }
+
+test.dependsOn ':cleanJUnit'
+scalaTest.dependsOn ':cleanScalaTest'

--- a/snappy-dunits/build.gradle
+++ b/snappy-dunits/build.gradle
@@ -1,42 +1,40 @@
 apply plugin: 'scala'
-//apply plugin: 'com.github.maiflai.scalatest'
-apply plugin: 'java'
 
-//allprojects {
-  compileScala.options.encoding = 'UTF-8'
+compileScala.options.encoding = 'UTF-8'
 
-  // fix scala+java mix to all use compileScala which uses correct dependency order
-  //sourceSets.main.scala.srcDir "src/main/java"
-  //sourceSets.main.java.srcDirs = []
+// fix scala+java mix to all use compileScala which uses correct dependency order
+sourceSets.main.scala.srcDir "src/main/java"
+sourceSets.main.java.srcDirs = []
 
-  dependencies {
-    compile project(':snappy-tools_' + scalaBinaryVersion)
-    compile 'org.apache.logging.log4j:log4j-api:2.1'
-    compile 'org.apache.logging.log4j:log4j-core:2.1'
-    compile 'commons-io:commons-io:2.4'
-    compile "junit:junit:${junitVersion}"
+dependencies {
+  compile project(':snappy-tools_' + scalaBinaryVersion)
+  compile 'org.apache.logging.log4j:log4j-api:2.1'
+  compile 'org.apache.logging.log4j:log4j-core:2.1'
+  compile 'commons-io:commons-io:2.4'
+  compile "junit:junit:${junitVersion}"
 
-    if (new File(rootDir, "snappy-store/build.gradle").exists()) {
-      compile project(':snappy-store:gemfirexd:client')
-      compile project(':snappy-store:gemfirexd:core')
-      compile project(':snappy-store:gemfirexd:tools')
-      testCompile project(path: ':snappy-store:gemfirexd:tools', configuration: 'testOutput')
-    } else {
-      compile files("${rootDir.getAbsolutePath()}/local-repo/gemfirexd-client-${gemfireXDVersion}.jar")
-      compile files("${rootDir.getAbsolutePath()}/local-repo/gemfirexd-${gemfireXDVersion}.jar")
-      compile files("${rootDir.getAbsolutePath()}/local-repo/gemfirexd-tools-${gemfireXDVersion}.jar")
-    }
+  if (new File(rootDir, "snappy-store/build.gradle").exists()) {
+    compile project(':snappy-store:gemfirexd:client')
+    compile project(':snappy-store:gemfirexd:core')
+    compile project(':snappy-store:gemfirexd:tools')
+    testCompile project(path: ':snappy-store:gemfirexd:tools', configuration: 'testOutput')
+  } else {
+    compile files("${rootDir.getAbsolutePath()}/local-repo/gemfirexd-client-${gemfireXDVersion}.jar")
+    compile files("${rootDir.getAbsolutePath()}/local-repo/gemfirexd-${gemfireXDVersion}.jar")
+    compile files("${rootDir.getAbsolutePath()}/local-repo/gemfirexd-tools-${gemfireXDVersion}.jar")
   }
+}
 
-  test {
-    minHeapSize '128m'
-    maxHeapSize '1g'
+test {
+  maxParallelForks = 1
+  minHeapSize '128m'
+  maxHeapSize '1g'
 
-    include '**/*DUnitTest.class'
-  }
+  include '**/*DUnitTest.class'
 
-  task distributedTest(type:Test) {
-    include '**/*DUnitTest.class'
-  }
+  workingDir = "${testResultsBase}/dunit"
 
-//}
+  binResultsDir = file("${workingDir}/binary")
+  reports.html.destination = file("${workingDir}/html")
+  reports.junitXml.destination = file(workingDir)
+}

--- a/snappy-tools/build.gradle
+++ b/snappy-tools/build.gradle
@@ -47,6 +47,10 @@ dependencies {
   testCompile project(path: ':snappy-core_' + scalaBinaryVersion, configuration: 'testOutput')
 }
 
+test.dependsOn ':cleanJUnit'
+scalaTest.dependsOn ':cleanScalaTest'
+check.dependsOn ':product'
+
 shadowJar {
   zip64 = true
 


### PR DESCRIPTION
- Adding separate global cleanup tasks to build so that for multiple projects tests do not clean out previous project test runs.
- Each project creates its own html output to avoid overwriting each other.
