### PR TITLE
Changes to store each qcs group at flush time to be stored in a singl…

### DIFF
--- a/snappy-core/src/main/scala/org/apache/spark/sql/columnar/ExternalStoreUtils.scala
+++ b/snappy-core/src/main/scala/org/apache/spark/sql/columnar/ExternalStoreUtils.scala
@@ -29,11 +29,13 @@ import org.apache.spark.sql.catalyst.expressions.SpecificMutableRow
 import org.apache.spark.sql.catalyst.{CatalystTypeConverters, InternalRow, expressions}
 import org.apache.spark.sql.collection.Utils._
 import org.apache.spark.sql.collection.{ToolsCallbackInit, Utils}
+import org.apache.spark.sql.columnar.CachedBatchHolder
 import org.apache.spark.sql.execution.ConnectionPool
 import org.apache.spark.sql.execution.datasources.jdbc.{DriverRegistry, JdbcUtils}
 import org.apache.spark.sql.jdbc.{JdbcDialect, JdbcDialects}
 import org.apache.spark.sql.row.{GemFireXDClientDialect, GemFireXDDialect}
 import org.apache.spark.sql.sources.{JdbcExtendedDialect, JdbcExtendedUtils}
+import org.apache.spark.sql.store.ExternalStore
 import org.apache.spark.sql.types._
 import org.apache.spark.sql.{AnalysisException, Row, SnappyContext, _}
 import org.apache.spark.{Logging, SparkContext}
@@ -517,43 +519,39 @@ object ConnectionType extends Enumeration {
   val Embedded, Net, Unknown = Value
 }
 
-private[sql] class ArrayBufferForRows(getConnection: () => Connection,
-    table: String,
+private[sql] class ArrayBufferForRows(externalStore: ExternalStore,
+    colTableName: String,
     schema: StructType,
-    url: String,
-    batchSize: Int) {
+    useCompression: Boolean,
+    bufferSize: Int) {
+  var holder = getCachedBatchHolder
 
-  var buff = new ArrayBuffer[InternalRow]()
-  val toScala = CatalystTypeConverters.createToScalaConverter(schema)
-  var rowCount = 0
+  def getCachedBatchHolder: CachedBatchHolder[Unit] =
+    new CachedBatchHolder[Unit](columnBuilders, 0,
+      Int.MaxValue, schema, new ArrayBuffer[InternalRow](1),
+      (u: Unit, c: CachedBatch) =>
+        externalStore.storeCachedBatch(colTableName, c))
 
-  val nullTypes = ExternalStoreUtils.getNullTypes(url, schema)
+  def columnBuilders: Array[ColumnBuilder] = schema.map {
+    attribute =>
+      val columnType = ColumnType(attribute.dataType)
+      val initialBufferSize = columnType.defaultSize * bufferSize
+      ColumnBuilder(attribute.dataType, initialBufferSize,
+        attribute.name, useCompression)
+  }.toArray
 
-  def appendRow_(row: InternalRow, flush: Boolean): Unit = {
-    if (row != expressions.EmptyRow) {
-      buff += row
-      rowCount += 1
-    }
-    if (rowCount % batchSize == 0 || flush) {
-      JdbcUtils.savePartition(getConnection, table, buff.iterator.map(
-        toScala(_).asInstanceOf[Row]), schema, nullTypes, batchSize)
-      buff = new ArrayBuffer[InternalRow]()
-      rowCount = 0
-    }
+  def appendRow_(row: InternalRow, flush: Boolean): Unit = holder.appendRow((), row)
+
+  def endRows(u: Unit): Unit = {
+    holder.forceEndOfBatch()
+    holder = getCachedBatchHolder
   }
-
-  // empty for now
-  def endRows(u: Unit): Unit = {}
 
   def appendRow(u: Unit, row: InternalRow): Unit = {
     appendRow_(row, flush = false)
   }
 
-  def forceEndOfBatch(): Unit = {
-    if (rowCount > 0) {
-      appendRow_(expressions.EmptyRow, flush = true)
-    }
-  }
+  def forceEndOfBatch(): Unit = endRows(())
 }
 
 case class ConnectionProperties(url: String, driver: String,

--- a/snappy-core/src/main/scala/org/apache/spark/sql/columnar/JDBCAppendableRelation.scala
+++ b/snappy-core/src/main/scala/org/apache/spark/sql/columnar/JDBCAppendableRelation.scala
@@ -286,9 +286,25 @@ case class JDBCAppendableRelation(
   def flushRowBuffer(): Unit = {
     // nothing by default
   }
+
+  private[sql] def externalColumnTableName: String = JDBCAppendableRelation.
+      cachedBatchTableName(table)
 }
 
 object JDBCAppendableRelation extends Logging {
+  final val INTERNAL_SCHEMA_NAME = "SNAPPYSYS_INTERNAL"
+  final val SHADOW_TABLE_SUFFIX = "_COLUMN_STORE_"
+
+  private[sql] final def cachedBatchTableName(table: String): String = {
+    val tableName = if (table.indexOf('.') > 0) {
+      table.replace(".", "__")
+    } else {
+      table
+    }
+
+    INTERNAL_SCHEMA_NAME + "." + tableName + SHADOW_TABLE_SUFFIX
+  }
+
   private def removePool(table: String): () => Iterator[Unit] = () => {
     ConnectionPool.removePoolReference(table)
     Iterator.empty

--- a/snappy-tools/src/main/scala/org/apache/spark/sql/columntable/ColumnFormatRelation.scala
+++ b/snappy-tools/src/main/scala/org/apache/spark/sql/columntable/ColumnFormatRelation.scala
@@ -436,8 +436,6 @@ class ColumnFormatRelation(
 object ColumnFormatRelation extends Logging with StoreCallback {
   // register the call backs with the JDBCSource so that
   // bucket region can insert into the column table
-  final val INTERNAL_SCHEMA_NAME = "SNAPPYSYS_INTERNAL"
-  final val SHADOW_TABLE_SUFFIX = "_COLUMN_STORE_"
 
   def flushLocalBuckets(resolvedName: String): Unit = {
     val pr = Misc.getRegionForTable(resolvedName, false)
@@ -465,16 +463,8 @@ object ColumnFormatRelation extends Logging with StoreCallback {
     Iterator.empty
   }
 
-  final def cachedBatchTableName(table: String) = {
-
-    val tableName = if(table.indexOf('.') > 0){
-      table.replace(".","__")
-    } else {
-      table
-    }
-    INTERNAL_SCHEMA_NAME + "." + tableName +
-        SHADOW_TABLE_SUFFIX
-  }
+  final def cachedBatchTableName(table: String): String =
+    JDBCAppendableRelation.cachedBatchTableName(table)
 }
 
 final class DefaultSource extends ColumnarRelationProvider {


### PR DESCRIPTION
## Changes proposed in this pull request

(Fill in the changes here)

## Patch testing

(Fill in the details that how was this patch tested)

## Other PRs 

(Does this change required changes in other projects- store, spark, spark-jobserver, aqp? Add the links of PR of the other subprojects that are related to this change)

…e bucket.

This is alternative to partitioning on qcs and weight column and will do not affect insert performance.