### PR TITLE
Added locality check for Snappy join optimizations. As our table RDDs…

### DIFF
--- a/snappy-core/src/main/scala/org/apache/spark/sql/execution/ExistingPlans.scala
+++ b/snappy-core/src/main/scala/org/apache/spark/sql/execution/ExistingPlans.scala
@@ -17,6 +17,7 @@ private[sql] case class PartitionedPhysicalRDD(
     rdd: RDD[InternalRow],
     numPartition: Int,
     partitionColumns: Seq[Expression],
+    partitionLocality : String,
     extraInformation: String) extends LeafNode {
 
   protected override def doExecute(): RDD[InternalRow] = rdd
@@ -24,7 +25,7 @@ private[sql] case class PartitionedPhysicalRDD(
   /** Specifies how data is partitioned across different nodes in the cluster. */
   override def outputPartitioning: Partitioning = {
     if (numPartition == 1) SinglePartition
-    else OrderlessHashPartitioning(partitionColumns, numPartition)
+    else OrderlessHashPartitioning(partitionColumns, numPartition, partitionLocality)
   }
 
   override def simpleString: String = "Partitioned Scan " + extraInformation +
@@ -37,9 +38,10 @@ private[sql] object PartitionedPhysicalRDD {
       output: Seq[Attribute],
       numPartition: Int,
       partitionColumns: Seq[Expression],
+      partitionLocality : String,
       rdd: RDD[InternalRow],
       relation: BaseRelation): PartitionedPhysicalRDD = {
-    PartitionedPhysicalRDD(output, rdd, numPartition, partitionColumns,
+    PartitionedPhysicalRDD(output, rdd, numPartition, partitionColumns, partitionLocality,
       relation.toString)
   }
 }
@@ -47,6 +49,8 @@ private[sql] object PartitionedPhysicalRDD {
 trait PartitionedDataSourceScan extends PrunedFilteredScan {
 
   def numPartitions: Int
+
+  def partitionLocality: String
 
   def partitionColumns: Seq[String]
 }

--- a/snappy-tools/src/main/scala/org/apache/spark/sql/rowtable/RowFormatRelation.scala
+++ b/snappy-tools/src/main/scala/org/apache/spark/sql/rowtable/RowFormatRelation.scala
@@ -110,6 +110,18 @@ class RowFormatRelation(
     partitionColumn
   }
 
+  override def partitionLocality: String = {
+    val resolvedName = StoreUtils.lookupName(table, tableSchema)
+    val region = Misc.getRegionForTable(resolvedName, true)
+    val masterTable = if (region.isInstanceOf[PartitionedRegion]) {
+      val region = Misc.getRegionForTable(resolvedName, true).asInstanceOf[PartitionedRegion]
+      val resolver = region.getPartitionResolver.asInstanceOf[GfxdPartitionByExpressionResolver]
+      resolver.getMasterTable(true)
+    } else {
+      ""
+    }
+    masterTable
+  }
 }
 
 final class DefaultSource extends MutableRelationProvider {

--- a/snappy-tools/src/test/scala/org/apache/spark/sql/store/SnappyJoinSuite.scala
+++ b/snappy-tools/src/test/scala/org/apache/spark/sql/store/SnappyJoinSuite.scala
@@ -153,7 +153,9 @@ class SnappyJoinSuite extends SnappyFunSuite with BeforeAndAfterAll {
         "USING row " +
         "options " +
         "(" +
-        "PARTITION_BY 'OrderId,OrderRef')")
+        "PARTITION_BY 'OrderId,OrderRef',"+
+        "COLOCATE_WITH 'PR_TABLE1')")
+
 
     val dimension2 = sc.parallelize(
       (1 to 1000).map(i => TestData2(i, i.toString, (i%5 + 1))))
@@ -162,6 +164,46 @@ class SnappyJoinSuite extends SnappyFunSuite with BeforeAndAfterAll {
     dimensionDf.write.format("row").mode(SaveMode.Append).options(props).saveAsTable("PR_TABLE2")
 
     partitionToPartitionJoinAssertions(snc, "PR_TABLE1", "PR_TABLE2")
+
+  }
+
+  test("Row PR table join with PR Table without colocation") {
+
+    val dimension1 = sc.parallelize(
+      (1 to 1000).map(i => TestData2(i, i.toString, (i%10 + 1))))
+    val refDf = snc.createDataFrame(dimension1)
+    snc.sql("DROP TABLE IF EXISTS PR_TABLE22")
+
+    snc.sql("CREATE TABLE PR_TABLE22(OrderId INT, description String, OrderRef INT)" +
+        "USING row " +
+        "options " +
+        "(" +
+        "PARTITION_BY 'OrderId,OrderRef')")
+
+
+    refDf.write.format("column").mode(SaveMode.Append).options(props).saveAsTable("PR_TABLE22")
+
+
+    snc.sql("DROP TABLE IF EXISTS PR_TABLE23")
+
+    snc.sql("CREATE TABLE PR_TABLE23(OrderId INT ,description String, OrderRef INT)" +
+        "USING row " +
+        "options " +
+        "(" +
+        "PARTITION_BY 'OrderId,OrderRef')")
+
+    val dimension2 = sc.parallelize(
+      (1 to 1000).map(i => TestData2(i, i.toString, (i%5 + 1))))
+
+    val dimensionDf = snc.createDataFrame(dimension2)
+    dimensionDf.write.format("column").mode(SaveMode.Append).options(props).saveAsTable("PR_TABLE23")
+
+    val excatJoinKeys = snc.sql(s"select P.OrderRef, P.description from " +
+        s"PR_TABLE22 P JOIN PR_TABLE23 R ON P.OrderId = R.OrderId AND P.OrderRef = R.OrderRef")
+    checkForShuffle(excatJoinKeys.logicalPlan, snc, true)
+
+    assert(excatJoinKeys.count() === 500)
+
 
   }
 
@@ -190,7 +232,8 @@ class SnappyJoinSuite extends SnappyFunSuite with BeforeAndAfterAll {
         "USING column " +
         "options " +
         "(" +
-        "PARTITION_BY 'OrderId,OrderRef')")
+        "PARTITION_BY 'OrderId,OrderRef'," +
+        "COLOCATE_WITH 'PR_TABLE3')")
 
     val dimension2 = sc.parallelize(
       (1 to 1000).map(i => TestData2(i, i.toString, (i%5 + 1))))
@@ -200,6 +243,46 @@ class SnappyJoinSuite extends SnappyFunSuite with BeforeAndAfterAll {
     val countdf1 = snc.sql("select * from PR_TABLE4")
     assert(countdf1.count() == 1000)
     partitionToPartitionJoinAssertions(snc, "PR_TABLE3", "PR_TABLE4")
+
+  }
+
+  test("Column PR table join with PR Table without colocation") {
+
+    val dimension1 = sc.parallelize(
+      (1 to 1000).map(i => TestData2(i, i.toString, (i%10 + 1))))
+    val refDf = snc.createDataFrame(dimension1)
+    snc.sql("DROP TABLE IF EXISTS PR_TABLE20")
+
+    snc.sql("CREATE TABLE PR_TABLE20(OrderId INT, description String, OrderRef INT)" +
+        "USING column " +
+        "options " +
+        "(" +
+        "PARTITION_BY 'OrderId,OrderRef')")
+
+
+    refDf.write.format("column").mode(SaveMode.Append).options(props).saveAsTable("PR_TABLE20")
+
+
+    snc.sql("DROP TABLE IF EXISTS PR_TABLE21")
+
+    snc.sql("CREATE TABLE PR_TABLE21(OrderId INT ,description String, OrderRef INT)" +
+        "USING column " +
+        "options " +
+        "(" +
+        "PARTITION_BY 'OrderId,OrderRef')")
+
+    val dimension2 = sc.parallelize(
+      (1 to 1000).map(i => TestData2(i, i.toString, (i%5 + 1))))
+
+    val dimensionDf = snc.createDataFrame(dimension2)
+    dimensionDf.write.format("column").mode(SaveMode.Append).options(props).saveAsTable("PR_TABLE21")
+
+    val excatJoinKeys = snc.sql(s"select P.OrderRef, P.description from " +
+        s"PR_TABLE20 P JOIN PR_TABLE21 R ON P.OrderId = R.OrderId AND P.OrderRef = R.OrderRef")
+    checkForShuffle(excatJoinKeys.logicalPlan, snc, true)
+
+    assert(excatJoinKeys.count() === 500)
+
 
   }
 
@@ -265,8 +348,8 @@ class SnappyJoinSuite extends SnappyFunSuite with BeforeAndAfterAll {
         "USING column " +
         "options " +
         "(" +
-        "PARTITION_BY 'OrderId, OrderRef')")
-
+        "PARTITION_BY 'OrderId, OrderRef'," +
+         "COLOCATE_WITH 'PR_TABLE7')")
 
     val dimension2 = sc.parallelize(
       (1 to 1000).map(i => TestData2(i, i.toString, (i%5 + 1))))


### PR DESCRIPTION
… are location dependent this is needed if tables are not colocated.

Once we achive location independence to evaluate a bucket we can safely revert this changes and do bucket to bucket joins
