### PR TITLE
SNAP-584

### DIFF
--- a/snappy-tools/sbin/snappy-start-all.sh
+++ b/snappy-tools/sbin/snappy-start-all.sh
@@ -18,7 +18,7 @@
 #
 
 # Start all snappy daemons - locator, lead and server on the nodes specified in the
-# conf/locators, conf/leads and conf/servers files repsectively
+# conf/locators, conf/leads and conf/servers files respectively
 
 sbin="`dirname "$0"`"
 sbin="`cd "$sbin"; pwd`"
@@ -27,11 +27,19 @@ sbin="`cd "$sbin"; pwd`"
 . "$sbin/spark-config.sh"
 . "$sbin/snappy-config.sh"
 
+if [ "$1" == "rowstore" ]; then
+    args="-row-store=true"
+else
+    args=
+fi
+
 # Start Locators
-"$sbin"/snappy-locators.sh start
+"$sbin"/snappy-locators.sh start $args
 
 # Start Servers
-"$sbin"/snappy-servers.sh start
+"$sbin"/snappy-servers.sh start $args
 
 # Start Leads
-"$sbin"/snappy-leads.sh start
+if [ "$1" != "rowstore" ]; then
+    "$sbin"/snappy-leads.sh start
+fi

--- a/snappy-tools/sbin/snappy-status-all.sh
+++ b/snappy-tools/sbin/snappy-status-all.sh
@@ -18,7 +18,7 @@
 #
 
 # Start all snappy daemons - locator, lead and server on the nodes specified in the
-# conf/locators, conf/leads and conf/servers files repsectively
+# conf/locators, conf/leads and conf/servers files respectively
 
 sbin="`dirname "$0"`"
 sbin="`cd "$sbin"; pwd`"


### PR DESCRIPTION
Updating start up script to start row store only. Also corrected couple of typos.

Related snappy store PR- https://github.com/SnappyDataInc/snappy-store/pull/28

Tested manually by starting/stopping using scripts.  Also created some persistent tabled using gemfirexd-maint (1.4.1.9) version, stopped the servers and restarted using Snappy scripts and jars.

To start rowstore use following command, this will skip starting the  lead node and start snappy servers using "-row-store=true"
```
sbin/snappy-start-all.sh rowstore
```
Output shile using the "sbin/snappy-stop-all.sh" when only row store was started, a message will be seen  as lead node was not started. Can suppress it by checking the lead status before stopping if required.

```
shirishd@shirishd-laptop ~/snappyData/snappy-commons/build-artifacts/scala-2.10/snappy $ sbin/snappy-stop-all.sh
localhost: The specified working directory (/home/shirishd/snappyData/snappy-commons/build-artifacts/scala-2.10/snappy/sbin/../work/localhost-lead-1) contains no status file
localhost: The SnappyData Server has stopped.
localhost: The SnappyData Locator has stopped.
```

@sumwale @kneeraj , please review.