### PR TITLE
SNAP-117 Added check for Java 1.7

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,9 @@
 apply plugin: 'wrapper'
 
+if(JavaVersion.current() != JavaVersion.VERSION_1_7){
+    throw new GradleException("==== This build must be run with java 7 ====")
+}
+
 buildscript {
   repositories {
     maven { url "https://plugins.gradle.org/m2" }


### PR DESCRIPTION
If you try to build with a java 1.8 compiler, you get errors, and it is
not obvious that the issue is java 1.8 vs java 1.7.
