### PR TITLE
creating table buckets on restart

### DIFF
--- a/snappy-core/src/main/scala/org/apache/spark/sql/columnar/JDBCAppendableRelation.scala
+++ b/snappy-core/src/main/scala/org/apache/spark/sql/columnar/JDBCAppendableRelation.scala
@@ -228,6 +228,13 @@ class JDBCAppendableRelation(
       val tableExists = JdbcExtendedUtils.tableExists(table, conn,
         dialect, sqlContext)
       if (mode == SaveMode.Ignore && tableExists) {
+        dialect match {
+          case d: JdbcExtendedDialect => {
+            d.initializeTable(table,
+              sqlContext.conf.caseSensitiveAnalysis, conn)
+          }
+          case _ => // do nothing
+        }
         return
       }
 

--- a/snappy-core/src/main/scala/org/apache/spark/sql/row/JDBCMutableRelation.scala
+++ b/snappy-core/src/main/scala/org/apache/spark/sql/row/JDBCMutableRelation.scala
@@ -67,6 +67,11 @@ class JDBCMutableRelation(
         dialect, sqlContext)
       val tableSchema = JdbcExtendedUtils.getCurrentSchema(conn, dialect)
       if (mode == SaveMode.Ignore && tableExists) {
+        dialect match {
+          case d: JdbcExtendedDialect => d.initializeTable(table,
+            sqlContext.conf.caseSensitiveAnalysis, conn)
+          case _ => // Do Nothing
+        }
         return tableSchema
       }
 

--- a/snappy-tools/src/main/scala/org/apache/spark/sql/columntable/ColumnFormatRelation.scala
+++ b/snappy-tools/src/main/scala/org/apache/spark/sql/columntable/ColumnFormatRelation.scala
@@ -226,6 +226,14 @@ class ColumnFormatRelation(
       val tableExists = JdbcExtendedUtils.tableExists(table, conn,
         dialect, sqlContext)
       if (mode == SaveMode.Ignore && tableExists) {
+        dialect match {
+          case GemFireXDDialect => {
+            GemFireXDDialect.initializeTable(table,
+              sqlContext.conf.caseSensitiveAnalysis, conn)
+            GemFireXDDialect.initializeTable(table + shadowTableNamePrefix, sqlContext.conf.caseSensitiveAnalysis, conn)
+          }
+          case _ => // Do nothing
+        }
         return
       }
 


### PR DESCRIPTION
creating all the buckets on restart. Basically whenever the relation object is constructed the create table is called again and if table exists then at least doing re initialization again.

Manually tested all table types.
