### PR TITLE
Bucket size should be calculated only for the datastores

### DIFF
--- a/core/src/main/scala/io/snappydata/SnappyStoreTableSizeProviders.scala
+++ b/core/src/main/scala/io/snappydata/SnappyStoreTableSizeProviders.scala
@@ -59,7 +59,7 @@ object StoreTableValueSizeProviderService extends Logging {
         val currentTableSizeInfo = mutable.HashMap[String, Long]()
 
         val result =
-          FunctionService.onMembers(GfxdMessage.getAllGfxdServers())
+          FunctionService.onMembers(GfxdMessage.getAllDataStores())
               .withCollector(new GfxdListResultCollector())
               .execute(RegionSizeCalculatorFunction.ID).getResult()
 


### PR DESCRIPTION
## Changes proposed in this pull request

instead of calling  function on all server it should be called only on datastore 

## Patch testing

clean precheckin

## Other PRs 
No
(Does this change required changes in other projects- store, spark, spark-jobserver, aqp? Add the links of PR of the other subprojects that are related to this change)

