### PR TITLE
Corrected the test assumptions, as JavaTestUtils.runStream() stops th…

### DIFF
--- a/core/src/test/java/org/apache/spark/streaming/JavaSnappyStreamingContextSuite.java
+++ b/core/src/test/java/org/apache/spark/streaming/JavaSnappyStreamingContextSuite.java
@@ -195,8 +195,7 @@ public class JavaSnappyStreamingContextSuite implements Serializable {
     snsc = null;
   }
 
-  @SuppressWarnings("unchecked")
-  @Ignore("ignoring due to SNAP-715 ")
+  @Test
   public void testGetActiveOrCreate() throws IOException{
 
     final SparkConf conf = new SparkConf().setMaster(master).setAppName(appName);
@@ -231,7 +230,7 @@ public class JavaSnappyStreamingContextSuite implements Serializable {
 
     JavaDStream<String> input = snsc.textFileStream(testDir.toString());
     JavaTestUtils.attachTestOutputStream(input);
-    List<List<String>> result = JavaTestUtils.runStreams(snsc, 1, 1);
+    snsc.start();
 
 
     JavaSnappyStreamingContext returnedSsc = JavaSnappyStreamingContext.getActiveOrCreate


### PR DESCRIPTION
## Changes proposed in this pull request
Corrected the test assumptions, as JavaTestUtils.runStream() stops the streaming and spark contexts.

## Patch testing
pre-checkin

## Other PRs 
NA