### PR TITLE
[SNAP-677] Create a separate PutIntoTable plan for PUT operations

### DIFF
--- a/core/src/main/scala/org/apache/spark/sql/SnappyContext.scala
+++ b/core/src/main/scala/org/apache/spark/sql/SnappyContext.scala
@@ -32,9 +32,9 @@ import org.apache.spark.api.java.JavaSparkContext
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.aqp.{SnappyContextDefaultFunctions, SnappyContextFunctions}
 import org.apache.spark.sql.catalyst.ParserDialect
-import org.apache.spark.sql.catalyst.analysis.Analyzer
-import org.apache.spark.sql.catalyst.expressions.{Cast, Alias, Attribute}
-import org.apache.spark.sql.catalyst.plans.logical.{Project, InsertIntoTable, LogicalPlan, Union}
+import org.apache.spark.sql.catalyst.analysis.{Analyzer, EliminateSubQueries}
+import org.apache.spark.sql.catalyst.expressions.{Alias, Cast}
+import org.apache.spark.sql.catalyst.plans.logical.{InsertIntoTable, LogicalPlan, Project, Union}
 import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.collection.{ToolsCallbackInit, Utils}
 import org.apache.spark.sql.execution.columnar.ExternalStoreUtils
@@ -1021,10 +1021,10 @@ private[sql] object PreInsertCheckCastAndRename extends Rule[LogicalPlan] {
 
     // Check for SchemaInsertableRelation first
     case i@InsertIntoTable(l@LogicalRelation(r:
-        SchemaInsertableRelation, _), _, child, _, _) =>
-      r.schemaForInsert(child.output) match {
+        SchemaInsertableRelation, _), _, query, _, _) =>
+      r.schemaForInsert(query.output) match {
         case Some(output) =>
-          PreInsertCastAndRename.castAndRenameChildOutput(i, output, child)
+          PreInsertCastAndRename.castAndRenameChildOutput(i, output, query)
         case None =>
           throw new AnalysisException(s"$l requires that the query in the " +
               "SELECT clause of the INSERT INTO/OVERWRITE statement " +
@@ -1032,16 +1032,23 @@ private[sql] object PreInsertCheckCastAndRename extends Rule[LogicalPlan] {
       }
 
     // Check for PUT
-    case p@PutIntoTable(l@LogicalRelation(r:
-        RowInsertableRelation, _), child) =>
-      // First, make sure the data to be inserted have the same number of
-      // fields with the schema of the relation.
-      if (l.output.size != child.output.size) {
-        throw new AnalysisException(s"$l requires that the query in the " +
-            "SELECT clause of the PUT INTO statement " +
-            "generates the same number of columns as its schema.")
+    // Need to eliminate subqueries here. Unlike InsertIntoTable whose
+    // subqueries have already been eliminated by special check in
+    // ResolveRelations, no such special rule has been added for PUT
+    case p@PutIntoTable(table, query) =>
+      EliminateSubQueries(table) match {
+        case l@LogicalRelation(_: RowInsertableRelation, _) =>
+          // First, make sure the data to be inserted have the same number of
+          // fields with the schema of the relation.
+          if (l.output.size != query.output.size) {
+            throw new AnalysisException(s"$l requires that the query in the " +
+                "SELECT clause of the PUT INTO statement " +
+                "generates the same number of columns as its schema.")
+          }
+          castAndRenameChildOutput(p, l, query)
+
+        case _ => p
       }
-      castAndRenameChildOutput(p, l.output, child)
 
     // We are inserting into an InsertableRelation or HadoopFsRelation.
     case i@InsertIntoTable(l@LogicalRelation(_: InsertableRelation |
@@ -1062,9 +1069,9 @@ private[sql] object PreInsertCheckCastAndRename extends Rule[LogicalPlan] {
    */
   def castAndRenameChildOutput(
       putInto: PutIntoTable,
-      expectedOutput: Seq[Attribute],
+      relation: LogicalRelation,
       child: LogicalPlan): PutIntoTable = {
-    val newChildOutput = expectedOutput.zip(child.output).map {
+    val newChildOutput = relation.output.zip(child.output).map {
       case (expected, actual) =>
         val needCast = !expected.dataType.sameType(actual.dataType)
         // We want to make sure the filed names in the data to be inserted exactly match
@@ -1078,9 +1085,33 @@ private[sql] object PreInsertCheckCastAndRename extends Rule[LogicalPlan] {
     }
 
     if (newChildOutput == child.output) {
-      putInto
+      putInto.copy(table = relation)
     } else {
-      putInto.copy(child = Project(newChildOutput, child))
+      putInto.copy(table = relation, child = Project(newChildOutput, child))
+    }
+  }
+}
+
+private[sql] case object PrePutCheck extends (LogicalPlan => Unit) {
+
+  def apply(plan: LogicalPlan): Unit = {
+    plan.foreach {
+      case PutIntoTable(LogicalRelation(t: RowPutRelation, _), query) =>
+        // Get all input data source relations of the query.
+        val srcRelations = query.collect {
+          case LogicalRelation(src: BaseRelation, _) => src
+        }
+        if (srcRelations.contains(t)) {
+          throw Utils.analysisException(
+            "Cannot put into table that is also being read from.")
+        } else {
+          // OK
+        }
+
+      case PutIntoTable(table, query) =>
+        throw Utils.analysisException(s"$table does not allow puts.")
+
+      case _ => // OK
     }
   }
 }

--- a/core/src/main/scala/org/apache/spark/sql/SnappyContext.scala
+++ b/core/src/main/scala/org/apache/spark/sql/SnappyContext.scala
@@ -33,7 +33,8 @@ import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.aqp.{SnappyContextDefaultFunctions, SnappyContextFunctions}
 import org.apache.spark.sql.catalyst.ParserDialect
 import org.apache.spark.sql.catalyst.analysis.Analyzer
-import org.apache.spark.sql.catalyst.plans.logical.{InsertIntoTable, LogicalPlan, Union}
+import org.apache.spark.sql.catalyst.expressions.{Cast, Alias, Attribute}
+import org.apache.spark.sql.catalyst.plans.logical.{Project, InsertIntoTable, LogicalPlan, Union}
 import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.collection.{ToolsCallbackInit, Utils}
 import org.apache.spark.sql.execution.columnar.ExternalStoreUtils
@@ -1030,17 +1031,57 @@ private[sql] object PreInsertCheckCastAndRename extends Rule[LogicalPlan] {
               "generates the same number of columns as its schema.")
       }
 
+    // Check for PUT
+    case p@PutIntoTable(l@LogicalRelation(r:
+        RowInsertableRelation, _), child) =>
+      // First, make sure the data to be inserted have the same number of
+      // fields with the schema of the relation.
+      if (l.output.size != child.output.size) {
+        throw new AnalysisException(s"$l requires that the query in the " +
+            "SELECT clause of the PUT INTO statement " +
+            "generates the same number of columns as its schema.")
+      }
+      castAndRenameChildOutput(p, l.output, child)
+
     // We are inserting into an InsertableRelation or HadoopFsRelation.
     case i@InsertIntoTable(l@LogicalRelation(_: InsertableRelation |
                                              _: HadoopFsRelation, _), _, child, _, _) =>
-      // First, make sure the data to be inserted have the same number of fields with the
-      // schema of the relation.
+      // First, make sure the data to be inserted have the same number of
+      // fields with the schema of the relation.
       if (l.output.size != child.output.size) {
         throw new AnalysisException(s"$l requires that the query in the " +
-            "SELECT clause of the INSERT/PUT INTO/OVERWRITE statement " +
+            "SELECT clause of the INSERT/OVERWRITE statement " +
             "generates the same number of columns as its schema.")
       }
       PreInsertCastAndRename.castAndRenameChildOutput(i, l.output, child)
+  }
+
+  /**
+   * If necessary, cast data types and rename fields to the expected
+   * types and names.
+   */
+  def castAndRenameChildOutput(
+      putInto: PutIntoTable,
+      expectedOutput: Seq[Attribute],
+      child: LogicalPlan): PutIntoTable = {
+    val newChildOutput = expectedOutput.zip(child.output).map {
+      case (expected, actual) =>
+        val needCast = !expected.dataType.sameType(actual.dataType)
+        // We want to make sure the filed names in the data to be inserted exactly match
+        // names in the schema.
+        val needRename = expected.name != actual.name
+        (needCast, needRename) match {
+          case (true, _) => Alias(Cast(actual, expected.dataType), expected.name)()
+          case (false, true) => Alias(actual, expected.name)()
+          case (_, _) => actual
+        }
+    }
+
+    if (newChildOutput == child.output) {
+      putInto
+    } else {
+      putInto.copy(child = Project(newChildOutput, child))
+    }
   }
 }
 

--- a/core/src/main/scala/org/apache/spark/sql/aqp/SnappyContextDefaultFunctions.scala
+++ b/core/src/main/scala/org/apache/spark/sql/aqp/SnappyContextDefaultFunctions.scala
@@ -119,7 +119,7 @@ object SnappyContextDefaultFunctions extends SnappyContextFunctions {
           else Nil)
 
       override val extendedCheckRules = Seq(
-        sparkexecution.datasources.PreWriteCheck(context.catalog))
+        sparkexecution.datasources.PreWriteCheck(context.catalog), PrePutCheck)
     }
 }
 

--- a/core/src/main/scala/org/apache/spark/sql/snappyParsers.scala
+++ b/core/src/main/scala/org/apache/spark/sql/snappyParsers.scala
@@ -35,7 +35,7 @@ import org.apache.spark.sql.collection.Utils
 import org.apache.spark.sql.execution.RunnableCommand
 import org.apache.spark.sql.execution.datasources.{CreateTableUsing, CreateTableUsingAsSelect, DDLException, DDLParser, ResolvedDataSource}
 import org.apache.spark.sql.hive.QualifiedTableName
-import org.apache.spark.sql.sources.ExternalSchemaRelationProvider
+import org.apache.spark.sql.sources.{PutIntoTable, ExternalSchemaRelationProvider}
 import org.apache.spark.sql.streaming.{StreamPlanProvider, WindowLogicalPlan}
 import org.apache.spark.sql.types._
 import org.apache.spark.streaming.{Duration, Milliseconds, Minutes, Seconds, SnappyStreamingContext}
@@ -601,8 +601,7 @@ class SnappyParser(caseSensitive: Boolean)
 
   protected def put: Rule1[LogicalPlan] = rule {
     PUT ~ INTO ~ TABLE ~ relation ~ select ~> ((r: LogicalPlan,
-        s: LogicalPlan) => InsertIntoTable(r, Map.empty[String, Option[String]],
-        s, overwrite = true, ifNotExists = false))
+        s: LogicalPlan) => PutIntoTable(r, s))
   }
 
   protected def withIdentifier: Rule1[LogicalPlan] = rule {

--- a/core/src/main/scala/org/apache/spark/sql/sources/StoreStrategy.scala
+++ b/core/src/main/scala/org/apache/spark/sql/sources/StoreStrategy.scala
@@ -16,12 +16,13 @@
  */
 package org.apache.spark.sql.sources
 
+import org.apache.spark.sql._
 import org.apache.spark.sql.catalyst.expressions.Attribute
-import org.apache.spark.sql.types.DataType
-import org.apache.spark.sql.{DataFrame, Row, SQLContext, _}
-import org.apache.spark.sql.catalyst.plans.logical.{InsertIntoTable, LogicalPlan}
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.apache.spark.sql.execution.datasources.{CreateTableUsing, CreateTableUsingAsSelect, LogicalRelation}
 import org.apache.spark.sql.execution.{ExecutedCommand, RunnableCommand, SparkPlan}
+import org.apache.spark.sql.types.DataType
+
 /**
  * Support for DML and other operations on external tables.
  *
@@ -54,8 +55,8 @@ object StoreStrategy extends Strategy {
     case DMLExternalTable(name, storeRelation: LogicalRelation, insertCommand) =>
       ExecutedCommand(ExternalTableDMLCmd(storeRelation, insertCommand)) :: Nil
 
-    case PutIntoTable(l@LogicalRelation(t: RowPutRelation, _),
-        query) => ExecutedCommand(PutIntoDataSource(l, t, query)) :: Nil
+    case PutIntoTable(l@LogicalRelation(t: RowPutRelation, _), query) =>
+      ExecutedCommand(PutIntoDataSource(l, t, query)) :: Nil
 
     case _ => Nil
   }
@@ -84,7 +85,7 @@ private[sql] case class PutIntoTable(
     child: LogicalPlan)
     extends LogicalPlan {
 
-  override def children: Seq[LogicalPlan] = child :: Nil
+  override def children: Seq[LogicalPlan] = table :: child :: Nil
 
   override def output: Seq[Attribute] = Seq.empty
 

--- a/core/src/main/scala/org/apache/spark/sql/sources/StoreStrategy.scala
+++ b/core/src/main/scala/org/apache/spark/sql/sources/StoreStrategy.scala
@@ -16,6 +16,8 @@
  */
 package org.apache.spark.sql.sources
 
+import org.apache.spark.sql.catalyst.expressions.Attribute
+import org.apache.spark.sql.types.DataType
 import org.apache.spark.sql.{DataFrame, Row, SQLContext, _}
 import org.apache.spark.sql.catalyst.plans.logical.{InsertIntoTable, LogicalPlan}
 import org.apache.spark.sql.execution.datasources.{CreateTableUsing, CreateTableUsingAsSelect, LogicalRelation}
@@ -52,9 +54,8 @@ object StoreStrategy extends Strategy {
     case DMLExternalTable(name, storeRelation: LogicalRelation, insertCommand) =>
       ExecutedCommand(ExternalTableDMLCmd(storeRelation, insertCommand)) :: Nil
 
-    case InsertIntoTable(l@LogicalRelation(t: RowPutRelation, _),
-    part, query, true, false) if part.isEmpty =>
-      ExecutedCommand(PutIntoDataSource(l, query)) :: Nil
+    case PutIntoTable(l@LogicalRelation(t: RowPutRelation, _),
+        query) => ExecutedCommand(PutIntoDataSource(l, t, query)) :: Nil
 
     case _ => Nil
   }
@@ -78,16 +79,33 @@ private[sql] case class ExternalTableDMLCmd(
   }
 }
 
