### PR TITLE
SnappyStreamingContext Java API

### DIFF
--- a/snappy-core/build.gradle
+++ b/snappy-core/build.gradle
@@ -34,6 +34,10 @@ dependencies {
   testCompile 'org.scala-lang:scala-actors:' + scalaVersion
   testCompile 'org.scalatest:scalatest_' + scalaBinaryVersion + ':2.2.1'
 
+  testCompile project(':snappy-spark:snappy-spark-streaming_' + scalaBinaryVersion).sourceSets.test.output
+  testCompile project(':snappy-spark:snappy-spark-core_' + scalaBinaryVersion).sourceSets.test.output
+
+
   testRuntime 'org.pegdown:pegdown:1.1.0'
   if (new File(rootDir, "snappy-store/build.gradle").exists()) {
     testRuntime project(':snappy-store:gemfirexd-client')

--- a/snappy-core/src/main/scala/org/apache/spark/sql/streaming/StreamSqlHelper.scala
+++ b/snappy-core/src/main/scala/org/apache/spark/sql/streaming/StreamSqlHelper.scala
@@ -16,9 +16,12 @@
  */
 package org.apache.spark.sql.streaming
 
+import java.beans.{BeanInfo, Introspector}
+
 import scala.reflect.runtime.universe.TypeTag
 
-import org.apache.spark.sql.catalyst.{CatalystTypeConverters, InternalRow, ScalaReflection}
+import org.apache.spark.sql.catalyst.expressions.{GenericInternalRow, AttributeReference}
+import org.apache.spark.sql.catalyst.{JavaTypeInference, CatalystTypeConverters, InternalRow, ScalaReflection}
 import org.apache.spark.sql.execution.RDDConversions
 import org.apache.spark.sql.execution.datasources.LogicalRelation
 import org.apache.spark.sql.hive.SnappyStoreHiveCatalog
@@ -26,7 +29,9 @@ import org.apache.spark.sql.sources.SchemaRelationProvider
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.sql.{AnalysisException, Row}
 import org.apache.spark.streaming.SnappyStreamingContext
+import org.apache.spark.streaming.api.java.JavaDStream
 import org.apache.spark.streaming.dstream.DStream
+import org.apache.spark.util.Utils
 
 object StreamSqlHelper {
 
@@ -36,6 +41,35 @@ object StreamSqlHelper {
 
   def clearStreams(): Unit ={
     StreamBaseRelation.clearStreams()
+  }
+
+  /**
+   * Returns a Catalyst Schema for the given java bean class.
+   */
+  protected def getSchema(beanClass: Class[_]): Seq[AttributeReference] = {
+    val (dataType, _) = JavaTypeInference.inferDataType(beanClass)
+    dataType.asInstanceOf[StructType].fields.map { f =>
+      AttributeReference(f.name, f.dataType, f.nullable)()
+    }
+  }
+
+  /**
+   * Converts an iterator of Java Beans to InternalRow using the provided
+   * bean info & schema. This is not related to the singleton, but is a static
+   * method for internal use.
+   */
+  private def beansToRows(data: Iterator[_], beanInfo: BeanInfo, attrs: Seq[AttributeReference]):
+  Iterator[InternalRow] = {
+    val extractors =
+      beanInfo.getPropertyDescriptors.filterNot(_.getName == "class").map(_.getReadMethod)
+    val methodsToConverts = extractors.zip(attrs).map { case (e, attr) =>
+      (e, CatalystTypeConverters.createToCatalystConverter(attr.dataType))
+    }
+    data.map{ element =>
+      new GenericInternalRow(
+        methodsToConverts.map { case (e, convert) => convert(e.invoke(element)) }.toArray[Any]
+      ): InternalRow
+    }
   }
 
 
@@ -67,6 +101,20 @@ object StreamSqlHelper {
     new SchemaDStream(ssc, logicalPlan)
   }
 
+
+  def createSchemaDStream(ssc: SnappyStreamingContext, rowStream: JavaDStream[_], beanClass: Class[_]): SchemaDStream = {
+    val attributeSeq: Seq[AttributeReference] = getSchema(beanClass)
+    val className = beanClass.getName
+    val internalRowStream = rowStream.dstream.mapPartitions { iter =>
+      // BeanInfo is not serializable so we must rediscover it remotely for each partition.
+      val localBeanInfo = Introspector.getBeanInfo(Utils.classForName(className))
+      beansToRows(iter, localBeanInfo, attributeSeq)
+    }
+
+    val logicalPlan = LogicalDStreamPlan(attributeSeq,
+      internalRowStream)(ssc)
+    new SchemaDStream(ssc, logicalPlan)
+  }
 }
 
 

--- a/snappy-core/src/main/scala/org/apache/spark/streaming/SnappyStreamingContext.scala
+++ b/snappy-core/src/main/scala/org/apache/spark/streaming/SnappyStreamingContext.scala
@@ -25,9 +25,11 @@ import org.apache.hadoop.conf.Configuration
 
 import org.apache.spark.annotation.Experimental
 import org.apache.spark.deploy.SparkHadoopUtil
+import org.apache.spark.sql.catalyst.expressions.AttributeReference
 import org.apache.spark.sql.streaming.{SchemaDStream, StreamSqlHelper}
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.sql.{DataFrame, Row, SnappyContext}
+import org.apache.spark.streaming.api.java.JavaDStream
 import org.apache.spark.streaming.dstream.DStream
 import org.apache.spark.{Logging, SparkConf, SparkContext}
 
@@ -179,7 +181,6 @@ class SnappyStreamingContext protected[spark](
   }
 
 
-
 }
 
 object SnappyStreamingContext extends Logging {
@@ -238,9 +239,8 @@ object SnappyStreamingContext extends Logging {
 
   /**
    * :: Experimental ::
-   *
    * Either return the "active" StreamingContext (that is, started but not stopped), or create a
-   * new StreamingContext that is
+   * new StreamingContext that is started by the creating function
    * @param creatingFunc   Function to create a new StreamingContext
    */
   @Experimental

--- a/snappy-core/src/main/scala/org/apache/spark/streaming/api/JavaSnappyStreamingContext.scala
+++ b/snappy-core/src/main/scala/org/apache/spark/streaming/api/JavaSnappyStreamingContext.scala
@@ -1,0 +1,232 @@
+/*
+ * Copyright (c) 2016 SnappyData, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License. You
+ * may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License. See accompanying
+ * LICENSE file.
+ */
+
+package org.apache.spark.streaming.api
+
+import com.google.common.base.Optional
+import org.apache.hadoop.conf.Configuration
+
+import org.apache.spark.SparkConf
+import org.apache.spark.annotation.Experimental
+import org.apache.spark.api.java.JavaSparkContext
+import org.apache.spark.api.java.function.{Function => JFunction, Function0 => JFunction0, Function2 => JFunction2}
+import org.apache.spark.deploy.SparkHadoopUtil
+import org.apache.spark.sql.DataFrame
+import org.apache.spark.sql.streaming.{SchemaDStream, StreamSqlHelper}
+import org.apache.spark.streaming.api.java.{JavaDStream, JavaStreamingContext}
+import org.apache.spark.streaming.{Checkpoint, CheckpointReader, Duration, SnappyStreamingContext, StreamingContext}
+
+class JavaSnappyStreamingContext(val snsc: SnappyStreamingContext) extends JavaStreamingContext(snsc) {
+
+
+  /**
+   * Create a JavaSnappyStreamingContext using an existing SparkContext.
+   * @param sparkContext existing SparkContext
+   * @param checkpoint checkpoint directory
+   * @param batchDuration the time interval at which streaming data will be divided
+   *                      into batches
+   */
+  def this(sparkContext: JavaSparkContext, checkpoint: Checkpoint, batchDuration: Duration) = {
+    this(new SnappyStreamingContext(sparkContext.sc, checkpoint, batchDuration))
+  }
+
+  /**
+   * Create a JavaSnappyStreamingContext using an existing SparkContext.
+   * @param sparkContext existing SparkContext
+   * @param batchDuration the time interval at which streaming data will be divided
+   *                      into batches
+   */
+  def this(sparkContext: JavaSparkContext, batchDuration: Duration) = {
+    this(new SnappyStreamingContext(sparkContext.sc, null, batchDuration))
+  }
+
+  /**
+   * Create a JavaSnappyStreamingContext by providing the configuration necessary for a
+   * new SparkContext.
+   * @param conf a org.apache.spark.SparkConf object specifying Spark parameters
+   * @param batchDuration the time interval at which streaming data will be divided into batches
+   */
+  def this(conf: SparkConf, batchDuration: Duration) = {
+    this(new SnappyStreamingContext(StreamingContext.createNewSparkContext(conf), null
+      , batchDuration))
+  }
+
+
+  /**
+   * Recreate a JavaSnappyStreamingContext from a checkpoint file.
+   * @param path Path to the directory that was specified as the checkpoint directory
+   * @param hadoopConf Optional, configuration object if necessary for reading from
+   *                   HDFS compatible filesystems
+   */
+  def this(path: String, hadoopConf: Configuration) =
+    this(new SnappyStreamingContext(null, CheckpointReader.read(path, new SparkConf(),
+      hadoopConf).get, null))
+
+  /**
+   * Recreate a JavaSnappyStreamingContext from a checkpoint file.
+   * @param path Path to the directory that was specified as the checkpoint directory
+   */
+  def this(path: String) = this(new SnappyStreamingContext(path, SparkHadoopUtil.get.conf))
+
+  /**
+   * Recreate a JavaSnappyStreamingContext from a checkpoint file using an existing SparkContext.
+   * @param path Path to the directory that was specified as the checkpoint directory
+   * @param sparkContext Existing SparkContext
+   */
+  def this(path: String, sparkContext: JavaSparkContext) = {
+    this(new SnappyStreamingContext(
+      sparkContext,
+      CheckpointReader.read(path, sparkContext.conf, sparkContext.hadoopConfiguration).get,
+      null))
+  }
+
+  /**
+   * Start the execution of the streams.
+   * Also registers population of AQP tables from stream tables if present.
+   *
+   * @throws IllegalStateException if the JavaSnappyStreamingContext is already stopped
+   */
+  override def start(): Unit = snsc.start()
+
+  override def stop(stopSparkContext: Boolean, stopGracefully: Boolean): Unit = snsc.stop()
+
+  def sql(sqlText: String): DataFrame = snsc.sql(sqlText)
+
+  /**
+   * Registers and executes given SQL query and
+   * returns [[SchemaDStream]] to consume the results
+   * @param queryStr
+   * @return
+   */
+  def registerCQ(queryStr: String): SchemaDStream = snsc.registerCQ(queryStr)
+
+  def createSchemaDStream(rowStream: JavaDStream[_], beanClass: Class[_]
+      ): SchemaDStream = {
+    StreamSqlHelper.createSchemaDStream(snsc, rowStream, beanClass)
+  }
+
+  def getSchemaDStream(tableName: String): SchemaDStream = {
+    StreamSqlHelper.getSchemaDStream(snsc, tableName)
+  }
+}
+
+object JavaSnappyStreamingContext {
+
+
+  private def jcontextOptionToOptional[T](option: Option[SnappyStreamingContext]
+      ): Optional[JavaSnappyStreamingContext] =
+    option match {
+      case Some(value) => Optional.of(new JavaSnappyStreamingContext(value))
+      case None => Optional.absent()
+    }
+
+  /**
+   * :: Experimental ::
+   *
+   * Get the currently created context, it may be started or not, but never stopped.
+   */
+  @Experimental
+  def getInstance(): Optional[JavaSnappyStreamingContext] = {
+    jcontextOptionToOptional(SnappyStreamingContext.getInstance())
+  }
+
+
+  /**
+   * :: Experimental ::   *
+   * Get the currently active context, if there is one. Active means started but not stopped.
+   */
+  @Experimental
+  def getActive(): Optional[JavaSnappyStreamingContext] = {
+    jcontextOptionToOptional(SnappyStreamingContext.getActive())
+  }
+
+  /**
+   * :: Experimental ::
+   *
+   * Either return the "active" JavaSnappyStreamingContext (that is, started but not stopped),
+   * or create a new JavaSnappyStreamingContext that is
+   * @param creatingFunc   Function to create a new StreamingContext
+   */
+  @Experimental
+  def getActiveOrCreate(creatingFunc: JFunction0[JavaSnappyStreamingContext]
+      ): JavaSnappyStreamingContext = {
+    val snsc = SnappyStreamingContext.getActiveOrCreate(() => creatingFunc.call().snsc)
+    new JavaSnappyStreamingContext(snsc)
+  }
+
+  /**
+   * :: Experimental ::
+   *
+   * Either get the currently active JavaSnappyStreamingContext (that is, started but
+   * not stopped), OR recreate a JavaSnappyStreamingContext from checkpoint data in
+   * the given path. If checkpoint data does not exist in the provided, then create
+   * a new JavaSnappyStreamingContext by calling the provided
+   * `creatingFunc`.
+   *
+   * @param checkpointPath Checkpoint directory used in an earlier JavaSnappyStreamingContext
+   *                       program
+   * @param creatingFunc   Function to create a new JavaSnappyStreamingContext
+   * @param hadoopConf     Optional Hadoop configuration if necessary for reading from the
+   *                       file system
+   * @param createOnError  Optional, whether to create a new JavaSnappyStreamingContext if there
+   *                       is an error in reading checkpoint data. By default, an exception will
+   *                       be thrown on error.
+   */
+  @Experimental
+  def getActiveOrCreate(
+      checkpointPath: String,
+      creatingFunc: JFunction0[JavaSnappyStreamingContext],
+      hadoopConf: Configuration = SparkHadoopUtil.get.conf,
+      createOnError: Boolean = false
+      ): JavaSnappyStreamingContext = {
+
+    val snsc = SnappyStreamingContext.getActiveOrCreate(checkpointPath
+      , () => creatingFunc.call().snsc, hadoopConf
+      , createOnError)
+
+    new JavaSnappyStreamingContext(snsc)
+  }
+
+  /**
+   * Either recreate a JavaSnappyStreamingContext from checkpoint data or create a new
+   * JavaSnappyStreamingContext.
+   * If checkpoint data exists in the provided `checkpointPath`, then JavaSnappyStreamingContext
+   * will be recreated from the checkpoint data. If the data does not exist, then the
+   * JavaSnappyStreamingContext will be created by called the provided `creatingFunc`.
+   *
+   * @param checkpointPath Checkpoint directory used in an earlier JavaSnappyStreamingContext
+   *                       program
+   * @param creatingFunc   Function to create a new JavaSnappyStreamingContext
+   * @param hadoopConf     Optional Hadoop configuration if necessary for reading from the
+   *                       file system
+   * @param createOnError  Optional, whether to create a new JavaSnappyStreamingContext if there
+   *                       is an error in reading checkpoint data. By default, an exception will
+   *                       be thrown on error.
+   */
+
+  def getOrCreate(
+      checkpointPath: String,
+      creatingFunc: JFunction0[JavaSnappyStreamingContext],
+      hadoopConf: Configuration = SparkHadoopUtil.get.conf,
+      createOnError: Boolean = false
+      ): JavaSnappyStreamingContext = {
+    val snsc = SnappyStreamingContext.getOrCreate(checkpointPath, () => creatingFunc.call().snsc, hadoopConf,
+      createOnError)
+
+    new JavaSnappyStreamingContext(snsc)
+  }
+}

--- a/snappy-core/src/test/java/org/apache/spark/streaming/JavaSnappyStreamingContextSuite.java
+++ b/snappy-core/src/test/java/org/apache/spark/streaming/JavaSnappyStreamingContextSuite.java
@@ -1,0 +1,318 @@
+/*
+ * Copyright (c) 2016 SnappyData, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License. You
+ * may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License. See accompanying
+ * LICENSE file.
+ */
+
+
+package org.apache.spark.streaming;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.Serializable;
+import java.nio.charset.Charset;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import com.google.common.base.Optional;
+import com.google.common.io.Files;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.spark.SparkConf;
+import org.apache.spark.api.java.JavaRDD;
+import org.apache.spark.api.java.JavaSparkContext;
+import org.apache.spark.api.java.function.Function0;
+import org.apache.spark.api.java.function.VoidFunction;
+import org.apache.spark.sql.DataFrame;
+import org.apache.spark.sql.streaming.SchemaDStream;
+import org.apache.spark.streaming.api.JavaSnappyStreamingContext;
+import org.apache.spark.streaming.api.java.JavaDStream;
+import org.apache.spark.util.Utils;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+
+public class JavaSnappyStreamingContextSuite implements Serializable {
+
+  protected transient JavaSnappyStreamingContext snsc;
+  private String master = "local[2]";
+  private String appName = this.getClass().getCanonicalName();
+  private Duration batchDuration = Milliseconds.apply(500);
+  private String sparkHome = "someDir";
+  private SparkConf conf = new SparkConf().setMaster(master).setAppName(appName);
+
+  StreamingContextSuite contextSuite = new StreamingContextSuite();
+
+  @Before
+  public void setUp() {
+  }
+
+  @After
+  public void tearDown() {
+    Optional<JavaSnappyStreamingContext> activeSsc = JavaSnappyStreamingContext.getActive();
+    if (activeSsc.isPresent()) {
+      JavaSnappyStreamingContext jnsc = activeSsc.get();
+      jnsc.stop(true, true);
+    }
+  }
+
+
+  private void simpleSetup() {
+
+    SparkConf conf = new SparkConf().setMaster(master).setAppName(appName);
+    JavaSparkContext sc = new JavaSparkContext(conf);
+    snsc = new JavaSnappyStreamingContext(sc, batchDuration);
+    Assert.assertTrue(JavaSnappyStreamingContext.getInstance() != null);
+  }
+
+
+  @SuppressWarnings("unchecked")
+  @Test
+  public void testSimpleConstructor() {
+
+    simpleSetup();
+
+    List<List<String>> inputData = Arrays.asList(
+        Arrays.asList("this", "is"),
+        Arrays.asList("a", "test"),
+        Arrays.asList("counting", "letters"));
+
+    JavaDStream<String> stream = JavaCheckpointTestUtils.attachTestInputStream(snsc, inputData, 1);
+
+    stream.foreachRDD(new VoidFunction<JavaRDD<String>>() {
+      @Override
+      public void call(JavaRDD<String> rdd) {
+        rdd.count();
+      }
+    });
+
+    snsc.start();
+
+    Assert.assertTrue(JavaSnappyStreamingContext.getActive() != null);
+  }
+
+  @SuppressWarnings("unchecked")
+  @Test
+  public void testSchemaDStream() {
+
+    simpleSetup();
+    List<List<String>> inputData = Arrays.asList(
+        Arrays.asList("this", "is"),
+        Arrays.asList("a", "test"),
+        Arrays.asList("counting", "letters"));
+
+    JavaDStream<String> stream = JavaCheckpointTestUtils.attachTestInputStream(snsc, inputData, 1);
+
+    SchemaDStream st = snsc.createSchemaDStream(stream, Message.class);
+
+    st.foreachDataFrame(new VoidFunction<DataFrame>() {
+      @Override
+      public void call(DataFrame rdd) {
+        rdd.count();
+      }
+    });
+
+    snsc.start();
+
+  }
+
+  @SuppressWarnings("unchecked")
+  @Test
+  public void testGetOrCreate() {
+    final SparkConf conf = new SparkConf().setMaster(master).setAppName(appName);
+
+
+    final AtomicBoolean newContextCreated = new AtomicBoolean(false);
+    Function0<JavaSnappyStreamingContext> creatingFunction = new
+        Function0<JavaSnappyStreamingContext>() {
+          @Override
+          public JavaSnappyStreamingContext call() throws Exception {
+            newContextCreated.set(true);
+            return new JavaSnappyStreamingContext(conf, batchDuration);
+          }
+
+        };
+
+    String emptyPath = Files.createTempDir().getAbsolutePath();
+
+    // getOrCreate should create new context with empty path
+    newContextCreated.set(false);
+    snsc = JavaSnappyStreamingContext.getOrCreate(emptyPath, creatingFunction
+        ,new Configuration(), false);
+    Assert.assertTrue("no context created" , snsc != null);
+    Assert.assertTrue("new context not created", newContextCreated.get());
+    snsc.stop();
+    snsc = null;
+
+    String corruptedCheckpointPath = contextSuite.createCorruptedCheckpoint();
+
+    // getOrCreate should throw exception with fake checkpoint file and createOnError = false
+    try {
+      snsc = JavaSnappyStreamingContext.getOrCreate(corruptedCheckpointPath, creatingFunction
+          ,new Configuration(),
+          false);
+      Assert.assertTrue("Code should not have reached here", false);
+    }catch(Exception e){
+      // Success
+    }
+
+    // getOrCreate should create new context with fake checkpoint file and createOnError = true
+
+    newContextCreated.set(false);
+    snsc = JavaSnappyStreamingContext.getOrCreate(
+          corruptedCheckpointPath, creatingFunction, new Configuration(),  true);
+    Assert.assertTrue("no context created" , snsc != null);
+    Assert.assertTrue("new context not created", newContextCreated.get());
+    snsc.stop();
+    snsc = null;
+
+    String checkpointPath = contextSuite.createValidCheckpoint();
+
+    // getOrCreate should recover context with checkpoint path, and recover old configuration
+    newContextCreated.set(false);
+    snsc = JavaSnappyStreamingContext.getOrCreate(checkpointPath, creatingFunction, new Configuration
+        (), false);
+    Assert.assertTrue("no context created" , snsc != null);
+    Assert.assertTrue("old context not recovered", !newContextCreated.get());
+    Assert.assertTrue("checkpointed config not " +
+        "recovered", snsc.sparkContext().getConf().get("someKey").equals("someValue"));
+
+    snsc.stop();
+    snsc = null;
+  }
+
+  @SuppressWarnings("unchecked")
+  @Test
+  public void testGetActiveOrCreate() throws IOException{
+
+    final SparkConf conf = new SparkConf().setMaster(master).setAppName(appName);
+    final AtomicBoolean newContextCreated = new AtomicBoolean(false);
+    Function0<JavaSnappyStreamingContext> creatingFunction = new
+        Function0<JavaSnappyStreamingContext>() {
+          @Override
+          public JavaSnappyStreamingContext call() throws Exception {
+            newContextCreated.set(true);
+            return new JavaSnappyStreamingContext(conf, batchDuration);
+          }
+
+        };
+
+    String emptyPath = Files.createTempDir().getAbsolutePath();
+    String checkpointPath = contextSuite.createValidCheckpoint();
+    String corruptedCheckpointPath = contextSuite.createCorruptedCheckpoint();
+
+
+    // getActiveOrCreate should return the current active context if there is one
+    newContextCreated.set(false);
+
+    SparkConf conf1 = conf.clone().set("spark.streaming.clock", "org.apache.spark.util" +
+        ".ManualClock");
+    SnappyStreamingContext sncContext = new SnappyStreamingContext(conf1,
+        batchDuration);
+
+    snsc = new JavaSnappyStreamingContext(sncContext);
+
+    File testDir = Utils.createTempDir(System.getProperty("java.io.tmpdir"), "spark");
+    List<List<String>> expected = fileTestPrepare(testDir);
+
+    JavaDStream<String> input = snsc.textFileStream(testDir.toString());
+    JavaTestUtils.attachTestOutputStream(input);
+    List<List<String>> result = JavaTestUtils.runStreams(snsc, 1, 1);
+
+
+    JavaSnappyStreamingContext returnedSsc = JavaSnappyStreamingContext.getActiveOrCreate
+        (checkpointPath,
+        creatingFunction,
+            new Configuration(), false);
+    Assert.assertTrue("new context created instead of returning", !newContextCreated.get());
+   // Assert.assertTrue("returned context is not the activated context", returnedSsc.eq(snsc));
+    snsc.stop();
+    snsc = null;
+
+    newContextCreated.set(false);
+
+    // getActiveOrCreate should create new context with empty path
+    snsc = JavaSnappyStreamingContext.getActiveOrCreate(emptyPath, creatingFunction,new Configuration
+        (), false);
+    Assert.assertTrue("no context created" , snsc != null);
+    Assert.assertTrue("new context not created", newContextCreated.get());
+
+    snsc.stop();
+    snsc = null;
+
+
+    // getActiveOrCreate should throw exception with fake checkpoint file and createOnError = false
+    try {
+      snsc = JavaSnappyStreamingContext.getActiveOrCreate(corruptedCheckpointPath, creatingFunction
+          , new Configuration(),
+          false);
+      Assert.assertTrue("Code should not have reached here", false);
+    }catch(Exception e){
+      // Success
+    }
+
+    // getActiveOrCreate should create new context with fake
+    // checkpoint file and createOnError = true
+    newContextCreated.set(false);
+    snsc = JavaSnappyStreamingContext.getActiveOrCreate(corruptedCheckpointPath, creatingFunction
+        , new Configuration(),
+        true);
+    Assert.assertTrue("no context created", snsc != null);
+    Assert.assertTrue("new context not created", newContextCreated.get());
+
+
+    snsc.stop();
+    snsc = null;
+
+    // getActiveOrCreate should recover context with checkpoint path, and recover old configuration
+    newContextCreated.set(false);
+    snsc = JavaSnappyStreamingContext.getActiveOrCreate(checkpointPath, creatingFunction, new Configuration
+        (), false);
+    Assert.assertTrue("no context created" , snsc != null);
+    Assert.assertTrue("old context not recovered", !newContextCreated.get());
+    Assert.assertTrue("checkpointed config not " +
+        "recovered", snsc.sparkContext().getConf().get("someKey").equals("someValue"));
+
+    snsc.stop();
+    snsc = null;
+
+  }
+
+  private static List<List<String>> fileTestPrepare(File testDir) throws IOException {
+    File existingFile = new File(testDir, "0");
+    Files.write("0\n", existingFile, Charset.forName("UTF-8"));
+    Assert.assertTrue(existingFile.setLastModified(1000));
+    Assert.assertEquals(1000, existingFile.lastModified());
+    return Arrays.asList(Arrays.asList("0"));
+  }
+
+  private static class Message {
+    public String getMessage() {
+      return message;
+    }
+
+    public void setMessage(String message) {
+      this.message = message;
+    }
+
+    private String message;
+
+    public void Message(String message) {
+      this.message = message;
+    }
+  }
+}
+


### PR DESCRIPTION
## Changes proposed in this pull request

a) added JavaSnappyStreamingContext: This will ease the usage of SnappyStreamingContext from Java. User does not have to maintgain two instance to work with methods from JavaStreamingContext and SnappyStreamingContext.
b) Added helper methods forEachDataFrame in SchemaDStream for Java.
c) Added test.

## Patch testing
Added Junit test to test all Java APIs

## Other PRs 
NA
