### PR TITLE
1) Added support for preserve partitions in Snappy column tables

### DIFF
--- a/snappy-core/src/main/scala/org/apache/spark/sql/columnar/InMemoryAppendableRelation.scala
+++ b/snappy-core/src/main/scala/org/apache/spark/sql/columnar/InMemoryAppendableRelation.scala
@@ -94,7 +94,7 @@ private[sql] class InMemoryAppendableRelation(
   }
 
   def batchAggregate(accumulated: ArrayBuffer[CachedBatch],
-      batch: CachedBatch): ArrayBuffer[CachedBatch] = {
+      batch: CachedBatch, index : Int): ArrayBuffer[CachedBatch] = {
     accumulated += batch
   }
 

--- a/snappy-tools/src/main/scala/org/apache/spark/sql/columntable/CachedBatchCreator.scala
+++ b/snappy-tools/src/main/scala/org/apache/spark/sql/columntable/CachedBatchCreator.scala
@@ -118,7 +118,7 @@ class CachedBatchCreator(
       batchID: UUID, bucketID: Int): mutable.HashSet[Any] = {
 
     def uuidBatchAggregate(accumulated: ArrayBuffer[UUIDRegionKey],
-        batch: CachedBatch): ArrayBuffer[UUIDRegionKey] = {
+        batch: CachedBatch, index : Int): ArrayBuffer[UUIDRegionKey] = {
       var rddId = -1
       StoreCallbacksImpl.stores.get(userTableName) match {
         case Some((_, _, id)) => rddId = id
@@ -148,10 +148,10 @@ class CachedBatchCreator(
     val mutableRow = new SpecificMutableRow(schema.fields.map(x => x.dataType))
     try {
       while (memHeapScanController.fetchNext(row)) {
-        batches.appendRow((), createInternalRow(row, mutableRow))
+        batches.appendRow((), createInternalRow(row, mutableRow), bucketID)
         keySet.add(row.getAllRegionAndKeyInfo.first().getKey)
       }
-      batches.forceEndOfBatch
+      batches.forceEndOfBatch(bucketID)
       keySet
     } finally {
       sc.close()

--- a/snappy-tools/src/main/scala/org/apache/spark/sql/columntable/ColumnFormatRelation.scala
+++ b/snappy-tools/src/main/scala/org/apache/spark/sql/columntable/ColumnFormatRelation.scala
@@ -39,7 +39,7 @@ import org.apache.spark.sql.rowtable.RowFormatScanRDD
 import org.apache.spark.sql.sources.{JdbcExtendedDialect, _}
 import org.apache.spark.sql.store.StoreFunctions._
 import org.apache.spark.sql.store.impl.{JDBCSourceAsColumnarStore, SparkShellRowRDD}
-import org.apache.spark.sql.store.{ExternalStore, StoreInitRDD, StoreUtils}
+import org.apache.spark.sql.store.{StoreRDD, ExternalStore, StoreInitRDD, StoreUtils}
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.sql.{DataFrame, SQLContext, SaveMode, _}
 import org.apache.spark.storage.{BlockManagerId, RDDInfo, StorageLevel}
@@ -73,6 +73,7 @@ class ColumnFormatRelation(
     _externalStore: ExternalStore,
     blockMap: Map[InternalDistributedMember, BlockManagerId],
     partitioningColumns: Seq[String],
+    preservePartitionOnInsert : Boolean =false,
     _context: SQLContext)
     extends JDBCAppendableRelation(_table, _provider, _mode, _userSchema,
      _origOptions, _externalStore, _context)
@@ -158,11 +159,11 @@ class ColumnFormatRelation(
   }
 
   override def uuidBatchAggregate(accumulated: ArrayBuffer[UUIDRegionKey],
-      batch: CachedBatch): ArrayBuffer[UUIDRegionKey] = {
+      batch: CachedBatch, index :Int): ArrayBuffer[UUIDRegionKey] = {
+
     //TODO - currently using the length from the part Object but it needs to be handled more generically
     //in order to replace UUID
     // if number of rows are greater than columnBatchSize then store otherwise store locally
-    if (batch.numRows >= columnBatchSize) {
       //TODO - rddID should be passed to the executors so that cachedBatch size can be shown be correctly even for non embedded mode
       val id = {
         StoreCallbacksImpl.stores.get(table) match {
@@ -171,21 +172,29 @@ class ColumnFormatRelation(
         }
       }
       val uuid = externalStore.storeCachedBatch(ColumnFormatRelation.
-          cachedBatchTableName(table), batch, rddId = id)
+          cachedBatchTableName(table), batch, bucketId = index, rddId = id)
       accumulated += uuid
-    } else {
-      //TODO: can we do it before compressing. Might save a bit
-      val converter = CatalystTypeConverters.createToScalaConverter(schema)
-      val unCachedRows = ExternalStoreUtils.cachedBatchesToRows(
-        Iterator(batch), schema.map(_.name).toArray, schema).map(converter)
-      insert(unCachedRows.toSeq.asInstanceOf[Seq[Row]])
-    }
-    accumulated
+
   }
 
   override def insert(data: DataFrame, overwrite: Boolean): Unit = {
+    if (preservePartitionOnInsert) {
+      val storeRDD = new StoreRDD(
+        sc = sqlContext.sparkContext,
+        df = data,
+        tableName = ColumnFormatRelation.cachedBatchTableName(table),
+        getConnection = connector,
+        schema = userSchema,
+        preservePartitioning = true,
+        blockMap = blockMap,
+        partitionColumns)
+      super.insert(storeRDD, data, overwrite)
+      return
+    }
     partitionColumns match {
-      case Nil => super.insert(data, overwrite)
+      case Nil => {
+        super.insert(data, overwrite)
+      }
       case _ => insert(data, if (overwrite) SaveMode.Overwrite else SaveMode.Append)
     }
   }
@@ -483,6 +492,9 @@ final class DefaultSource extends ColumnarRelationProvider {
       options: Map[String, String], schema: StructType) = {
     val parameters = new CaseInsensitiveMutableHashMap(options)
 
+    val preservePartitionsOnInsert = parameters.remove("PRESERVE_PARTITION")
+        .getOrElse("false").toBoolean
+
     val table = ExternalStoreUtils.removeInternalProps(parameters)
     val sc = sqlContext.sparkContext
     val partitions = ExternalStoreUtils.getTotalPartitions(sc, parameters,
@@ -536,6 +548,7 @@ final class DefaultSource extends ColumnarRelationProvider {
       externalStore,
       blockMap,
       partitioningColumn,
+      preservePartitionsOnInsert,
       sqlContext)
     try {
       relation.createTable(mode)

--- a/snappy-tools/src/test/scala/org/apache/spark/sql/store/ColumnTableTest.scala
+++ b/snappy-tools/src/test/scala/org/apache/spark/sql/store/ColumnTableTest.scala
@@ -26,7 +26,7 @@ import org.scalatest.{BeforeAndAfterAll, BeforeAndAfter}
 import scala.collection.JavaConverters._
 
 import org.apache.spark.Logging
-import org.apache.spark.sql.execution.QueryExecution
+import org.apache.spark.sql.execution.{Exchange, QueryExecution}
 import org.apache.spark.sql.{AnalysisException, SaveMode}
 
 /**
@@ -87,9 +87,13 @@ class ColumnTableTest
     println(result.logicalPlan)
 
     val qe = new QueryExecution(snc, result.logicalPlan)
+    val lj = qe.executedPlan collect {
+      case ex : Exchange => ex
+    }
     println(qe.executedPlan)
+    assert(lj.length == 0)
     r = result.collect
-    println(r.length)
+    assert(r.length == 500)
 
     snc.sql("drop table MY_TABLE1" )
     snc.sql("drop table MY_TABLE2" )
@@ -99,7 +103,7 @@ class ColumnTableTest
 
 
 
- /* test("Test the creation/dropping of column table using Schema") {
+  test("Test the creation/dropping of column table using Schema") {
     val data = Seq(Seq(1, 2, 3), Seq(7, 8, 9), Seq(9, 2, 3), Seq(4, 2, 3), Seq(5, 6, 7))
     val rdd = sc.parallelize(data, data.length).map(s => new Data(s(0), s(1), s(2)))
     val dataDF = snc.createDataFrame(rdd)
@@ -550,5 +554,5 @@ class ColumnTableTest
     }
 
   }
-*/
+
 }


### PR DESCRIPTION
1) Added support for preserve partitions in Snappy column tables
2) Removed the code which used to store data in row buffer in case of a dataframe insert and partition column empty.
3) We can define an option for table as PRESERVE_PARTITION. It will always try to do a local insert. In rare cases it will do a remote put( bucket moved cases)

API for the change is more or less same as before. One thing we need to check is how to provide PRESERVE_PARTITION option. Right now I have added it in table level option.
