### PR TITLE
SNAP-505: Changes to fix OOME cases with defaults

### DIFF
--- a/snappy-tools/src/main/scala/io/snappydata/tools/LeaderLauncher.scala
+++ b/snappy-tools/src/main/scala/io/snappydata/tools/LeaderLauncher.scala
@@ -82,6 +82,8 @@ class LeaderLauncher(baseName: String) extends GfxdServerLauncher(baseName) {
     super.run(initStartupArgs(ArrayBuffer(args: _*)))
   }
 
+  override protected def setDefaultHeapSize(): Boolean = false
+
   @throws(classOf[Exception])
   override protected def startServerVM(props: Properties) : Unit = {
     val leadImpl = getFabricServiceInstance.asInstanceOf[LeadImpl]


### PR DESCRIPTION
Users trying out will likely follow our simple guide and we cannot hope to have them read everything to understand the fine points of heap-size, overflow etc. Ideally we should also be setting ASYNC PERSISTENCE by default at least for column tables in my opinion, but not addressing that in this PR. Is trivial to add if team agrees.

 * set eviction policy to OVERFLOW by default for column tables (including sample tables)
 * skip default heap-size setting for lead node

Also see related PR on snappy-store https://github.com/SnappyDataInc/snappy-store/pull/17

With these settings I have tested full dataset load with default scripts, and then loading even more data which causes overflow just fine without affecting the system usability. Load performance goes down for second one by ~20% primarily due to disk activity and GC hits (440s vs 360s) which is quite reasonable. Query performance gets hit by 15-20% for base table queries after overflow which is expected and very reasonable. In my rough estimate it is about 20-30% data which has overflown to disk (haven't looked at precise stats). Performance of sample table queries is hardly affected.

@hbhanawat @soubhik-c @suranjan please take a look too