### PR TITLE
default-persistent conn property added ( but ignored in scala tests )

### DIFF
--- a/snappy-tools/build.gradle
+++ b/snappy-tools/build.gradle
@@ -54,6 +54,9 @@ testClasses.doLast {
 
 test.dependsOn ':cleanJUnit'
 scalaTest {
+  // This property is a temporary fix for scala tests to not use default-persistent
+  // connection property in SnappyHiveCatalog
+  systemProperty "scalaTest", "true"
   dependsOn ':cleanScalaTest'
   doFirst {
     // cleanup files since scalatest plugin does not honour workingDir yet

--- a/snappy-tools/src/main/java/io/snappydata/impl/SnappyHiveCatalog.java
+++ b/snappy-tools/src/main/java/io/snappydata/impl/SnappyHiveCatalog.java
@@ -167,7 +167,13 @@ public class SnappyHiveCatalog implements ExternalCatalog {
     }
 
     private void initHMC() {
-      String snappyDataUrl = "jdbc:snappydata:;user=HIVE_METASTORE";
+      // for unit tests we are not using default-persistent=true as tables of different types
+      // with same test name is causing problems with Hive metastore configured with gemfirexd.
+      // Need to see proper cleanup of the metastore entries between tests. Will put a proper
+      // cleanup soon.
+      boolean snappyFunSuite = Boolean.parseBoolean(System.getProperty("scalaTest", "false"));
+      String snappyDataUrl = snappyFunSuite ? "jdbc:snappydata:;user=HIVE_METASTORE" :
+      "jdbc:snappydata:;user=HIVE_METASTORE;default-persistent=true";
       HiveConf metadataConf = new HiveConf();
       metadataConf.setVar(HiveConf.ConfVars.METASTORECONNECTURLKEY,
           snappyDataUrl);


### PR DESCRIPTION
Adding 'default-persistent' conn property in SnappyHiveCatalog as true, equivalent to

 the connection properties of SnappyStoreHiveCatalog
- Not using it temporarily for scala tests (based on a system property added). Proper fix will be to add proper cleanup in SnappyHiveCatalog too.
- Working on it.

@sumwale @vivekwiz plz review
