### PR TITLE
[SNAP-837] Add packageTests to dtests archives to enable publishing of tests jar

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,6 @@ buildscript {
     classpath 'io.snappydata:gradle-scalatest:0.13-1'
     classpath 'org.github.ngbinh.scalastyle:gradle-scalastyle-plugin_2.10:0.8.2'
     classpath 'com.github.jengelman.gradle.plugins:shadow:1.2.3'
-    classpath 'de.undercouch:gradle-download-task:3.0.0'
   }
 }
 

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -1,6 +1,9 @@
+plugins {
+  id "de.undercouch.download" version "3.0.0"
+}
+
 apply plugin: 'scala'
 apply plugin: 'com.github.johnrengelman.shadow'
-apply plugin: 'de.undercouch.download'
 
 compileScala.options.encoding = 'UTF-8'
 // fix scala+java mix to all use compileScala which uses correct dependency order

--- a/dtests/build.gradle
+++ b/dtests/build.gradle
@@ -76,22 +76,21 @@ task packageScalaDocs(type: Jar, dependsOn: scaladoc) {
     classifier = 'javadoc'
     from scaladoc
 }
+
+artifacts {
+  archives packageTests
+}
 if (rootProject.hasProperty('enablePublish')) {
     artifacts {
         archives packageScalaDocs, packageSources
     }
 }
 
-
-
 archivesBaseName = 'gemfirexd-scala-tests'
 
-
 testClasses.doLast {
-    copyTestsCommonResources(buildDir)
-}
-
-copy {
+  copyTestsCommonResources(buildDir)
+  copy {
     def osDir = osName.getFamilyName().replace(" ", "").toLowerCase()
     from (rootDir.getAbsolutePath() + '/dtests/src/test/java') {
         include '**/*.bt'
@@ -100,5 +99,5 @@ copy {
         include '**/*.sql'
     }
     into rootDir.getAbsolutePath() + '/store/tests/sql/build-artifacts/' + osDir + '/classes/main'
+  }
 }
-

--- a/dtests/build.gradle
+++ b/dtests/build.gradle
@@ -90,14 +90,15 @@ archivesBaseName = 'gemfirexd-scala-tests'
 
 testClasses.doLast {
   copyTestsCommonResources(buildDir)
-  copy {
-    def osDir = osName.getFamilyName().replace(" ", "").toLowerCase()
-    from (rootDir.getAbsolutePath() + '/dtests/src/test/java') {
-        include '**/*.bt'
-        include '**/*.conf'
-        include '**/*.inc'
-        include '**/*.sql'
+  if (new File(rootDir, "store/build.gradle").exists()) {
+    copy {
+      from (sourceSets.test.java.srcDirs) {
+          include '**/*.bt'
+          include '**/*.conf'
+          include '**/*.inc'
+          include '**/*.sql'
+      }
+      into project(':snappy-store:gemfirexd-tests').sourceSets.main.output.classesDir
     }
-    into rootDir.getAbsolutePath() + '/store/tests/sql/build-artifacts/' + osDir + '/classes/main'
   }
 }


### PR DESCRIPTION
## Changes proposed in this pull request

Addition of packageTests task to dtests archives enables the "-tests" jar to be published in local and remote maven.

- moved the dangling copy task in dtests/build.gradle inside testsClass.doLast
- also moved the download plugin separately into core so as to not conflict with
  store/native declaration (which runs both as sub-project or independent project)

## Patch testing

Checked publishLocal that it does place the gemfirexd-scala-tests...-tests jar in local m2 repository.

## Other PRs 

NA