### PR TITLE
updated jobs.md to show the python api

### DIFF
--- a/docs/jobs.md
+++ b/docs/jobs.md
@@ -31,7 +31,16 @@ Below are examples to create a SnappyContext from SparkContext.
   // get the SnappyContext
   SnappyContext snc = SnappyContext.getOrCreate(sc);
 ```
+###### Python
+```python
+from pyspark.sql.snappy import SnappyContext
+from pyspark import SparkContext, SparkConf
 
+conf = SparkConf().setAppName("ExampleTest").setMaster("local[*]")
+sc = SparkContext(conf=conf)
+# get the SnappyContext
+snc = SnappyContext(sc)
+```
 Create columnar tables using API. Other than `create`, `drop` table rest is all based on the Spark SQL Data Source APIs. 
 
 ###### Scala
@@ -97,6 +106,33 @@ Create columnar tables using API. Other than `create`, `drop` table rest is all 
     }
 
 ```
+###### Python
+
+```python
+from pyspark.sql.types import *
+
+data = [(1,2,3),(7,8,9),(9,2,3),(4,2,3),(5,6,7)]
+rdd = sc.parallelize(data)
+schema=StructType([StructField("col1", IntegerType()), 
+                   StructField("col2", IntegerType()), 
+                   StructField("col3", IntegerType())])
+
+dataDF = snc.createDataFrame(rdd, schema)
+
+# create a column table
+snc.dropTable("COLUMN_TABLE", True)
+#"column" is the table format (that is row or column)
+#dataDF.schema provides the schema for table
+snc.createTable("COLUMN_TABLE", "column", dataDF.schema, True, buckets="11")
+
+#append dataDF into the table
+dataDF.write.insertInto("COLUMN_TABLE")
+results1 = snc.sql("SELECT * FROM COLUMN_TABLE")
+
+print("contents of column table are:")
+results1.select("col1", "col2", "col3"). show()
+```
+
 
 The optional BUCKETS attribute specifies the number of partitions or buckets to use. In SnappyStore, when data migrates between nodes (say if the cluster was expanded) a bucket is the smallest unit that can be moved around. For more details about the properties ('props1' map in above example) and createTable API refer to documentation for [row and column tables](rowAndColumnTables.md)
 
@@ -136,7 +172,7 @@ Create row tables using API, update the contents of row table
 
 ### Running Spark programs inside the database
 
-> Note: Above simple example uses local mode(i.e. development mode) to create tables and update data. In the production environment, users will want to deploy the SnappyData system as a unified cluster (default cluster model that consists of servers that embed colocated Spark executors and Snappy stores, locators, and a job server enabled lead node) or as a split cluster (where Spark executors and Snappy stores form independent clusters). Refer to the  [deployment](deployment.md) chapter for all the supported deployment modes and the [configuration](configuration.md) chapter for configuring the cluster.
+> Note: Above simple example uses local mode(i.e. development mode) to create tables and update data. In the production environment, users will want to deploy the SnappyData system as a unified cluster (default cluster model that consists of servers that embed colocated Spark executors and Snappy stores, locators, and a job server enabled lead node) or as a split cluster (where Spark executors and Snappy stores form independent clusters). Refer to the  [deployment](deployment.md) chapter for all the supported deployment modes and the [configuration](configuration.md) chapter for configuring the cluster.This mode is supported in both Java and Scala. Support for Python is yet not added.
 
 To create a job that can be submitted through the job server, the job must implement the _SnappySQLJob or SnappyStreamingJob_ trait. Your job will look like:
 

--- a/python/pyspark/sql/snappy/context.py
+++ b/python/pyspark/sql/snappy/context.py
@@ -58,7 +58,7 @@ class SnappyContext(SQLContext):
     def _get_snappy_ctx(self):
         return self._jvm.SnappyContext(self._jsc.sc())
 
-    def createTable(self, tableName, provider=None, schema=None,  **options):
+    def createTable(self, tableName, provider=None, schema=None, allowExisting=True, **options):
         """
         Creates a Snappy managed table. Any relation providers (e.g. parquet, jdbc etc)
         supported by Spark & Snappy can be created here. Unlike SqlContext.createExternalTable this
@@ -67,21 +67,23 @@ class SnappyContext(SQLContext):
         :param provider  Provider name 'ROW' and 'JDBC'.
         :param schema Table schema either as a StructType or  String
                 schemaStringExample = "(OrderId INT NOT NULL PRIMARY KEY,ItemId INT, ITEMREF INT)"
+        :param allowExisting When set to true it will ignore if a table with the same name is
+                          present , else it will throw table exist exception
         :param options   Properties for table creation. See options list for different tables.
         :return: :class:`DataFrame`
          """
         if provider is None:
             provider = self.getConf("spark.sql.sources.default", "org.apache.spark.sql.parquet")
         if schema is None:
-            df = self._ssql_ctx.createTable(tableName, provider, options)
+            df = self._ssql_ctx.createTable(tableName, provider, allowExisting, options)
         else:
             if isinstance(schema, str):
-                df = self._ssql_ctx.createTable(tableName, provider, schema, options)
+                df = self._ssql_ctx.createTable(tableName, provider, schema, options, allowExisting)
             elif not isinstance(schema, StructType):
                 raise TypeError("schema should be StructType or a String")
             else:
                 scala_datatype = self._ssql_ctx.parseDataType(schema.json())
-                df = self._ssql_ctx.createTable(tableName, provider, scala_datatype, options)
+                df = self._ssql_ctx.createTable(tableName, provider, scala_datatype, options, allowExisting)
 
         return DataFrame(df, self)
 


### PR DESCRIPTION
## Changes proposed in this pull request
updated jobs.md to show the python api
added allowExisting parameter in the create table
## Patch testing
executed tests.py for sql test
## Other PRs 
No
(Does this change required changes in other projects- store, spark, spark-jobserver, aqp? Add the links of PR of the other subprojects that are related to this change)

added allowExisting parameter in the create table