### PR TITLE
SNAP-474: fix the test

### DIFF
--- a/snappy-tools/src/test/scala/io/snappydata/app/streaming/StreamingSuite.scala
+++ b/snappy-tools/src/test/scala/io/snappydata/app/streaming/StreamingSuite.scala
@@ -42,21 +42,12 @@ with BeforeAndAfterAll with BeforeAndAfter {
   def batchDuration: Duration = Seconds(1)
 
   before {
-    super.beforeAll()
+    SnappyStreamingContext.stop()
     ssnc = SnappyStreamingContext(snc, batchDuration)
   }
 
   after {
-    this.afterAll()
-  }
-
-  override def afterAll(): Unit = {
-
-    super.afterAll()
-    if (ssnc != null) {
-
-      SnappyStreamingContext.stop()
-    }
+    SnappyStreamingContext.stop()
   }
 
   test("SNAP-414") {


### PR DESCRIPTION
cleanup SnappyStreamingContext in before/after of StreamingSuite but don't invoke beforeAll/afterAll
