### PR TITLE
enabling jobserver when started from script.

### DIFF
--- a/snappy-core/src/main/scala/io/snappydata/Literals.scala
+++ b/snappy-core/src/main/scala/io/snappydata/Literals.scala
@@ -15,6 +15,8 @@ object Constant {
 
   private[snappydata] val PROPERTY_PREFIX = "snappydata."
 
+  private[snappydata] val JOBSERVER_PROPERTY_PREFIX = "jobserver."
+
 }
 
 /**
@@ -30,7 +32,7 @@ object Property {
 
   val mcastPort = s"${Constant.PROPERTY_PREFIX}mcast-port"
 
-  val jobserverEnabled = s"jobserver.enabled"
+  val jobserverEnabled = s"${Constant.JOBSERVER_PROPERTY_PREFIX}enabled"
 
-  val jobserverConfigFile = "jobserver.configFile"
+  val jobserverConfigFile = s"${Constant.JOBSERVER_PROPERTY_PREFIX}configFile"
 }

--- a/snappy-tools/src/test/scala/io/snappydata/ServerStartSuite.scala
+++ b/snappy-tools/src/test/scala/io/snappydata/ServerStartSuite.scala
@@ -33,6 +33,7 @@ class ServerStartSuite extends SnappyFunSuite with BeforeAndAfterAll {
 
     fs.stop(null)
   }
+
   ignore("Snappy Lead start") {
     val fs: Lead = ServiceManager.getLeadInstance
 


### PR DESCRIPTION
- jobServer.enabled is set to true
- avoiding snappydata. prefix addition for jobserver. prefixed properties. Thus these properties don't percolate down to gem.

test: precheckin underway
