### PR TITLE
Fixes and refactoring for SNAP-608

### DIFF
--- a/snappy-core/build.gradle
+++ b/snappy-core/build.gradle
@@ -26,8 +26,8 @@ dependencies {
     compile 'io.snappydata:snappy-spark-streaming-twitter_' + scalaBinaryVersion + ':' + sparkVersion
   }
 
-  compile 'org.apache.tomcat:tomcat-jdbc:8.0.28'
-  compile 'com.zaxxer:HikariCP-java6:2.3.12'
+  compile 'org.apache.tomcat:tomcat-jdbc:8.0.32'
+  compile 'com.zaxxer:HikariCP:2.4.4'
 
   testCompile 'org.scala-lang:scala-actors:' + scalaVersion
   testCompile 'org.scalatest:scalatest_' + scalaBinaryVersion + ':2.2.1'

--- a/snappy-core/src/main/scala/io/snappydata/Literals.scala
+++ b/snappy-core/src/main/scala/io/snappydata/Literals.scala
@@ -45,6 +45,8 @@ object Constant {
   val DEFAULT_CONFIDENCE: Double = 0.95
 
   val COLUMN_MIN_BATCH_SIZE: Int = 200
+
+  val DEFAULT_USE_HIKARICP = false
 }
 
 /**

--- a/snappy-core/src/main/scala/org/apache/spark/sql/collection/Utils.scala
+++ b/snappy-core/src/main/scala/org/apache/spark/sql/collection/Utils.scala
@@ -35,6 +35,7 @@ import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.apache.spark.sql.catalyst.util.{ArrayData, MapData}
 import org.apache.spark.sql.catalyst.{CatalystTypeConverters, InternalRow}
 import org.apache.spark.sql.execution.datasources.DDLException
+import org.apache.spark.sql.execution.datasources.jdbc.DriverRegistry
 import org.apache.spark.sql.hive.SnappyStoreHiveCatalog
 import org.apache.spark.sql.sources.CastLongTime
 import org.apache.spark.sql.types._
@@ -512,6 +513,27 @@ object Utils {
       }
       case _ => result.append(value)
     }
+  }
+
+  /**
+   * Register given driver class with Spark's loader.
+   */
+  def registerDriver(driver: String): Unit = {
+    try {
+      DriverRegistry.register(driver)
+    } catch {
+      case cnfe: ClassNotFoundException => throw new IllegalArgumentException(
+        s"Couldn't find driver class $driver", cnfe)
+    }
+  }
+
+  /**
+   * Register driver for given JDBC URL and return the driver class name.
+   */
+  def registerDriverUrl(url: String): String = {
+    val driver = DriverRegistry.getDriverClassName(url)
+    registerDriver(driver)
+    driver
   }
 }
 

--- a/snappy-core/src/main/scala/org/apache/spark/sql/columnar/JDBCAppendableRelation.scala
+++ b/snappy-core/src/main/scala/org/apache/spark/sql/columnar/JDBCAppendableRelation.scala
@@ -29,7 +29,6 @@ import org.apache.spark.sql.catalyst.{CatalystTypeConverters, InternalRow}
 import org.apache.spark.sql.collection.{UUIDRegionKey, Utils}
 import org.apache.spark.sql.execution.ConnectionPool
 import org.apache.spark.sql.execution.datasources.ResolvedDataSource
-import org.apache.spark.sql.execution.datasources.jdbc.DriverRegistry
 import org.apache.spark.sql.hive.SnappyStoreHiveCatalog
 import org.apache.spark.sql.jdbc.JdbcDialects
 import org.apache.spark.sql.row.GemFireXDBaseDialect
