### PR TITLE
Snap 365

### DIFF
--- a/snappy-tools/src/main/scala/org/apache/spark/sql/store/StoreUtils.scala
+++ b/snappy-tools/src/main/scala/org/apache/spark/sql/store/StoreUtils.scala
@@ -113,7 +113,7 @@ object StoreUtils extends Logging {
     val regionMembers = if (Utils.isLoner(sc)) {
       Set(Misc.getGemFireCache.getDistributedSystem.getDistributedMember)
     } else {
-      region.getDistributionAdvisor().adviseReplicates().asScala
+      region.getDistributionAdvisor().adviseInitializedReplicates().asScala
     }
     val prefNodes = regionMembers.map(v => blockMap(v)).toSeq
     partitions(0) = new MultiExecutorLocalPartition(0, prefNodes)


### PR DESCRIPTION
Replicated region preferred location was considered for only one server. Ideally it should be all the servers holding the region.
