### PR TITLE
Override sql method in sqlContext and added same in SnappyContext.

### DIFF
--- a/core/src/main/scala/org/apache/spark/sql/SnappyContext.scala
+++ b/core/src/main/scala/org/apache/spark/sql/SnappyContext.scala
@@ -131,6 +131,8 @@ class SnappyContext protected[spark](
   override protected[sql] def executePlan(plan: LogicalPlan) =
     snappyContextFunctions.executePlan(this, plan)
 
+  override def sql(sqlText: String): DataFrame = snappyContextFunctions.sql(super.sql(sqlText))
+
   private[sql] val queryHints: mutable.Map[String, String] = mutable.Map.empty
 
   def getPreviousQueryHints: Map[String, String] = Utils.immutableMap(queryHints)

--- a/core/src/main/scala/org/apache/spark/sql/aqp/SnappyContextDefaultFunctions.scala
+++ b/core/src/main/scala/org/apache/spark/sql/aqp/SnappyContextDefaultFunctions.scala
@@ -137,6 +137,8 @@ object SnappyContextDefaultFunctions extends SnappyContextFunctions {
 
   def handleErrorLimitExceeded[T](fn: => (RDD[InternalRow], DataFrame) => T,
       rowRDD: RDD[InternalRow], df: DataFrame, lp: LogicalPlan): T = fn(rowRDD, df)
+
+  def sql[T](fn: => T): T = fn
 }
 
 class DefaultPlanner(snappyContext: SnappyContext)

--- a/core/src/main/scala/org/apache/spark/sql/aqp/SnappyContextFunctions.scala
+++ b/core/src/main/scala/org/apache/spark/sql/aqp/SnappyContextFunctions.scala
@@ -89,4 +89,6 @@ trait SnappyContextFunctions {
 
   def handleErrorLimitExceeded[T](fn: => (RDD[InternalRow], DataFrame) => T,
       rowRDD: RDD[InternalRow], df: DataFrame, lp: LogicalPlan): T
+
+  def sql[T](fn: => T): T
 }


### PR DESCRIPTION
## Changes proposed in this pull request
sql method has been overridden now in snappycontext (from its base class sqlContext).

## Patch testing
precheckin

## ReleaseNotes.txt changes
No

## Other PRs 
https://github.com/SnappyDataInc/snappy-aqp/pull/79