### PR TITLE
TestUtil is creating a new SnappyContext while dropping tables. This …

### DIFF
--- a/core/src/test/scala/io/snappydata/util/TestUtils.scala
+++ b/core/src/test/scala/io/snappydata/util/TestUtils.scala
@@ -30,7 +30,7 @@ object TestUtils {
   def dropAllTables(snc: => SnappyContext): Unit = {
     val sc = SnappyContext.globalSparkContext
     if (sc != null && !sc.isStopped) {
-      val snc = SnappyContext(sc)
+      val snc = SnappyContext.getOrCreate(sc)
       try {
         // drop all the stream tables that can have dependents at the end
         // also drop parents in colocated chain last (assuming chain length = 1)


### PR DESCRIPTION
## Changes proposed in this pull request

TestUtil is creating a new SnappyContext while dropping tables. This is incorrect , as we need any existing SnappyContext.

## Patch testing
Ran precheckin

## Other PRs 
NA