### PR TITLE
Reverse the order of stopping servers in ./sbin/snappy-stop-all.sh

### DIFF
--- a/cluster/sbin/snappy-nodes.sh
+++ b/cluster/sbin/snappy-nodes.sh
@@ -94,7 +94,7 @@ fi
 
 MEMBERS_FILE="$SPARK_HOME/work/members.txt"
 
-function startComponent() {
+function execute() {
   dirparam="$(echo $args | sed -n 's/^.*\(-dir=[^ ]*\).*$/\1/p')"
 
   # Set directory folder if not already set.
@@ -175,7 +175,7 @@ if [ -n "${HOSTLIST}" ]; then
     host="$(echo "$slave "| tr -s ' ' | cut -d ' ' -f1)"
     args="$(echo "$slave "| tr -s ' ' | cut -d ' ' -f2-)"
     if echo $"${@// /\\ }" | grep -wq "start\|status"; then
-      startComponent "$@"
+      execute "$@"
     fi
     ((index++))
   done < $HOSTLIST
@@ -187,14 +187,14 @@ if [ -n "${HOSTLIST}" ]; then
         CONF_ARG=${arr[$i]}
         host="$(echo "$CONF_ARG "| tr -s ' ' | cut -d ' ' -f1)"
         args="$(echo "$CONF_ARG "| tr -s ' ' | cut -d ' ' -f2-)"
-        startComponent "$@"
+        execute "$@"
       done
     fi
   fi
 else
     host="localhost"
     args=""
-    startComponent "$@"
+    execute "$@"
 fi
 wait
 


### PR DESCRIPTION
## Changes proposed in this pull request

Currently the order of stopping servers is as specified in /conf/servers file. We use the same order during ./sbin/snappy-start-all.sh as well, as a result of this the last server stopped is also the last server started.
Changes made to stop the servers in reverse order as specified in /conf/servers.

## Patch testing
Verified changes with running snappy-start-all, snappy-stop-all and snappy-status-all .

## ReleaseNotes.txt changes

NA

## Other PRs 

No