### PR TITLE
SNAP-652 - Buckets with empty host-list are provided with other hosts.

### DIFF
--- a/core/src/main/scala/io/snappydata/impl/SparkShellRDDHelper.scala
+++ b/core/src/main/scala/io/snappydata/impl/SparkShellRDDHelper.scala
@@ -56,11 +56,14 @@ final class SparkShellRDDHelper {
     DriverRegistry.register(Constant.JDBC_CLIENT_DRIVER)
     val resolvedName = StoreUtils.lookupName(tableName, conn.getSchema)
     val par = split.index
+
+    if (!useLocatorURL) {
+      val ps = conn.createStatement()
+      ps.execute(s"call sys.SET_BUCKETS_FOR_LOCAL_EXECUTION('$resolvedName', $par)")
+      ps.close()
+    }
+
     val statement = conn.createStatement()
-
-    if (!useLocatorURL)
-      statement.execute(s"call sys.SET_BUCKETS_FOR_LOCAL_EXECUTION('$resolvedName', $par)")
-
     val rs = statement.executeQuery(query)
     (statement, rs)
   }
@@ -149,6 +152,8 @@ object SparkShellRDDHelper {
         ClientAttribute.LOAD_BALANCE + "=false"
     val membersToNetServers = GemFireXDUtils.getGfxdAdvisor.
         getAllDRDAServersAndCorrespondingMemberMapping
+    var availableNetUrls = ArrayBuffer.empty[(String, String)]
+    val orphanBuckets = ArrayBuffer.empty[Int]
     Misc.getRegionForTable(resolvedName, true).asInstanceOf[Region[_, _]] match {
       case pr: PartitionedRegion =>
         val bidToAdvisorMap = pr.getRegionAdvisor.
@@ -163,7 +168,21 @@ object SparkShellRDDHelper {
           val netUrls = ArrayBuffer.empty[(String, String)]
           bOwners.asScala.foreach(fillNetUrlsForServer(_,
             membersToNetServers, urlPrefix, urlSuffix, netUrls))
-          allNetUrls(bid) = netUrls
+
+          if (netUrls.isEmpty) {
+            // Save the bucket which does not have a neturl, and later assign available ones to it.
+            orphanBuckets += bid
+          } else {
+            for (e <- netUrls) {
+              if (!availableNetUrls.contains(e)) {
+                availableNetUrls += e
+              }
+            }
+            allNetUrls(bid) = netUrls
+          }
+        }
+        for (bucket <- orphanBuckets) {
+          allNetUrls(bucket) = availableNetUrls
         }
         allNetUrls
 

--- a/core/src/main/scala/io/snappydata/impl/SparkShellRDDHelper.scala
+++ b/core/src/main/scala/io/snappydata/impl/SparkShellRDDHelper.scala
@@ -56,11 +56,11 @@ final class SparkShellRDDHelper {
     DriverRegistry.register(Constant.JDBC_CLIENT_DRIVER)
     val resolvedName = StoreUtils.lookupName(tableName, conn.getSchema)
     val par = split.index
-
     val statement = conn.createStatement()
 
     if (!useLocatorURL)
       statement.execute(s"call sys.SET_BUCKETS_FOR_LOCAL_EXECUTION('$resolvedName', $par)")
+
     val rs = statement.executeQuery(query)
     (statement, rs)
   }

--- a/core/src/main/scala/io/snappydata/impl/SparkShellRDDHelper.scala
+++ b/core/src/main/scala/io/snappydata/impl/SparkShellRDDHelper.scala
@@ -57,13 +57,10 @@ final class SparkShellRDDHelper {
     val resolvedName = StoreUtils.lookupName(tableName, conn.getSchema)
     val par = split.index
 
-    if (!useLocatorURL) {
-      val ps = conn.createStatement()
-      ps.execute(s"call sys.SET_BUCKETS_FOR_LOCAL_EXECUTION('$resolvedName', $par)")
-      ps.close()
-    }
-
     val statement = conn.createStatement()
+
+    if (!useLocatorURL)
+      statement.execute(s"call sys.SET_BUCKETS_FOR_LOCAL_EXECUTION('$resolvedName', $par)")
     val rs = statement.executeQuery(query)
     (statement, rs)
   }
@@ -152,7 +149,7 @@ object SparkShellRDDHelper {
         ClientAttribute.LOAD_BALANCE + "=false"
     val membersToNetServers = GemFireXDUtils.getGfxdAdvisor.
         getAllDRDAServersAndCorrespondingMemberMapping
-    var availableNetUrls = ArrayBuffer.empty[(String, String)]
+    val availableNetUrls = ArrayBuffer.empty[(String, String)]
     val orphanBuckets = ArrayBuffer.empty[Int]
     Misc.getRegionForTable(resolvedName, true).asInstanceOf[Region[_, _]] match {
       case pr: PartitionedRegion =>

--- a/core/src/main/scala/org/apache/spark/sql/store/StoreUtils.scala
+++ b/core/src/main/scala/org/apache/spark/sql/store/StoreUtils.scala
@@ -81,6 +81,7 @@ object StoreUtils extends Logging {
 
   val SHADOW_COLUMN = s"$SHADOW_COLUMN_NAME bigint generated always as identity"
 
+  var skewTaskDistributionForTests = false
 
   def lookupName(tableName: String, schema: String): String = {
     val lookupName = {
@@ -101,7 +102,11 @@ object StoreUtils extends Logging {
     val partitions = new Array[Partition](numPartitions)
 
     for (p <- 0 until numPartitions) {
-      val distMembers = region.getRegionAdvisor.getBucketOwners(p).asScala
+      val num = skewTaskDistributionForTests match {
+        case true => 0
+        case _ => p
+      }
+      val distMembers = region.getRegionAdvisor.getBucketOwners(num).asScala
       val prefNodes = distMembers.map(
         m => blockMap.get(m)
       )

--- a/tests/dunit/src/test/scala/io/snappydata/dunit/cluster/ClusterManagerTestBase.scala
+++ b/tests/dunit/src/test/scala/io/snappydata/dunit/cluster/ClusterManagerTestBase.scala
@@ -13,6 +13,7 @@ import io.snappydata.{Locator, Server, ServiceManager}
 import org.slf4j.LoggerFactory
 
 import org.apache.spark.sql.SnappyContext
+import org.apache.spark.sql.store.StoreUtils
 import org.apache.spark.{SparkConf, SparkContext}
 
 /**
@@ -125,6 +126,8 @@ class ClusterManagerTestBase(s: String) extends DistributedTestBase(s) {
   override def tearDown2(): Unit = {
     super.tearDown2()
     GemFireXDUtils.IS_TEST_MODE = false
+    StoreUtils.skewTaskDistributionForTests = false
+    println("Successfully reset the flag StoreUtils.skewTaskDistributionForTests")
     cleanupTestData(getClass.getName, getName)
     Array(vm3, vm2, vm1, vm0).foreach(_.invoke(getClass, "cleanupTestData",
       Array[AnyRef](getClass.getName, getName)))

--- a/tests/dunit/src/test/scala/io/snappydata/dunit/externalstore/ExternalShellDUnitTest.scala
+++ b/tests/dunit/src/test/scala/io/snappydata/dunit/externalstore/ExternalShellDUnitTest.scala
@@ -54,13 +54,16 @@ class ExternalShellDUnitTest(s: String)
     vm3.invoke(this.getClass, "stopSparkCluster")
   }
 
-  def testColumnTableCreation(): Unit = {
+  def doTestColumnTableCreation(skewTaskDistribution : Boolean = false): Unit = {
     vm0.invoke(classOf[ClusterManagerTestBase], "startNetServer",
       AvailablePortHelper.getRandomAvailableTCPPort)
     vm1.invoke(classOf[ClusterManagerTestBase], "startNetServer",
       AvailablePortHelper.getRandomAvailableTCPPort)
-    vm2.invoke(classOf[ClusterManagerTestBase], "startNetServer",
-      AvailablePortHelper.getRandomAvailableTCPPort)
+    if (!skewTaskDistribution) {
+      vm2.invoke(classOf[ClusterManagerTestBase], "startNetServer",
+        AvailablePortHelper.getRandomAvailableTCPPort)
+    }
+    StoreUtils.skewTaskDistributionForTests = skewTaskDistribution
 
     // Embedded Cluster Operations
     createTablesAndInsertData("column")
@@ -73,6 +76,14 @@ class ExternalShellDUnitTest(s: String)
     verifyShellModeOperations("column", isComplex = false, props)
 
     println("Test Completed Successfully")
+  }
+
+  def testColumnTableCreation(): Unit = {
+    doTestColumnTableCreation()
+  }
+
+  def testRemoteIteratorSNAP652(): Unit = {
+    doTestColumnTableCreation(true)
   }
 
   def testRowTableCreation(): Unit = {


### PR DESCRIPTION
## Changes proposed in this pull request
- Partial fix for SNAP-652. Buckets with empty host-list (network servers) are given other buckets host-list for executors to process them on. See Other PRs section for the other part of the fix.

- Added a unit test for remote iteration in both the - unified and split cluster - modes.

## Patch testing
- precheckin
- New dunit test: ExternalShellDUnitTest.testRemoteIteratorSNAP652()

## Other PRs 
- https://github.com/SnappyDataInc/snappy-store/pull/52

