### PR TITLE
[SNAP-859] Moved registration of InternalDistributedMember from Spark…

### DIFF
--- a/cluster/src/dunit/scala/io/snappydata/serializer/KryoSerializerDUnitTest.scala
+++ b/cluster/src/dunit/scala/io/snappydata/serializer/KryoSerializerDUnitTest.scala
@@ -1,0 +1,59 @@
+package io.snappydata.serializer
+
+import io.snappydata.cluster.ClusterManagerTestBase
+
+/**
+ * Created by sachin on 14/6/16.
+ * This class has tests that are used to verify basic functionality is working when kryoserializer is set
+ */
+class KryoSerializerDUnitTest(s: String) extends ClusterManagerTestBase(s) {
+
+  bootProps.setProperty("spark.serializer", "org.apache.spark.serializer.KryoSerializer")
+
+  //Setting kryo registrator explicitly as SparkContext is created in ClusterManagerTest instead of lead node
+  bootProps.setProperty("spark.kryo.registrator", "io.snappydata.serializer.SnappyKryoRegistrator")
+
+  def createTestTable(): Unit = {
+
+    val snc = org.apache.spark.sql.SnappyContext(sc)
+    snc.sql(s"CREATE TABLE TEST(col1 int,col2 int) USING column " +
+        "options " +
+        "(" +
+        "PARTITION_BY 'Col1'," +
+        "BUCKETS '1')")
+
+  }
+
+  def dropTestTable(): Unit = {
+    val snc = org.apache.spark.sql.SnappyContext(sc)
+    snc.sql(s"DROP table TEST")
+  }
+
+  def testCreateColumnTable(): Unit = {
+    createTestTable()
+    dropTestTable()
+
+  }
+
+
+  def testInsertColumnTable(): Unit = {
+    createTestTable()
+    val snc = org.apache.spark.sql.SnappyContext(sc)
+    snc.sql("insert into test values(1,2)")
+    snc.sql("insert into test values(2,3)")
+    val count=snc.sql("select * from test").count()
+    assert((count==2))
+    dropTestTable()
+
+    }
+
+  def testRepartition(): Unit = {
+    createTestTable()
+    val snc = org.apache.spark.sql.SnappyContext(sc)
+    snc.sql("insert into test values(1,2)")
+    snc.sql("insert into test values(5,6)")
+    snc.sql("select * from test").repartition(2)
+    dropTestTable()
+
+  }
+}

--- a/cluster/src/main/scala/io/snappydata/impl/LeadImpl.scala
+++ b/cluster/src/main/scala/io/snappydata/impl/LeadImpl.scala
@@ -357,9 +357,9 @@ class LeadImpl extends ServerImpl with Lead with Logging {
   def getSnappyKryoRegistrarClass(): String = {
 
     Try {
-      val miror = Class.forName("org.apache.spark.sql.execution.serializer.SnappyKryoAQPRegistrator")
+      val miror = Class.forName("org.apache.spark.sql.execution.serializer.SnappyAQPKryoRegistrator")
     } match {
-      case Success(v) => "org.apache.spark.sql.execution.serializer.SnappyKryoAQPRegistrator"
+      case Success(v) => "org.apache.spark.sql.execution.serializer.SnappyAQPKryoRegistrator"
       case Failure(_) => "io.snappydata.serializer.SnappyKryoRegistrator"
     }
   }

--- a/cluster/src/main/scala/io/snappydata/impl/LeadImpl.scala
+++ b/cluster/src/main/scala/io/snappydata/impl/LeadImpl.scala
@@ -128,7 +128,7 @@ class LeadImpl extends ServerImpl with Lead with Logging {
       /**
        * If kryoserializer is being used then register snappyclasses for kryoserializer.
        * The snappyclasses will not get registered if user is creating its own spark context.
-       * In that case user has to specify the snappy kryo registrator registrator externally
+       * In that case user has to specify the snappy kryo registrator externally
        */
       if (conf.contains("spark.serializer") && conf.get("spark.serializer").equals("org.apache.spark.serializer.KryoSerializer")) {
         conf.set("spark.kryo.registrator", getSnappyKryoRegistrarClass())

--- a/cluster/src/main/scala/io/snappydata/impl/LeadImpl.scala
+++ b/cluster/src/main/scala/io/snappydata/impl/LeadImpl.scala
@@ -21,6 +21,7 @@ import java.util.Properties
 import java.util.concurrent.atomic.AtomicReference
 
 import scala.collection.JavaConverters._
+import scala.util.{Failure, Success, Try}
 
 import akka.actor.ActorSystem
 import com.gemstone.gemfire.distributed.internal.DistributionConfig
@@ -123,6 +124,15 @@ class LeadImpl extends ServerImpl with Lead with Logging {
         }
         conf.set(key, v)
       })
+
+      /**
+       * If kryoserializer is being used then register snappyclasses for kryoserializer.
+       * The snappyclasses will not get registered if user is creating its own spark context.
+       * In that case user has to specify the snappy kryo registrator registrator externally
+       */
+      if (conf.contains("spark.serializer") && conf.get("spark.serializer").equals("org.apache.spark.serializer.KryoSerializer")) {
+        conf.set("spark.kryo.registrator", getSnappyKryoRegistrarClass())
+      }
 
       logInfo("About to initialize SparkContext with SparkConf=" + conf.toDebugString)
 
@@ -342,6 +352,18 @@ class LeadImpl extends ServerImpl with Lead with Logging {
   override def stopAllNetworkServers(): Unit = {
     // nothing to do as none of the net servers are allowed to start.
   }
+
+
+  def getSnappyKryoRegistrarClass(): String = {
+
+    Try {
+      val miror = Class.forName("org.apache.spark.sql.execution.serializer.SnappyKryoAQPRegistrator")
+    } match {
+      case Success(v) => "org.apache.spark.sql.execution.serializer.SnappyKryoAQPRegistrator"
+      case Failure(_) => "io.snappydata.serializer.SnappyKryoRegistrator"
+    }
+  }
+
 }
 
 object LeadImpl {

--- a/core/src/main/scala/io/snappydata/serializer/SnappyKryoRegistrator.scala
+++ b/core/src/main/scala/io/snappydata/serializer/SnappyKryoRegistrator.scala
@@ -1,0 +1,18 @@
+package io.snappydata.serializer
+
+import com.esotericsoftware.kryo.Kryo
+import com.gemstone.gemfire.distributed.internal.membership.InternalDistributedMember
+
+import org.apache.spark.serializer.KryoRegistrator
+
+/**
+ * This class is used as a kryo registrator for registering snappy related classes.
+ * All the classes that needs to be registered along with their serializer should be added in this class
+ */
+class SnappyKryoRegistrator extends KryoRegistrator{
+
+  override def registerClasses(kryo: Kryo): Unit = {
+    kryo.register(classOf[InternalDistributedMember], new com.esotericsoftware.kryo.serializers.JavaSerializer())
+  }
+
+}


### PR DESCRIPTION
## Changes proposed in this pull request

-Changes related to SNAP-859
-Moved registration of InternalDritributedManager to SnappyKryoRegistrator instead of spark code base
-Changed LeadImpl to register SnappykryoRegistrator
## Patch testing

Added DUnitTest for this change
## ReleaseNotes.txt changes

(Does this change require an entry in ReleaseNotes.txt? If yes, has it been added to it?)
## Other PRs

Yes
 [snappy-aqp PR-70](https://github.com/SnappyDataInc/snappy-aqp/pull/70) ,[SnappySpark PR-37](https://github.com/SnappyDataInc/snappy-spark/pull/37)
