### PR TITLE
While chunking data from lead node to executor node, we send metadata…

### DIFF
--- a/cluster/src/main/scala/io/snappydata/gemxd/SparkSQLExecuteImpl.scala
+++ b/cluster/src/main/scala/io/snappydata/gemxd/SparkSQLExecuteImpl.scala
@@ -122,6 +122,8 @@ class SparkSQLExecuteImpl(val sql: String,
           }
           logTrace(s"Sent one batch for result, current partition $p.")
           hdos.clearForReuse()
+          assert(metaDataSent)
+          hdos.writeByte(0x00)
         }
 
         // clear persisted block

--- a/cluster/src/test/scala/io/snappydata/cluster/QueryRoutingSingleNodeSuite.scala
+++ b/cluster/src/test/scala/io/snappydata/cluster/QueryRoutingSingleNodeSuite.scala
@@ -1,0 +1,91 @@
+package io.snappydata.cluster
+
+import java.sql.DriverManager
+
+import com.pivotal.gemfirexd.TestUtil
+import com.pivotal.gemfirexd.internal.engine.distributed.utils.GemFireXDUtils
+import io.snappydata.SnappyFunSuite
+import org.scalatest.BeforeAndAfterAll
+
+class QueryRoutingSingleNodeSuite extends SnappyFunSuite with BeforeAndAfterAll {
+
+  val default_chunk_size = GemFireXDUtils.DML_MAX_CHUNK_SIZE
+  var serverHostPort = ""
+  val tableName = "order_line_col"
+
+  override def beforeAll(): Unit = {
+    super.beforeAll()
+    // reducing DML chunk size size to force lead node to send
+    // results in multiple batches
+    setDMLMaxChunkSize(50L)
+  }
+
+  override def afterAll(): Unit = {
+    setDMLMaxChunkSize(default_chunk_size)
+    super.afterAll()
+  }
+
+  def setDMLMaxChunkSize(size: Long): Unit = {
+    GemFireXDUtils.DML_MAX_CHUNK_SIZE = size
+  }
+
+  def insertRows(numRows: Int): Unit = {
+
+    val conn = DriverManager.getConnection(
+      "jdbc:snappydata://" + serverHostPort)
+
+    val rows = (1 to numRows).toSeq
+    val stmt = conn.createStatement()
+    try {
+      var i = 1
+      rows.foreach(d => {
+        stmt.addBatch(s"insert into $tableName values($i, '1')")
+        i += 1
+        if (i % 1000 == 0) {
+          stmt.executeBatch()
+          i = 0
+        }
+      })
+      stmt.executeBatch()
+      println(s"committed $numRows rows")
+    } finally {
+      stmt.close()
+      conn.close()
+    }
+  }
+
+  def query(): Unit = {
+    val conn = DriverManager.getConnection(
+      "jdbc:snappydata://" + serverHostPort)
+
+    val stmt = conn.createStatement()
+    try {
+      val rs = stmt.executeQuery(
+        s"select ol_w_id  from $tableName ")
+      var index = 0
+      while (rs.next()) {
+        rs.getInt(1)
+        index += 1
+      }
+      println("Number of rows read " + index)
+      rs.close()
+    } finally {
+      stmt.close()
+      conn.close()
+    }
+  }
+
+  test("test serialization with lesser dml chunk size") {
+
+    snc.sql("create table order_line_col (ol_w_id  integer,ol_d_id STRING) using column " +
+        "options( partition_by 'ol_w_id, ol_d_id', buckets '5')")
+
+
+    serverHostPort = TestUtil.startNetServer()
+    println("network server started")
+    insertRows(1000)
+
+
+    (1 to 5).foreach(d => query())
+  }
+}


### PR DESCRIPTION
## Changes proposed in this pull request
While chunking data from lead node to executor node, we send metadata once. At receiving side we check if metadata flag is on , then we try to read metadata. But if we are not sending metadata in subsequent chunks we don't set the metadata flag to false. Changed the code to set the flag to false if metadata is not being sent.

## Patch testing
pre-checkin

## Other PRs 
NA