### PR TITLE
Fixed external table creation if no schema is provided.

### DIFF
--- a/snappy-core/src/main/scala/org/apache/spark/sql/snappyParsers.scala
+++ b/snappy-core/src/main/scala/org/apache/spark/sql/snappyParsers.scala
@@ -198,8 +198,8 @@ private[sql] class SnappyDDLParser(parseQuery: String => LogicalPlan)
           }
           val userSpecifiedSchema = if (hasExternalSchema) None
           else {
-            phrase(tableCols)(new lexical.Scanner(schemaString)) match {
-              case Success(columns, _) => Some(StructType(columns))
+            phrase(tableCols.?)(new lexical.Scanner(schemaString)) match {
+              case Success(columns, _) => columns.flatMap(fields => Some(StructType(fields)))
               case failure => throw new DDLException(failure.toString)
             }
           }


### PR DESCRIPTION
e.g. CREATE TABLE IF NOT EXISTS AIRLINE_PARQUET_SOURCE using parquet OPTIONS(path '$hfile')
