### PR TITLE
Fix the datatype mismatch issue when number of cols > 8 (SNAP-607)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -246,7 +246,6 @@ subprojects {
       }
     }
   })
-  check.dependsOn test, scalaTest
 
   // apply default manifest
   if (rootProject.hasProperty('enablePublish')) {
@@ -732,6 +731,9 @@ task checkAll {
   }
   if (project.hasProperty('spark')) {
     dependsOn project(':snappy-spark').getTasksByName('check', true).collect { it.path }
+  }
+  if (project.hasProperty('store')) {
+    dependsOn ':snappy-store:checkAll'
   }
   mustRunAfter buildAll
 }

--- a/snappy-core/build.gradle
+++ b/snappy-core/build.gradle
@@ -72,3 +72,4 @@ test {
   maxHeapSize '2g'
   dependsOn ':cleanJUnit'
 }
+check.dependsOn test, scalaTest

--- a/snappy-tools/build.gradle
+++ b/snappy-tools/build.gradle
@@ -139,7 +139,7 @@ scalaTest {
     cleanIntermediateFiles(project.path)
   }
 }
-check.dependsOn ':product'
+check.dependsOn ':product', test, scalaTest
 
 shadowJar {
   zip64 = true

--- a/snappy-tools/src/main/scala/io/snappydata/gemxd/SparkSQLExecuteImpl.scala
+++ b/snappy-tools/src/main/scala/io/snappydata/gemxd/SparkSQLExecuteImpl.scala
@@ -226,7 +226,7 @@ object SparkSQLExecuteImpl {
     // columns in each row is divided into sets of 8 columns. Per eight column group a
     // byte will be sent to indicate which all column in that group has a
     // non-null value.
-    while (groupNum < numEightColGroups - 1) {
+    while (groupNum < numEightColGroups) {
       writeAGroup(groupNum, 8, row, schema, hdos)
       groupNum += 1
     }
@@ -299,12 +299,12 @@ object SparkSQLExecuteImpl {
   def readDVDArray(dvds: Array[DataValueDescriptor], types: Array[Int],
       in: ByteArrayDataInput, numEightColGroups: Int,
       numPartialCols: Int): Unit = {
-    var groupNum: Int = 0
+    var groupNum = 0
     // using the gemfirexd way of sending results where in the number of
     // columns in each row is divided into sets of 8 columns. Per eight column
     // group a byte will be sent to indicate which all column in that group
     // has a non-null value.
-    while (groupNum < numEightColGroups - 1) {
+    while (groupNum < numEightColGroups) {
       readAGroup(groupNum, 8, dvds, types, in)
       groupNum += 1
     }
@@ -320,7 +320,7 @@ object SparkSQLExecuteImpl {
       val dvdIndex = (groupNum << 3) + index
       val dvd = dvds(dvdIndex)
       if (ActiveColumnBits.isNormalizedColumnOn(index, activeByteForGroup)) {
-        types(index) match {
+        types(dvdIndex) match {
           case StoredFormatIds.SQL_CLOB_ID =>
             val utfLen = InternalDataSerializer.readSignedVL(in).toInt
             if (utfLen >= 0) {
@@ -387,13 +387,15 @@ class ExecutionHandler(sql: String, schema: StructType, rddId: Int,
 
   private[snappydata] def rowIter(itr: Iterator[InternalRow]): Array[Byte] = {
 
-    var (numCols, numEightColGroups, numPartCols) = (-1, -1, -1)
+    var numCols = -1
+    var numEightColGroups = -1
+    var numPartCols = -1
 
     def evalNumColumnGroups(row: InternalRow): Unit = {
       if (row != null) {
         numCols = row.numFields
-        numEightColGroups = (numCols + 7) / 8
-        numPartCols = ((numCols - 1) % 8) + 1
+        numEightColGroups = numCols / 8
+        numPartCols = numCols % 8
       }
     }
     val dos = new GfxdHeapDataOutputStream(


### PR DESCRIPTION
 * use the correct index into the datatype array and not the current group index
 * simplified the logic of splitting into groups of 8 to be just /8 and %8 to go with corresponding changes in snappy-store; updated snappy-store link for (https://github.com/SnappyDataInc/snappy-store/pull/33)
 * added test for SNAP-607 in QueryRoutingDUnitTest.testSNAP193_608 and also enabled the test for SNAP-609

Also see https://github.com/SnappyDataInc/snappy-store/pull/33 for corresponding PR on snappy-store.