### PR TITLE
Added interface JavaSnappySQLJob to work easily with SnappyContext fr…

### DIFF
--- a/cluster/src/main/java/org/apache/spark/sql/JavaSnappySQLJob.java
+++ b/cluster/src/main/java/org/apache/spark/sql/JavaSnappySQLJob.java
@@ -1,0 +1,25 @@
+package org.apache.spark.sql;
+
+import com.typesafe.config.Config;
+import spark.jobserver.SparkJobValidation;
+
+/**
+ * Created by rishim on 29/4/16.
+ */
+public abstract class JavaSnappySQLJob  implements SnappySQLJob {
+
+  abstract public  Object runJavaJob(SnappyContext snc, Config jobConfig);
+
+  abstract public JSparkJobValidation isValidJob(SnappyContext snc, Config jobConfig);
+
+  @Override
+  public Object runJob(Object sc, Config jobConfig) {
+    return runJavaJob((SnappyContext)sc, jobConfig);
+  }
+
+  @Override
+  public SparkJobValidation validate(Object sc, Config config) {
+    JSparkJobValidation  status = isValidJob((SnappyContext)sc, config);
+    return JavaJobValidate.validate(status);
+  }
+}

--- a/cluster/src/main/java/org/apache/spark/streaming/JavaSnappyStreamingJob.java
+++ b/cluster/src/main/java/org/apache/spark/streaming/JavaSnappyStreamingJob.java
@@ -14,29 +14,32 @@
  * permissions and limitations under the License. See accompanying
  * LICENSE file.
  */
-package org.apache.spark.sql;
+package org.apache.spark.streaming;
+
 
 import com.typesafe.config.Config;
+import org.apache.spark.sql.JSparkJobValidation;
+import org.apache.spark.sql.JavaJobValidate;
+import org.apache.spark.sql.streaming.SnappyStreamingJob;
+import org.apache.spark.streaming.api.JavaSnappyStreamingContext;
 import spark.jobserver.SparkJobValidation;
 
