### PR TITLE
Added quickstart for snappy python api

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -516,6 +516,10 @@ task product {
         into "${snappyProductDir}/python"
       }
       copy {
+        from("${examplesProject.projectDir}/src/main/python")
+        into "${examplesProject.buildDir}"
+      }
+      copy {
         from "${project(':snappy-spark').projectDir}/data"
         into "${snappyProductDir}/data"
       }
@@ -752,6 +756,17 @@ task runQuickstart(dependsOn: product) {
       println "${airlineappresult}"
       if (airlineappresult.toLowerCase().contains("exception")) {
         throw new GradleException("Failed to submit AirlineDataSparkApp")
+      }
+
+      def examplesdir = project(":snappy-examples_${scalaBinaryVersion}")
+
+      def airlinepythonappresult = runScript("${snappyProductDir}/bin/spark-submit",
+          ["--master", "spark://${hostname}:7077", "--conf", "snappydata.store.locators=localhost:10334",
+           "--conf", "spark.ui.port=4042", "${examplesdir.buildDir}/AirlineDataPythonApp.py"]);
+
+      println "${airlinepythonappresult}"
+      if (airlinepythonappresult.toLowerCase().contains("exception")) {
+        throw new GradleException("Failed to submit airlinepythonappresult")
       }
 
     } finally {

--- a/examples/build.gradle
+++ b/examples/build.gradle
@@ -32,6 +32,10 @@ if (rootProject.hasProperty('enablePublish')) {
 }
 
 task productExamples(dependsOn: 'jar') << {
+  copy {
+    from "src/main/python/*"
+    into "${buildDir}" }
+
   def productDir = file("${rootProject.buildDir}/snappy")
   productDir.mkdirs()
   def exampleArchiveName = "quickstart-${version}.jar"

--- a/examples/src/main/python/AirlineDataPythonApp.py
+++ b/examples/src/main/python/AirlineDataPythonApp.py
@@ -1,0 +1,66 @@
+from pyspark.conf import SparkConf
+from pyspark.context import SparkContext
+from pyspark.sql import SQLContext, Row
+from pyspark.sql.snappy import SnappyContext
+from pyspark.rdd import RDD
+from pyspark.sql.dataframe import DataFrame
+from pyspark.sql.functions import col
+import time
+import sys
+
+# This application depicts how a Spark cluster can
+# connect to a Snappy cluster to fetch and query the tables
+# using Python APIs in a Spark App.
+
+
+## Constants
+APP_NAME = " Python Airline Data Application "
+COLUMN_TABLE_NAME = "airline"
+ROW_TABLE_NAME = "airlineref"
+
+
+def main(sqlContext):
+    sqlContext.sql("set spark.sql.shuffle.partitions=6")
+    # Get the tables that were created using sql scripts via snappy-shell
+    airlineDF = sqlContext.table(COLUMN_TABLE_NAME)
+    airlineCodeDF = sqlContext.table(ROW_TABLE_NAME)
+
+    # Data Frame query :Which Airlines Arrive On Schedule? JOIN with reference table
+    colResult = airlineDF.alias('airlineDF') \
+        .join(airlineCodeDF.alias('airlineCodeDF'), col('airlineDF.UniqueCarrier') == col('airlineCodeDF.CODE')) \
+        .groupBy(col('airlineDF.UniqueCarrier'), col('airlineCodeDF.Description')) \
+        .agg({"ArrDelay": "avg"}). \
+        orderBy("avg(ArrDelay)")
+
+    print("Airline arrival schedule")
+    start = int(time.time() * 1000)
+    colResult.show()
+    totalTimeCol = int(time.time() * 1000) - start
+    print("Query time: %dms" % totalTimeCol)
+
+    # Suppose a particular Airline company say 'Delta Air Lines Inc.'
+    # re-brands itself as 'Delta America'.Update the row table.
+    query = " CODE ='DL'"
+    newColumnValues = ["Delta America Renewed"]
+    sqlContext.update(ROW_TABLE_NAME, query, newColumnValues, ["DESCRIPTION"])
+
+    # Data Frame query :Which Airlines Arrive On Schedule? JOIN with reference table
+    colResultAftUpd = airlineDF.alias('airlineDF') \
+        .join(airlineCodeDF.alias('airlineCodeDF'), col('airlineDF.UniqueCarrier') == col('airlineCodeDF.CODE')) \
+        .groupBy(col('airlineDF.UniqueCarrier'), col('airlineCodeDF.Description')) \
+        .agg({"ArrDelay": "avg"}). \
+        orderBy("avg(ArrDelay)")
+
+    print("Airline arrival schedule after Updated values:")
+
+    startColUpd = int(time.time() * 1000)
+    colResultAftUpd.show()
+    totalTimeColUpd = int(time.time() * 1000) - startColUpd
+    print("Query time:%dms" % totalTimeColUpd)
+
+if __name__ == "__main__":
+    # Configure Spark
+    conf = SparkConf().setAppName(APP_NAME)
+    sc = SparkContext(conf=conf)
+    snc = SnappyContext(sc)
+    main(snc)

--- a/python/pyspark/sql/snappy/context.py
+++ b/python/pyspark/sql/snappy/context.py
@@ -130,20 +130,20 @@ class SnappyContext(SQLContext):
         else:
             raise TypeError("rows should be tuple or a list")
 
-    def update(self, tableName, filterExpr, newColumnValues, *updateColumns):
+    def update(self, tableName, filterExpr, newColumnValues, updateColumns):
         """
         update all rows in table that match passed filter expression
         :param tableName: Table name which needs to be updated
         :param filterExpr: SQL WHERE criteria to select rows that will be updated
-        :param newColumnValues:  single Row containing all updated column values.
+        :param newColumnValues:  single list containing all updated column values.
         They MUST match the updateColumn list
         :param updateColumns   List of all column names being updated
         :return: List of all column names being updated
         """
-        if isinstance(newColumnValues, tuple):
+        if isinstance(newColumnValues, list) and isinstance(updateColumns, list):
             return self._ssql_ctx.update(tableName, filterExpr, newColumnValues, updateColumns)
         else:
-            raise TypeError("newColumnValues should be tuple")
+            raise TypeError("newColumnValues and updateColumns should be list")
 
     def delete(self, tableName, filterExpr):
         """

--- a/python/pyspark/sql/snappy/tests.py
+++ b/python/pyspark/sql/snappy/tests.py
@@ -158,8 +158,7 @@ class SnappyContextTests(ReusedPySparkTestCase):
 
     def update_table(self):
         sqlcontext = SnappyContext.getOrCreate(self.sc)
-        newColumnvalues = Row(col1=7L)
-        modifiedrows = sqlcontext.update(SnappyContextTests.tablename, "COL2 =2", newColumnvalues, "COL1")
+        modifiedrows = sqlcontext.update(SnappyContextTests.tablename, "COL2 =2", [7L], ["COL1"])
         self.assertTrue(modifiedrows == 3)
 
     def truncate_table(self):


### PR DESCRIPTION
## Changes proposed in this pull request

added the python example under the runQuickstart  target
change the gradle build  to build the new python files
smalll correction in update API

## Patch testing
precheckin clean

## Other PRs 

(Does this change required changes in other projects- store, spark, spark-jobserver, aqp? Add the links of PR of the other subprojects that are related to this change)
NO 

added the python example under the runQuickstart  target
change the gradle build  to build the new python files
smalll correction in update API