### PR TITLE
Potential fix for SNAP-755. Maintaning the order of registration of t…

### DIFF
--- a/core/src/main/scala/org/apache/spark/sql/SnappyContext.scala
+++ b/core/src/main/scala/org/apache/spark/sql/SnappyContext.scala
@@ -139,6 +139,10 @@ class SnappyContext protected[spark](
   @transient
   override lazy val catalog = this.snappyContextFunctions.getSnappyCatalog(this)
 
+
+  def clear(): Unit = {
+    snappyContextFunctions.clear()
+  }
   /**
    * :: DeveloperApi ::
    * @todo do we need this anymore? If useful functionality, make this

--- a/core/src/main/scala/org/apache/spark/sql/SnappyContext.scala
+++ b/core/src/main/scala/org/apache/spark/sql/SnappyContext.scala
@@ -674,6 +674,7 @@ class SnappyContext protected[spark](
     val plan = LogicalRelation(resolved.relation)
     catalog.registerDataSourceTable(tableIdent, schema, Array.empty[String],
       source, params, resolved.relation)
+    snappyContextFunctions.postRelationCreation(resolved.relation, this)
     plan
   }
 
@@ -734,6 +735,7 @@ class SnappyContext protected[spark](
       catalog.registerDataSourceTable(tableIdent, Some(data.schema),
         partitionColumns, source, params, resolved.relation)
     }
+    snappyContextFunctions.postRelationCreation(resolved.relation, this)
     LogicalRelation(resolved.relation)
   }
 

--- a/core/src/main/scala/org/apache/spark/sql/aqp/SnappyContextDefaultFunctions.scala
+++ b/core/src/main/scala/org/apache/spark/sql/aqp/SnappyContextDefaultFunctions.scala
@@ -24,7 +24,7 @@ import org.apache.spark.sql.catalyst.rules.RuleExecutor
 import org.apache.spark.sql.execution._
 import org.apache.spark.sql.execution.datasources.{DDLParser, ResolveDataSource, StoreDataSourceStrategy}
 import org.apache.spark.sql.hive.{ExternalTableType, QualifiedTableName, SnappyStoreHiveCatalog}
-import org.apache.spark.sql.sources.StoreStrategy
+import org.apache.spark.sql.sources.{BaseRelation, StoreStrategy}
 import org.apache.spark.sql.streaming.StreamBaseRelation
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.sql.{execution => sparkexecution, _}
@@ -34,6 +34,7 @@ object SnappyContextDefaultFunctions extends SnappyContextFunctions {
 
 
   def clear(): Unit = {}
+  def postRelationCreation(relation: BaseRelation, snc: SnappyContext): Unit ={}
   def getAQPRuleExecutor(sqlContext: SQLContext): RuleExecutor[SparkPlan] =
     new RuleExecutor[SparkPlan] {
       val batches = Seq(

--- a/core/src/main/scala/org/apache/spark/sql/aqp/SnappyContextDefaultFunctions.scala
+++ b/core/src/main/scala/org/apache/spark/sql/aqp/SnappyContextDefaultFunctions.scala
@@ -33,6 +33,7 @@ import org.apache.spark.util.Utils
 object SnappyContextDefaultFunctions extends SnappyContextFunctions {
 
 
+  def clear(): Unit = {}
   def getAQPRuleExecutor(sqlContext: SQLContext): RuleExecutor[SparkPlan] =
     new RuleExecutor[SparkPlan] {
       val batches = Seq(

--- a/core/src/main/scala/org/apache/spark/sql/aqp/SnappyContextFunctions.scala
+++ b/core/src/main/scala/org/apache/spark/sql/aqp/SnappyContextFunctions.scala
@@ -29,7 +29,10 @@ import org.apache.spark.sql.types.StructType
 
 trait SnappyContextFunctions {
 
+  def clear(): Unit
+
   def registerAQPErrorFunctions(context: SnappyContext)
+
 
   protected[sql] def executePlan(context: SnappyContext,
       plan: LogicalPlan): QueryExecution

--- a/core/src/main/scala/org/apache/spark/sql/aqp/SnappyContextFunctions.scala
+++ b/core/src/main/scala/org/apache/spark/sql/aqp/SnappyContextFunctions.scala
@@ -25,6 +25,7 @@ import org.apache.spark.sql.catalyst.{InternalRow, ParserDialect}
 import org.apache.spark.sql.execution._
 import org.apache.spark.sql.execution.datasources.DDLParser
 import org.apache.spark.sql.hive.{QualifiedTableName, SnappyStoreHiveCatalog}
+import org.apache.spark.sql.sources.BaseRelation
 import org.apache.spark.sql.types.StructType
 
 trait SnappyContextFunctions {
@@ -33,6 +34,7 @@ trait SnappyContextFunctions {
 
   def registerAQPErrorFunctions(context: SnappyContext)
 
+  def postRelationCreation(relation: BaseRelation, snc: SnappyContext): Unit
 
   protected[sql] def executePlan(context: SnappyContext,
       plan: LogicalPlan): QueryExecution

--- a/core/src/main/scala/org/apache/spark/streaming/SnappyStreamingContext.scala
+++ b/core/src/main/scala/org/apache/spark/streaming/SnappyStreamingContext.scala
@@ -112,10 +112,10 @@ class SnappyStreamingContext protected[spark](
    * @throws IllegalStateException if the StreamingContext is already stopped
    */
   override def start(): Unit = synchronized {
-   /* if (getState() == StreamingContextState.INITIALIZED) {
+    if (getState() == StreamingContextState.INITIALIZED) {
       // register population of AQP tables from stream tables
       snappyContext.snappyContextFunctions.aqpTablePopulator(snappyContext)
-    }*/
+    }
     super.start()
     SnappyStreamingContext.setActiveContext(self)
   }

--- a/core/src/main/scala/org/apache/spark/streaming/SnappyStreamingContext.scala
+++ b/core/src/main/scala/org/apache/spark/streaming/SnappyStreamingContext.scala
@@ -112,10 +112,10 @@ class SnappyStreamingContext protected[spark](
    * @throws IllegalStateException if the StreamingContext is already stopped
    */
   override def start(): Unit = synchronized {
-    if (getState() == StreamingContextState.INITIALIZED) {
+   /* if (getState() == StreamingContextState.INITIALIZED) {
       // register population of AQP tables from stream tables
       snappyContext.snappyContextFunctions.aqpTablePopulator(snappyContext)
-    }
+    }*/
     super.start()
     SnappyStreamingContext.setActiveContext(self)
   }
@@ -128,6 +128,7 @@ class SnappyStreamingContext protected[spark](
       SnappyStreamingContext.setInstanceContext(null)
     } finally {
       snappyContext.clearCache()
+      snappyContext.clear()
       StreamSqlHelper.registerRelationDestroy() //Not sure why we need this @TODO
       StreamSqlHelper.clearStreams()
 


### PR DESCRIPTION
I suspect the bug is caused due to a race condition arising out of the fact , that though we create TopK structures , we do not register the job to populate it till it is time to start the streaming context.  So in the test, though we create TopK & asscociate it with dstream before creating main table , with the  expectation that data if present in main table, would be present in TopK.  But that does not happen because dstream is registered with the task of populating main table first & task of populating TopK structure is registered later.

(Fill in the changes here)

## Patch testing

(Fill in the details that how was this patch tested)

## Other PRs 

(Does this change required changes in other projects- store, spark, spark-jobserver, aqp? Add the links of PR of the other subprojects that are related to this change)

…ask with dstream for the population of AQP structures