### PR TITLE
Avoid creation of executor inside the Gem accessor that is a Spark dr…

### DIFF
--- a/snappy-core/src/main/scala/org/apache/spark/SparkCallbacks.scala
+++ b/snappy-core/src/main/scala/org/apache/spark/SparkCallbacks.scala
@@ -30,6 +30,7 @@ object SparkCallbacks {
     if (env != null) {
       SparkHadoopUtil.get.runAsSparkUser { () =>
         env.stop()
+        SparkEnv.set(null)
       }
     }
   }
@@ -50,6 +51,11 @@ object SparkCallbacks {
 
   def isExecutorStartupConf(key: String) : Boolean = {
     SparkConf.isExecutorStartupConf(key)
+  }
+
+  def isDriver() : Boolean = {
+    SparkEnv.get != null &&
+        SparkEnv.get.executorId == SparkContext.DRIVER_IDENTIFIER
   }
 
 }

--- a/snappy-tools/src/main/scala/io/snappydata/cluster/ExecutorInitiator.scala
+++ b/snappy-tools/src/main/scala/io/snappydata/cluster/ExecutorInitiator.scala
@@ -190,6 +190,14 @@ object ExecutorInitiator extends Logging {
    */
   def startOrTransmuteExecutor(driverURL: Option[String],
       driverDM: InternalDistributedMember): Unit = {
+    // Avoid creation of executor inside the Gem accessor
+    // that is a Spark driver but has joined the gem system
+    // in the non embedded mode
+    if (SparkCallbacks.isDriver()) {
+      logInfo("Executor cannot be instantiated in this VM as a Spark driver is already running. ")
+      return
+    }
+
     executorRunnable.setDriverDetails(driverURL, driverDM)
     // start the executor thread if driver URL is set and the thread
     // is not already started.


### PR DESCRIPTION
Avoid creation of executor inside the Gem accessor that is a Spark driver but has joined the gem system in the non embedded mode. 
