### PR TITLE
Fixed the build failure , which was caused by validating pulseDir. Mo…

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -892,15 +892,14 @@ task packagePulse {
     pulseDir = "${projectDir}/../pulse"
   }
 
-  if (!file(pulseDir).canWrite()){
-    throw  new Exception(" Pulse directroy can not be empty while building product")
-  }
-
-  println "Using Pulse location ${pulseDir}"
-
-  runScript("${pulseDir}/build.sh", pulseDir, ["clean", "build-all"])
-
   doFirst {
+    if (!file(pulseDir).canWrite()){
+      throw  new Exception(" Pulse directroy can not be empty while building product")
+    }
+    println "Using Pulse location ${pulseDir}"
+
+    runScript("${pulseDir}/build.sh", pulseDir, ["clean", "build-all"])
+
     delete "${snappyProductDir}/lib/pulse.war"
   }
 


### PR DESCRIPTION
## Changes proposed in this pull request

Fixed the build failure , which was caused by validating pulseDir. Moved the validation to a method so that it will be called only when packagePulse is called.

## Patch testing

Checked gradle task without pulse dir

## Other PRs 

NA