### PR TITLE
doc update - python job execution

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -571,7 +571,7 @@ task product {
       }
       copy {
         from("${examplesProject.projectDir}/src/main/python")
-        into "${examplesProject.buildDir}"
+        into  "${snappyProductDir}/python/examples"
       }
       copy {
         from "${project(':snappy-spark').projectDir}/data"
@@ -825,7 +825,7 @@ task runQuickstart {
 
       def airlinepythonappresult = runScript("${snappyProductDir}/bin/spark-submit", workingDir,
           ["--master", "spark://${hostname}:7077", "--conf", "snappydata.store.locators=localhost:10334",
-           "--conf", "spark.ui.port=4042", "${examplesdir.buildDir}/AirlineDataPythonApp.py"]);
+           "--conf", "spark.ui.port=4042", "${snappyProductDir}/python/examples/AirlineDataPythonApp.py"]);
 
       println "${airlinepythonappresult}"
       if (airlinepythonappresult.toLowerCase().contains("exception")) {

--- a/docs/jobs.md
+++ b/docs/jobs.md
@@ -295,6 +295,15 @@ $ bin/snappy-job.sh submit  \
 ```
 The status of this job can be queried in the same manner as shown above. The result of the this job will return a file path that has the query results. 
 
+Python users can also submit the python script using spark-submit in split cluster mode. For example below script can be used to read the data loaded by the CreateAndLoadAirlineDataJob. "snappydata.store.locators" propery specified the locator url of the snappy cluster and it is used to connect to the snappy cluster.
+```
+$ bin/spark-submit \
+  --master spark://pnq-nthanvi02:7077 \
+  --conf snappydata.store.locators=localhost:10334 \
+  --conf spark.ui.port=4042  
+  python/examples/AirlineDataPythonApp.py
+```
+
 
 #### Streaming jobs
 

--- a/docs/jobs.md
+++ b/docs/jobs.md
@@ -295,7 +295,7 @@ $ bin/snappy-job.sh submit  \
 ```
 The status of this job can be queried in the same manner as shown above. The result of the this job will return a file path that has the query results. 
 
-Python users can also submit the python script using spark-submit in split cluster mode. For example below script can be used to read the data loaded by the CreateAndLoadAirlineDataJob. "snappydata.store.locators" propery specified the locator url of the snappy cluster and it is used to connect to the snappy cluster.
+Python users can also submit the python script using spark-submit in split cluster mode. For example below script can be used to read the data loaded by the CreateAndLoadAirlineDataJob. "snappydata.store.locators" property denotes the locator url of the snappy cluster and it is used to connect to the snappy cluster.
 ```
 $ bin/spark-submit \
   --master spark://pnq-nthanvi02:7077 \


### PR DESCRIPTION
## Changes proposed in this pull request

Added required details on how to submit a python job in split cluster mode
specified the example
updated the build.gradle to copy the files in python/examples so that
it can be use in doc easily

## Patch testing
clean build
executed :runQuickstart

## Other PRs 
NO
(Does this change required changes in other projects- store, spark, spark-jobserver, aqp? Add the links of PR of the other subprojects that are related to this change)