-/**
- * This class acts as a helper class to implement Java jobs in Spark job server with
- * SnappyContext implicitly provided.
- */
-public abstract class JavaSnappySQLJob  implements SnappySQLJob {
+public abstract class JavaSnappyStreamingJob implements SnappyStreamingJob {
 
-  abstract public  Object runJavaJob(SnappyContext snc, Config jobConfig);
+  abstract public  Object runJavaJob(JavaSnappyStreamingContext snc, Config jobConfig);
 
-  abstract public JSparkJobValidation isValidJob(SnappyContext snc, Config jobConfig);
+  abstract public JSparkJobValidation isValidJob(JavaSnappyStreamingContext snc,
+      Config jobConfig);
 
   @Override
   public Object runJob(Object sc, Config jobConfig) {
-    return runJavaJob((SnappyContext)sc, jobConfig);
+    return runJavaJob(new JavaSnappyStreamingContext((SnappyStreamingContext)sc), jobConfig);
   }
 
   @Override
   public SparkJobValidation validate(Object sc, Config config) {
-    JSparkJobValidation  status = isValidJob((SnappyContext)sc, config);
+    JSparkJobValidation  status =
+        isValidJob(new JavaSnappyStreamingContext((SnappyStreamingContext)sc), config);
     return JavaJobValidate.validate(status);
   }
 }

--- a/cluster/src/main/scala/org/apache/spark/sql/SnappyContextFactory.scala
+++ b/cluster/src/main/scala/org/apache/spark/sql/SnappyContextFactory.scala
@@ -19,13 +19,29 @@ package org.apache.spark.sql
 import com.typesafe.config.Config
 import io.snappydata.impl.LeadImpl
 import spark.jobserver.context.SparkContextFactory
-import spark.jobserver.{ContextLike, SparkJobBase}
+import spark.jobserver.{SparkJobValid, SparkJobInvalid, SparkJobValidation, SparkJob, ContextLike, SparkJobBase}
 
-import org.apache.spark.SparkConf
+import org.apache.spark.api.java.JavaSparkContext
+import org.apache.spark.streaming.api.java.JavaDStream
+import org.apache.spark.{SparkContext, SparkConf}
 
 trait SnappySQLJob extends SparkJobBase {
   type C = SnappyContext
 }
+
+object JavaJobValidate{
+  def validate(status :JSparkJobValidation) : SparkJobValidation ={
+    status match {
+      case j : JSparkJobValid => SparkJobValid
+      case j : JSparkJobInvalid => SparkJobInvalid(j.reason)
+      case _ => SparkJobInvalid("isValid method is not correct")
+    }
+  }
+}
+trait JSparkJobValidation
+case class JSparkJobValid extends JSparkJobValidation
+case class JSparkJobInvalid(reason : String) extends JSparkJobValidation
+
 
 class SnappyContextFactory extends SparkContextFactory {
 

--- a/core/src/main/scala/org/apache/spark/streaming/api/JavaSnappyStreamingContext.scala
+++ b/core/src/main/scala/org/apache/spark/streaming/api/JavaSnappyStreamingContext.scala
@@ -25,13 +25,14 @@ import org.apache.spark.annotation.Experimental
 import org.apache.spark.api.java.JavaSparkContext
 import org.apache.spark.api.java.function.{Function => JFunction, Function0 => JFunction0, Function2 => JFunction2}
 import org.apache.spark.deploy.SparkHadoopUtil
-import org.apache.spark.sql.DataFrame
+import org.apache.spark.sql.{SnappyContext, DataFrame}
 import org.apache.spark.sql.streaming.{SchemaDStream, StreamSqlHelper}
 import org.apache.spark.streaming.api.java.{JavaDStream, JavaStreamingContext}
 import org.apache.spark.streaming.{Checkpoint, CheckpointReader, Duration, SnappyStreamingContext, StreamingContext}
 
 class JavaSnappyStreamingContext(val snsc: SnappyStreamingContext) extends JavaStreamingContext(snsc) {
 
+  def snappyContext = snsc.snappyContext
 
   /**
    * Create a JavaSnappyStreamingContext using an existing SparkContext.
@@ -102,7 +103,9 @@ class JavaSnappyStreamingContext(val snsc: SnappyStreamingContext) extends JavaS
    */
   override def start(): Unit = snsc.start()
 
-  override def stop(stopSparkContext: Boolean, stopGracefully: Boolean): Unit = snsc.stop()
+  override def stop(stopSparkContext: Boolean, stopGracefully: Boolean): Unit = {
+    snsc.stop(stopSparkContext, stopGracefully)
+  }
 
   def sql(sqlText: String): DataFrame = snsc.sql(sqlText)
 

--- a/docs/jobs.md
+++ b/docs/jobs.md
@@ -139,6 +139,9 @@ Create row tables using API, update the contents of row table
 > Note: Above simple example uses local mode(i.e. development mode) to create tables and update data. In the production environment, users will want to deploy the SnappyData system as a unified cluster (default cluster model that consists of servers that embed colocated Spark executors and Snappy stores, locators, and a job server enabled lead node) or as a split cluster (where Spark executors and Snappy stores form independent clusters). Refer to the  [deployment](deployment.md) chapter for all the supported deployment modes and the [configuration](configuration.md) chapter for configuring the cluster.
 
 To create a job that can be submitted through the job server, the job must implement the _SnappySQLJob or SnappyStreamingJob_ trait. Your job will look like:
+
+###### Scala
+
 ```scala
 class SnappySampleJob implements SnappySQLJob {
   /** Snappy uses this as an entry point to execute Snappy jobs. **/
@@ -149,6 +152,19 @@ class SnappySampleJob implements SnappySQLJob {
 }
 ```
 
+###### Java
+```java
+class SnappySampleJob extends JavaSnappySQLJob {
+  /** Snappy uses this as an entry point to execute Snappy jobs. **/
+  public Object runJavaJob(SnappyContext snc, Config jobConfig) {//Implementation}
+
+  /** SnappyData calls this function to validate the job input and reject invalid job requests **/
+  public JSparkJobValidation isValidJob(SnappyContext snc, Config config) {//validate}
+}
+
+```
+
+###### Scala
 ```scala
 class SnappyStreamingSampleJob implements SnappyStreamingJob {
   /** Snappy uses this as an entry point to execute Snappy jobs. **/
@@ -159,11 +175,29 @@ class SnappyStreamingSampleJob implements SnappyStreamingJob {
 }
 ```
 
+###### Java
+```java
+class SnappyStreamingSampleJob extends JavaSnappyStreamingJob {
+  /** Snappy uses this as an entry point to execute Snappy jobs. **/
+  public Object runJavaJob(JavaSnappyStreamingContext snsc, Config jobConfig) {//implementation }
+
+  /** SnappyData calls this function to validate the job input and reject invalid job requests **/
+  public JSparkJobValidation isValidJob(JavaSnappyStreamingContext snc, Config jobConfig)
+  {//validate}
+}
+```
+
 > The _Job_ traits are simply extensions of the _SparkJob_ implemented by [Spark JobServer](https://github.com/spark-jobserver/spark-jobserver). 
 
-• ```runJob``` contains the implementation of the Job. The [SnappyContext](http://snappydatainc.github.io/snappydata/apidocs/#org.apache.spark.sql.SnappyContext)/[SnappyStreamingContext](http://snappydatainc.github.io/snappydata/apidocs/#org.apache.spark.sql.streaming.SnappyStreamingContext) is managed by the SnappyData Leader (which runs an instance of Spark JobServer) and will be provided to the job through this method. This relieves the developer from the boiler-plate configuration management that comes with the creation of a Spark job and allows the Job Server to manage and re-use contexts.
+• ```runJob```/```runJavaJob``` contains the implementation of the Job.
+The [SnappyContext](http://snappydatainc.github.io/snappydata/apidocs/#org.apache.spark.sql.SnappyContext)/[SnappyStreamingContext](http://snappydatainc.github.io/snappydata/apidocs/#org.apache.spark.sql.streaming.SnappyStreamingContext) is managed by the SnappyData Leader (which runs an instance of Spark JobServer) and will be provided to the job through this method. This relieves the developer from the boiler-plate configuration management that comes with the creation of a Spark job and allows the Job Server to manage and re-use contexts.
 
-• ```validate``` allows for an initial validation of the context and any provided configuration. If the context and configuration are OK to run the job, returning spark.jobserver.SparkJobValid will let the job execute, otherwise returning spark.jobserver.SparkJobInvalid(reason) prevents the job from running and provides means to convey the reason of failure. In this case, the call immediately returns an HTTP/1.1 400 Bad Request status code. validate helps you preventing running jobs that will eventually fail due to missing or wrong configuration and save both time and resources.
+• ```validate```/```isValidJob``` allows for an initial validation of the context and any provided configuration.
+ If the context and configuration are OK to run the job, returning spark.jobserver.SparkJobValid
+ (org.apache.spark.sql.JSparkJobValid for Java)
+  will let the job execute, otherwise returning spark.jobserver.SparkJobInvalid(reason)
+  (org.apache.spark.sql.JSparkJobInvalid for Java) prevents
+   the job from running and provides means to convey the reason of failure. In this case, the call immediately returns an HTTP/1.1 400 Bad Request status code. validate helps you preventing running jobs that will eventually fail due to missing or wrong configuration and save both time and resources.
 
 See [examples](https://github.com/SnappyDataInc/snappydata/tree/master/snappy-examples/src/main/scala/io/snappydata/examples) for Spark and spark streaming jobs. 
 

--- a/examples/src/main/java/io/snappydata/examples/JavaCreateAndLoadAirlineDataJob.java
+++ b/examples/src/main/java/io/snappydata/examples/JavaCreateAndLoadAirlineDataJob.java
@@ -1,0 +1,155 @@
+package io.snappydata.examples;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import com.typesafe.config.Config;
+import org.apache.spark.sql.DataFrame;
+import org.apache.spark.sql.JSparkJobInvalid;
+import org.apache.spark.sql.JSparkJobValid;
+import org.apache.spark.sql.JSparkJobValidation;
+import org.apache.spark.sql.JavaSnappySQLJob;
+import org.apache.spark.sql.SaveMode;
+import org.apache.spark.sql.SnappyContext;
+import org.apache.spark.sql.types.StructField;
+import org.apache.spark.sql.types.StructType;
+
+/**
+ * Creates and loads Airline data from parquet files in row and column
+ * tables. Also samples the data and stores it in a column table.
+ */
+public class JavaCreateAndLoadAirlineDataJob extends JavaSnappySQLJob {
+
+
+  private String airlinefilePath = null;
+  private String airlinereftablefilePath = null;
+  private static final String colTable = "AIRLINE";
+  private static final String rowTable = "AIRLINEREF";
+  private static final String sampleTable = "AIRLINE_SAMPLE";
+  private static final String stagingAirline = "STAGING_AIRLINE";
+
+  @Override
+  public Object runJavaJob(SnappyContext snc, Config jobConfig) {
+    PrintWriter pw = null;
+    String currentDirectory = null;
+    boolean success = false;
+
+    try {
+      currentDirectory = new java.io.File(".").getCanonicalPath();
+      pw = new PrintWriter("JavaCreateAndLoadAirlineDataJob.out");
+      // Drop tables if already exists
+      snc.dropTable(sampleTable, true);
+      snc.dropTable(colTable, true);
+      snc.dropTable(rowTable, true);
+      snc.dropTable(stagingAirline, true);
+
+      pw.println("****** JavaCreateAndLoadAirlineDataJob ******");
+
+      // Create a DF from the parquet data file and make it a table
+      Map<String, String> props = new HashMap<>();
+      props.put("path", airlinefilePath);
+      DataFrame airlineDF = snc.createExternalTable(stagingAirline, "parquet", props);
+      StructType updatedSchema = replaceReservedWords(airlineDF.schema());
+
+      // Create a table in snappy store
+      Map<String, String> columnTableProps = new HashMap<>();
+      columnTableProps.put("buckets", "11");
+      snc.createTable(colTable, "column",
+          updatedSchema, columnTableProps, false);
+
+      // Populate the table in snappy store
+      airlineDF.write().mode(SaveMode.Append).saveAsTable(colTable);
+      pw.println("Created and imported data in $colTable table.");
+
+      // Create a DF from the airline ref data file
+      DataFrame airlinerefDF = snc.read().load(airlinereftablefilePath);
+
+      // Create a table in snappy store
+      snc.createTable(rowTable, "row",
+          airlinerefDF.schema(), Collections.<String, String>emptyMap(), false);
+
+      // Populate the table in snappy store
+      airlinerefDF.write().mode(SaveMode.Append).saveAsTable(rowTable);
+
+      pw.println("Created and imported data in $rowTable table");
+
+      // Create a sample table sampling parameters.
+
+      Map<String, String> sampleTableProps = new HashMap<>();
+      sampleTableProps.put("buckets", "7");
+      sampleTableProps.put("qcs", "UniqueCarrier, Year_, Month_");
+      sampleTableProps.put("fraction", "0.03");
+      sampleTableProps.put("strataReservoirSize", "50");
+      sampleTableProps.put("basetable", "Airline");
+
+      snc.createSampleTable(sampleTable, sampleTableProps, false);
+
+      // Initiate the sampling from base table to sample table.
+      snc.table(colTable).write().mode(SaveMode.Append).saveAsTable(sampleTable);
+
+      pw.println("Created and imported data in $sampleTable table.");
+
+      pw.println("****** Job finished ******");
+      success = true;
+
+    } catch (IOException e) {
+      pw.close();
+    } finally {
+      if (success) {
+        String returnValue = String.format("See %s/JavaCreateAndLoadAirlineDataJob.out", currentDirectory);
+        return returnValue;
+      }
+      pw.close();
+    }
+    return null;
+  }
+
+  @Override
+  public JSparkJobValidation isValidJob(SnappyContext snc, Config config) {
+
+    if (config.hasPath("airline_file")) {
+      airlinefilePath = config.getString("airline_file");
+    } else {
+      airlinefilePath = "../../quickstart/data/airlineParquetData";
+    }
+
+    if (!(new File(airlinefilePath)).exists()) {
+      return new JSparkJobInvalid("Incorrect airline path. " +
+          "Specify airline_file property in APP_PROPS");
+    }
+
+    if (config.hasPath("airlineref_file")) {
+      airlinereftablefilePath = config.getString("airlineref_file");
+    } else {
+      airlinereftablefilePath = "../../quickstart/data/airportcodeParquetData";
+    }
+    if (!(new File(airlinereftablefilePath)).exists()) {
+      return new JSparkJobInvalid("Incorrect airline ref path. " +
+          "Specify airlineref_file property in APP_PROPS");
+    }
+
+    return new JSparkJobValid();
+  }
+
+  private static StructType replaceReservedWords(StructType airlineSchema) {
+    StructField[] fields = airlineSchema.fields();
+    StructField[] newFields = new StructField[fields.length];
+    for (StructField s : fields) {
+      StructField newField = null;
+      if (s.name().equals("Year")) {
+        newField = new StructField("Year_", s.dataType(), s.nullable(), s.metadata());
+      } else if (s.name().equals("Month")) {
+        newField = new StructField("Month_", s.dataType(), s.nullable(), s.metadata());
+      } else {
+        newField = s;
+      }
+      newFields[airlineSchema.indexOf(s)] = newField;
+    }
+    return new StructType(newFields);
+  }
+
+}

--- a/examples/src/main/java/io/snappydata/examples/JavaTwitterPopularTagsJob.java
+++ b/examples/src/main/java/io/snappydata/examples/JavaTwitterPopularTagsJob.java
@@ -1,0 +1,209 @@
+package io.snappydata.examples;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.util.HashMap;
+import java.util.Map;
+
+import com.typesafe.config.Config;
+import org.apache.spark.api.java.function.VoidFunction;
+import org.apache.spark.sql.DataFrame;
+import org.apache.spark.sql.JSparkJobValid;
+import org.apache.spark.sql.JSparkJobValidation;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.SaveMode;
+import org.apache.spark.sql.streaming.SchemaDStream;
+import org.apache.spark.sql.types.StructField;
+import org.apache.spark.sql.types.StructType;
+import org.apache.spark.streaming.JavaSnappyStreamingJob;
+import org.apache.spark.streaming.api.JavaSnappyStreamingContext;
+import org.apache.spark.streaming.api.java.JavaDStream;
+
+import static org.apache.spark.sql.types.DataTypes.StringType;
+import static org.apache.spark.sql.types.DataTypes.createStructField;
+
+/**
+ * Run this on your local machine:
+ * <p/>
+ * `$ sbin/snappy-start-all.sh`
+ * <p/>
+ * To run with live twitter streaming, export twitter credentials
+ * `$ export APP_PROPS="consumerKey=<consumerKey>,consumerSecret=<consumerSecret>, \
+ * accessToken=<accessToken>,accessTokenSecret=<accessTokenSecret>"`
+ * <p/>
+ * `$ ./bin/snappy-job.sh submit --lead localhost:8090 \
+ * --app-name JavaTwitterPopularTagsJob --class io.snappydata.examples.JavaTwitterPopularTagsJob \
+ * --app-jar $SNAPPY_HOME/lib/quickstart-0.1.0-SNAPSHOT.jar --stream`
+ * <p/>
+ * To run with stored twitter data, run simulateTwitterStream after the Job is submitted:
+ * `$ ./quickstart/scripts/simulateTwitterStream`
+ */
+
+
+public class JavaTwitterPopularTagsJob extends JavaSnappyStreamingJob {
+  @Override
+  public Object runJavaJob(JavaSnappyStreamingContext snsc, Config jobConfig) {
+
+    JavaDStream stream = null;
+    PrintWriter pw = null;
+    String currentDirectory = null;
+    boolean success = false;
+    String outFileName = null;
+
+    try {
+      currentDirectory = new java.io.File(".").getCanonicalPath();
+      outFileName = String.format("JavaTwitterPopularTagsJob-%d.out", System.currentTimeMillis());
+      pw = new PrintWriter(outFileName);
+
+      StructType schema = new StructType(new StructField[]{
+          createStructField("hashtag", StringType, false)
+      });
+
+      snsc.snappyContext().sql("DROP TABLE IF EXISTS topktable");
+      snsc.snappyContext().sql("DROP TABLE IF EXISTS hashtagtable");
+      snsc.snappyContext().sql("DROP TABLE IF EXISTS retweettable");
+
+
+      if (jobConfig.hasPath("consumerKey") && jobConfig.hasPath("consumerKey")
+          && jobConfig.hasPath("accessToken") && jobConfig.hasPath("accessTokenSecret")) {
+        pw.println("##### Running example with live twitter stream #####");
+
+        String consumerKey = jobConfig.getString("consumerKey");
+        String consumerSecret = jobConfig.getString("consumerSecret");
+        String accessToken = jobConfig.getString("accessToken");
+        String accessTokenSecret = jobConfig.getString("accessTokenSecret");
+
+        // Create twitter stream table
+        snsc.sql("CREATE STREAM TABLE hashtagtable (hashtag STRING) USING " +
+            "twitter_stream OPTIONS (" +
+            String.format("consumerKey '%s',", consumerKey) +
+            String.format("consumerSecret '%s',", consumerSecret) +
+            String.format("accessToken '%s',", accessToken) +
+            String.format("accessTokenSecret '%s',", accessTokenSecret) +
+            String.format("rowConverter '%s'", "org.apache.spark.sql.streaming.TweetToHashtagRow")
+                +")"
+            );
+
+        snsc.sql("CREATE STREAM TABLE retweettable (retweetId LONG, retweetCnt INT, " +
+            "retweetTxt STRING) USING twitter_stream OPTIONS (" +
+            String.format("consumerKey '%s',", consumerKey) +
+            String.format("consumerSecret '%s',", consumerSecret) +
+            String.format("accessToken '%s',", accessToken) +
+            String.format("accessTokenSecret '%s',", accessTokenSecret) +
+            String.format("rowConverter '%s'", "org.apache.spark.sql.streaming.TweetToRetweetRow")
+                +")"
+          );
+
+      } else {
+        // Create file stream table
+        pw.println("##### Running example with stored tweet data #####");
+        snsc.sql("CREATE STREAM TABLE hashtagtable (hashtag STRING) USING file_stream " +
+            "OPTIONS (storagelevel 'MEMORY_AND_DISK_SER_2', " +
+            "rowConverter 'org.apache.spark.sql.streaming.TweetToHashtagRow'," +
+            "directory '/tmp/copiedtwitterdata')");
+
+        snsc.sql("CREATE STREAM TABLE retweettable (retweetId LONG, retweetCnt INT, " +
+            "retweetTxt STRING) USING file_stream " +
+            "OPTIONS (storagelevel 'MEMORY_AND_DISK_SER_2', " +
+            "rowConverter 'org.apache.spark.sql.streaming.TweetToRetweetRow'," +
+            "directory '/tmp/copiedtwitterdata')");
+      }
+
+      // Register continuous queries on the tables and specify window clauses
+      SchemaDStream retweetStream = snsc.registerCQ("SELECT * FROM retweettable " +
+          "WINDOW (DURATION 2 SECONDS, SLIDE 2 SECONDS)");
+
+      Map topKOption = new HashMap();
+      topKOption.put("epoch", new Long(System.currentTimeMillis()).toString());
+      topKOption.put("timeInterval", "2000ms");
+      topKOption.put("size", "10");
+      topKOption.put("basetable", "hashtagtable");
+
+
+      // Create TopK table on the base stream table which is hashtagtable
+      // TopK object is automatically populated from the stream table
+      snsc.snappyContext().createApproxTSTopK("topktable", "hashtag",
+          schema, topKOption, false);
+
+      final String tableName = "retweetStore";
+
+      snsc.snappyContext().dropTable(tableName, true);
+
+      // Create row table to insert retweets based on retweetId as Primary key
+      // When a tweet is retweeted multiple times, the previous entry of the tweet
+      // is over written by the new retweet count.
+      snsc.snappyContext().sql(String.format("CREATE TABLE %s (retweetId BIGINT PRIMARY KEY, " +
+          "retweetCnt INT, retweetTxt STRING) USING row OPTIONS ()",tableName));
+
+      // Save data in snappy store
+      retweetStream.foreachDataFrame(new VoidFunction<DataFrame>() {
+        @Override
+        public void call(DataFrame df) {
+          df.write().mode(SaveMode.Append).saveAsTable(tableName);
+        }
+      });
+      snsc.start();
+
+
+      int runTime;
+
+      if (jobConfig.hasPath("streamRunTime")) {
+        runTime = Integer.parseInt(jobConfig.getString("streamRunTime")) * 1000;
+      } else {
+        runTime = 120 * 1000;
+      }
+
+      long end = System.currentTimeMillis() + runTime;
+
+      while (end > System.currentTimeMillis()) {
+        Thread.sleep(2000);
+        pw.println("\n******** Top 10 hash tags of last two seconds *******\n");
+
+        // Query the topk structure for the popular hashtags of last two seconds
+        Row[] result = snsc.snappyContext().queryApproxTSTopK("topktable",
+            System.currentTimeMillis() - 2000, System.currentTimeMillis())
+            .collect();
+
+        printResult(result, pw);
+
+      }
+
+      // Query the topk structure for the popular hashtags of until now
+      Row[] result = snsc.sql("SELECT * FROM topktable").collect();
+      printResult(result, pw);
+
+      // Query the snappystore Row table to find out the top retweets
+      pw.println("\n####### Top 10 popular tweets - Query Row table #######\n");
+      result = snsc.snappyContext().sql("SELECT retweetId AS RetweetId, " +
+          "retweetCnt AS RetweetsCount, retweetTxt AS Text FROM " + tableName +
+          " ORDER BY RetweetsCount DESC LIMIT 10")
+          .collect();
+
+      printResult(result, pw);
+
+      pw.println("\n#######################################################");
+
+     success = true;
+    } catch (IOException e) {
+      //pw.close();
+    } catch (InterruptedException e) {
+      //pw.close();
+    } finally {
+      pw.close();
+
+      snsc.stop(false, true);
+    }
+    return "See "+ currentDirectory +"/" + outFileName;
+  }
+
+  private void printResult(Row[] result, PrintWriter pw) {
+    for (Row row : result) {
+      pw.println(row.toString());
+    }
+  }
+
+  @Override
+  public JSparkJobValidation isValidJob(JavaSnappyStreamingContext snc, Config jobConfig) {
+    return new JSparkJobValid();
+  }
+}

--- a/examples/src/main/scala/io/snappydata/examples/AirlineDataJob.scala
+++ b/examples/src/main/scala/io/snappydata/examples/AirlineDataJob.scala
@@ -8,7 +8,7 @@ import com.typesafe.config.Config
 import spark.jobserver.{SparkJobValid, SparkJobValidation}
 
 import org.apache.spark.sql.snappy._
-import org.apache.spark.sql.{DataFrame, SnappySQLJob}
+import org.apache.spark.sql.{SnappyContext, DataFrame, SnappySQLJob}
 
 /**
  * Fetches already created tables. Airline table is already persisted in
@@ -19,7 +19,7 @@ import org.apache.spark.sql.{DataFrame, SnappySQLJob}
  */
 object AirlineDataJob extends SnappySQLJob {
 
-  override def runJob(snc: C, jobConfig: Config): Any = {
+  override def runJob(snc: SnappyContext, jobConfig: Config): Any = {
     val colTable = "AIRLINE"
     val parquetTable = "STAGING_AIRLINE"
     val rowTable = "AIRLINEREF"

--- a/examples/src/main/scala/io/snappydata/examples/TwitterPopularTagsJob.scala
+++ b/examples/src/main/scala/io/snappydata/examples/TwitterPopularTagsJob.scala
@@ -84,7 +84,7 @@ object TwitterPopularTagsJob extends SnappyStreamingJob {
 
     // Register continuous queries on the tables and specify window clauses
     val retweetStream: SchemaDStream = snsc.registerCQ("SELECT * FROM retweettable " +
-      "WINDOW (DURATION '2' SECONDS, SLIDE '2' SECONDS)")
+      "WINDOW (DURATION 2 SECONDS, SLIDE 2 SECONDS)")
 
     val topKOption = Map(
         "epoch" -> System.currentTimeMillis().toString,


### PR DESCRIPTION
## Changes proposed in this pull request
Added interface JavaSnappySQLJob to work easily with SnappyContext from Java and job server. 

We needed to add a new interface in Java as its not possible to define an concrete class , which implements an interface in scala with abstract type members in this case SparkJobBase.

Added a test examples/src/main/java/io/snappydata/examples/JavaCreateAndLoadAirlineDataJob.java to test the new interface.

## Patch testing

Tested with the new Java based job from job server

## Other PRs 

(Does this change required changes in other projects- store, spark, spark-jobserver, aqp? Add the links of PR of the other subprojects that are related to this change)
NA