### PR TITLE
* Renaming gemfirexd* jars to snappydata-store* jars.

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE
+++ b/.github/PULL_REQUEST_TEMPLATE
@@ -4,8 +4,12 @@
 
 ## Patch testing
 
-(Fill in the details that how was this patch tested)
+(Fill in the details about how this patch was tested)
+
+## ReleaseNotes.txt changes
+
+(Does this change require an entry in ReleaseNotes.txt? If yes, has it been added to it?)
 
 ## Other PRs 
 
-(Does this change required changes in other projects- store, spark, spark-jobserver, aqp? Add the links of PR of the other subprojects that are related to this change)
+(Does this change require changes in other projects- store, spark, spark-jobserver, aqp? Add the links of PR of the other subprojects that are related to this change)

--- a/ReleaseNotes.txt
+++ b/ReleaseNotes.txt
@@ -11,7 +11,11 @@ Release 0.5-preview
 
   Rowstore quickstarts are now packaged into the SnappyData distribution.
 
-  [SPARK] Optimizations in Bootstrap.
+  [AQP] Optimizations of bootstrap for sort based aggregate.
+
+  [AQP] Minimize the query plan size for bootstrap.
+
+  [AQP] Optimized the Declarative aggregate function.
 
   [SNAP-858] Added documentation for Python APIs.
 

--- a/ReleaseNotes.txt
+++ b/ReleaseNotes.txt
@@ -1,0 +1,25 @@
+####################################################################################################
+# PLEASE KEEP THE WIDTH OF THE LINES BELOW WITHIN 100 CHARACTERS.                                  #
+# MOST RECENT CHANGE AT THE TOP.                                                                   #
+# KEEP THE DESCRIPTION OF EACH OF YOUR CHANGES THAT NEEDS TO BE PUT INTO THE RELEASE NOTES TO ONE  #
+# TO THREE LINES.                                                                                  #
+# KEEP A LINE BLANK BETWEEN TWO NOTES.                                                             #
+# ADD THE JIRA TICKET ID, IF APPLICABLE.                                                           #
+####################################################################################################
+
+Release 0.5-preview
+
+[SNAP-817][TESTS] Added support in tests for starting of jobs by allowing passing of properties
+using APP_PROPS. Added support for deleting streaming data generated during test run.
+    
+[QUICKSTART] Packaged rowstore quickstart in snappydata distributions.
+
+[SNAP-570][TESTS] Added support for starting split cluster mode and submitting the spark jobs in
+hydra tests.
+
+[SNAP-833][TESTS] Added tests to verify upgrading gemfirexd cluster to snappydata-store works as
+expected.
+
+[SNAP-858][DOCS] Added documentation for Python APIs.
+
+[SNAP-852] Added new fields on the Snappy Store tab in Spark UI.

--- a/ReleaseNotes.txt
+++ b/ReleaseNotes.txt
@@ -9,17 +9,10 @@
 
 Release 0.5-preview
 
-[SNAP-817][TESTS] Added support in tests for starting of jobs by allowing passing of properties
-using APP_PROPS. Added support for deleting streaming data generated during test run.
-    
-[QUICKSTART] Packaged rowstore quickstart in snappydata distributions.
+  Rowstore quickstarts are now packaged into the SnappyData distribution.
 
-[SNAP-570][TESTS] Added support for starting split cluster mode and submitting the spark jobs in
-hydra tests.
+  [SPARK] Optimizations in Bootstrap.
 
-[SNAP-833][TESTS] Added tests to verify upgrading gemfirexd cluster to snappydata-store works as
-expected.
+  [SNAP-858] Added documentation for Python APIs.
 
-[SNAP-858][DOCS] Added documentation for Python APIs.
-
-[SNAP-852] Added new fields on the Snappy Store tab in Spark UI.
+  [SNAP-852] Added new fields on the Snappy Store tab in Spark UI.

--- a/dtests/build.gradle
+++ b/dtests/build.gradle
@@ -86,7 +86,7 @@ if (rootProject.hasProperty('enablePublish')) {
     }
 }
 
-archivesBaseName = 'gemfirexd-scala-tests'
+archivesBaseName = 'snappydata-store-scala-tests'
 
 testClasses.doLast {
   copyTestsCommonResources(buildDir)


### PR DESCRIPTION
## Changes proposed in this pull request
* Renaming gemfirexd* jars to snappydata-store* jars.
* Adding ReleaseNotes.txt to keep a record of changes
  that may need to be published.
* Added a section in GitHub PR template to update
  ReleaseNotes.txt

## Patch testing
./gradlew clean buildAll

## Other PRs 
https://github.com/SnappyDataInc/snappy-store/pull/81

