### PR TITLE
Added support for collecting stats in the framework

### DIFF
--- a/dtests/src/test/java/io/snappydata/hydra/cluster/SnappyPrms.java
+++ b/dtests/src/test/java/io/snappydata/hydra/cluster/SnappyPrms.java
@@ -87,6 +87,12 @@ public class SnappyPrms extends BasePrms {
     public static Long tableDefaultPartitioned;
 
     /**
+     * (boolean) - whether to enable time statistics. snappy hydra already sets the enable-time-statistics to true.
+     */
+    public static Long enableTimeStatistics;
+
+
+    /**
      * (String) userAppJar containing the user snappy job class
      */
     public static Long userAppJar;
@@ -225,6 +231,11 @@ public class SnappyPrms extends BasePrms {
     public static boolean getTableDefaultDataPolicy() {
         Long key = tableDefaultPartitioned;
         return tasktab().booleanAt(key, tab().booleanAt(key, false));
+    }
+
+    public static boolean getTimeStatistics() {
+        Long key = enableTimeStatistics;
+        return tasktab().booleanAt(key, tab().booleanAt(key, true));
     }
 
     public static Vector getSQLScriptNamesForInitTask() {

--- a/dtests/src/test/java/io/snappydata/hydra/cluster/SnappyTest.java
+++ b/dtests/src/test/java/io/snappydata/hydra/cluster/SnappyTest.java
@@ -279,9 +279,10 @@ public class SnappyTest implements Serializable {
         String locatorHost = null;
         String dirPath = snappyTest.getLogDir();
         String nodeLogDir = null;
+        String timeStatistics = " -enable-time-statistics=" + SnappyPrms.getTimeStatistics() + " -statistic-archive-file=";
         switch (snappyNode) {
             case LOCATOR:
-                nodeLogDir = HostHelper.getLocalHost() + " -dir=" + dirPath + clientPort + port + " -enable-time-statistics=" + SnappyPrms.getTimeStatistics() + " -statistic-archive-file=snappylocator.gfs";
+                nodeLogDir = HostHelper.getLocalHost() + " -dir=" + dirPath + clientPort + port + timeStatistics + "snappylocator.gfs";
                 SnappyBB.getBB().getSharedMap().put("locatorHost", HostHelper.getLocalHost());
                 SnappyBB.getBB().getSharedMap().put("locatorPort", Integer.toString(port));
                 Log.getLogWriter().info("Generated locator endpoint: " + endpoint);
@@ -289,14 +290,14 @@ public class SnappyTest implements Serializable {
                 break;
             case SERVER:
                 locatorHost = (String) SnappyBB.getBB().getSharedMap().get("locatorHost");
-                nodeLogDir = HostHelper.getLocalHost() + " " + locators + locatorHost + ":" + 10334 + " -dir=" + dirPath + clientPort + port + " -J-Xmx" + SnappyPrms.getServerMemory() + " -conserve-sockets=" + SnappyPrms.getConserveSockets() + " -J-Dgemfirexd.table-default-partitioned=" + SnappyPrms.getTableDefaultDataPolicy() + " -enable-time-statistics=" + SnappyPrms.getTimeStatistics() + " -statistic-archive-file=snappyserver.gfs";
+                nodeLogDir = HostHelper.getLocalHost() + " " + locators + locatorHost + ":" + 10334 + " -dir=" + dirPath + clientPort + port + " -J-Xmx" + SnappyPrms.getServerMemory() + " -conserve-sockets=" + SnappyPrms.getConserveSockets() + " -J-Dgemfirexd.table-default-partitioned=" + SnappyPrms.getTableDefaultDataPolicy() + timeStatistics + "snappyserver.gfs";
                 Log.getLogWriter().info("Generated peer server endpoint: " + endpoint);
                 SnappyNetworkServerBB.getBB().getSharedMap().put("server" + "_" + RemoteTestModule.getMyVmid(), endpoint);
                 break;
             case LEAD:
                 locatorHost = (String) SnappyBB.getBB().getSharedMap().get("locatorHost");
                 nodeLogDir = HostHelper.getLocalHost() + " " + locators + locatorHost + ":" + 10334 + " -spark.executor.cores=" + SnappyPrms.getExecutorCores() + " -spark.driver.maxResultSize=" + SnappyPrms.getDriverMaxResultSize() + " -dir=" + dirPath + clientPort + port + " -J-Xmx" + SnappyPrms.getLeadMemory()
-                        + " -spark.sql.autoBroadcastJoinThreshold=" + SnappyPrms.getSparkSqlBroadcastJoinThreshold() + " -spark.scheduler.mode=" + SnappyPrms.getSparkSchedulerMode() + " -spark.sql.inMemoryColumnarStorage.compressed=" + SnappyPrms.getCompressedInMemoryColumnarStorage() + " -conserve-sockets=" + SnappyPrms.getConserveSockets() + " -enable-time-statistics=" + SnappyPrms.getTimeStatistics() + " -statistic-archive-file=snappyleader.gfs";
+                        + " -spark.sql.autoBroadcastJoinThreshold=" + SnappyPrms.getSparkSqlBroadcastJoinThreshold() + " -spark.scheduler.mode=" + SnappyPrms.getSparkSchedulerMode() + " -spark.sql.inMemoryColumnarStorage.compressed=" + SnappyPrms.getCompressedInMemoryColumnarStorage() + " -conserve-sockets=" + SnappyPrms.getConserveSockets() + timeStatistics + "snappyleader.gfs";
                 if (leadHost == null) {
                     leadHost = HostHelper.getLocalHost();
                 }

--- a/dtests/src/test/java/io/snappydata/hydra/cluster/SnappyTest.java
+++ b/dtests/src/test/java/io/snappydata/hydra/cluster/SnappyTest.java
@@ -281,7 +281,7 @@ public class SnappyTest implements Serializable {
         String nodeLogDir = null;
         switch (snappyNode) {
             case LOCATOR:
-                nodeLogDir = HostHelper.getLocalHost() + " -dir=" + dirPath + clientPort + port;
+                nodeLogDir = HostHelper.getLocalHost() + " -dir=" + dirPath + clientPort + port + " -enable-time-statistics=" + SnappyPrms.getTimeStatistics() + " -statistic-archive-file=snappylocator.gfs";
                 SnappyBB.getBB().getSharedMap().put("locatorHost", HostHelper.getLocalHost());
                 SnappyBB.getBB().getSharedMap().put("locatorPort", Integer.toString(port));
                 Log.getLogWriter().info("Generated locator endpoint: " + endpoint);

--- a/dtests/src/test/java/io/snappydata/hydra/cluster/SnappyTest.java
+++ b/dtests/src/test/java/io/snappydata/hydra/cluster/SnappyTest.java
@@ -289,14 +289,14 @@ public class SnappyTest implements Serializable {
                 break;
             case SERVER:
                 locatorHost = (String) SnappyBB.getBB().getSharedMap().get("locatorHost");
-                nodeLogDir = HostHelper.getLocalHost() + " " + locators + locatorHost + ":" + 10334 + " -dir=" + dirPath + clientPort + port + " -J-Xmx" + SnappyPrms.getServerMemory() + " -conserve-sockets=" + SnappyPrms.getConserveSockets() + " -J-Dgemfirexd.table-default-partitioned=" + SnappyPrms.getTableDefaultDataPolicy();
+                nodeLogDir = HostHelper.getLocalHost() + " " + locators + locatorHost + ":" + 10334 + " -dir=" + dirPath + clientPort + port + " -J-Xmx" + SnappyPrms.getServerMemory() + " -conserve-sockets=" + SnappyPrms.getConserveSockets() + " -J-Dgemfirexd.table-default-partitioned=" + SnappyPrms.getTableDefaultDataPolicy() + " -enable-time-statistics=" + SnappyPrms.getTimeStatistics() + " -statistic-archive-file=snappyserver.gfs";
                 Log.getLogWriter().info("Generated peer server endpoint: " + endpoint);
                 SnappyNetworkServerBB.getBB().getSharedMap().put("server" + "_" + RemoteTestModule.getMyVmid(), endpoint);
                 break;
             case LEAD:
                 locatorHost = (String) SnappyBB.getBB().getSharedMap().get("locatorHost");
                 nodeLogDir = HostHelper.getLocalHost() + " " + locators + locatorHost + ":" + 10334 + " -spark.executor.cores=" + SnappyPrms.getExecutorCores() + " -spark.driver.maxResultSize=" + SnappyPrms.getDriverMaxResultSize() + " -dir=" + dirPath + clientPort + port + " -J-Xmx" + SnappyPrms.getLeadMemory()
-                        + " -spark.sql.autoBroadcastJoinThreshold=" + SnappyPrms.getSparkSqlBroadcastJoinThreshold() + " -spark.scheduler.mode=" + SnappyPrms.getSparkSchedulerMode() + " -spark.sql.inMemoryColumnarStorage.compressed=" + SnappyPrms.getCompressedInMemoryColumnarStorage() + " -conserve-sockets=" + SnappyPrms.getConserveSockets();
+                        + " -spark.sql.autoBroadcastJoinThreshold=" + SnappyPrms.getSparkSqlBroadcastJoinThreshold() + " -spark.scheduler.mode=" + SnappyPrms.getSparkSchedulerMode() + " -spark.sql.inMemoryColumnarStorage.compressed=" + SnappyPrms.getCompressedInMemoryColumnarStorage() + " -conserve-sockets=" + SnappyPrms.getConserveSockets() + " -enable-time-statistics=" + SnappyPrms.getTimeStatistics() + " -statistic-archive-file=snappyleader.gfs";
                 if (leadHost == null) {
                     leadHost = HostHelper.getLocalHost();
                 }
@@ -1265,7 +1265,12 @@ public class SnappyTest implements Serializable {
         try {
             for (int i = 0; i < jobClassNames.size(); i++) {
                 String userJob = (String) jobClassNames.elementAt(i);
-                String APP_PROPS = SnappyPrms.getCommaSepAPPProps() + ",shufflePartitions=" + SnappyPrms.getShufflePartitions();
+                String APP_PROPS = null;
+                if (SnappyPrms.getCommaSepAPPProps() == null) {
+                    APP_PROPS = "shufflePartitions=" + SnappyPrms.getShufflePartitions();
+                } else {
+                    APP_PROPS = SnappyPrms.getCommaSepAPPProps() + ",shufflePartitions=" + SnappyPrms.getShufflePartitions();
+                }
                 String contextName = "snappyStreamingContext" + System.currentTimeMillis();
                 String contextFactory = "org.apache.spark.sql.streaming.SnappyStreamingContextFactory";
                 String curlCommand1 = "curl --data-binary @" + snappyTest.getUserAppJarLocation(userAppJar) + " " + leadHost + ":8090/jars/myapp";
@@ -1300,7 +1305,11 @@ public class SnappyTest implements Serializable {
                 String userJob = (String) jobClassNames.elementAt(i);
                 pb = new ProcessBuilder(snappyJobScript, "submit", "--lead", leadHost + ":8090", "--app-name", "myapp", "--class", userJob, "--app-jar", snappyTest.getUserAppJarLocation(userAppJar), "--stream");
                 java.util.Map<String, String> env = pb.environment();
-                env.put("APP_PROPS", SnappyPrms.getCommaSepAPPProps() + ",shufflePartitions=" + SnappyPrms.getShufflePartitions());
+                if (SnappyPrms.getCommaSepAPPProps() == null) {
+                    env.put("APP_PROPS", "shufflePartitions=" + SnappyPrms.getShufflePartitions());
+                } else {
+                    env.put("APP_PROPS", SnappyPrms.getCommaSepAPPProps() + ",shufflePartitions=" + SnappyPrms.getShufflePartitions());
+                }
                 log = new File(".");
                 String dest = log.getCanonicalPath() + File.separator + logFileName;
                 logFile = new File(dest);
@@ -1333,7 +1342,12 @@ public class SnappyTest implements Serializable {
         try {
             for (int i = 0; i < jobClassNames.size(); i++) {
                 String userJob = (String) jobClassNames.elementAt(i);
-                String APP_PROPS = SnappyPrms.getCommaSepAPPProps() + ",logFileName=" + logFileName + ",shufflePartitions=" + SnappyPrms.getShufflePartitions();
+                String APP_PROPS = null;
+                if (SnappyPrms.getCommaSepAPPProps() == null) {
+                    APP_PROPS = "logFileName=" + logFileName + ",shufflePartitions=" + SnappyPrms.getShufflePartitions();
+                } else {
+                    APP_PROPS = SnappyPrms.getCommaSepAPPProps() + ",logFileName=" + logFileName + ",shufflePartitions=" + SnappyPrms.getShufflePartitions();
+                }
                 String curlCommand1 = "curl --data-binary @" + snappyTest.getUserAppJarLocation(userAppJar) + " " + leadHost + ":8090/jars/myapp";
                 String curlCommand2 = "curl -d " + APP_PROPS + " '" + leadHost + ":8090/jobs?appName=myapp&classPath=" + userJob + "'";
                 pb = new ProcessBuilder("/bin/bash", "-c", curlCommand1);

--- a/dtests/src/test/java/io/snappydata/hydra/cluster/sample.conf
+++ b/dtests/src/test/java/io/snappydata/hydra/cluster/sample.conf
@@ -40,17 +40,29 @@ INITTASK     taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = 
   runMode = always
   threadGroups = snappyThreads, locatorThreads, snappyStoreThreads, leadThreads;
 
-INITTASK     taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = HydraTask_generateSnappyConfig
-  runMode = always
-  threadGroups = locatorThreads;
+INITTASK     taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = HydraTask_generateSnappyLocatorConfig
+    runMode = always
+    threadGroups = locatorThreads;
 
-INITTASK     taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = HydraTask_generateSnappyConfig
-  runMode = always
-  threadGroups = snappyStoreThreads, leadThreads, snappyThreads;
+INITTASK     taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = HydraTask_writeLocatorConfigData
+    runMode = always
+    threadGroups = snappyThreads;
 
-INITTASK     taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = HydraTask_writeConfigDataToFiles
-  runMode = always
-  threadGroups = snappyThreads;
+INITTASK     taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = HydraTask_generateSnappyServerConfig
+    runMode = always
+    threadGroups = snappyStoreThreads;
+
+INITTASK     taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = HydraTask_writeServerConfigData
+    runMode = always
+    threadGroups = snappyThreads;
+
+INITTASK     taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = HydraTask_generateSnappyLeadConfig
+    runMode = always
+    threadGroups = leadThreads, snappyThreads;
+
+INITTASK     taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = HydraTask_writeLeadConfigData
+    runMode = always
+    threadGroups = snappyThreads;
 
 INITTASK     taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = HydraTask_createAndStartSnappyLocator
   runMode = always

--- a/dtests/src/test/java/io/snappydata/hydra/concStreamingWithAirlineDataQueries.conf
+++ b/dtests/src/test/java/io/snappydata/hydra/concStreamingWithAirlineDataQueries.conf
@@ -39,17 +39,29 @@ INITTASK     taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = 
   runMode = always
   threadGroups = snappyThreads, locatorThreads, snappyStoreThreads, leadThreads;
 
-INITTASK     taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = HydraTask_generateSnappyConfig
-  runMode = always
-  threadGroups = locatorThreads;
+INITTASK     taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = HydraTask_generateSnappyLocatorConfig
+    runMode = always
+    threadGroups = locatorThreads;
 
-INITTASK     taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = HydraTask_generateSnappyConfig
-  runMode = always
-  threadGroups = snappyStoreThreads, leadThreads, snappyThreads;
+INITTASK     taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = HydraTask_writeLocatorConfigData
+    runMode = always
+    threadGroups = snappyThreads;
 
-INITTASK     taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = HydraTask_writeConfigDataToFiles
-  runMode = always
-  threadGroups = snappyThreads;
+INITTASK     taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = HydraTask_generateSnappyServerConfig
+    runMode = always
+    threadGroups = snappyStoreThreads;
+
+INITTASK     taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = HydraTask_writeServerConfigData
+    runMode = always
+    threadGroups = snappyThreads;
+
+INITTASK     taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = HydraTask_generateSnappyLeadConfig
+    runMode = always
+    threadGroups = leadThreads, snappyThreads;
+
+INITTASK     taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = HydraTask_writeLeadConfigData
+    runMode = always
+    threadGroups = snappyThreads;
 
 INITTASK     taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = HydraTask_createAndStartSnappyLocator
   runMode = always

--- a/dtests/src/test/java/io/snappydata/hydra/serialStreamingWithAirlineDataQueries.conf
+++ b/dtests/src/test/java/io/snappydata/hydra/serialStreamingWithAirlineDataQueries.conf
@@ -39,17 +39,29 @@ INITTASK     taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = 
   runMode = always
   threadGroups = snappyThreads, locatorThreads, snappyStoreThreads, leadThreads;
 
-INITTASK     taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = HydraTask_generateSnappyConfig
-  runMode = always
-  threadGroups = locatorThreads;
+INITTASK     taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = HydraTask_generateSnappyLocatorConfig
+    runMode = always
+    threadGroups = locatorThreads;
 
-INITTASK     taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = HydraTask_generateSnappyConfig
-  runMode = always
-  threadGroups = snappyStoreThreads, leadThreads, snappyThreads;
+INITTASK     taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = HydraTask_writeLocatorConfigData
+    runMode = always
+    threadGroups = snappyThreads;
 
-INITTASK     taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = HydraTask_writeConfigDataToFiles
-  runMode = always
-  threadGroups = snappyThreads;
+INITTASK     taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = HydraTask_generateSnappyServerConfig
+    runMode = always
+    threadGroups = snappyStoreThreads;
+
+INITTASK     taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = HydraTask_writeServerConfigData
+    runMode = always
+    threadGroups = snappyThreads;
+
+INITTASK     taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = HydraTask_generateSnappyLeadConfig
+    runMode = always
+    threadGroups = leadThreads, snappyThreads;
+
+INITTASK     taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = HydraTask_writeLeadConfigData
+    runMode = always
+    threadGroups = snappyThreads;
 
 INITTASK     taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = HydraTask_createAndStartSnappyLocator
   runMode = always


### PR DESCRIPTION
## Changes proposed in this pull request

- Added support for collecting stats in the framework
- Modified the existing tests to use new methods for creating the configuration data for writting to the respective files under conf directory
- Added a check if in case appPropsForJobServer parameter is not provided in conf file. The method should use default APP_PROPS in this case

## Patch testing

Verified the changes by running sample.bt

## Other PRs 

No