### PR TITLE
(SNAP-837)Added artifact packageTest so that test package will be cre…

### DIFF
--- a/dtests/build.gradle
+++ b/dtests/build.gradle
@@ -11,6 +11,8 @@ compileScala.options.encoding = 'UTF-8'
 sourceSets.main.scala.srcDir "src/main/java"
 sourceSets.main.java.srcDirs = []
 sourceSets.test.resources.srcDirs "src/resources"
+sourceSets.test.java.srcDirs "src/test/java"
+
 
 
 repositories {
@@ -76,6 +78,11 @@ task packageScalaDocs(type: Jar, dependsOn: scaladoc) {
     classifier = 'javadoc'
     from scaladoc
 }
+
+artifacts {
+    archives packageTests
+}
+
 if (rootProject.hasProperty('enablePublish')) {
     artifacts {
         archives packageScalaDocs, packageSources
@@ -89,16 +96,17 @@ archivesBaseName = 'gemfirexd-scala-tests'
 
 testClasses.doLast {
     copyTestsCommonResources(buildDir)
+    copy {
+        def osDir = osName.getFamilyName().replace(" ", "").toLowerCase()
+        from (rootDir.getAbsolutePath() + '/dtests/src/test/java') {
+            include '**/*.bt'
+            include '**/*.conf'
+            include '**/*.inc'
+            include '**/*.sql'
+        }
+        into rootDir.getAbsolutePath() + '/store/tests/sql/build-artifacts/' + osDir + '/classes/main'
+    }
 }
 
-copy {
-    def osDir = osName.getFamilyName().replace(" ", "").toLowerCase()
-    from (rootDir.getAbsolutePath() + '/dtests/src/test/java') {
-        include '**/*.bt'
-        include '**/*.conf'
-        include '**/*.inc'
-        include '**/*.sql'
-    }
-    into rootDir.getAbsolutePath() + '/store/tests/sql/build-artifacts/' + osDir + '/classes/main'
-}
+
 

--- a/dtests/src/test/java/io/snappydata/hydra/cluster/SnappyPrms.java
+++ b/dtests/src/test/java/io/snappydata/hydra/cluster/SnappyPrms.java
@@ -90,6 +90,76 @@ public class SnappyPrms extends BasePrms {
      */
     public static Long waitTimeBeforeNextCycleVM;
 
+    /**
+     * TODO: It should be removed. Swati is working on this
+     */
+    public static Long  appPropsForJobServer;
+
+    /**
+     * TODO: Swati is gone add proper support for all below SnappyPrms.
+     */
+    public static Long executorCores;
+    public static int getExecutorCores() {
+        Long key = executorCores;
+        return tasktab().intAt(key, tab().intAt(key, 1));
+    }
+
+    public static Long driverMaxResultSize;
+    public static String getDriverMaxResultSize() {
+        Long key = driverMaxResultSize;
+        return tab().stringAt(key, "1g").toLowerCase();
+    }
+
+    public static Long locatorMemory;
+    public static String getLocatorMemory() {
+        Long key = locatorMemory;
+        return tab().stringAt(key, "1G");
+    }
+    public static Long serverMemory;
+    public static String getServerMemory() {
+        Long key = serverMemory;
+        return tab().stringAt(key, "1G");
+    }
+    public static Long leadMemory;
+    public static String getLeadMemory() {
+        Long key = leadMemory;
+        return tab().stringAt(key,"1G");
+    }
+
+    public static Long sparkSchedulerMode;
+    public static String getSparkSchedulerMode() {
+        Long key = sparkSchedulerMode;
+        return tab().stringAt(key, "FAIR");
+    }
+
+    public static Long sparkSqlBroadcastJoinThreshold;
+    public static int getSparkSqlBroadcastJoinThreshold() {
+        Long key = sparkSqlBroadcastJoinThreshold;
+        return tasktab().intAt(key, tab().intAt(key, -1));
+    }
+
+    public static Long compressedInMemoryColumnarStorage;
+    public static boolean getCompressedInMemoryColumnarStorage() {
+        Long key = compressedInMemoryColumnarStorage;
+        return tasktab().booleanAt(key, tab().booleanAt(key, false));
+    }
+
+    public static Long conserveSockets;
+    public static boolean getConserveSockets() {
+        Long key = conserveSockets;
+        return tasktab().booleanAt(key, tab().booleanAt(key, false));
+    }
+
+    public static Long shufflePartitions;
+    public static int getShufflePartitions() {
+        Long key = shufflePartitions;
+        return tasktab().intAt(key, tab().intAt(key, 1));
+    }
+
+    public static String getCommaSepAPPProps() {
+        Long key = appPropsForJobServer;
+        return BasePrms.tasktab().stringAt(key, BasePrms.tab().stringAt(key, null));
+    }
 
     public static Vector getSQLScriptNamesForInitTask() {
         Long key = sqlScriptNamesForInitTask;

--- a/dtests/src/test/scala/io/snappydata/hydra/BenchmarkingStreamingJob.scala
+++ b/dtests/src/test/scala/io/snappydata/hydra/BenchmarkingStreamingJob.scala
@@ -20,11 +20,12 @@ package io.snappydata.hydra
 import java.io.PrintWriter
 
 import com.typesafe.config.Config
+import spark.jobserver.{SparkJobValid, SparkJobValidation}
+
 import org.apache.spark.sql._
 import org.apache.spark.sql.streaming.SnappyStreamingJob
-import org.apache.spark.sql.types.{TimestampType, IntegerType, LongType, StructType}
+import org.apache.spark.sql.types.{IntegerType, StructType, TimestampType}
 import org.apache.spark.streaming.Duration
-import spark.jobserver.{SparkJobValid, SparkJobValidation}
 
 class BenchmarkingStreamingJob extends SnappyStreamingJob {
 
@@ -62,9 +63,7 @@ class BenchmarkingStreamingJob extends SnappyStreamingJob {
 
     val windowStreamAsTable = snsc.createSchemaDStream(window_rows, schema)
 
-    snsc.sql("set spark.sql.shuffle.partitions=53")
-
-    import org.apache.spark.sql.functions._
+    snsc.sql("set spark.sql.shuffle.partitions="+ jobConfig.getInt("shufflePartitions"))
     windowStreamAsTable.foreachDataFrame(df =>
       {
         val outFileName = s"BenchmarkingStreamingJob-${System.currentTimeMillis()}.out"

--- a/dtests/src/test/scala/io/snappydata/hydra/OLAPQueries.scala
+++ b/dtests/src/test/scala/io/snappydata/hydra/OLAPQueries.scala
@@ -508,7 +508,7 @@ object OLAPQueries extends SnappySQLJob {
 
     // scalastyle:off println
     var stream: DStream[_] = null
-    snsc.sql("set spark.sql.shuffle.partitions=53")
+    snsc.sql("set spark.sql.shuffle.partitions="+ jobConfig.getInt("shufflePartitions"))
 
     var i: Int = 0
     // Let it run for unlimited time. The Lead will anyway be


### PR DESCRIPTION
## Changes proposed in this pull request

(Fill in the changes here)

## Patch testing

(Fill in the details that how was this patch tested)

## Other PRs 

(Does this change required changes in other projects- store, spark, spark-jobserver, aqp? Add the links of PR of the other subprojects that are related to this change)

…ated and published to local repository

()Added following parameters in SnapptPrms to avoid all hardcoding :Swati should use these parameter when doing changes in SnappyTest in master appPropsForJobServer,executorCores,driverMaxResultSize,locatorMemory,serverMemory,leadMemory,sparkSchedulerMode,sparkSqlBroadcastJoinThreshold,compressedInMemoryColumnarStorage,conserveSockets,shufflePartitions
SnappyTest.generateSnappyConfig removes hardcoding and uses SnappyPrms attributes to configure locator, server and lead
(SNAP-819)Added HydraTask_getClientConnection_Snappy whcih creats connection for thin client and same is set in hydraThreadLocals
Added HydraTask_executeSnappyStreamingJob_benchmarking which was removed by recent merge from master
Removed hardcoded shuffle partitions from OLAPQueries and BenchmarkingStreamingJob.