### PR TITLE
Adding aqp classes to assembly jar

### DIFF
--- a/snappy-tools/build.gradle
+++ b/snappy-tools/build.gradle
@@ -46,6 +46,10 @@ dependencies {
   testCompile 'org.scalatest:scalatest_' + scalaBinaryVersion + ':2.2.1'
 
   testRuntime 'org.pegdown:pegdown:1.1.0'
+  
+  if (new File(rootDir, "snappy-aqp/build.gradle").exists()) {
+    compile project(':snappy-aqp')
+  }
 }
 
 testClasses.doLast {


### PR DESCRIPTION
We had made a decision to ship aqp classes in assembly jar but not to ship aqp code.

So, I have added code in the build.gradle that checks if the aqp project exists, if yes, it adds the aqp classes to the assembly jar. If no, nothing is done for now. Later we can upload the aqp jar somewhere and this code will fetch that jar and make it part of assembly jar.
