### PR TITLE
If analytic thread can not get data for any table store in snappy, it…

### DIFF
--- a/core/src/main/scala/io/snappydata/SnappyDaemons.scala
+++ b/core/src/main/scala/io/snappydata/SnappyDaemons.scala
@@ -30,6 +30,7 @@ import scala.reflect.ClassTag
 import com.google.common.util.concurrent.ThreadFactoryBuilder
 import io.snappydata.Constant._
 
+import org.apache.spark.sql.SQLContext
 import org.apache.spark.sql.execution.ConnectionPool
 import org.apache.spark.sql.execution.columnar.ExternalStoreUtils
 import org.apache.spark.sql.execution.columnar.impl.ColumnFormatRelation
@@ -111,21 +112,26 @@ object SnappyAnalyticsService extends Logging {
     tablename.startsWith(INTERNAL_SCHEMA_NAME) && tablename.endsWith(SHADOW_TABLE_SUFFIX)
 
 
-  def getTableSize(tableName: String, isColumnTable: Boolean = false): Long = {
+  def getTableSize(sqlContext: SQLContext, tableName: String, isColumnTable: Boolean = false):
+  Long = {
     val currentTableStats = tableStats
     if (currentTableStats == null || !currentTableStats.contains(tableName)) {
-      defaultStats.valueSize
+      defaultSizeForPlanning(sqlContext)
     }
     else {
       if (isColumnTable) {
         currentTableStats.get(ColumnFormatRelation.cachedBatchTableName(tableName))
-            .getOrElse(defaultStats).valueSize
+            .getOrElse(defaultSizeForPlanning(sqlContext))
         +currentTableStats.get(tableName).get.valueSize
       } else {
         currentTableStats.get(tableName).get.valueSize
       }
     }
   }
+
+  def defaultSizeForPlanning(sqlContext: SQLContext) : Long =
+    (sqlContext.getConf("spark.sql.autoBroadcastJoinThreshold") + 1).toLong
+
 
   def getUIInfo: Seq[UIAnalytics] = {
     val currentTableStats = tableStats

--- a/core/src/main/scala/io/snappydata/SnappyDaemons.scala
+++ b/core/src/main/scala/io/snappydata/SnappyDaemons.scala
@@ -112,25 +112,25 @@ object SnappyAnalyticsService extends Logging {
     tablename.startsWith(INTERNAL_SCHEMA_NAME) && tablename.endsWith(SHADOW_TABLE_SUFFIX)
 
 
-  def getTableSize(sqlContext: SQLContext, tableName: String, isColumnTable: Boolean = false):
-  Long = {
+  def getTableSize(tableName: String, isColumnTable: Boolean = false):
+  Option[Long] = {
     val currentTableStats = tableStats
     if (currentTableStats == null || !currentTableStats.contains(tableName)) {
-      defaultSizeForPlanning(sqlContext)
+      None
     }
     else {
       if (isColumnTable) {
-        currentTableStats.get(ColumnFormatRelation.cachedBatchTableName(tableName))
-            .getOrElse(defaultSizeForPlanning(sqlContext))
-        +currentTableStats.get(tableName).get.valueSize
+        val optStat = currentTableStats.get(ColumnFormatRelation.cachedBatchTableName(tableName))
+        if (optStat.isDefined) {
+          Some(optStat.get.valueSize + currentTableStats.get(tableName).get.valueSize)
+        } else {
+          None
+        }
       } else {
-        currentTableStats.get(tableName).get.valueSize
+        Some(currentTableStats.get(tableName).get.valueSize)
       }
     }
   }
-
-  def defaultSizeForPlanning(sqlContext: SQLContext) : Long =
-    (sqlContext.getConf("spark.sql.autoBroadcastJoinThreshold") + 1).toLong
 
 
   def getUIInfo: Seq[UIAnalytics] = {

--- a/core/src/main/scala/org/apache/spark/sql/execution/columnar/JDBCAppendableRelation.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/columnar/JDBCAppendableRelation.scala
@@ -67,7 +67,7 @@ case class JDBCAppendableRelation(
   protected final val connFactory = JdbcUtils.createConnectionFactory(
     connProperties.url, connProperties.connProps)
 
-  override def sizeInBytes: Long = SnappyAnalyticsService.getTableSize(table,
+  override def sizeInBytes: Long = SnappyAnalyticsService.getTableSize(sqlContext, table,
     isColumnTable = true)
 
   protected final def dialect = connProperties.dialect

--- a/core/src/main/scala/org/apache/spark/sql/execution/columnar/JDBCAppendableRelation.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/columnar/JDBCAppendableRelation.scala
@@ -67,8 +67,8 @@ case class JDBCAppendableRelation(
   protected final val connFactory = JdbcUtils.createConnectionFactory(
     connProperties.url, connProperties.connProps)
 
-  override def sizeInBytes: Long = SnappyAnalyticsService.getTableSize(sqlContext, table,
-    isColumnTable = true)
+  override def sizeInBytes: Long = SnappyAnalyticsService.getTableSize(table,
+    isColumnTable = true).getOrElse(sqlContext.conf.defaultSizeInBytes)
 
   protected final def dialect = connProperties.dialect
 

--- a/core/src/main/scala/org/apache/spark/sql/row/JDBCMutableRelation.scala
+++ b/core/src/main/scala/org/apache/spark/sql/row/JDBCMutableRelation.scala
@@ -58,7 +58,8 @@ class JDBCMutableRelation(
 
   override val needConversion: Boolean = false
 
-  override def sizeInBytes: Long = SnappyAnalyticsService.getTableSize(sqlContext, table)
+  override def sizeInBytes: Long = SnappyAnalyticsService.getTableSize(table).
+      getOrElse(sqlContext.conf.defaultSizeInBytes)
 
   val driver = Utils.registerDriverUrl(connProperties.url)
 

--- a/core/src/main/scala/org/apache/spark/sql/row/JDBCMutableRelation.scala
+++ b/core/src/main/scala/org/apache/spark/sql/row/JDBCMutableRelation.scala
@@ -58,7 +58,7 @@ class JDBCMutableRelation(
 
   override val needConversion: Boolean = false
 
-  override def sizeInBytes: Long = SnappyAnalyticsService.getTableSize(table)
+  override def sizeInBytes: Long = SnappyAnalyticsService.getTableSize(sqlContext, table)
 
   val driver = Utils.registerDriverUrl(connProperties.url)
 

--- a/core/src/test/scala/io/snappydata/SnappyAnalyticsServiceTest.scala
+++ b/core/src/test/scala/io/snappydata/SnappyAnalyticsServiceTest.scala
@@ -76,7 +76,7 @@ class SnappyAnalyticsServiceTest
     val analytics = queryMemoryAnalytics(fullTableName)
 
     def check(expectedValueSize: Long, expectedTotalSize: Long): Boolean = {
-      val mValueSize = SnappyAnalyticsService.getTableSize(fullTableName)
+      val mValueSize = SnappyAnalyticsService.getTableSize(snc, fullTableName)
       val uiDetails = SnappyAnalyticsService.getUIInfo
           .filter(_.tableName == fullTableName)
       if (uiDetails.nonEmpty) {
@@ -109,7 +109,7 @@ class SnappyAnalyticsServiceTest
     def check(expectedValueSize: Long, expectedRowSize: Long,
         expectedColumnSize: Long): Boolean = {
       val fullTableName = s"APP.$columnTableName"
-      val mValueSize = SnappyAnalyticsService.getTableSize(fullTableName)
+      val mValueSize = SnappyAnalyticsService.getTableSize(snc, fullTableName)
       val uiDetails = SnappyAnalyticsService.getUIInfo
           .filter(_.tableName == fullTableName)
       if (uiDetails.nonEmpty) {

--- a/core/src/test/scala/io/snappydata/SnappyAnalyticsServiceTest.scala
+++ b/core/src/test/scala/io/snappydata/SnappyAnalyticsServiceTest.scala
@@ -76,11 +76,12 @@ class SnappyAnalyticsServiceTest
     val analytics = queryMemoryAnalytics(fullTableName)
 
     def check(expectedValueSize: Long, expectedTotalSize: Long): Boolean = {
-      val mValueSize = SnappyAnalyticsService.getTableSize(snc, fullTableName)
+      val mValueSize = SnappyAnalyticsService.getTableSize(fullTableName)
+
       val uiDetails = SnappyAnalyticsService.getUIInfo
           .filter(_.tableName == fullTableName)
       if (uiDetails.nonEmpty) {
-        expectedValueSize == mValueSize &&
+        expectedValueSize == mValueSize.get &&
             expectedTotalSize == uiDetails.head.rowBufferSize
       } else {
         false
@@ -109,12 +110,12 @@ class SnappyAnalyticsServiceTest
     def check(expectedValueSize: Long, expectedRowSize: Long,
         expectedColumnSize: Long): Boolean = {
       val fullTableName = s"APP.$columnTableName"
-      val mValueSize = SnappyAnalyticsService.getTableSize(snc, fullTableName)
+      val mValueSize = SnappyAnalyticsService.getTableSize(fullTableName)
       val uiDetails = SnappyAnalyticsService.getUIInfo
           .filter(_.tableName == fullTableName)
       if (uiDetails.nonEmpty) {
         val tableUIDetails = uiDetails.head
-        expectedValueSize == mValueSize &&
+        expectedValueSize == mValueSize.get &&
             expectedRowSize == tableUIDetails.rowBufferSize &&
             expectedColumnSize == tableUIDetails.columnBufferSize
       } else {


### PR DESCRIPTION
## Changes proposed in this pull request

  If analytic thread can not get data for any table store in snappy, it should default the size one more than broadcast join threshold.
After SNAP-473, this might not be needed.

## Patch testing
Tested with pre checkin

## Other PRs 
NA