### PR TITLE
Moved ccreation of logical plan above registration to catalog.

### DIFF
--- a/snappy-core/src/main/scala/org/apache/spark/sql/SnappyContext.scala
+++ b/snappy-core/src/main/scala/org/apache/spark/sql/SnappyContext.scala
@@ -471,10 +471,11 @@ class SnappyContext protected[spark] (@transient sc: SparkContext)
               (mode != SaveMode.ErrorIfExists).toString))
     }
 
+    val plan = LogicalRelation(resolved.relation)
     catalog.registerExternalTable(tableIdent, userSpecifiedSchema,
       Array.empty[String], source, params,
       ExternalTableType.getTableType(resolved.relation))
-    LogicalRelation(resolved.relation)
+    plan
   }
 
   /**


### PR DESCRIPTION
In some cases LogicalRelation creation might discover some problem with the relation and table creation should fail, without registering into
catalog.
A classic case being parquet relation which validates its metadata during LogicalRelation creation rather than relation itself.
It looks like a problem with Spark code itself. But we need to handle it gracefully.
