### PR TITLE
Added support in hydra to wait for a job completion instead of relying on waitTime parameter

### DIFF
--- a/dtests/src/test/java/io/snappydata/hydra/cluster/SnappyPrms.java
+++ b/dtests/src/test/java/io/snappydata/hydra/cluster/SnappyPrms.java
@@ -122,6 +122,10 @@ public class SnappyPrms extends BasePrms {
      */
     public static Long enableTimeStatistics;
 
+    /**
+     * (String) log level to be applied while generating logs for snappy members. Defaults to config if not provided.
+     */
+    public static Long logLevel;
 
     /**
      * (String) userAppJar containing the user snappy job class
@@ -148,11 +152,13 @@ public class SnappyPrms extends BasePrms {
      */
     public static Long waitTimeBeforeNextCycleVM;
 
-    /** (int) The number of VMs to stop (then restart) at a time.
+    /**
+     * (int) The number of VMs to stop (then restart) at a time.
      */
     public static Long numVMsToStop;
 
-    /** (int) The number of lead VMs to stop (then restart).
+    /**
+     * (int) The number of lead VMs to stop (then restart).
      */
     public static Long numLeadsToStop;
 
@@ -275,6 +281,11 @@ public class SnappyPrms extends BasePrms {
     public static boolean getTimeStatistics() {
         Long key = enableTimeStatistics;
         return tasktab().booleanAt(key, tab().booleanAt(key, true));
+    }
+
+    public static String getLogLevel() {
+        Long key = logLevel;
+        return tab().stringAt(key, "config");
     }
 
     public static Vector getSQLScriptNamesForInitTask() {

--- a/dtests/src/test/java/io/snappydata/hydra/cluster/SnappyPrms.java
+++ b/dtests/src/test/java/io/snappydata/hydra/cluster/SnappyPrms.java
@@ -27,31 +27,19 @@ import java.util.Vector;
  */
 public class SnappyPrms extends BasePrms {
     /**
-     * Parameter used to get the user specified script names for INITTASK.
+     * Parameter used to get the user specified script names.
      * (VectosetValues of Strings) A list of values for script Names to execute.
      */
     public static Long sqlScriptNames;
 
     /**
-     * Parameter used to get the user specified param List for INITTASK.
+     * Parameter used to get the user specified param List.
      * (VectosetValues of Strings) A list of values for parameters to be replaced in the sql scripts.
      * If no parameter is required for sql script then expected value to be provided for param is : Empty String : " " in case if user don't want to maintain the sequence.
-     * Or else provide the script that does not require any parameter at the end in list of sqlScriptNamesForInitTask parameter.
+     * Or else provide the script that does not require any parameter at the end in list of sqlScriptNames parameter.
      * Framework will treat its corresponding parameter as " " string in this case.
      */
     public static Long sqlScriptParams;
-
-    /**
-     * Parameter used to get the user specified script names for TASK.
-     * (VectosetValuesr of Strings) A list of values for script Names to execute.
-     */
-    public static Long sqlScriptNamesForTask;
-
-    /**
-     * Parameter used to get the user specified snappy job class names for CLOSETASK.
-     * (VectosetValues of Strings) A list of values for snappy-job Names to execute.
-     */
-//    public static Long jobClassNamesForCloseTask;
 
     /**
      * Parameter used to get the user specified snappy job class names.
@@ -134,19 +122,9 @@ public class SnappyPrms extends BasePrms {
     public static Long userAppJar;
 
     /**
-     * (int) how long (milliseconds) it should wait for getting the job status in Task
-     */
-//    public static Long jobExecutionTimeInMillisForTask;
-
-    /**
      * (int) how long (milliseconds) it should wait for getting the job status
      */
     public static Long streamingJobExecutionTimeInMillis;
-
-    /**
-     * (int) how long (milliseconds) it should wait for getting the job status in Close Task
-     */
-//    public static Long jobExecutionTimeInMillisForCloseTask;
 
     /**
      * (int) how long (milliseconds) it should wait before Cycle VMs again
@@ -304,11 +282,6 @@ public class SnappyPrms extends BasePrms {
         return BasePrms.tasktab().vecAt(key, BasePrms.tab().vecAt(key, new HydraVector()));
     }
 
-    /*public static Vector getSQLScriptNamesForTask() {
-        Long key = sqlScriptNamesForTask;
-        return BasePrms.tasktab().vecAt(key, BasePrms.tab().vecAt(key, null));
-    }*/
-
     public static Vector getSnappyJobClassNames() {
         Long key = jobClassNames;
         return BasePrms.tasktab().vecAt(key, BasePrms.tab().vecAt(key, null));
@@ -323,11 +296,6 @@ public class SnappyPrms extends BasePrms {
         Long key = streamingJobClassNames;
         return BasePrms.tasktab().vecAt(key, BasePrms.tab().vecAt(key, null));
     }
-
-    /*public static Vector getSnappyJobClassNamesForCloseTask() {
-        Long key = jobClassNamesForCloseTask;
-        return BasePrms.tasktab().vecAt(key, BasePrms.tab().vecAt(key, null));
-    }*/
 
     static {
         BasePrms.setValues(SnappyPrms.class);

--- a/dtests/src/test/java/io/snappydata/hydra/cluster/SnappyPrms.java
+++ b/dtests/src/test/java/io/snappydata/hydra/cluster/SnappyPrms.java
@@ -17,6 +17,7 @@
 package io.snappydata.hydra.cluster;
 
 import hydra.BasePrms;
+import hydra.HydraVector;
 
 import java.util.Vector;
 
@@ -29,7 +30,7 @@ public class SnappyPrms extends BasePrms {
      * Parameter used to get the user specified script names for INITTASK.
      * (VectosetValues of Strings) A list of values for script Names to execute.
      */
-    public static Long sqlScriptNamesForInitTask;
+    public static Long sqlScriptNames;
 
     /**
      * Parameter used to get the user specified param List for INITTASK.
@@ -38,7 +39,7 @@ public class SnappyPrms extends BasePrms {
      * Or else provide the script that does not require any parameter at the end in list of sqlScriptNamesForInitTask parameter.
      * Framework will treat its corresponding parameter as " " string in this case.
      */
-    public static Long sqlScriptParamsForInitTask;
+    public static Long sqlScriptParams;
 
     /**
      * Parameter used to get the user specified script names for TASK.
@@ -50,25 +51,25 @@ public class SnappyPrms extends BasePrms {
      * Parameter used to get the user specified snappy job class names for CLOSETASK.
      * (VectosetValues of Strings) A list of values for snappy-job Names to execute.
      */
-    public static Long jobClassNamesForCloseTask;
+//    public static Long jobClassNamesForCloseTask;
 
     /**
-     * Parameter used to get the user specified snappy job class names for TASK.
+     * Parameter used to get the user specified snappy job class names.
      * (VectosetValues of Strings) A list of values for snappy-job Names to execute.
      */
-    public static Long jobClassNamesForTask;
+    public static Long jobClassNames;
 
     /**
-     * Parameter used to get the user specified spark job class names for TASK.
+     * Parameter used to get the user specified spark job class names.
      * (VectosetValues of Strings) A list of values for spark-job Names to execute.
      */
-    public static Long sparkJobClassNamesForTask;
+    public static Long sparkJobClassNames;
 
     /**
-     * Parameter used to get the user specified snappy streaming job class names for TASK.
+     * Parameter used to get the user specified snappy streaming job class names.
      * (VectosetValues of Strings) A list of values for snappy-job Names to execute.
      */
-    public static Long streamingJobClassNamesForTask;
+    public static Long streamingJobClassNames;
 
     /**
      * (boolean) for testing HA
@@ -135,17 +136,17 @@ public class SnappyPrms extends BasePrms {
     /**
      * (int) how long (milliseconds) it should wait for getting the job status in Task
      */
-    public static Long jobExecutionTimeInMillisForTask;
+//    public static Long jobExecutionTimeInMillisForTask;
 
     /**
-     * (int) how long (milliseconds) it should wait for getting the job status in Task
+     * (int) how long (milliseconds) it should wait for getting the job status
      */
-    public static Long streamingJobExecutionTimeInMillisForTask;
+    public static Long streamingJobExecutionTimeInMillis;
 
     /**
      * (int) how long (milliseconds) it should wait for getting the job status in Close Task
      */
-    public static Long jobExecutionTimeInMillisForCloseTask;
+//    public static Long jobExecutionTimeInMillisForCloseTask;
 
     /**
      * (int) how long (milliseconds) it should wait before Cycle VMs again
@@ -288,40 +289,45 @@ public class SnappyPrms extends BasePrms {
         return tab().stringAt(key, "config");
     }
 
-    public static Vector getSQLScriptNamesForInitTask() {
-        Long key = sqlScriptNamesForInitTask;
+    public static Vector getSQLScriptNames() {
+        Long key = sqlScriptNames;
         return BasePrms.tasktab().vecAt(key, BasePrms.tab().vecAt(key, null));
     }
 
-    public static Vector getSQLScriptParamsForInitTask() {
-        Long key = sqlScriptParamsForInitTask;
-        return BasePrms.tasktab().vecAt(key, BasePrms.tab().vecAt(key, null));
+    public static String getUserAppJar() {
+        Long key = userAppJar;
+        return BasePrms.tasktab().stringAt(key, BasePrms.tab().stringAt(key, null));
     }
 
-    public static Vector getSQLScriptNamesForTask() {
+    public static Vector getSQLScriptParams() {
+        Long key = sqlScriptParams;
+        return BasePrms.tasktab().vecAt(key, BasePrms.tab().vecAt(key, new HydraVector()));
+    }
+
+    /*public static Vector getSQLScriptNamesForTask() {
         Long key = sqlScriptNamesForTask;
         return BasePrms.tasktab().vecAt(key, BasePrms.tab().vecAt(key, null));
-    }
+    }*/
 
-    public static Vector getSnappyJobClassNamesForTask() {
-        Long key = jobClassNamesForTask;
+    public static Vector getSnappyJobClassNames() {
+        Long key = jobClassNames;
         return BasePrms.tasktab().vecAt(key, BasePrms.tab().vecAt(key, null));
     }
 
-    public static Vector getSparkJobClassNamesForTask() {
-        Long key = sparkJobClassNamesForTask;
+    public static Vector getSparkJobClassNames() {
+        Long key = sparkJobClassNames;
         return BasePrms.tasktab().vecAt(key, BasePrms.tab().vecAt(key, null));
     }
 
-    public static Vector getSnappyStreamingJobClassNamesForTask() {
-        Long key = streamingJobClassNamesForTask;
+    public static Vector getSnappyStreamingJobClassNames() {
+        Long key = streamingJobClassNames;
         return BasePrms.tasktab().vecAt(key, BasePrms.tab().vecAt(key, null));
     }
 
-    public static Vector getSnappyJobClassNamesForCloseTask() {
+    /*public static Vector getSnappyJobClassNamesForCloseTask() {
         Long key = jobClassNamesForCloseTask;
         return BasePrms.tasktab().vecAt(key, BasePrms.tab().vecAt(key, null));
-    }
+    }*/
 
     static {
         BasePrms.setValues(SnappyPrms.class);

--- a/dtests/src/test/java/io/snappydata/hydra/cluster/SnappyTest.java
+++ b/dtests/src/test/java/io/snappydata/hydra/cluster/SnappyTest.java
@@ -104,6 +104,8 @@ public class SnappyTest implements Serializable {
     public static final int THOUSAND = 1000;
     public static String cycleVMTarget = TestConfig.tab().stringAt(SnappyPrms.cycleVMTarget, "snappyStore");
     public static String cycleLeadVMTarget = TestConfig.tab().stringAt(SnappyPrms.cycleVMTarget, "lead");
+    public static final String LEAD_PORT = "8090";
+    public static final String MASTER_PORT = "7077";
 
     private Connection connection = null;
     private static HydraThreadLocal localconnection = new HydraThreadLocal();
@@ -1380,9 +1382,9 @@ public class SnappyTest implements Serializable {
                 }
                 String contextName = "snappyStreamingContext" + System.currentTimeMillis();
                 String contextFactory = "org.apache.spark.sql.streaming.SnappyStreamingContextFactory";
-                String curlCommand1 = "curl --data-binary @" + snappyTest.getUserAppJarLocation(userAppJar) + " " + leadHost + ":8090/jars/myapp";
-                String curlCommand2 = "curl -d  \"\"" + " '" + leadHost + ":8090/" + "contexts/" + contextName + "?context-factory=" + contextFactory + "'";
-                String curlCommand3 = "curl -d " + APP_PROPS + " '" + leadHost + ":8090/jobs?appName=myapp&classPath=" + userJob + "&context=" + contextName + "'";
+                String curlCommand1 = "curl --data-binary @" + snappyTest.getUserAppJarLocation(userAppJar) + " " + leadHost + ":" + LEAD_PORT + "/jars/myapp";
+                String curlCommand2 = "curl -d  \"\"" + " '" + leadHost + ":" + LEAD_PORT + "/" + "contexts/" + contextName + "?context-factory=" + contextFactory + "'";
+                String curlCommand3 = "curl -d " + APP_PROPS + " '" + leadHost + ":" + LEAD_PORT + "/jobs?appName=myapp&classPath=" + userJob + "&context=" + contextName + "'";
                 pb = new ProcessBuilder("/bin/bash", "-c", curlCommand1);
                 log = new File(".");
                 String dest = log.getCanonicalPath() + File.separator + logFileName;
@@ -1409,7 +1411,7 @@ public class SnappyTest implements Serializable {
         try {
             for (int i = 0; i < jobClassNames.size(); i++) {
                 String userJob = (String) jobClassNames.elementAt(i);
-                pb = new ProcessBuilder(snappyJobScript, "submit", "--lead", leadHost + ":8090", "--app-name", "myapp", "--class", userJob, "--app-jar", snappyTest.getUserAppJarLocation(userAppJar), "--stream");
+                pb = new ProcessBuilder(snappyJobScript, "submit", "--lead", leadHost + ":" + LEAD_PORT, "--app-name", "myapp", "--class", userJob, "--app-jar", snappyTest.getUserAppJarLocation(userAppJar), "--stream");
                 java.util.Map<String, String> env = pb.environment();
                 if (SnappyPrms.getCommaSepAPPProps() == null) {
                     env.put("APP_PROPS", "shufflePartitions=" + SnappyPrms.getShufflePartitions());
@@ -1456,8 +1458,8 @@ public class SnappyTest implements Serializable {
                 if (isLongRunningTest) {
                     leadHost = getLeadHostFromFile();
                 }
-                String curlCommand1 = "curl --data-binary @" + snappyTest.getUserAppJarLocation(userAppJar) + " " + leadHost + ":8090/jars/myapp";
-                String curlCommand2 = "curl -d " + APP_PROPS + " '" + leadHost + ":8090/jobs?appName=myapp&classPath=" + userJob + "'";
+                String curlCommand1 = "curl --data-binary @" + snappyTest.getUserAppJarLocation(userAppJar) + " " + leadHost + ":" + LEAD_PORT + "/jars/myapp";
+                String curlCommand2 = "curl -d " + APP_PROPS + " '" + leadHost + ":" + LEAD_PORT + "/jobs?appName=myapp&classPath=" + userJob + "'";
                 pb = new ProcessBuilder("/bin/bash", "-c", curlCommand1);
                 log = new File(".");
                 String dest = log.getCanonicalPath() + File.separator + logFileName;
@@ -1483,7 +1485,7 @@ public class SnappyTest implements Serializable {
                 String userJob = (String) jobClassNames.elementAt(i);
                 String masterHost = (String) SnappyBB.getBB().getSharedMap().get("masterHost");
                 String locatorHost = (String) SnappyBB.getBB().getSharedMap().get("locatorHost");
-                String command = snappyJobScript + " --class " + userJob + " --master spark://" + masterHost + ":7077 " + "--conf snappydata.store.locators=" + locatorHost + ":" + 10334 + " " + snappyTest.getUserAppJarLocation(userAppJar);
+                String command = snappyJobScript + " --class " + userJob + " --master spark://" + masterHost + ":" + MASTER_PORT + " --conf snappydata.store.locators=" + locatorHost + ":" + 10334 + " " + snappyTest.getUserAppJarLocation(userAppJar);
                 log = new File(".");
                 String dest = log.getCanonicalPath() + File.separator + logFileName;
                 logFile = new File(dest);
@@ -1589,7 +1591,7 @@ public class SnappyTest implements Serializable {
             }
             inputFile.close();
             for (String str : jobIds) {
-                ProcessBuilder pb = new ProcessBuilder(snappyJobScript, "status", "--lead", leadHost + ":8090", "--job-id", str);
+                ProcessBuilder pb = new ProcessBuilder(snappyJobScript, "status", "--lead", leadHost + ":" + LEAD_PORT, "--job-id", str);
                 File log = new File(".");
                 String dest = log.getCanonicalPath() + File.separator + "jobStatus_" + RemoteTestModule.getCurrentThread().getThreadId() + ".log";
                 statusLogFile = new File(dest);

--- a/dtests/src/test/java/io/snappydata/hydra/cluster/SnappyTest.java
+++ b/dtests/src/test/java/io/snappydata/hydra/cluster/SnappyTest.java
@@ -1540,7 +1540,7 @@ public class SnappyTest implements Serializable {
                 String dest = log.getCanonicalPath() + File.separator + "jobStatus_" + RemoteTestModule.getCurrentThread().getThreadId() + "_" + System.currentTimeMillis() + ".log";
                 File commandOutput = new File(dest);
                 String expression = snappyJobScript + " status --lead " + leadHost + ":" + LEAD_PORT + " --job-id " + str + " > " + commandOutput + " 2>&1 ; grep -e '\"status\": \"FINISHED\"' -e 'curl:' " + commandOutput + " | wc -l)\"";
-                String command = "while [ \"$(" + expression + " -lt  1 ] || [ \"$(" + expression + " !=  1 ] ; do rm " + commandOutput + " ;  touch " + commandOutput + "   ; done";
+                String command = "while [ \"$(" + expression + " -le  0 ] ; do rm " + commandOutput + " ;  touch " + commandOutput + "  ; done";
                 ProcessBuilder pb = new ProcessBuilder("/bin/bash", "-c", command);
                 Log.getLogWriter().info("job " + str + " starts at: " + System.currentTimeMillis());
                 executeProcess(pb, commandOutput);

--- a/dtests/src/test/java/io/snappydata/hydra/cluster/runAirlineDataJobs.conf
+++ b/dtests/src/test/java/io/snappydata/hydra/cluster/runAirlineDataJobs.conf
@@ -14,7 +14,8 @@ INITTASK     taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = 
 INITTASK     taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = HydraTask_getClientConnection
   threadGroups = snappyThreads;
 
-TASK     taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = HydraTask_executeSnappyJobInTask
+TASK     taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = HydraTask_executeSnappyJob
+  io.snappydata.hydra.cluster.SnappyPrms-jobClassNames = io.snappydata.hydra.AirlineDataQueriesJob
   threadGroups = snappyThreads
   ;
 
@@ -27,8 +28,5 @@ hydra.Prms-maxCloseTaskResultWaitSec  = 900;
 
 io.snappydata.hydra.cluster.SnappyPrms-isStopMode = true;
 io.snappydata.hydra.cluster.SnappyPrms-isLongRunningTest = true;
-
-io.snappydata.hydra.cluster.SnappyPrms-jobClassNamesForTask = io.snappydata.hydra.AirlineDataQueriesJob;
-io.snappydata.hydra.cluster.SnappyPrms-jobExecutionTimeInMillisForTask = 720000;
 
 io.snappydata.hydra.cluster.SnappyPrms-userAppJar = snappydata-store-scala-tests-0.1.0-SNAPSHOT-tests.jar;

--- a/dtests/src/test/java/io/snappydata/hydra/cluster/runAirlineDataQueries.conf
+++ b/dtests/src/test/java/io/snappydata/hydra/cluster/runAirlineDataQueries.conf
@@ -14,7 +14,8 @@ INITTASK     taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = 
 INITTASK     taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = HydraTask_getClientConnection
   threadGroups = snappyThreads;
 
-TASK     taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = HydraTask_executeSQLScriptsInTask
+TASK     taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = HydraTask_executeSQLScripts
+  io.snappydata.hydra.cluster.SnappyPrms-sqlScriptNames = olap_queries.sql oltp_queries.sql
   threadGroups = snappyThreads
   ;
 
@@ -27,5 +28,3 @@ hydra.Prms-maxCloseTaskResultWaitSec  = 1800;
 
 io.snappydata.hydra.cluster.SnappyPrms-isStopMode = true;
 io.snappydata.hydra.cluster.SnappyPrms-isLongRunningTest = true;
-
-io.snappydata.hydra.cluster.SnappyPrms-sqlScriptNamesForTask = olap_queries.sql oltp_queries.sql;

--- a/dtests/src/test/java/io/snappydata/hydra/cluster/runAirlineDataQueriesAndJobs.conf
+++ b/dtests/src/test/java/io/snappydata/hydra/cluster/runAirlineDataQueriesAndJobs.conf
@@ -20,18 +20,22 @@ INITTASK     taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = 
 INITTASK     taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = HydraTask_getClientConnection
   threadGroups = snappyThreads;
 
-INITTASK     taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = HydraTask_executeSQLScriptsInInitTask
+INITTASK     taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = HydraTask_executeSQLScripts
+  io.snappydata.hydra.cluster.SnappyPrms-sqlScriptNames = create_and_load_column_table.sql create_and_load_sample_table.sql create_and_load_row_table.sql olap_queries.sql
+  io.snappydata.hydra.cluster.SnappyPrms-sqlScriptParams = airlineParquetData " " airportcodeParquetData
   threadGroups = snappySingleThread;
 
 
 INITTASK     taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = runQuery
   threadGroups = snappyThreads;
 
-TASK     taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = HydraTask_executeSQLScriptsInTask
+TASK     taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = HydraTask_executeSQLScripts
+  io.snappydata.hydra.cluster.SnappyPrms-sqlScriptNames = olap_queries.sql oltp_queries.sql
   threadGroups = snappyThreads, snappySingleThread
   ;
 
-TASK     taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = HydraTask_executeSnappyJobInTask
+TASK     taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = HydraTask_executeSnappyJob
+  io.snappydata.hydra.cluster.SnappyPrms-jobClassNames = io.snappydata.hydra.AirlineDataQueriesJob
   threadGroups = snappyThreads
   ;
 
@@ -44,12 +48,5 @@ hydra.Prms-maxCloseTaskResultWaitSec  = 1800;
 
 io.snappydata.hydra.cluster.SnappyPrms-isStopMode = true;
 io.snappydata.hydra.cluster.SnappyPrms-isLongRunningTest = true;
-
-io.snappydata.hydra.cluster.SnappyPrms-sqlScriptNamesForInitTask = create_and_load_column_table.sql create_and_load_sample_table.sql create_and_load_row_table.sql olap_queries.sql;
-io.snappydata.hydra.cluster.SnappyPrms-sqlScriptParamsForInitTask = airlineParquetData " " airportcodeParquetData;
-
-io.snappydata.hydra.cluster.SnappyPrms-sqlScriptNamesForTask = olap_queries.sql oltp_queries.sql;
-io.snappydata.hydra.cluster.SnappyPrms-jobClassNamesForTask = io.snappydata.hydra.AirlineDataQueriesJob;
-io.snappydata.hydra.cluster.SnappyPrms-jobExecutionTimeInMillisForTask = 720000;
 
 io.snappydata.hydra.cluster.SnappyPrms-userAppJar = snappydata-store-scala-tests-0.1.0-SNAPSHOT-tests.jar;

--- a/dtests/src/test/java/io/snappydata/hydra/cluster/sample.inc
+++ b/dtests/src/test/java/io/snappydata/hydra/cluster/sample.inc
@@ -74,18 +74,23 @@ INITTASK     taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = 
 INITTASK     taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = HydraTask_getClientConnection
   threadGroups = snappyThreads;
 
-INITTASK     taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = HydraTask_executeSQLScriptsInInitTask
-  threadGroups = snappyThreads;
-
+INITTASK     taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = HydraTask_executeSQLScripts
+  io.snappydata.hydra.cluster.SnappyPrms-sqlScriptNames = create_and_load_column_table.sql create_and_load_sample_table.sql create_and_load_row_table.sql olap_queries.sql
+  io.snappydata.hydra.cluster.SnappyPrms-sqlScriptParams = airlineParquetData " " airportcodeParquetData
+  threadGroups = snappyThreads
+  ;
 
 INITTASK     taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = runQuery
   threadGroups = snappyThreads;
 
-TASK     taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = HydraTask_executeSQLScriptsInTask
+TASK     taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = HydraTask_executeSQLScripts
+  io.snappydata.hydra.cluster.SnappyPrms-sqlScriptNames = olap_queries.sql oltp_queries.sql
   threadGroups = snappyThreads
   ;
 
-TASK     taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = HydraTask_executeSnappyJobInTask
+TASK     taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = HydraTask_executeSnappyJob
+  io.snappydata.hydra.cluster.SnappyPrms-jobClassNames = io.snappydata.hydra.AirlineDataQueriesJob
+  io.snappydata.hydra.cluster.SnappyPrms-userAppJar = snappydata-store-scala-tests-0.1.0-SNAPSHOT-tests.jar
   threadGroups = leadThreads
   maxTimesToRun = 3;
 
@@ -96,9 +101,9 @@ ENDTASK     taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = H
 clientNames = locator1;
 
 hydra.Prms-totalTaskTimeSec           = 900;
-hydra.Prms-maxResultWaitSec           = 900;
+hydra.Prms-maxResultWaitSec           = 1800;
 
-hydra.Prms-maxCloseTaskResultWaitSec  = 900;
+hydra.Prms-maxCloseTaskResultWaitSec  = 1800;
 hydra.Prms-serialExecution            = false;
 
 hydra.CachePrms-names = defaultCache;
@@ -115,12 +120,3 @@ hydra.VmPrms-extraVMArgs   += fcn "hydra.TestConfigFcns.duplicate
                                   (\"-Xms512m -Xmx1g \", ${${B}Hosts}, true)"
                              ncf;
 hydra.VmPrms-extraVMArgsSUN += "-XX:PermSize=64M -XX:MaxPermSize=256m";
-
-io.snappydata.hydra.cluster.SnappyPrms-sqlScriptNamesForInitTask = create_and_load_column_table.sql create_and_load_sample_table.sql create_and_load_row_table.sql olap_queries.sql;
-io.snappydata.hydra.cluster.SnappyPrms-sqlScriptParamsForInitTask = airlineParquetData " " airportcodeParquetData;
-
-io.snappydata.hydra.cluster.SnappyPrms-sqlScriptNamesForTask = olap_queries.sql oltp_queries.sql;
-io.snappydata.hydra.cluster.SnappyPrms-jobClassNamesForTask = io.snappydata.hydra.AirlineDataQueriesJob;
-io.snappydata.hydra.cluster.SnappyPrms-jobExecutionTimeInMillisForTask = 720000;
-
-io.snappydata.hydra.cluster.SnappyPrms-userAppJar = snappydata-store-scala-tests-0.1.0-SNAPSHOT-tests.jar;

--- a/dtests/src/test/java/io/snappydata/hydra/cluster/sampleLeadHA.conf
+++ b/dtests/src/test/java/io/snappydata/hydra/cluster/sampleLeadHA.conf
@@ -25,6 +25,12 @@ TASK        taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = H
             weight = 60
             threadGroups = snappyStoreThreads;
 
+CLOSETASK   taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = HydraTask_executeSnappyJob
+            io.snappydata.hydra.cluster.SnappyPrms-jobClassNames = io.snappydata.hydra.AirlineDataQueriesJob
+            io.snappydata.hydra.cluster.SnappyPrms-userAppJar = snappydata-store-scala-tests-0.1.0-SNAPSHOT-tests.jar
+            threadGroups = snappyThreads
+            ;
+
 CLOSETASK    taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = restoreLeadConfigData
             threadGroups = snappyThreads;
 

--- a/dtests/src/test/java/io/snappydata/hydra/cluster/sampleSplitMode.conf
+++ b/dtests/src/test/java/io/snappydata/hydra/cluster/sampleSplitMode.conf
@@ -99,18 +99,22 @@ INITTASK     taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = 
 INITTASK     taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = HydraTask_getClientConnection
     threadGroups = snappyThreads;
 
-INITTASK     taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = HydraTask_executeSQLScriptsInInitTask
+INITTASK     taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = HydraTask_executeSQLScripts
+    io.snappydata.hydra.cluster.SnappyPrms-sqlScriptNames = create_and_load_column_table.sql create_and_load_row_table.sql
+    io.snappydata.hydra.cluster.SnappyPrms-sqlScriptParams = airlineParquetData airportcodeParquetData
     threadGroups = snappyThreads;
 
 
 INITTASK     taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = runQuery
     threadGroups = snappyThreads;
 
-TASK     taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = HydraTask_executeSQLScriptsInTask
+TASK     taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = HydraTask_executeSQLScripts
+    io.snappydata.hydra.cluster.SnappyPrms-sqlScriptNames = olap_queries.sql oltp_queries.sql
     threadGroups = snappyThreads
     maxTimesToRun = 5;
 
-TASK     taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = HydraTask_executeSparkJobInTask
+TASK     taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = HydraTask_executeSparkJob
+    io.snappydata.hydra.cluster.SnappyPrms-sparkJobClassNames = io.snappydata.hydra.AirlineDataSparkJobApp
     threadGroups = workerThreads
     maxThreads = 1
     maxTimesToRun = 1;
@@ -157,12 +161,5 @@ hydra.VmPrms-extraVMArgs   += fcn "hydra.TestConfigFcns.duplicate
                              ncf;
 hydra.VmPrms-extraVMArgsSUN += "-XX:PermSize=64M -XX:MaxPermSize=256m";
 
-io.snappydata.hydra.cluster.SnappyPrms-sqlScriptNamesForInitTask = create_and_load_column_table.sql create_and_load_row_table.sql;
-io.snappydata.hydra.cluster.SnappyPrms-sqlScriptParamsForInitTask = airlineParquetData airportcodeParquetData;
-
-io.snappydata.hydra.cluster.SnappyPrms-sqlScriptNamesForTask = olap_queries.sql oltp_queries.sql;
-
-io.snappydata.hydra.cluster.SnappyPrms-sparkJobClassNamesForTask = io.snappydata.hydra.AirlineDataSparkJobApp;
 io.snappydata.hydra.cluster.SnappyPrms-userAppJar = snappydata-store-scala-tests-0.1.0-SNAPSHOT-tests.jar;
-
 io.snappydata.hydra.cluster.SnappyPrms-useSplitMode = true;

--- a/dtests/src/test/java/io/snappydata/hydra/concStreamingWithAirlineDataQueries.conf
+++ b/dtests/src/test/java/io/snappydata/hydra/concStreamingWithAirlineDataQueries.conf
@@ -75,15 +75,21 @@ INITTASK     taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = 
   runMode = always
   threadGroups = leadThreads;
 
-INITTASK     taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = HydraTask_executeSQLScriptsInInitTask
+INITTASK     taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = HydraTask_executeSQLScripts
+  io.snappydata.hydra.cluster.SnappyPrms-sqlScriptNames = create_and_load_column_table.sql create_and_load_row_table.sql
+  io.snappydata.hydra.cluster.SnappyPrms-sqlScriptParams = airlineParquetData airportcodeParquetData
   threadGroups = snappyThreads;
 
-TASK     taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = HydraTask_executeSnappyStreamingJob
+TASK     taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = HydraTask_executeSnappyStreamingJobWithFileStream
+  io.snappydata.hydra.cluster.SnappyPrms-streamingJobExecutionTimeInMillis = 700000
+  io.snappydata.hydra.cluster.SnappyPrms-simulateStreamScriptName = simulateFileStream
+  io.snappydata.hydra.cluster.SnappyPrms-streamingJobClassNames = io.snappydata.hydra.FileStreamingJob
   threadGroups = snappyThreads
   maxTimesToRun = 1
   ;
 
-TASK     taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = HydraTask_executeSnappyJobInTask
+TASK     taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = HydraTask_executeSnappyJob
+  io.snappydata.hydra.cluster.SnappyPrms-jobClassNames = io.snappydata.hydra.AirlineDataQueriesJob
   threadGroups = leadThreads;
 
 CLOSETASK     taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = HydraTask_stopSnappy
@@ -125,18 +131,5 @@ hydra.VmPrms-extraVMArgs   += fcn "hydra.TestConfigFcns.duplicate
                              ncf;
 hydra.VmPrms-extraVMArgsSUN += "-XX:PermSize=64M -XX:MaxPermSize=256m";
 
-io.snappydata.hydra.cluster.SnappyPrms-sqlScriptNamesForInitTask = create_and_load_column_table.sql create_and_load_row_table.sql;
-io.snappydata.hydra.cluster.SnappyPrms-sqlScriptParamsForInitTask = airlineParquetData airportcodeParquetData;
-io.snappydata.hydra.cluster.SnappyPrms-streamingJobClassNamesForTask = io.snappydata.hydra.FileStreamingJob;
-io.snappydata.hydra.cluster.SnappyPrms-jobClassNamesForTask = io.snappydata.hydra.AirlineDataQueriesJob;
-
-io.snappydata.hydra.cluster.SnappyPrms-simulateStreamScriptName = simulateFileStream;
-//io.snappydata.hydra.cluster.SnappyPrms-simulateStreamScriptDestinationFolder = /home/swati;
-
-//io.snappydata.hydra.cluster.SnappyPrms-jobExecutionTimeInMillisForCloseTask = 900000;
-io.snappydata.hydra.cluster.SnappyPrms-jobExecutionTimeInMillisForTask = 900000;
-io.snappydata.hydra.cluster.SnappyPrms-streamingJobExecutionTimeInMillisForTask = 700000;
-
 io.snappydata.hydra.cluster.SnappyPrms-userAppJar = snappydata-store-scala-tests-0.1.0-SNAPSHOT-tests.jar;
-
 io.snappydata.hydra.cluster.SnappyPrms-appPropsForJobServer = "dataDirName=$GEMFIRE/../../../dtests/";

--- a/dtests/src/test/java/io/snappydata/hydra/serialStreamingWithAirlineDataQueries.conf
+++ b/dtests/src/test/java/io/snappydata/hydra/serialStreamingWithAirlineDataQueries.conf
@@ -75,15 +75,20 @@ INITTASK     taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = 
   runMode = always
   threadGroups = leadThreads;
 
-INITTASK     taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = HydraTask_executeSQLScriptsInInitTask
+INITTASK     taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = HydraTask_executeSQLScripts
+  io.snappydata.hydra.cluster.SnappyPrms-sqlScriptNames = create_and_load_column_table.sql create_and_load_row_table.sql
+  io.snappydata.hydra.cluster.SnappyPrms-sqlScriptParams = airlineParquetData airportcodeParquetData
   threadGroups = snappyThreads;
 
-TASK     taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = HydraTask_executeSnappyStreamingJob
+TASK     taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = HydraTask_executeSnappyStreamingJobWithFileStream
+  io.snappydata.hydra.cluster.SnappyPrms-streamingJobClassNames = io.snappydata.hydra.FileStreamingJob
+  io.snappydata.hydra.cluster.SnappyPrms-simulateStreamScriptName = simulateFileStream
+  io.snappydata.hydra.cluster.SnappyPrms-streamingJobExecutionTimeInMillis = 700000
   threadGroups = snappyThreads
-  maxTimesToRun = 1
-  ;
+  maxTimesToRun = 1;
 
-CLOSETASK     taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = HydraTask_executeSnappyJobInCloseTask
+CLOSETASK     taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = HydraTask_executeSnappyJob
+  io.snappydata.hydra.cluster.SnappyPrms-jobClassNames = io.snappydata.hydra.AirlineDataQueriesJob
   threadGroups = leadThreads;
 
 //CLOSETASK     taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = HydraTask_getSnappyJobOutputCollectively
@@ -128,20 +133,5 @@ hydra.VmPrms-extraVMArgs   += fcn "hydra.TestConfigFcns.duplicate
                              ncf;
 hydra.VmPrms-extraVMArgsSUN += "-XX:PermSize=64M -XX:MaxPermSize=256m";
 
-io.snappydata.hydra.cluster.SnappyPrms-sqlScriptNamesForInitTask = create_and_load_column_table.sql create_and_load_row_table.sql;
-io.snappydata.hydra.cluster.SnappyPrms-sqlScriptParamsForInitTask = airlineParquetData airportcodeParquetData;
-//io.snappydata.hydra.cluster.SnappyPrms-sqlScriptNamesForTask = olap_queries.sql oltp_queries.sql;
-
-io.snappydata.hydra.cluster.SnappyPrms-streamingJobClassNamesForTask = io.snappydata.hydra.FileStreamingJob;
-io.snappydata.hydra.cluster.SnappyPrms-jobClassNamesForCloseTask = io.snappydata.hydra.AirlineDataQueriesJob;
-
-io.snappydata.hydra.cluster.SnappyPrms-simulateStreamScriptName = simulateFileStream;
-//io.snappydata.hydra.cluster.SnappyPrms-simulateStreamScriptDestinationFolder = /home/swati;
-
-io.snappydata.hydra.cluster.SnappyPrms-jobExecutionTimeInMillisForCloseTask = 900000;
-io.snappydata.hydra.cluster.SnappyPrms-jobExecutionTimeInMillisForTask = 700000;
-io.snappydata.hydra.cluster.SnappyPrms-streamingJobExecutionTimeInMillisForTask = 700000;
-
 io.snappydata.hydra.cluster.SnappyPrms-userAppJar = snappydata-store-scala-tests-0.1.0-SNAPSHOT-tests.jar;
-
 io.snappydata.hydra.cluster.SnappyPrms-appPropsForJobServer = "dataDirName=$GEMFIRE/../../../dtests/";


### PR DESCRIPTION
## Changes proposed in this pull request

- Added support to set log-level while generating logs for snappy members.
- Added support in hydra to wait for a job completion instead of relying on waitTime parameter.
- Removed obsolete methods from SnappyTest

## Patch testing

Verified the changes by running sample.conf test

## ReleaseNotes.txt changes

NA

## Other PRs 

No