+private[sql] case class PutIntoTable(
+    table: LogicalPlan,
+    child: LogicalPlan)
+    extends LogicalPlan {
+
+  override def children: Seq[LogicalPlan] = child :: Nil
+
+  override def output: Seq[Attribute] = Seq.empty
+
+  override lazy val resolved: Boolean = childrenResolved &&
+      child.output.zip(table.output).forall {
+        case (childAttr, tableAttr) =>
+          DataType.equalsIgnoreCompatibleNullability(childAttr.dataType,
+            tableAttr.dataType)
+      }
+}
+
 /**
  * Puts the results of `query` in to a relation that extends [[RowPutRelation]].
  */
 private[sql] case class PutIntoDataSource(
     logicalRelation: LogicalRelation,
+    relation: RowPutRelation,
     query: LogicalPlan)
     extends RunnableCommand {
 
   override def run(sqlContext: SQLContext): Seq[Row] = {
-    val relation = logicalRelation.relation.asInstanceOf[RowPutRelation]
     val data = DataFrame(sqlContext, query)
     // Apply the schema of the existing table to the new data.
     val df = sqlContext.internalCreateDataFrame(data.queryExecution.toRdd,


### PR DESCRIPTION
## Changes proposed in this pull request

Avoid overloading the InsertIntoTable for puts into row tables else primary key violations are never detected for bulk inserts.

Uses reflection for DataWriter implicit putInto method since DataFrame is private (and not exposed at all).

## Patch testing

Existing tests like RowTableTest that use putInto.

## Other PRs

Fix to other part of SNAP-677 in #215