@@ -61,7 +60,7 @@ case class JDBCAppendableRelation(
 
   override val needConversion: Boolean = false
 
-  val driver = DriverRegistry.getDriverClassName(externalStore.connProperties.url)
+  val driver = Utils.registerDriverUrl(externalStore.connProperties.url)
 
   final val dialect = JdbcDialects.get(externalStore.connProperties.url)
 

--- a/snappy-core/src/main/scala/org/apache/spark/sql/row/JDBCMutableRelation.scala
+++ b/snappy-core/src/main/scala/org/apache/spark/sql/row/JDBCMutableRelation.scala
@@ -58,7 +58,7 @@ class JDBCMutableRelation(
 
   override val needConversion: Boolean = false
 
-  val driver = DriverRegistry.getDriverClassName(url)
+  val driver = Utils.registerDriverUrl(url)
 
   final val dialect = JdbcDialects.get(url)
 
@@ -177,7 +177,7 @@ class JDBCMutableRelation(
       throw new IllegalArgumentException(
         "JDBCUpdatableRelation.insert: no rows provided")
     }
-    val connection = ConnectionPool.getPoolConnection(table, None, dialect,
+    val connection = ConnectionPool.getPoolConnection(table, dialect,
       poolProperties, connProperties, hikariCP)
     try {
       val stmt = connection.prepareStatement(rowInsertStr)
@@ -203,7 +203,7 @@ class JDBCMutableRelation(
   }
 
   override def executeUpdate(sql: String): Int = {
-    val connection = ConnectionPool.getPoolConnection(table, None, dialect,
+    val connection = ConnectionPool.getPoolConnection(table, dialect,
       poolProperties, connProperties, hikariCP)
     try {
       val stmt = connection.prepareStatement(sql)
@@ -233,7 +233,7 @@ class JDBCMutableRelation(
               s""""$col" among (${schema.fieldNames.mkString(", ")})""")))
       index += 1
     }
-    val connection = ConnectionPool.getPoolConnection(table, None, dialect,
+    val connection = ConnectionPool.getPoolConnection(table, dialect,
       poolProperties, connProperties, hikariCP)
     try {
       val setStr = updateColumns.mkString("SET ", "=?, ", "=?")
@@ -252,7 +252,7 @@ class JDBCMutableRelation(
   }
 
   override def delete(filterExpr: String): Int = {
-    val connection = ConnectionPool.getPoolConnection(table, None, dialect,
+    val connection = ConnectionPool.getPoolConnection(table, dialect,
       poolProperties, connProperties, hikariCP)
     try {
       val whereStr =

--- a/snappy-core/src/main/scala/org/apache/spark/sql/store/JDBCSourceAsStore.scala
+++ b/snappy-core/src/main/scala/org/apache/spark/sql/store/JDBCSourceAsStore.scala
@@ -25,6 +25,7 @@ import scala.collection.mutable.ArrayBuffer
 import scala.language.implicitConversions
 import scala.reflect.ClassTag
 import scala.util.Random
+import scala.util.control.NonFatal
 
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.InternalRow
@@ -33,7 +34,7 @@ import org.apache.spark.sql.columnar.{CachedBatch, ConnectionProperties, Externa
 import org.apache.spark.sql.execution.{ConnectionPool, SparkSqlSerializer}
 import org.apache.spark.sql.jdbc.JdbcDialects
 import org.apache.spark.storage.{BlockId, BlockStatus, RDDBlockId, StorageLevel}
-import org.apache.spark.{Partition, SparkContext, TaskContext}
+import org.apache.spark.{Logging, Partition, SparkContext, TaskContext}
 
 /*
 Generic class to query column table from Snappy.
@@ -104,7 +105,7 @@ class JDBCSourceAsStore(override val connProperties: ConnectionProperties,
   }
 
   override def getConnection(id: String): Connection = {
-    ConnectionPool.getPoolConnection(id, None, dialect, connProperties.poolProps,
+    ConnectionPool.getPoolConnection(id, dialect, connProperties.poolProps,
       connProperties.connProps, connProperties.hikariCP)
   }
 
@@ -143,36 +144,70 @@ class JDBCSourceAsStore(override val connProperties: ConnectionProperties,
   }
 }
 
-final class CachedBatchIteratorOnRS(conn: Connection,
-    requiredColumns: Array[String],
-    ps: Statement, rs: ResultSet) extends Iterator[CachedBatch] {
+abstract class ResultSetIterator[A](conn: Connection,
+    stmt: Statement, rs: ResultSet, context: TaskContext)
+    extends Iterator[A] with Logging {
 
-  var _hasNext = moveNext()
+  protected final var hasNextValue = true
 
-  override def hasNext: Boolean = _hasNext
+  context.addTaskCompletionListener { context => close() }
+  moveNext()
 
-  override def next() = {
-    val result = getCachedBatchFromRow(requiredColumns, rs)
-    _hasNext = moveNext()
-    result
-  }
+  override final def hasNext: Boolean = hasNextValue
 
-  private def moveNext(): Boolean = {
+  protected final def moveNext(): Unit = {
     var success = false
     try {
+      // TODO: see if optimization using rs.lightWeightNext
+      // and explicit context pop in close possible (was causing trouble)
       success = rs.next()
-      success
+    } catch {
+      case NonFatal(e) => logWarning("Exception iterating resultSet", e)
     } finally {
       if (!success) {
-        rs.close()
-        ps.close()
-        conn.close()
+        close()
       }
     }
   }
 
-  private def getCachedBatchFromRow(requiredColumns: Array[String],
-      rs: ResultSet): CachedBatch = {
+  protected def getNextValue(rs: ResultSet): A
+
+  final def next(): A = {
+    val result = getNextValue(rs)
+    moveNext()
+    result
+  }
+
+  final def close() {
+    if (!hasNextValue) return
+    try {
+      // GfxdConnectionWrapper.restoreContextStack(stmt, rs)
+      // rs.lightWeightClose()
+      rs.close()
+    } catch {
+      case e: Exception => logWarning("Exception closing resultSet", e)
+    }
+    try {
+      stmt.close()
+    } catch {
+      case e: Exception => logWarning("Exception closing statement", e)
+    }
+    try {
+      conn.close()
+      logDebug("closed connection for task " + context.partitionId())
+    } catch {
+      case e: Exception => logWarning("Exception closing connection", e)
+    }
+    hasNextValue = false
+  }
+}
+
+final class CachedBatchIteratorOnRS(conn: Connection,
+    requiredColumns: Array[String],
+    stmt: Statement, rs: ResultSet, context: TaskContext)
+    extends ResultSetIterator[CachedBatch](conn, stmt, rs, context) {
+
+  protected override def getNextValue(rs: ResultSet): CachedBatch = {
     // it will be having the information of the columns to fetch
     val numCols = requiredColumns.length
     val colBuffers = new Array[Array[Byte]](numCols)
@@ -208,7 +243,7 @@ class ExternalStorePartitionedRDD[T: ClassTag](@transient _sc: SparkContext,
         val query = "select " + requiredColumns.mkString(", ") +
             s", numRows, stats from $resolvedName where bucketid = $par"
         val rs = stmt.executeQuery(query)
-        new CachedBatchIteratorOnRS(conn, requiredColumns, stmt, rs)
+        new CachedBatchIteratorOnRS(conn, requiredColumns, stmt, rs, context)
     }, closeOnSuccess = false)
   }
 

--- a/snappy-tools/build.gradle
+++ b/snappy-tools/build.gradle
@@ -56,8 +56,8 @@ dependencies {
   } else {
     compile group: 'io.snappydata', name: 'spark-jobserver', version: '0.6.0'
   }
-  nospark 'org.apache.tomcat:tomcat-jdbc:8.0.28'
-  nospark 'com.zaxxer:HikariCP-java6:2.3.12'
+  nospark 'org.apache.tomcat:tomcat-jdbc:8.0.32'
+  nospark 'com.zaxxer:HikariCP:2.4.4'
 
   testCompile project(path: ':snappy-core_' + scalaBinaryVersion, configuration: 'testOutput')
   testCompile 'org.scalatest:scalatest_' + scalaBinaryVersion + ':2.2.1'

--- a/snappy-tools/src/main/scala/io/snappydata/Utils.scala
+++ b/snappy-tools/src/main/scala/io/snappydata/Utils.scala
@@ -35,7 +35,7 @@ import com.pivotal.gemfirexd.jdbc.ClientAttribute
 
 import org.apache.spark.Partition
 import org.apache.spark.sql.collection.ExecutorLocalShellPartition
-import org.apache.spark.sql.columnar.ConnectionProperties
+import org.apache.spark.sql.columnar.{ConnectionProperties, ExternalStoreUtils}
 import org.apache.spark.sql.execution.ConnectionPool
 import org.apache.spark.sql.execution.datasources.jdbc.DriverRegistry
 import org.apache.spark.sql.row.GemFireXDClientDialect
@@ -95,13 +95,10 @@ final class SparkShellRDDHelper {
     createConnection(connectionProperties, urlsOfNetServerHost)
   }
 
-  def createConnection(connProps: ConnectionProperties, hostList: ArrayBuffer[(String, String)])
-  : Connection = {
+  def createConnection(connProps: ConnectionProperties,
+      hostList: ArrayBuffer[(String, String)]): Connection = {
     val localhost = SocketCreator.getLocalHost
     var index = -1
-    // setup pool properties
-    val maxPoolSize = String.valueOf(math.max(
-      32, Runtime.getRuntime.availableProcessors() * 2))
 
     val jdbcUrl = if (useLocatorURL) {
       connProps.url
@@ -111,15 +108,13 @@ final class SparkShellRDDHelper {
       hostList(index)._2
     }
 
-    val props = if (connProps.hikariCP) {
-      connProps.poolProps + ("jdbcUrl" -> jdbcUrl) + ("maximumPoolSize" -> maxPoolSize)
-    } else {
-      connProps.poolProps + ("url" -> jdbcUrl) + ("maxActive" -> maxPoolSize)
-    }
+    // setup pool properties
+    val props = ExternalStoreUtils.getAllPoolProperties(jdbcUrl, null,
+      connProps.poolProps, connProps.hikariCP, isEmbedded = false)
     try {
       // use jdbcUrl as the key since a unique pool is required for each server
-      ConnectionPool.getPoolConnection(jdbcUrl, None,
-        GemFireXDClientDialect, props, connProps.connProps, connProps.hikariCP)
+      ConnectionPool.getPoolConnection(jdbcUrl, GemFireXDClientDialect,
+        props, connProps.connProps, connProps.hikariCP)
     } catch {
       case sqlException: SQLException =>
         if (hostList.size == 1 || useLocatorURL)

--- a/snappy-tools/src/main/scala/org/apache/spark/sql/columntable/ColumnFormatRelation.scala
+++ b/snappy-tools/src/main/scala/org/apache/spark/sql/columntable/ColumnFormatRelation.scala
@@ -212,7 +212,7 @@ class ColumnFormatRelation(
       throw new IllegalArgumentException(
         "ColumnFormatRelation.insert: no rows provided")
     }
-    val connection = ConnectionPool.getPoolConnection(table, None, dialect,
+    val connection = ConnectionPool.getPoolConnection(table, dialect,
       externalStore.connProperties.poolProps, externalStore.connProperties.connProps,
       externalStore.connProperties.hikariCP)
     try {
@@ -408,7 +408,7 @@ class ColumnFormatRelation(
    * Execute a DML SQL and return the number of rows affected.
    */
   override def executeUpdate(sql: String): Int = {
-    val connection = ConnectionPool.getPoolConnection(table, None, dialect,
+    val connection = ConnectionPool.getPoolConnection(table, dialect,
       externalStore.connProperties.poolProps, externalStore.connProperties.connProps,
       externalStore.connProperties.hikariCP)
     try {

--- a/snappy-tools/src/main/scala/org/apache/spark/sql/rowtable/RowFormatRelation.scala
+++ b/snappy-tools/src/main/scala/org/apache/spark/sql/rowtable/RowFormatRelation.scala
@@ -157,7 +157,7 @@ class RowFormatRelation(
       throw new IllegalArgumentException(
         "RowFormatRelation.put: no rows provided")
     }
-    val connection = ConnectionPool.getPoolConnection(table, None, dialect,
+    val connection = ConnectionPool.getPoolConnection(table, dialect,
       poolProperties, connProperties, hikariCP)
     try {
       val stmt = connection.prepareStatement(putStr)

--- a/snappy-tools/src/main/scala/org/apache/spark/sql/store/impl/JDBCSourceAsColumnarStore.scala
+++ b/snappy-tools/src/main/scala/org/apache/spark/sql/store/impl/JDBCSourceAsColumnarStore.scala
@@ -19,21 +19,22 @@ package org.apache.spark.sql.store.impl
 import java.sql.{Connection, ResultSet, Statement}
 import java.util.{Properties, UUID}
 
+import scala.reflect.ClassTag
+
 import com.gemstone.gemfire.distributed.internal.membership.InternalDistributedMember
 import com.gemstone.gemfire.internal.cache.{AbstractRegion, PartitionedRegion}
 import com.pivotal.gemfirexd.internal.engine.Misc
 import io.snappydata.SparkShellRDDHelper
+
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.collection._
-import org.apache.spark.sql.columnar.{ExternalStoreUtils, CachedBatch, ConnectionProperties, ConnectionType}
+import org.apache.spark.sql.columnar.{CachedBatch, ConnectionProperties, ConnectionType, ExternalStoreUtils}
 import org.apache.spark.sql.rowtable.RowFormatScanRDD
 import org.apache.spark.sql.sources.Filter
 import org.apache.spark.sql.store.{CachedBatchIteratorOnRS, ExternalStore, JDBCSourceAsStore, StoreUtils}
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.storage.BlockManagerId
 import org.apache.spark.{Logging, Partition, SparkContext, TaskContext}
-
-import scala.reflect.ClassTag
 
 /**
  * Column Store implementation for GemFireXD.
@@ -112,7 +113,7 @@ class ColumnarStorePartitionedRDD[T: ClassTag](@transient _sc: SparkContext,
 
         val rs = ps.executeQuery()
         ps1.close()
-        new CachedBatchIteratorOnRS(conn, requiredColumns, ps, rs)
+        new CachedBatchIteratorOnRS(conn, requiredColumns, ps, rs, context)
     }, closeOnSuccess = false)
   }
 
@@ -142,7 +143,7 @@ class SparkShellCachedBatchRDD[T: ClassTag](@transient _sc: SparkContext,
     val query: String = helper.getSQLStatement(StoreUtils.lookupName(tableName, conn.getSchema),
       requiredColumns, split.index)
     val (statement, rs) = helper.executeQuery(conn, tableName, split, query)
-    new CachedBatchIteratorOnRS(conn, requiredColumns, statement, rs)
+    new CachedBatchIteratorOnRS(conn, requiredColumns, statement, rs, context)
   }
 
   override def getPreferredLocations(split: Partition): Seq[String] = {


### PR DESCRIPTION
 * moved all ResultSet iteration code into a ResultSetIterator class taken mostly from InternalRowIteratorOnRS
   for cleanly closing it even if not iterated fully (like for LIMIT); also simplified handling a bit
   and now both InternalRowIteratorOnRS and CachedBatchIteratorOnRS extend it. This fixes SNAP-608
 * added a test section in existing QueryRoutingDUnitTest.testSNAP193 to check the fix
 * moved all disparate pool property handling (max/idle sizes etc) into ExternalStoreUtils.getAllPoolProperties
   where the respective properties will not be overwritten if explicitly provided
 * removed DriverRegistry.register call in every ConnectionPool get and instead have it only in few places
   like creation of Relation objects on driver, and ExternalStoreUtils.getConnector call on executors
 * updated tomcat pool and hikariCP versions; added the choice of default Tomcat vs Hikari in Constant