### PR TITLE
Added the conf param spark.sql.autoBroadcastJoinThreshold to -1 , so …

### DIFF
--- a/cluster/src/dunit/scala/io/snappydata/cluster/SplitSnappyClusterDUnitTest.scala
+++ b/cluster/src/dunit/scala/io/snappydata/cluster/SplitSnappyClusterDUnitTest.scala
@@ -257,7 +257,7 @@ object SplitSnappyClusterDUnitTest extends SplitClusterDUnitTestObject {
         .set("spark.executor.extraClassPath",
           getEnvironmentVariable("SNAPPY_DIST_CLASSPATH"))
         .set("spark.testing.reservedMemory", "0")
-
+    conf.set("spark.sql.autoBroadcastJoinThreshold", "-1")
     val sc = SparkContext.getOrCreate(conf)
     val snc = SnappyContext(sc)
 


### PR DESCRIPTION
## Changes proposed in this pull request

  Added the conf param spark.sql.autoBroadcastJoinThreshold to -1 , so that broadcast join is disabled during the scope of the test. Or else the size of the table determines shuffle or broadcast. As we are using a small table size this is necessary.

## Patch testing
precheckin is clean

## ReleaseNotes.txt changes
NA

## Other PRs 
NA