### PR TITLE
helper method to check if relation exists in store

### DIFF
--- a/core/src/main/scala/org/apache/spark/sql/execution/columnar/impl/StoreCallbacksImpl.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/columnar/impl/StoreCallbacksImpl.scala
@@ -16,8 +16,8 @@
  */
 package org.apache.spark.sql.execution.columnar.impl
 
-import java.lang
 import java.util.{Collections, UUID}
+
 import scala.collection.JavaConversions
 import scala.collection.concurrent.TrieMap
 
@@ -138,11 +138,11 @@ object StoreCallbacksImpl extends StoreCallbacks with Logging with Serializable 
     partioner.hashValue(dvds)
   }
 
-  override def haveRegisteredExternalStore(tableName: String): lang.Boolean = {
+  override def haveRegisteredExternalStore(tableName: String): Boolean = {
     // TODO -  remove below that deals with default schema and all
     // entries in store should come with fully qualified tableName
     val table = if (tableName.startsWith(Constant.DEFAULT_SCHEMA + ".")) {
-      tableName.split("\\.")(1)
+      tableName.substring(Constant.DEFAULT_SCHEMA.length + 1)
     } else tableName
     stores.contains(table)
   }

--- a/core/src/main/scala/org/apache/spark/sql/execution/columnar/impl/StoreCallbacksImpl.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/columnar/impl/StoreCallbacksImpl.scala
@@ -16,8 +16,8 @@
  */
 package org.apache.spark.sql.execution.columnar.impl
 
+import java.lang
 import java.util.{Collections, UUID}
-
 import scala.collection.JavaConversions
 import scala.collection.concurrent.TrieMap
 
@@ -137,6 +137,16 @@ object StoreCallbacksImpl extends StoreCallbacks with Logging with Serializable 
   override def getHashCodeSnappy(dvds: scala.Array[Object]): Int = {
     partioner.hashValue(dvds)
   }
+
+  override def haveRegisteredExternalStore(tableName: String): lang.Boolean = {
+    // TODO -  remove below that deals with default schema and all
+    // entries in store should come with fully qualified tableName
+    val table = if (tableName.startsWith(Constant.DEFAULT_SCHEMA + ".")) {
+      tableName.split("\\.")(1)
+    } else tableName
+    stores.contains(table)
+  }
+
 }
 
 trait StoreCallback extends Serializable {


### PR DESCRIPTION
## Changes proposed in this pull request
disabling the concurrency checks for the row buffers so that tombstone creation can be avoided.

Before table creation if this method can be used to check if the table
is column table or not simply by looking the entry into the store.
currently it contains hack for default schema but in next commit will
fix  this issue by setting the default schema

## Patch testing
precheckin

## Other PRs 
Yes.
https://github.com/SnappyDataInc/snappy-store/pull/74

(Does this change required changes in other projects- store, spark, spark-jobserver, aqp? Add the links of PR of the other subprojects that are related to this change)

Before table creation if this method can be used to check if the table
is column table or not simply by looking the entry into the store.
currently it contains hack for default schema but in next commit will
fix  this issue by setting the default schema