### PR TITLE
Currently locator url is expected in the form of locator[port]

### DIFF
--- a/snappy-tools/src/main/scala/org/apache/spark/scheduler/cluster/SnappyEmbeddedModeClusterManager.scala
+++ b/snappy-tools/src/main/scala/org/apache/spark/scheduler/cluster/SnappyEmbeddedModeClusterManager.scala
@@ -43,7 +43,7 @@ object SnappyEmbeddedModeClusterManager extends ExternalClusterManager {
         else if (locator.isEmpty ||
             locator == "" ||
             locator == "null" ||
-            !locator.matches(".+\\[[0-9]+\\]")
+            !(locator.matches("(.+:[0-9]+)|(.+\\[[0-9]+\\])"))
         ) {
           throw new Exception(s"locator info not provided in the snappy embedded url ${sc.master}")
         }


### PR DESCRIPTION
because gemxd expects it to be this way. Now this is changed to
locator:port  which is in compliance with spark.
