### PR TITLE
[SNAP-950] Multiple optimizations seen during profiling

### DIFF
--- a/cluster/build.gradle
+++ b/cluster/build.gradle
@@ -66,7 +66,7 @@ dependencies {
 */
   testCompile 'org.scalatest:scalatest_' + scalaBinaryVersion + ':2.2.6'
 
-  testRuntime 'org.pegdown:pegdown:1.1.0'
+  testRuntime 'org.pegdown:pegdown:1.6.0'
 }
 
 // Creates the version properties file and writes it to the resources dir

--- a/cluster/src/main/scala/io/snappydata/cluster/ExecutorInitiator.scala
+++ b/cluster/src/main/scala/io/snappydata/cluster/ExecutorInitiator.scala
@@ -19,10 +19,6 @@ package io.snappydata.cluster
 import java.io.File
 import java.net.URL
 import java.util
-import java.util.concurrent.locks.ReentrantLock
-
-import com.pivotal.gemfirexd.internal.engine.store.ServerGroupUtils
-import io.snappydata.gemxd.ClusterCallbacksImpl
 
 import scala.collection.mutable
 import scala.util.control.NonFatal
@@ -32,6 +28,8 @@ import com.gemstone.gemfire.distributed.internal.membership.InternalDistributedM
 import com.gemstone.gemfire.internal.cache.GemFireCacheImpl
 import com.pivotal.gemfirexd.internal.engine.Misc
 import com.pivotal.gemfirexd.internal.engine.distributed.utils.GemFireXDUtils
+import com.pivotal.gemfirexd.internal.engine.store.ServerGroupUtils
+import io.snappydata.gemxd.ClusterCallbacksImpl
 
 import org.apache.spark.deploy.SparkHadoopUtil
 import org.apache.spark.executor.SnappyCoarseGrainedExecutorBackend
@@ -56,7 +54,7 @@ object ExecutorInitiator extends Logging {
     private var driverDM: InternalDistributedMember = null
     @volatile var stopTask = false
     private var retryTask: Boolean = false
-    private val lock = new ReentrantLock
+    private val lock = new Object()
 
     val membershipListener = new MembershipListener {
       override def quorumLost(failures: util.Set[InternalDistributedMember],
@@ -112,8 +110,8 @@ object ExecutorInitiator extends Logging {
             Misc.checkIfCacheClosing(null)
             if (prevDriverURL == getDriverURLString && !getRetryFlag) {
               lock.synchronized {
-                if (prevDriverURL == getDriverURLString && !getRetryFlag) {
-                  lock.wait()
+                while (prevDriverURL == getDriverURLString && !getRetryFlag) {
+                  lock.wait(5000)
                 }
               }
             } else {
@@ -125,7 +123,7 @@ object ExecutorInitiator extends Logging {
                 // if it's a retry, wait for sometime before we retry.
                 // This is a measure to ensure that some unforeseen circumstance
                 // does not lead to continous retries and the thread hogs the CPU.
-                numTries = numTries + 1
+                numTries += 1
                 Thread.sleep(3000)
                 setRetryFlag(false)
               }
@@ -203,11 +201,11 @@ object ExecutorInitiator extends Logging {
 
                     rpcenv.setupEndpoint("Executor", executor)
                   }
+                  prevDriverURL = url
                 case None =>
-                // If driver url is none, already running executor is stopped.
+                  // If driver url is none, already running executor is stopped.
+                  prevDriverURL = ""
               }
-              prevDriverURL = getDriverURLString
-
             }
           } catch {
             case e@(NonFatal(_) | _: InterruptedException) =>

--- a/cluster/src/main/scala/io/snappydata/gemxd/SparkSQLExecuteImpl.scala
+++ b/cluster/src/main/scala/io/snappydata/gemxd/SparkSQLExecuteImpl.scala
@@ -65,7 +65,7 @@ class SparkSQLExecuteImpl(val sql: String,
   private[this] val hdos = new GfxdHeapDataOutputStream(
     Misc.getMemStore.thresholdListener(), sql, true, senderVersion)
 
-  private[this] val tableSchema = df.schema
+  private[this] val querySchema = df.schema
 
   private[this] val resultsRdd = df.queryExecution.executedPlan.execute()
 
@@ -83,12 +83,12 @@ class SparkSQLExecuteImpl(val sql: String,
     val isLocalExecution = msg.isLocallyExecuted
     val bm = SparkEnv.get.blockManager
     val partitionBlockIds = new Array[RDDBlockId](resultsRdd.partitions.length)
-    val serializeComplexType = !complexTypeAsClob && tableSchema.exists(
+    val serializeComplexType = !complexTypeAsClob && querySchema.exists(
       _.dataType match {
         case _: ArrayType | _: MapType | _: StructType => true
         case _ => false
       })
-    val handler = new ExecutionHandler(sql, tableSchema, resultsRdd.id,
+    val handler = new ExecutionHandler(sql, querySchema, resultsRdd.id,
       partitionBlockIds, serializeComplexType)
     var blockReadSuccess = false
     try {
@@ -204,11 +204,11 @@ class SparkSQLExecuteImpl(val sql: String,
   }
 
   def getColumnNames: Array[String] = {
-    tableSchema.fieldNames
+    querySchema.fieldNames
   }
 
   private def getColumnTypes: Array[(Int, Int, Int)] =
-    tableSchema.map(f => getSQLType(f.dataType)).toArray
+    querySchema.map(f => getSQLType(f.dataType)).toArray
 
   private def getSQLType(dataType: DataType): (Int, Int, Int) = {
     dataType match {

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -20,6 +20,7 @@ dependencies {
   provided 'org.scala-lang:scala-reflect:' + scalaVersion
   provided 'org.scala-lang:scala-compiler:' + scalaVersion
 
+  compile group: 'com.esotericsoftware.kryo', name: 'kryo', version: '2.24.0'
   // always use stock spark so that snappy extensions don't get accidently
   // included here in snappy-core code.
   provided("org.apache.spark:spark-core_${scalaBinaryVersion}:${sparkVersion}")

--- a/core/src/main/scala/org/apache/spark/sql/SnappyContext.scala
+++ b/core/src/main/scala/org/apache/spark/sql/SnappyContext.scala
@@ -756,10 +756,12 @@ class SnappyContext protected[spark](
 
   private[sql] def addBaseTableOption(baseTable: Option[_],
       options: Map[String, String]): Map[String, String] = baseTable match {
+    // TODO: SW: proper schema handling here and every in our query
+    // processing rules as well as of Catalyst
     case Some(t: TableIdentifier) => options + (JdbcExtendedUtils
-        .BASETABLE_PROPERTY -> catalog.newQualifiedTableName(t).toString())
+        .BASETABLE_PROPERTY -> catalog.processTableIdentifier(t.table))
     case Some(s: String) => options + (JdbcExtendedUtils
-        .BASETABLE_PROPERTY -> catalog.newQualifiedTableName(s).toString())
+        .BASETABLE_PROPERTY -> catalog.processTableIdentifier(s).toString())
     case _ => options
   }
 

--- a/core/src/main/scala/org/apache/spark/sql/execution/CompactExecRowToMutableRow.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/CompactExecRowToMutableRow.scala
@@ -57,9 +57,10 @@ trait CompactExecRowToMutableRow extends ResultWasNull {
       fieldTypes(i) match {
         case StoreUtils.STRING_TYPE =>
           // TODO: SW: change format in SQLChar to be full UTF8
-          val v = execRow.getAsBytes(pos, this)
+          // and then use getAsBytes+UTF8String.fromBytes here
+          val v = execRow.getAsString(pos, this)
           if (v != null) {
-            mutableRow.update(i, UTF8String.fromBytes(v))
+            mutableRow.update(i, UTF8String.fromString(v))
           } else {
             mutableRow.setNullAt(i)
             wasNull = false

--- a/core/src/main/scala/org/apache/spark/sql/execution/columnar/CachedBatchCreator.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/columnar/CachedBatchCreator.scala
@@ -16,150 +16,32 @@
  */
 package org.apache.spark.sql.execution.columnar
 
-import java.sql.Types
 import java.util.UUID
 
 import scala.collection.mutable
-import scala.collection.mutable.ArrayBuffer
 
 import com.pivotal.gemfirexd.internal.engine.access.heap.MemHeapScanController
 import com.pivotal.gemfirexd.internal.engine.store.AbstractCompactExecRow
-import com.pivotal.gemfirexd.internal.iapi.sql.execute.ExecRow
 import com.pivotal.gemfirexd.internal.iapi.store.access.ScanController
 
-import org.apache.spark.sql.catalyst.InternalRow
-import org.apache.spark.sql.catalyst.expressions.{SpecificMutableRow, UnsafeArrayData, UnsafeMapData, UnsafeRow}
-import org.apache.spark.sql.catalyst.util.DateTimeUtils
-import org.apache.spark.sql.collection.UUIDRegionKey
-import org.apache.spark.sql.types._
-import org.apache.spark.unsafe.Platform
-import org.apache.spark.unsafe.types.UTF8String
+import org.apache.spark.sql.catalyst.expressions.SpecificMutableRow
+import org.apache.spark.sql.execution.CompactExecRowToMutableRow
+import org.apache.spark.sql.types.StructType
 
-class CachedBatchCreator(
+final class CachedBatchCreator(
     val tableName: String, // internal column table name
     val userTableName: String, // user given table name (row buffer)
-    val schema: StructType,
+    override val schema: StructType,
     val externalStore: ExternalStore,
     val columnBatchSize: Int,
-    val useCompression: Boolean) {
-
-  type JDBCConversion = (SpecificMutableRow, ExecRow, Int) => Unit
-
-  def createInternalRow(execRow: ExecRow,
-      mutableRow: SpecificMutableRow): InternalRow = {
-    var i = 0
-    while (i < schema.length) {
-      val pos = i + 1
-      schema.fields(i).dataType match {
-        // TODO(davies): use getBytes for better performance,
-        // if the encoding is UTF-8
-        case StringType => mutableRow.update(i,
-          UTF8String.fromString(execRow.getColumn(pos).getString))
-        case IntegerType =>
-          mutableRow.setInt(i, execRow.getColumn(pos).getInt)
-        case LongType =>
-          if (schema.fields(i).metadata.contains("binarylong")) {
-            val bytes = execRow.getColumn(pos).getBytes
-            var ans = 0L
-            var j = 0
-            while (j < bytes.size) {
-              ans = 256 * ans + (255 & bytes(j))
-              j = j + 1
-            }
-            mutableRow.setLong(i, ans)
-          } else {
-            mutableRow.setLong(i, execRow.getColumn(pos).getLong)
-          }
-        case ShortType =>
-          mutableRow.setShort(i, execRow.getColumn(pos).getShort)
-        case ByteType =>
-          mutableRow.setByte(i, execRow.getColumn(pos).getByte)
-        case BooleanType =>
-          mutableRow.setBoolean(i, execRow.getColumn(pos).getBoolean)
-        case DateType =>
-          // DateTimeUtils.fromJavaDate does not handle null value,
-          // so we need to check it.
-          val dateVal = execRow.getColumn(pos).getDate(null)
-          if (dateVal != null) {
-            mutableRow.setInt(i, DateTimeUtils.fromJavaDate(dateVal))
-          } else {
-            mutableRow.update(i, null)
-          }
-        // When connecting with Oracle DB through JDBC, the precision and scale
-        // of BigDecimal object returned by ResultSet.getBigDecimal is not
-        // correctly matched to the table schema reported by
-        // ResultSetMetaData.getPrecision and ResultSetMetaData.getScale.
-        // If inserting values like 19999 into a column with NUMBER(12, 2)
-        // type, you get through a BigDecimal object with scale as 0. But the
-        // dataframe schema has correct type as DecimalType(12, 2).
-        // Thus, after saving the dataframe into parquet file and then
-        // retrieve it, you will get wrong result 199.99. So it is needed
-        // to set precision and scale for Decimal based on JDBC metadata.
-        case d: DecimalType =>
-          val dvd = execRow.getColumn(pos)
-          if (dvd == null || dvd.isNull) {
-            mutableRow.update(i, null)
-          } else {
-            val p = d.precision
-            val s = d.scale
-            dvd.typeToBigDecimal() match {
-              case Types.DECIMAL => mutableRow.update(i,
-                Decimal(dvd.getObject.asInstanceOf[java.math.BigDecimal], p, s))
-              case Types.CHAR => mutableRow.update(i,
-                Decimal(BigDecimal(dvd.getString), p, s))
-              case Types.BIGINT => mutableRow.update(i,
-                Decimal(dvd.getLong, p, s))
-              case o => throw new IllegalArgumentException(
-                s"Unsupported typeToBigDecimal result = $o")
-            }
-          }
-        case DoubleType =>
-          mutableRow.setDouble(i, execRow.getColumn(pos).getDouble)
-        case FloatType =>
-          mutableRow.setFloat(i, execRow.getColumn(pos).getFloat)
-        case TimestampType =>
-          val t = execRow.getColumn(pos).getTimestamp(null)
-          if (t != null) {
-            mutableRow.setLong(i, DateTimeUtils.fromJavaTimestamp(t))
-          } else {
-            mutableRow.update(i, null)
-          }
-        case BinaryType =>
-          mutableRow.update(i, execRow.getColumn(pos).getBytes)
-        case _: ArrayType =>
-          val bytes = execRow.getColumn(pos).getBytes
-          val array = new UnsafeArrayData
-          array.pointTo(bytes, Platform.BYTE_ARRAY_OFFSET, bytes.length)
-          mutableRow.update(i, array)
-        case _: MapType =>
-          val bytes = execRow.getColumn(pos).getBytes
-          val map = new UnsafeMapData
-          map.pointTo(bytes, Platform.BYTE_ARRAY_OFFSET, bytes.length)
-          mutableRow.update(i, map)
-        case s: StructType =>
-          val bytes = execRow.getColumn(pos).getBytes
-          val row = new UnsafeRow
-          row.pointTo(bytes, Platform.BYTE_ARRAY_OFFSET,
-            s.fields.length, bytes.length)
-          mutableRow.update(i, row)
-        case _ => throw new IllegalArgumentException(
-          s"Unsupported field ${schema.fields(i)}")
-      }
-      if (execRow.getColumn(pos).isNull) {
-        mutableRow.setNullAt(i)
-      }
-      i = i + 1
-    }
-    mutableRow
-  }
+    val useCompression: Boolean) extends CompactExecRowToMutableRow {
 
   def createAndStoreBatch(sc: ScanController, row: AbstractCompactExecRow,
-      batchID: UUID, bucketID: Int): mutable.HashSet[Any] = {
+      batchID: UUID, bucketID: Int): mutable.HashSet[AnyRef] = {
 
-    def uuidBatchAggregate(accumulated: ArrayBuffer[UUIDRegionKey],
-        batch: CachedBatch): ArrayBuffer[UUIDRegionKey] = {
-      val uuid = externalStore.storeCachedBatch(tableName , batch, bucketID, Option(batchID))
-      accumulated += uuid
+    def cachedBatchAggregate(batch: CachedBatch): Unit = {
+      externalStore.storeCachedBatch(tableName, batch,
+        bucketID, Option(batchID))
     }
 
     def columnBuilders = schema.map {
@@ -172,15 +54,15 @@ class CachedBatchCreator(
 
     // adding one variable so that only one cached batch is created
     val holder = new CachedBatchHolder(columnBuilders, 0, Integer.MAX_VALUE,
-      schema, new ArrayBuffer[UUIDRegionKey](1), uuidBatchAggregate)
+      schema, cachedBatchAggregate)
 
     val memHeapScanController = sc.asInstanceOf[MemHeapScanController]
     memHeapScanController.setAddRegionAndKey()
-    val keySet = new mutable.HashSet[Any]
-    val mutableRow = new SpecificMutableRow(schema.fields.map(_.dataType))
+    val keySet = new mutable.HashSet[AnyRef]
+    val mutableRow = new SpecificMutableRow(dataTypes)
     try {
       while (memHeapScanController.fetchNext(row)) {
-        holder.appendRow((), createInternalRow(row, mutableRow))
+        holder.appendRow(createInternalRow(row, mutableRow))
         keySet.add(row.getAllRegionAndKeyInfo.first().getKey)
       }
       holder.forceEndOfBatch()

--- a/core/src/main/scala/org/apache/spark/sql/execution/columnar/CachedBatchCreator.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/columnar/CachedBatchCreator.scala
@@ -18,8 +18,6 @@ package org.apache.spark.sql.execution.columnar
 
 import java.util.UUID
 
-import scala.collection.mutable
-
 import com.pivotal.gemfirexd.internal.engine.access.heap.MemHeapScanController
 import com.pivotal.gemfirexd.internal.engine.store.AbstractCompactExecRow
 import com.pivotal.gemfirexd.internal.iapi.store.access.ScanController
@@ -37,7 +35,7 @@ final class CachedBatchCreator(
     val useCompression: Boolean) extends CompactExecRowToMutableRow {
 
   def createAndStoreBatch(sc: ScanController, row: AbstractCompactExecRow,
-      batchID: UUID, bucketID: Int): mutable.HashSet[AnyRef] = {
+      batchID: UUID, bucketID: Int): java.util.HashSet[AnyRef] = {
 
     def cachedBatchAggregate(batch: CachedBatch): Unit = {
       externalStore.storeCachedBatch(tableName, batch,
@@ -58,7 +56,7 @@ final class CachedBatchCreator(
 
     val memHeapScanController = sc.asInstanceOf[MemHeapScanController]
     memHeapScanController.setAddRegionAndKey()
-    val keySet = new mutable.HashSet[AnyRef]
+    val keySet = new java.util.HashSet[AnyRef]
     val mutableRow = new SpecificMutableRow(dataTypes)
     try {
       while (memHeapScanController.fetchNext(row)) {

--- a/core/src/main/scala/org/apache/spark/sql/execution/columnar/ExternalStore.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/columnar/ExternalStore.scala
@@ -23,23 +23,19 @@ import scala.reflect.ClassTag
 
 import org.apache.spark.SparkContext
 import org.apache.spark.rdd.RDD
-import org.apache.spark.sql.collection.UUIDRegionKey
 import org.apache.spark.sql.sources.ConnectionProperties
 
 trait ExternalStore extends Serializable {
 
   final val columnPrefix = "Col_"
 
-  def storeCachedBatch(tableName: String, batch: CachedBatch, bucketId: Int = -1,
-      batchId: Option[UUID] = None): UUIDRegionKey
+  def storeCachedBatch(tableName: String, batch: CachedBatch,
+      partitionId: Int = -1, batchId: Option[UUID] = None): Unit
 
   def getCachedBatchRDD(tableName: String, requiredColumns: Array[String],
       sparkContext: SparkContext): RDD[CachedBatch]
 
   def getConnection(id: String, onExecutor: Boolean): java.sql.Connection
-
-  def getUUIDRegionKey(tableName: String, bucketId: Int = -1,
-      batchId: Option[UUID] = None): UUIDRegionKey
 
   def connProperties: ConnectionProperties
 

--- a/core/src/main/scala/org/apache/spark/sql/execution/columnar/JDBCSourceAsStore.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/columnar/JDBCSourceAsStore.scala
@@ -28,14 +28,12 @@ import scala.util.control.NonFatal
 
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.InternalRow
-import org.apache.spark.sql.collection.UUIDRegionKey
-import org.apache.spark.sql.execution.{ConnectionPool, SparkSqlSerializer}
+import org.apache.spark.sql.execution.ConnectionPool
 import org.apache.spark.sql.sources.ConnectionProperties
-import org.apache.spark.{Logging}
-import org.apache.spark.{Partition, SparkContext, TaskContext}
+import org.apache.spark.{Logging, Partition, SparkContext, TaskContext}
 
 /*
-Generic class to query column table from Snappy.
+Generic class to query column table from SnappyData execution.
  */
 class JDBCSourceAsStore(override val connProperties: ConnectionProperties,
     numPartitions: Int) extends ExternalStore {
@@ -49,31 +47,35 @@ class JDBCSourceAsStore(override val connProperties: ConnectionProperties,
   def getCachedBatchRDD(tableName: String,
       requiredColumns: Array[String],
       sparkContext: SparkContext): RDD[CachedBatch] = {
-    new ExternalStorePartitionedRDD(sparkContext, tableName, requiredColumns, numPartitions, this)
+    new ExternalStorePartitionedRDD(sparkContext, tableName, requiredColumns,
+      numPartitions, this)
   }
 
   override def storeCachedBatch(tableName: String, batch: CachedBatch,
-      bucketId: Int = -1, batchId: Option[UUID] = None): UUIDRegionKey = {
-    val uuid = getUUIDRegionKey(tableName, bucketId, batchId)
-    storeCurrentBatch(tableName, batch, uuid)
-    uuid
+      partitionId: Int = -1, batchId: Option[UUID] = None): Unit = {
+    storeCurrentBatch(tableName, batch, batchId.getOrElse(UUID.randomUUID()),
+      getPartitionID(tableName, partitionId))
   }
 
-  override def getUUIDRegionKey(tableName: String, bucketId: Int = -1,
-      batchId: Option[UUID] = None): UUIDRegionKey = {
-    genUUIDRegionKey(rand.nextInt(numPartitions))
+  protected def getPartitionID(tableName: String,
+      partitionId: Int = -1): Int = {
+    rand.nextInt(numPartitions)
   }
 
   def storeCurrentBatch(tableName: String, batch: CachedBatch,
-      uuid: UUIDRegionKey): Unit = {
+      batchId: UUID, partitionId: Int): Unit = {
     tryExecute(tableName, {
       connection =>
         val rowInsertStr = getRowInsertStr(tableName, batch.buffers.length)
         val stmt = connection.prepareStatement(rowInsertStr)
-        stmt.setString(1, uuid.getUUID.toString)
-        stmt.setInt(2, uuid.getBucketId)
+        stmt.setString(1, batchId.toString)
+        stmt.setInt(2, partitionId)
         stmt.setInt(3, batch.numRows)
-        stmt.setBytes(4, SparkSqlSerializer.serialize(batch.stats))
+        // TODO: set to null since stats are currently not being used
+        // Need to use them for partition/CachedBatch pruning but also
+        // add more efficient custom serialization below (shows perf impact)
+        // stmt.setBytes(4, SparkSqlSerializer.serialize(batch.stats))
+        stmt.setNull(4, java.sql.Types.BLOB)
         var columnIndex = 5
         batch.buffers.foreach(buffer => {
           stmt.setBytes(columnIndex, buffer)
@@ -90,11 +92,6 @@ class JDBCSourceAsStore(override val connProperties: ConnectionProperties,
     ConnectionPool.getPoolConnection(id, connProperties.dialect,
       connProperties.poolProps, connProps, connProperties.hikariCP)
   }
-
-  protected def genUUIDRegionKey(bucketId: Int = -1) = new UUIDRegionKey(bucketId)
-
-  protected def genUUIDRegionKey(bucketID: Int, batchID: UUID) =
-    new UUIDRegionKey(bucketID, batchID)
 
   protected val insertStrings: mutable.HashMap[String, String] =
     new mutable.HashMap[String, String]()
@@ -133,11 +130,10 @@ abstract class ResultSetIterator[A](conn: Connection,
   protected final var hasNextValue = true
 
   context.addTaskCompletionListener { context => close() }
-  moveNext()
 
   override final def hasNext: Boolean = hasNextValue
 
-  protected final def moveNext(): Unit = {
+  protected[execution] final def moveNext(): Unit = {
     var success = false
     try {
       // TODO: see if optimization using rs.lightWeightNext
@@ -150,14 +146,6 @@ abstract class ResultSetIterator[A](conn: Connection,
         close()
       }
     }
-  }
-
-  protected def getNextValue(rs: ResultSet): A
-
-  final def next(): A = {
-    val result = getNextValue(rs)
-    moveNext()
-    result
   }
 
   final def close() {
@@ -192,14 +180,20 @@ final class CachedBatchIteratorOnRS(conn: Connection,
   private val numCols = requiredColumns.length
   private val colBuffers = new Array[Array[Byte]](numCols)
 
-  protected override def getNextValue(rs: ResultSet): CachedBatch = {
+  // move once to next at the start (or close if no result available)
+  moveNext()
+
+  override def next(): CachedBatch = {
     var i = 0
     while (i < numCols) {
       colBuffers(i) = rs.getBytes(i + 1)
       i += 1
     }
-    val stats = SparkSqlSerializer.deserialize[InternalRow](rs.getBytes("stats"))
-    CachedBatch(rs.getInt("numRows"), colBuffers, stats)
+    // val stats = SparkSqlSerializer.deserialize[InternalRow](rs.getBytes("stats"))
+    val stats: InternalRow = null
+    val numRows = rs.getInt("numRows")
+    moveNext()
+    CachedBatch(numRows, colBuffers, stats)
   }
 }
 

--- a/core/src/main/scala/org/apache/spark/sql/execution/columnar/impl/ColumnFormatRelation.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/columnar/impl/ColumnFormatRelation.scala
@@ -18,8 +18,6 @@ package org.apache.spark.sql.execution.columnar.impl
 
 import java.sql.Connection
 
-import scala.collection.mutable.ArrayBuffer
-
 import com.gemstone.gemfire.distributed.internal.membership.InternalDistributedMember
 import com.gemstone.gemfire.internal.cache.PartitionedRegion
 import com.pivotal.gemfirexd.internal.engine.Misc
@@ -27,7 +25,7 @@ import com.pivotal.gemfirexd.internal.engine.Misc
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.SortDirection
-import org.apache.spark.sql.collection.{UUIDRegionKey, Utils}
+import org.apache.spark.sql.collection.Utils
 import org.apache.spark.sql.execution.columnar.ExternalStoreUtils.CaseInsensitiveMutableHashMap
 import org.apache.spark.sql.execution.columnar._
 import org.apache.spark.sql.execution.datasources.LogicalRelation
@@ -89,16 +87,13 @@ class BaseColumnFormatRelation(
 
   lazy val connectionType = ExternalStoreUtils.getConnectionType(dialect)
 
-  private val resolvedName: String = externalStore.tryExecute(table, conn => {
-    StoreUtils.lookupName(table, conn.getSchema)
-  })
-
   val rowInsertStr = ExternalStoreUtils.getInsertStringWithColumnName(
     resolvedName, userSchema)
 
+  @transient protected lazy val region = Misc.getRegionForTable(resolvedName,
+    true).asInstanceOf[PartitionedRegion]
+
   override lazy val numPartitions: Int = {
-    val region = Misc.getRegionForTable(resolvedName, true).
-        asInstanceOf[PartitionedRegion]
     region.getTotalNumberOfBuckets
   }
 
@@ -116,7 +111,6 @@ class BaseColumnFormatRelation(
   // will see that later.
   override def buildScan(requiredColumns: Array[String],
       filters: Array[Filter]): RDD[Row] = {
-    logInfo(s"SW: scan with projection = ${requiredColumns.toSeq} on $table filters = ${filters.toSeq}")
     val colRdd = scanTable(table, requiredColumns, filters)
     // TODO: Suranjan scanning over column rdd before row will make sure
     // that we don't have duplicates; we may miss some results though
@@ -126,13 +120,15 @@ class BaseColumnFormatRelation(
     // finally skipping any IDs greater than the noted ones.
     // However, with plans for mutability in column store (via row buffer) need
     // to re-think in any case and provide proper snapshot isolation in store.
+    val isPartitioned = region.getPartitionAttributes != null
     val zipped = connectionType match {
       case ConnectionType.Embedded =>
         val rowRdd = new RowFormatScanRDD(
           sqlContext.sparkContext,
           executorConnector,
           ExternalStoreUtils.pruneSchema(schemaFields, requiredColumns),
-          table,
+          resolvedName,
+          isPartitioned,
           requiredColumns,
           connProperties,
           filters,
@@ -143,16 +139,15 @@ class BaseColumnFormatRelation(
         rowRdd.zipPartitions(colRdd) { (leftItr, rightItr) =>
           leftItr ++ rightItr
         }
-
       case _ =>
         val rowRdd = new SparkShellRowRDD(
           sqlContext.sparkContext,
           executorConnector,
           ExternalStoreUtils.pruneSchema(schemaFields, requiredColumns),
-          table,
+          resolvedName,
+          isPartitioned,
           requiredColumns,
           connProperties,
-          externalStore,
           filters
         ).asInstanceOf[RDD[Row]]
 
@@ -163,22 +158,18 @@ class BaseColumnFormatRelation(
     zipped
   }
 
-  override def uuidBatchAggregate(accumulated: ArrayBuffer[UUIDRegionKey],
-      batch: CachedBatch): ArrayBuffer[UUIDRegionKey] = {
-    // TODO - currently using the length from the part Object but it needs
-    // to be handled more generically in order to replace UUID
-    // if number of rows are greater than columnBatchSize then store otherwise store locally
+  override def cachedBatchAggregate(batch: CachedBatch): Unit = {
+    // if number of rows are greater than columnBatchSize then store
+    // otherwise store locally
     if (batch.numRows >= columnBatchSize) {
-      val uuid = externalStore.storeCachedBatch(ColumnFormatRelation.
+      externalStore.storeCachedBatch(ColumnFormatRelation.
           cachedBatchTableName(table), batch)
-      accumulated += uuid
     } else {
       // TODO: can we do it before compressing. Might save a bit
       val unCachedRows = ExternalStoreUtils.cachedBatchesToRows(
-        Iterator(batch), schema.map(_.name).toArray, schema)
+        Iterator(batch), schema.map(_.name).toArray, schema, forScan = true)
       insert(unCachedRows)
     }
-    accumulated
   }
 
   override def insert(data: DataFrame, overwrite: Boolean): Unit = {
@@ -324,14 +315,15 @@ class BaseColumnFormatRelation(
     val (primarykey, partitionStrategy) = dialect match {
       // The driver if not a loner should be an accessor only
       case d: JdbcExtendedDialect =>
-        (s"constraint ${tableName}_bucketCheck check (bucketId != -1), " +
-            "primary key (uuid, bucketId) ", d.getPartitionByClause("bucketId"))
-      case _ => ("primary key (uuid)", "") // TODO. How to get primary key contraint from each DB
+        (s"constraint ${tableName}_partitionCheck check (partitionId != -1), " +
+            "primary key (uuid, partitionId) ",
+            d.getPartitionByClause("partitionId"))
+      case _ => ("primary key (uuid)", "")
     }
     val colocationClause = s"COLOCATE WITH ($table)"
 
     createTable(externalStore, s"create table $tableName (uuid varchar(36) " +
-        "not null, bucketId integer, numRows integer not null, stats blob, " +
+        "not null, partitionId integer, numRows integer not null, stats blob, " +
         userSchema.fields.map(structField => externalStore.columnPrefix +
         structField.name + " blob").mkString(" ", ",", " ") +
         s", $primarykey) $partitionStrategy $colocationClause $ddlExtensionForShadowTable",

--- a/core/src/main/scala/org/apache/spark/sql/execution/columnar/impl/JDBCSourceAsColumnarStore.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/columnar/impl/JDBCSourceAsColumnarStore.scala
@@ -17,7 +17,6 @@
 package org.apache.spark.sql.execution.columnar.impl
 
 import java.sql.{Connection, ResultSet, Statement}
-import java.util.UUID
 
 import scala.reflect.ClassTag
 
@@ -28,13 +27,10 @@ import io.snappydata.impl.SparkShellRDDHelper
 
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.collection._
-import org.apache.spark.sql.execution.columnar.{CachedBatchIteratorOnRS, ExternalStore, JDBCSourceAsStore}
+import org.apache.spark.sql.execution.columnar._
 import org.apache.spark.sql.execution.row.RowFormatScanRDD
-import org.apache.spark.sql.sources.{ConnectionProperties}
-
-import org.apache.spark.sql.execution.columnar.{CachedBatch, ConnectionType, ExternalStoreUtils}
-import org.apache.spark.sql.sources.Filter
-import org.apache.spark.sql.store.{StoreUtils}
+import org.apache.spark.sql.sources.{ConnectionProperties, Filter}
+import org.apache.spark.sql.store.StoreUtils
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.storage.BlockManagerId
 import org.apache.spark.{Logging, Partition, SparkContext, TaskContext}
@@ -67,33 +63,33 @@ final class JDBCSourceAsColumnarStore(_connProperties: ConnectionProperties,
     }
   }
 
-  override def getUUIDRegionKey(tableName: String, bucketId: Int = -1,
-      batchId: Option[UUID] = None): UUIDRegionKey = {
+  override protected def getPartitionID(tableName: String,
+      partitionId: Int = -1): Int = {
     val connection = getConnection(tableName, onExecutor = true)
     try {
-      val uuid = connectionType match {
+      connectionType match {
         case ConnectionType.Embedded =>
-          val resolvedName = StoreUtils.lookupName(tableName,
+          val resolvedName = ExternalStoreUtils.lookupName(tableName,
             connection.getSchema)
           val region = Misc.getRegionForTable(resolvedName, true)
           region.asInstanceOf[AbstractRegion] match {
             case pr: PartitionedRegion =>
-              if (bucketId == -1) {
+              if (partitionId == -1) {
                 val primaryBucketIds = pr.getDataStore.
                     getAllLocalPrimaryBucketIdArray
-                genUUIDRegionKey(primaryBucketIds.getQuick(
-                  rand.nextInt(primaryBucketIds.size())),
-                  batchId.getOrElse(UUID.randomUUID))
+                // TODO: do load-balancing among partitions instead
+                // of random selection
+                primaryBucketIds.getQuick(
+                  rand.nextInt(primaryBucketIds.size()))
+              } else {
+                partitionId
               }
-              else {
-                genUUIDRegionKey(bucketId, batchId.getOrElse(UUID.randomUUID))
-              }
-            case _ =>
-              genUUIDRegionKey()
+            case _ => partitionId
           }
-        case _ => genUUIDRegionKey(rand.nextInt(_numPartitions))
+        // TODO: SW: for split mode, get connection to one of the
+        // local servers and a bucket ID for only one of those
+        case _ => rand.nextInt(_numPartitions)
       }
-      uuid
     } finally {
       connection.close()
     }
@@ -109,7 +105,8 @@ class ColumnarStorePartitionedRDD[T: ClassTag](@transient _sc: SparkContext,
       context: TaskContext): Iterator[CachedBatch] = {
     store.tryExecute(tableName,
       conn => {
-        val resolvedName = StoreUtils.lookupName(tableName, conn.getSchema)
+        val resolvedName = ExternalStoreUtils.lookupName(tableName,
+          conn.getSchema)
         val par = split.index
         val ps1 = conn.prepareStatement(
           "call sys.SET_BUCKETS_FOR_LOCAL_EXECUTION(?, ?)")
@@ -132,8 +129,11 @@ class ColumnarStorePartitionedRDD[T: ClassTag](@transient _sc: SparkContext,
 
   override protected def getPartitions: Array[Partition] = {
     store.tryExecute(tableName, conn => {
-      StoreUtils.getPartitionsPartitionedTable(_sc, tableName,
-        conn.getSchema, store.blockMap)
+      val resolvedName = ExternalStoreUtils.lookupName(tableName,
+        conn.getSchema)
+      val region = Misc.getRegionForTable(resolvedName, true)
+      StoreUtils.getPartitionsPartitionedTable(_sc,
+        region.asInstanceOf[PartitionedRegion], store.blockMap)
     })
   }
 }
@@ -148,8 +148,8 @@ class SparkShellCachedBatchRDD[T: ClassTag](@transient _sc: SparkContext,
       context: TaskContext): Iterator[CachedBatch] = {
     val helper = new SparkShellRDDHelper
     val conn: Connection = helper.getConnection(connProperties, split)
-    val query: String = helper.getSQLStatement(StoreUtils.lookupName(tableName, conn.getSchema),
-      requiredColumns, split.index)
+    val query: String = helper.getSQLStatement(ExternalStoreUtils.lookupName(
+      tableName, conn.getSchema), requiredColumns, split.index)
     val (statement, rs) = helper.executeQuery(conn, tableName, split, query)
     new CachedBatchIteratorOnRS(conn, requiredColumns, statement, rs, context)
   }
@@ -160,7 +160,7 @@ class SparkShellCachedBatchRDD[T: ClassTag](@transient _sc: SparkContext,
   }
 
   override def getPartitions: Array[Partition] = {
-    SparkShellRDDHelper.getPartitions(tableName, store)
+    store.tryExecute(tableName, SparkShellRDDHelper.getPartitions(tableName, _))
   }
 }
 
@@ -168,32 +168,35 @@ class SparkShellRowRDD[T: ClassTag](@transient sc: SparkContext,
     getConnection: () => Connection,
     schema: StructType,
     tableName: String,
+    isPartitioned: Boolean,
     columns: Array[String],
     connProperties: ConnectionProperties,
-    store: ExternalStore,
     filters: Array[Filter] = Array.empty[Filter],
     partitions: Array[Partition] = Array.empty[Partition],
     blockMap: Map[InternalDistributedMember, BlockManagerId] =
     Map.empty[InternalDistributedMember, BlockManagerId])
-    extends RowFormatScanRDD(sc, getConnection, schema, tableName, columns,
-      connProperties, filters, partitions, blockMap) {
+    extends RowFormatScanRDD(sc, getConnection, schema, tableName,
+      isPartitioned, columns, connProperties, filters, partitions, blockMap) {
 
   override def computeResultSet(
       thePart: Partition): (Connection, Statement, ResultSet) = {
     val helper = new SparkShellRDDHelper
     val conn: Connection = helper.getConnection(
       connProperties, thePart)
-    val resolvedName = StoreUtils.lookupName(tableName, conn.getSchema)
-    // TODO: this will fail if no network server is available unless SNAP-365 is
-    // fixed with the approach of having an iterator that can fetch from remote
-    val ps = conn.prepareStatement(
-      "call sys.SET_BUCKETS_FOR_LOCAL_EXECUTION(?, ?)")
-    ps.setString(1, resolvedName)
-    ps.setInt(2, thePart.index)
-    ps.executeUpdate()
-    ps.close()
 
-    val sqlText = s"SELECT $columnList FROM $resolvedName$filterWhereClause"
+    if (isPartitioned) {
+      val ps = conn.prepareStatement(
+        "call sys.SET_BUCKETS_FOR_LOCAL_EXECUTION(?, ?)")
+      try {
+        ps.setString(1, tableName)
+        ps.setInt(2, thePart.index)
+        ps.executeUpdate()
+      } finally {
+        ps.close()
+      }
+    }
+
+    val sqlText = s"SELECT $columnList FROM $tableName$filterWhereClause"
     val args = filterWhereArgs
     val stmt = conn.prepareStatement(sqlText)
     if (args ne null) {
@@ -214,7 +217,12 @@ class SparkShellRowRDD[T: ClassTag](@transient sc: SparkContext,
   }
 
   override def getPartitions: Array[Partition] = {
-    SparkShellRDDHelper.getPartitions(tableName, store)
+    val conn = getConnection()
+    try {
+      SparkShellRDDHelper.getPartitions(tableName, conn)
+    } finally {
+      conn.close()
+    }
   }
 
   def getSQLStatement(resolvedTableName: String,

--- a/core/src/main/scala/org/apache/spark/sql/execution/columnar/impl/StoreCallbacksImpl.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/columnar/impl/StoreCallbacksImpl.scala
@@ -67,7 +67,7 @@ object StoreCallbacksImpl extends StoreCallbacks with Logging with Serializable 
   }
 
   override def createCachedBatch(region: BucketRegion, batchID: UUID,
-      bucketID: Int): java.util.Set[Any] = {
+      bucketID: Int): java.util.Set[AnyRef] = {
     val container: GemFireContainer = region.getPartitionedRegion
         .getUserAttribute.asInstanceOf[GemFireContainer]
     val store = stores.get(container.getQualifiedTableName)
@@ -120,7 +120,7 @@ object StoreCallbacksImpl extends StoreCallbacks with Logging with Serializable 
         }
       }
     } else {
-      new java.util.HashSet()
+      java.util.Collections.emptySet[AnyRef]()
     }
   }
 

--- a/core/src/main/scala/org/apache/spark/sql/execution/columnar/impl/StoreCallbacksImpl.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/columnar/impl/StoreCallbacksImpl.scala
@@ -18,7 +18,6 @@ package org.apache.spark.sql.execution.columnar.impl
 
 import java.util.{Collections, UUID}
 
-import scala.collection.JavaConversions
 import scala.collection.concurrent.TrieMap
 
 import com.gemstone.gemfire.internal.cache.BucketRegion
@@ -44,7 +43,6 @@ object StoreCallbacksImpl extends StoreCallbacks with Logging with Serializable 
   val stores = new TrieMap[String, (StructType, ExternalStore)]
 
   val partioner = new StoreHashFunction
-
 
   var useCompression = false
   var cachedBatchSize = 0
@@ -104,15 +102,12 @@ object StoreCallbacksImpl extends StoreCallbacks with Logging with Serializable 
             ColumnFormatRelation.cachedBatchTableName(container.getQualifiedTableName),
             container.getQualifiedTableName, schema,
             externalStore, cachedBatchSize, useCompression)
-          val keys = batchCreator.createAndStoreBatch(sc, row,
+          batchCreator.createAndStoreBatch(sc, row,
             batchID, bucketID)
-          JavaConversions.mutableSetAsJavaSet(keys)
-        }
-        finally {
+        } finally {
           lcc.setExecuteLocally(null, null, false, null)
         }
-      }
-      catch {
+      } catch {
         case e: Throwable => throw e
       } finally {
         if (contextSet) {

--- a/core/src/main/scala/org/apache/spark/sql/execution/datasources/StoreDataSourceStrategy.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/datasources/StoreDataSourceStrategy.scala
@@ -94,16 +94,26 @@ private[sql] object StoreDataSourceStrategy extends Strategy with Logging {
 
     val projectSet = AttributeSet(projects.flatMap(_.references))
     val filterSet = AttributeSet(filterPredicates.flatMap(_.references))
-    val filterCondition = filterPredicates.reduceLeftOption(expressions.And)
-
 
     val candidatePredicates = filterPredicates.map { _ transform {
       case a: AttributeReference => relation.attributeMap(a) // Match original case of attributes.
     }}
 
-
     val (unhandledPredicates, pushedFilters) =
       selectFilters(relation.relation, candidatePredicates)
+
+    // A set of column attributes that are only referenced by pushed down filters.  We can eliminate
+    // them from requested columns.
+    val handledSet = {
+      val handledPredicates = filterPredicates.filterNot(unhandledPredicates.contains)
+      val unhandledSet = AttributeSet(unhandledPredicates.flatMap(_.references))
+      AttributeSet(handledPredicates.flatMap(_.references)) --
+          (projectSet ++ unhandledSet).map(relation.attributeMap)
+    }
+
+    // Combines all Catalyst filter `Expression`s that are either not convertible to data source
+    // `Filter`s or cannot be handled by `relation`.
+    val filterCondition = unhandledPredicates.reduceLeftOption(expressions.And)
 
     // Get the partition column attribute INFO from relation schema
     val sqlContext = relation.relation.sqlContext
@@ -123,16 +133,20 @@ private[sql] object StoreDataSourceStrategy extends Strategy with Logging {
       val requestedColumns =
         projects.asInstanceOf[Seq[Attribute]] // Safe due to if above.
           .map(relation.attributeMap) // Match original case of attributes.
+          // Don't request columns that are only referenced by pushed filters.
+          .filterNot(handledSet.contains)
 
       val scan = execution.PartitionedPhysicalRDD.createFromDataSource(
         projects.map(_.toAttribute),
         numPartition,
         joinedCols,
-        scanBuilder(requestedColumns,candidatePredicates, pushedFilters),
+        scanBuilder(requestedColumns, candidatePredicates, pushedFilters),
         relation.relation)
       filterCondition.map(execution.Filter(_, scan)).getOrElse(scan)
     } else {
-      val requestedColumns = (projectSet ++ filterSet).map(relation.attributeMap).toSeq
+      // Don't request columns that are only referenced by pushed filters.
+      val requestedColumns =
+        (projectSet ++ filterSet -- handledSet).map(relation.attributeMap).toSeq
 
       val scan = execution.PartitionedPhysicalRDD.createFromDataSource(
         requestedColumns,
@@ -140,8 +154,8 @@ private[sql] object StoreDataSourceStrategy extends Strategy with Logging {
         joinedCols,
         scanBuilder(requestedColumns, candidatePredicates, pushedFilters),
         relation.relation)
-      execution.Project(projects, filterCondition.map(execution.Filter(_, scan)).getOrElse(scan))
+      execution.Project(
+        projects, filterCondition.map(execution.Filter(_, scan)).getOrElse(scan))
     }
   }
-
 }

--- a/core/src/main/scala/org/apache/spark/sql/execution/row/RowFormatRelation.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/row/RowFormatRelation.scala
@@ -16,17 +16,20 @@
  */
 package org.apache.spark.sql.execution.row
 
-import com.gemstone.gemfire.cache.Region
+import scala.collection.mutable
+
 import com.gemstone.gemfire.distributed.internal.membership.InternalDistributedMember
-import com.gemstone.gemfire.internal.cache.PartitionedRegion
+import com.gemstone.gemfire.internal.cache.{LocalRegion, PartitionedRegion}
 import com.pivotal.gemfirexd.internal.engine.Misc
+import com.pivotal.gemfirexd.internal.engine.access.index.GfxdIndexManager
 import com.pivotal.gemfirexd.internal.engine.ddl.resolver.GfxdPartitionByExpressionResolver
 
 import org.apache.spark.Partition
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql._
-import org.apache.spark.sql.catalyst.expressions.{Descending, Ascending, SortDirection}
+import org.apache.spark.sql.catalyst.expressions.{Ascending, Descending, SortDirection}
 import org.apache.spark.sql.execution.columnar.ExternalStoreUtils.CaseInsensitiveMutableHashMap
+import org.apache.spark.sql.execution.columnar.impl.SparkShellRowRDD
 import org.apache.spark.sql.execution.columnar.{ConnectionType, ExternalStoreUtils}
 import org.apache.spark.sql.execution.datasources.jdbc.JDBCPartition
 import org.apache.spark.sql.execution.{ConnectionPool, PartitionedDataSourceScan}
@@ -64,28 +67,65 @@ class RowFormatRelation(
 
   override def toString: String = s"RowFormatRelation[$table]"
 
-  lazy val connectionType = ExternalStoreUtils.getConnectionType(dialect)
+  protected val connectionType = ExternalStoreUtils.getConnectionType(dialect)
 
   final lazy val putStr = ExternalStoreUtils.getPutString(table, schema)
 
+  private[this] lazy val resolvedName = ExternalStoreUtils.lookupName(table,
+    tableSchema)
+
+  @transient private[this] lazy val region: LocalRegion =
+    Misc.getRegionForTable(resolvedName, true).asInstanceOf[LocalRegion]
+
+  private[this] lazy val indexedColumns: mutable.HashSet[String] = {
+    val cols = new mutable.HashSet[String]()
+    val im = region.getIndexUpdater.asInstanceOf[GfxdIndexManager]
+    if (im != null && im.getIndexConglomerateDescriptors != null) {
+      val baseColumns = im.getContainer.getTableDescriptor.getColumnNamesArray
+      val itr = im.getIndexConglomerateDescriptors.iterator()
+      while (itr.hasNext) {
+        // first column of index has to be present in filter to be usable
+        val indexCols = itr.next().getIndexDescriptor.baseColumnPositions()
+        cols += baseColumns(indexCols(0))
+      }
+    }
+    cols
+  }
+
+  override def unhandledFilters(filters: Array[Filter]): Array[Filter] =
+    filters.filter(ExternalStoreUtils.unhandledFilter(_, indexedColumns))
+
   override def buildScan(requiredColumns: Array[String],
       filters: Array[Filter]): RDD[Row] = {
+    val handledFilters = filters.filter(ExternalStoreUtils
+        .handledFilter(_, indexedColumns) eq ExternalStoreUtils.SOME_TRUE)
+    val isPartitioned = region.getPartitionAttributes != null
     connectionType match {
       case ConnectionType.Embedded =>
         new RowFormatScanRDD(
           sqlContext.sparkContext,
           executorConnector,
           ExternalStoreUtils.pruneSchema(schemaFields, requiredColumns),
-          table,
+          resolvedName,
+          isPartitioned,
           requiredColumns,
           connProperties,
-          filters,
+          handledFilters,
           parts,
           blockMap
         ).asInstanceOf[RDD[Row]]
 
       case _ =>
-        super.buildScan(requiredColumns, filters)
+        new SparkShellRowRDD(
+          sqlContext.sparkContext,
+          executorConnector,
+          ExternalStoreUtils.pruneSchema(schemaFields, requiredColumns),
+          resolvedName,
+          isPartitioned,
+          requiredColumns,
+          connProperties,
+          handledFilters
+        ).asInstanceOf[RDD[Row]]
     }
   }
 
@@ -99,8 +139,6 @@ class RowFormatRelation(
    *
    */
   override lazy val numPartitions: Int = {
-    val resolvedName = StoreUtils.lookupName(table, tableSchema)
-    val region: Region[_, _] = Misc.getRegionForTable(resolvedName, true)
     region match {
       case pr: PartitionedRegion => pr.getTotalNumberOfBuckets
       case _ => 1
@@ -108,9 +146,7 @@ class RowFormatRelation(
   }
 
   override def partitionColumns: Seq[String] = {
-    val resolvedName = StoreUtils.lookupName(table, tableSchema)
-    val region: Region[_, _] = Misc.getRegionForTable(resolvedName, true)
-    val partitionColumn = region match {
+    region match {
       case pr: PartitionedRegion =>
         val resolver = pr.getPartitionResolver
             .asInstanceOf[GfxdPartitionByExpressionResolver]
@@ -118,7 +154,6 @@ class RowFormatRelation(
         parColumn.toSeq
       case _ => Seq.empty[String]
     }
-    partitionColumn
   }
 
   /**
@@ -186,7 +221,7 @@ class RowFormatRelation(
       case Some(x) => x
       case None => ""
     }
-    return s"CREATE $indexType INDEX $indexName ON $baseTable ($columns)"
+    s"CREATE $indexType INDEX $indexName ON $baseTable ($columns)"
   }
 }
 

--- a/core/src/main/scala/org/apache/spark/sql/execution/row/RowFormatScanRDD.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/row/RowFormatScanRDD.scala
@@ -17,20 +17,23 @@
 package org.apache.spark.sql.execution.row
 
 import java.sql.{Connection, ResultSet, Statement}
+import java.util.GregorianCalendar
 
 import scala.collection.mutable.ArrayBuffer
 
 import com.gemstone.gemfire.distributed.internal.membership.InternalDistributedMember
-import com.gemstone.gemfire.internal.cache.PartitionedRegion
+import com.gemstone.gemfire.internal.cache.{CacheDistributionAdvisee, PartitionedRegion}
 import com.pivotal.gemfirexd.internal.engine.Misc
+import com.pivotal.gemfirexd.internal.engine.store.AbstractCompactExecRow
+import com.pivotal.gemfirexd.internal.impl.jdbc.EmbedResultSet
 
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.{SpecificMutableRow, UnsafeArrayData, UnsafeMapData, UnsafeRow}
 import org.apache.spark.sql.catalyst.util.DateTimeUtils
 import org.apache.spark.sql.collection.MultiExecutorLocalPartition
-import org.apache.spark.sql.execution.ConnectionPool
 import org.apache.spark.sql.execution.columnar.{ExternalStoreUtils, ResultSetIterator}
 import org.apache.spark.sql.execution.datasources.jdbc.JDBCRDD
+import org.apache.spark.sql.execution.{CompactExecRowToMutableRow, ConnectionPool}
 import org.apache.spark.sql.sources._
 import org.apache.spark.sql.store.StoreUtils
 import org.apache.spark.sql.types._
@@ -49,6 +52,7 @@ class RowFormatScanRDD(@transient sc: SparkContext,
     getConnection: () => Connection,
     schema: StructType,
     tableName: String,
+    isPartitioned: Boolean,
     columns: Array[String],
     connProperties: ConnectionProperties,
     filters: Array[Filter] = Array.empty[Filter],
@@ -68,10 +72,10 @@ class RowFormatScanRDD(@transient sc: SparkContext,
     if (numFilters > 0) {
       val sb = new StringBuilder().append(" WHERE ")
       val args = new ArrayBuffer[Any](numFilters)
+      val initLen = sb.length
       filters.foreach { s =>
-        compileFilter(s, sb, args, sb.length > 7)
+        compileFilter(s, sb, args, sb.length > initLen)
       }
-      // if no filter added return empty
       if (args.nonEmpty) {
         filterWhereArgs = args
         sb.toString()
@@ -79,41 +83,72 @@ class RowFormatScanRDD(@transient sc: SparkContext,
     } else ""
   }
 
-  // TODO: needs to be updated to use unhandledFilters of Spark 1.6.0
-
+  // below should exactly match ExternalStoreUtils.handledFilter
   private def compileFilter(f: Filter, sb: StringBuilder,
       args: ArrayBuffer[Any], addAnd: Boolean): Unit = f match {
-    case EqualTo(attr, value) =>
+    case EqualTo(col, value) =>
       if (addAnd) {
         sb.append(" AND ")
       }
-      sb.append(attr).append(" = ?")
+      sb.append(col).append(" = ?")
       args += value
-    case LessThan(attr, value) =>
+    case LessThan(col, value) =>
       if (addAnd) {
         sb.append(" AND ")
       }
-      sb.append(attr).append(" < ?")
+      sb.append(col).append(" < ?")
       args += value
-    case GreaterThan(attr, value) =>
+    case GreaterThan(col, value) =>
       if (addAnd) {
         sb.append(" AND ")
       }
-      sb.append(attr).append(" > ?")
+      sb.append(col).append(" > ?")
       args += value
-    case LessThanOrEqual(attr, value) =>
+    case LessThanOrEqual(col, value) =>
       if (addAnd) {
         sb.append(" AND ")
       }
-      sb.append(attr).append(" <= ?")
+      sb.append(col).append(" <= ?")
       args += value
-    case GreaterThanOrEqual(attr, value) =>
+    case GreaterThanOrEqual(col, value) =>
       if (addAnd) {
         sb.append(" AND ")
       }
-      sb.append(attr).append(" >= ?")
+      sb.append(col).append(" >= ?")
       args += value
-    case _ => // no filter
+    case StringStartsWith(col, value) =>
+      if (addAnd) {
+        sb.append(" AND ")
+      }
+      sb.append(col).append(" LIKE ?")
+      args += (value + '%')
+    case In(col, values) =>
+      if (addAnd) {
+        sb.append(" AND ")
+      }
+      sb.append(col).append(" IN (")
+      (1 until values.length).foreach(sb.append("?,"))
+      sb.append("?)")
+      args ++= values
+    case And(left, right) =>
+      if (addAnd) {
+        sb.append(" AND ")
+      }
+      sb.append('(')
+      compileFilter(left, sb, args, addAnd = false)
+      sb.append(") AND (")
+      compileFilter(right, sb, args, addAnd = false)
+      sb.append(')')
+    case Or(left, right) =>
+      if (addAnd) {
+        sb.append(" AND ")
+      }
+      sb.append('(')
+      compileFilter(left, sb, args, addAnd = false)
+      sb.append(") OR (")
+      compileFilter(right, sb, args, addAnd = false)
+      sb.append(')')
+    case _ => // no filter pushdown
   }
 
   /**
@@ -134,19 +169,19 @@ class RowFormatScanRDD(@transient sc: SparkContext,
       thePart: Partition): (Connection, Statement, ResultSet) = {
     val conn = getConnection()
 
-    val resolvedName = StoreUtils.lookupName(tableName, conn.getSchema)
-    val region = Misc.getRegionForTable(resolvedName, true)
-
-    if (region.isInstanceOf[PartitionedRegion]) {
+    if (isPartitioned) {
       val ps = conn.prepareStatement(
         "call sys.SET_BUCKETS_FOR_LOCAL_EXECUTION(?, ?)")
-      ps.setString(1, resolvedName)
-      ps.setInt(2, thePart.index)
-      ps.executeUpdate()
-      ps.close()
+      try {
+        ps.setString(1, tableName)
+        ps.setInt(2, thePart.index)
+        ps.executeUpdate()
+      } finally {
+        ps.close()
+      }
     }
 
-    val sqlText = s"SELECT $columnList FROM $resolvedName$filterWhereClause"
+    val sqlText = s"SELECT $columnList FROM $tableName$filterWhereClause"
     val args = filterWhereArgs
     val stmt = conn.prepareStatement(sqlText)
     if (args ne null) {
@@ -175,7 +210,20 @@ class RowFormatScanRDD(@transient sc: SparkContext,
   override def compute(thePart: Partition,
       context: TaskContext): Iterator[InternalRow] = {
     val (conn, stmt, rs) = computeResultSet(thePart)
-    new InternalRowIteratorOnRS(conn, stmt, rs, context, schema)
+    val itr = new InternalRowIteratorOnRS(conn, stmt, rs, context, schema)
+    // move once to next at the start (or close if no result available)
+    itr.moveNext()
+    // switch to optimized iterator for CompactExecRows
+    rs match {
+      case r: EmbedResultSet =>
+        if (itr.hasNext && r.currentRow.isInstanceOf[AbstractCompactExecRow]) {
+          // use the optimized iterator
+          new CompactExecRowIteratorOnRS(conn, stmt, r, context, schema)
+        } else {
+          itr
+        }
+      case _ => itr
+    }
   }
 
   override def getPreferredLocations(split: Partition): Seq[String] = {
@@ -188,12 +236,13 @@ class RowFormatScanRDD(@transient sc: SparkContext,
       connProperties.connProps, connProperties.hikariCP)
     try {
       val tableSchema = conn.getSchema
-      val resolvedName = StoreUtils.lookupName(tableName, tableSchema)
-      val region = Misc.getRegionForTable(resolvedName, true)
-      if (region.isInstanceOf[PartitionedRegion]) {
-        StoreUtils.getPartitionsPartitionedTable(sc, tableName, tableSchema, blockMap)
-      } else {
-        StoreUtils.getPartitionsReplicatedTable(sc, resolvedName, tableSchema, blockMap)
+      val resolvedName = ExternalStoreUtils.lookupName(tableName, tableSchema)
+      Misc.getRegionForTable(resolvedName, true)
+          .asInstanceOf[CacheDistributionAdvisee] match {
+        case pr: PartitionedRegion =>
+          StoreUtils.getPartitionsPartitionedTable(sc, pr, blockMap)
+        case dr =>
+          StoreUtils.getPartitionsReplicatedTable(sc, dr, blockMap)
       }
     } finally {
       conn.close()
@@ -205,122 +254,184 @@ final class InternalRowIteratorOnRS(conn: Connection,
     stmt: Statement, rs: ResultSet, context: TaskContext, schema: StructType)
     extends ResultSetIterator[InternalRow](conn, stmt, rs, context) {
 
-  private[this] val types = schema.fields.map(_.dataType)
-  private[this] val mutableRow = new SpecificMutableRow(types)
+  private[this] lazy val defaultCal = new GregorianCalendar()
 
-  override def getNextValue(rs: ResultSet): InternalRow = {
+  private[this] val dataTypes: ArrayBuffer[DataType] =
+    new ArrayBuffer[DataType](schema.length)
+
+  private[this] val fieldTypes = StoreUtils.mapCatalystTypes(schema, dataTypes)
+
+  private[this] val mutableRow = new SpecificMutableRow(dataTypes)
+
+  override def next(): InternalRow = {
     var i = 0
-    while (i < types.length) {
+    while (i < schema.length) {
       val pos = i + 1
-      types(i) match {
-        case StringType =>
-          // TODO: can use direct bytes from CompactExecRows
-          mutableRow.update(i, UTF8String.fromString(rs.getString(pos)))
-        case IntegerType =>
-          val iv = rs.getInt(pos)
-          if (iv != 0 || !rs.wasNull()) {
-            mutableRow.setInt(i, iv)
+      fieldTypes(i) match {
+        case StoreUtils.STRING_TYPE =>
+          val v = rs.getString(pos)
+          if (v != null) {
+            mutableRow.update(i, UTF8String.fromString(v))
           } else {
             mutableRow.setNullAt(i)
           }
-        case LongType =>
-          if (schema.fields(i).metadata.contains("binarylong")) {
-            val bytes = rs.getBytes(pos)
-            if (bytes ne null) {
-              var lv = 0L
-              var j = 0
-              while (j < bytes.size) {
-                lv = 256 * lv + (255 & bytes(j))
-                j = j + 1
-              }
-              mutableRow.setLong(i, lv)
-            } else {
-              mutableRow.setNullAt(i)
+        case StoreUtils.INT_TYPE =>
+          val v = rs.getInt(pos)
+          if (v != 0 || !rs.wasNull()) {
+            mutableRow.setInt(i, v)
+          } else {
+            mutableRow.setNullAt(i)
+          }
+        case StoreUtils.LONG_TYPE =>
+          val v = rs.getLong(pos)
+          if (v != 0L || !rs.wasNull()) {
+            mutableRow.setLong(i, v)
+          } else {
+            mutableRow.setNullAt(i)
+          }
+        case StoreUtils.BINARY_LONG_TYPE =>
+          val bytes = rs.getBytes(pos)
+          if (bytes != null) {
+            var v = 0L
+            var j = 0
+            val numBytes = bytes.size
+            while (j < numBytes) {
+              v = 256 * v + (255 & bytes(j))
+              j = j + 1
             }
+            mutableRow.setLong(i, v)
           } else {
-            val lv = rs.getLong(pos)
-            if (lv != 0L || !rs.wasNull()) {
-              mutableRow.setLong(i, lv)
-            } else {
-              mutableRow.setNullAt(i)
-            }
+            mutableRow.setNullAt(i)
           }
-        case DoubleType =>
-          val dv = rs.getDouble(pos)
+        case StoreUtils.SHORT_TYPE =>
+          val v = rs.getShort(pos)
+          if (v != 0 || !rs.wasNull()) {
+            mutableRow.setShort(i, v)
+          } else {
+            mutableRow.setNullAt(i)
+          }
+        case StoreUtils.BYTE_TYPE =>
+          val v = rs.getByte(pos)
+          if (v != 0 || !rs.wasNull()) {
+            mutableRow.setByte(i, v)
+          } else {
+            mutableRow.setNullAt(i)
+          }
+        case StoreUtils.BOOLEAN_TYPE =>
+          val v = rs.getBoolean(pos)
           if (!rs.wasNull()) {
-            mutableRow.setDouble(i, dv)
+            mutableRow.setBoolean(i, v)
           } else {
             mutableRow.setNullAt(i)
           }
-        case FloatType =>
-          val fv = rs.getFloat(pos)
+        case StoreUtils.DECIMAL_TYPE =>
+          // When connecting with Oracle DB through JDBC, the precision and
+          // scale of BigDecimal object returned by ResultSet.getBigDecimal
+          // is not correctly matched to the table schema reported by
+          // ResultSetMetaData.getPrecision and ResultSetMetaData.getScale.
+          // If inserting values like 19999 into a column with NUMBER(12, 2)
+          // type, you get through a BigDecimal object with scale as 0. But the
+          // dataframe schema has correct type as DecimalType(12, 2).
+          // Thus, after saving the dataframe into parquet file and then
+          // retrieve it, you will get wrong result 199.99. So it is needed
+          // to set precision and scale for Decimal based on JDBC metadata.
+          val v = rs.getBigDecimal(pos)
+          if (v != null) {
+            val d = schema.fields(i).dataType.asInstanceOf[DecimalType]
+            mutableRow.update(i, Decimal(v, d.precision, d.scale))
+          } else {
+            mutableRow.setNullAt(i)
+          }
+        case StoreUtils.DOUBLE_TYPE =>
+          val v = rs.getDouble(pos)
           if (!rs.wasNull()) {
-            mutableRow.setFloat(i, fv)
+            mutableRow.setDouble(i, v)
           } else {
             mutableRow.setNullAt(i)
           }
-        case BooleanType =>
-          val bv = rs.getBoolean(pos)
-          if (bv || !rs.wasNull()) {
-            mutableRow.setBoolean(i, bv)
+        case StoreUtils.FLOAT_TYPE =>
+          val v = rs.getFloat(pos)
+          if (!rs.wasNull()) {
+            mutableRow.setFloat(i, v)
           } else {
             mutableRow.setNullAt(i)
           }
-        // When connecting with Oracle DB through JDBC, the precision and
-        // scale of BigDecimal object returned by ResultSet.getBigDecimal
-        // is not correctly matched to the table schema reported by
-        // ResultSetMetaData.getPrecision and ResultSetMetaData.getScale.
-        // If inserting values like 19999 into a column with NUMBER(12, 2)
-        // type, you get through a BigDecimal object with scale as 0.
-        // But the dataframe schema has correct type as DecimalType(12, 2).
-        // Thus, after saving the dataframe into parquet file and then
-        // retrieve it, you will get wrong result 199.99.
-        // So it is needed to set precision and scale for Decimal
-        // based on JDBC metadata.
-        case DecimalType.Fixed(p, s) =>
-          val decimalVal = rs.getBigDecimal(pos)
-          if (decimalVal ne null) {
-            mutableRow.update(i, Decimal(decimalVal, p, s))
+        case StoreUtils.DATE_TYPE =>
+          val cal = this.defaultCal
+          cal.clear()
+          val v = rs.getDate(pos, cal)
+          if (v != null) {
+            mutableRow.setInt(i, DateTimeUtils.fromJavaDate(v))
           } else {
             mutableRow.setNullAt(i)
           }
-        case TimestampType =>
-          val t = rs.getTimestamp(pos)
-          if (t ne null) {
-            mutableRow.setLong(i, DateTimeUtils.fromJavaTimestamp(t))
+        case StoreUtils.TIMESTAMP_TYPE =>
+          val cal = this.defaultCal
+          cal.clear()
+          val v = rs.getTimestamp(pos, cal)
+          if (v != null) {
+            mutableRow.setLong(i, DateTimeUtils.fromJavaTimestamp(v))
           } else {
             mutableRow.setNullAt(i)
           }
-        case DateType =>
-          // DateTimeUtils.fromJavaDate does not handle null value, so we need to check it.
-          val dateVal = rs.getDate(pos)
-          if (dateVal ne null) {
-            mutableRow.setInt(i, DateTimeUtils.fromJavaDate(dateVal))
+        case StoreUtils.BINARY_TYPE =>
+          val v = rs.getBytes(pos)
+          if (v != null) {
+            mutableRow.update(i, v)
           } else {
             mutableRow.setNullAt(i)
           }
-        case BinaryType => mutableRow.update(i, rs.getBytes(pos))
-        case _: ArrayType =>
-          val bytes = rs.getBytes(pos)
-          val array = new UnsafeArrayData
-          array.pointTo(bytes, Platform.BYTE_ARRAY_OFFSET, bytes.length)
-          mutableRow.update(i, array)
-        case _: MapType =>
-          val bytes = rs.getBytes(pos)
-          val map = new UnsafeMapData
-          map.pointTo(bytes, Platform.BYTE_ARRAY_OFFSET, bytes.length)
-          mutableRow.update(i, map)
-        case s: StructType =>
-          val bytes = rs.getBytes(pos)
-          val row = new UnsafeRow
-          row.pointTo(bytes, Platform.BYTE_ARRAY_OFFSET,
-            s.fields.length, bytes.length)
-          mutableRow.update(i, row)
+        case StoreUtils.ARRAY_TYPE =>
+          val v = rs.getBytes(pos)
+          if (v != null) {
+            val array = new UnsafeArrayData
+            array.pointTo(v, Platform.BYTE_ARRAY_OFFSET, v.length)
+            mutableRow.update(i, array)
+          } else {
+            mutableRow.setNullAt(i)
+          }
+        case StoreUtils.MAP_TYPE =>
+          val v = rs.getBytes(pos)
+          if (v != null) {
+            val map = new UnsafeMapData
+            map.pointTo(v, Platform.BYTE_ARRAY_OFFSET, v.length)
+            mutableRow.update(i, map)
+          } else {
+            mutableRow.setNullAt(i)
+          }
+        case StoreUtils.STRUCT_TYPE =>
+          val v = rs.getBytes(pos)
+          if (v != null) {
+            val s = schema.fields(i).dataType.asInstanceOf[StructType]
+            val row = new UnsafeRow
+            row.pointTo(v, Platform.BYTE_ARRAY_OFFSET,
+              s.fields.length, v.length)
+            mutableRow.update(i, row)
+          } else {
+            mutableRow.setNullAt(i)
+          }
         case _ => throw new IllegalArgumentException(
           s"Unsupported field ${schema.fields(i)}")
       }
-      i += 1
+      i = i + 1
     }
+    moveNext()
     mutableRow
+  }
+}
+
+final class CompactExecRowIteratorOnRS(conn: Connection,
+    stmt: Statement, ers: EmbedResultSet, context: TaskContext,
+    override val schema: StructType)
+    extends ResultSetIterator[InternalRow](conn, stmt, ers, context)
+    with CompactExecRowToMutableRow {
+
+  private[this] val mutableRow = new SpecificMutableRow(dataTypes)
+
+  override def next(): InternalRow = {
+    val result = createInternalRow(
+      ers.currentRow.asInstanceOf[AbstractCompactExecRow], mutableRow)
+    moveNext()
+    result
   }
 }

--- a/core/src/main/scala/org/apache/spark/sql/row/JDBCMutableRelation.scala
+++ b/core/src/main/scala/org/apache/spark/sql/row/JDBCMutableRelation.scala
@@ -18,7 +18,7 @@ package org.apache.spark.sql.row
 
 import java.sql.Connection
 
-import io.snappydata.{StoreTableValueSizeProviderService}
+import io.snappydata.StoreTableValueSizeProviderService
 
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql._
@@ -71,6 +71,9 @@ class JDBCMutableRelation(
     connProperties.url, table, connProperties.connProps)
 
   final lazy val schemaFields = Utils.schemaFields(schema)
+
+  override def unhandledFilters(filters: Array[Filter]): Array[Filter] =
+    filters.filter(ExternalStoreUtils.unhandledFilter)
 
   protected final val connFactory = JdbcUtils.createConnectionFactory(
     connProperties.url, connProperties.connProps)
@@ -144,7 +147,7 @@ class JDBCMutableRelation(
       ExternalStoreUtils.pruneSchema(schemaFields, requiredColumns),
       table,
       requiredColumns,
-      filters,
+      filters.filterNot(ExternalStoreUtils.unhandledFilter),
       parts,
       connProperties.url,
       connProperties.executorConnProps).asInstanceOf[RDD[Row]]

--- a/core/src/main/scala/org/apache/spark/sql/store/StoreUtils.scala
+++ b/core/src/main/scala/org/apache/spark/sql/store/StoreUtils.scala
@@ -17,12 +17,12 @@
 package org.apache.spark.sql.store
 
 import scala.collection.JavaConverters._
+import scala.collection.generic.Growable
 import scala.collection.mutable
 
 import com.gemstone.gemfire.distributed.internal.membership.InternalDistributedMember
-import com.gemstone.gemfire.internal.cache.{DistributedRegion, PartitionedRegion}
+import com.gemstone.gemfire.internal.cache.{CacheDistributionAdvisee, PartitionedRegion}
 import com.pivotal.gemfirexd.internal.engine.Misc
-import io.snappydata.util.ServiceUtils
 
 import org.apache.spark.sql.collection.{MultiExecutorLocalPartition, Utils}
 import org.apache.spark.sql.execution.columnar.ExternalStoreUtils
@@ -69,6 +69,24 @@ object StoreUtils extends Logging {
   val LRUCOUNT = "LRUCOUNT"
   val GEM_INDEXED_TABLE = "INDEXED_TABLE"
 
+  // int values for Spark SQL types for efficient switching avoiding reflection
+  val STRING_TYPE = 0
+  val INT_TYPE = 1
+  val LONG_TYPE = 2
+  val BINARY_LONG_TYPE = 3
+  val SHORT_TYPE = 4
+  val BYTE_TYPE = 5
+  val BOOLEAN_TYPE = 6
+  val DECIMAL_TYPE = 7
+  val DOUBLE_TYPE = 8
+  val FLOAT_TYPE = 9
+  val DATE_TYPE = 10
+  val TIMESTAMP_TYPE = 11
+  val BINARY_TYPE = 12
+  val ARRAY_TYPE = 13
+  val MAP_TYPE = 14
+  val STRUCT_TYPE = 15
+
   val ddlOptions = Seq(PARTITION_BY, REPLICATE, BUCKETS, COLOCATE_WITH,
     REDUNDANCY, RECOVERYDELAY, MAXPARTSIZE, EVICTION_BY,
     PERSISTENT, SERVER_GROUPS, OFFHEAP, EXPIRE, OVERFLOW,
@@ -81,21 +99,10 @@ object StoreUtils extends Logging {
 
   val SHADOW_COLUMN = s"$SHADOW_COLUMN_NAME bigint generated always as identity"
 
-  def lookupName(tableName: String, schema: String): String = {
-    val lookupName = {
-      if (tableName.indexOf('.') <= 0) {
-        schema + '.' + tableName
-      } else tableName
-    }
-    lookupName
-  }
-
   def getPartitionsPartitionedTable(sc: SparkContext,
-      tableName: String, schema: String,
+      region: PartitionedRegion,
       blockMap: Map[InternalDistributedMember, BlockManagerId]): Array[Partition] = {
 
-    val resolvedName = lookupName(tableName, schema)
-    val region = Misc.getRegionForTable(resolvedName, true).asInstanceOf[PartitionedRegion]
     val numPartitions = region.getTotalNumberOfBuckets
     val partitions = new Array[Partition](numPartitions)
 
@@ -111,18 +118,16 @@ object StoreUtils extends Logging {
   }
 
   def getPartitionsReplicatedTable(sc: SparkContext,
-      tableName: String, schema: String,
+      region: CacheDistributionAdvisee,
       blockMap: Map[InternalDistributedMember, BlockManagerId]): Array[Partition] = {
 
-    val resolvedName = lookupName(tableName, schema)
-    val region = Misc.getRegionForTable(resolvedName, true).asInstanceOf[DistributedRegion]
     val numPartitions = 1
     val partitions = new Array[Partition](numPartitions)
 
     val regionMembers = if (Utils.isLoner(sc)) {
       Set(Misc.getGemFireCache.getDistributedSystem.getDistributedMember)
     } else {
-      region.getDistributionAdvisor.adviseInitializedReplicates().asScala
+      region.getCacheDistributionAdvisor.adviseInitializedReplicates().asScala
     }
     val prefNodes = regionMembers.map(v => blockMap(v)).toSeq
     partitions(0) = new MultiExecutorLocalPartition(0, prefNodes)
@@ -316,5 +321,40 @@ object StoreUtils extends Logging {
       }
       true
     })
+  }
+
+  def mapCatalystTypes(schema: StructType,
+      types: Growable[DataType]): Array[Int] = {
+    var i = 0
+    val result = new Array[Int](schema.length)
+    while (i < schema.length) {
+      val field = schema.fields(i)
+      val dataType = field.dataType
+      if (types != null) {
+        types += dataType
+      }
+      result(i) = dataType match {
+        case StringType => STRING_TYPE
+        case IntegerType => INT_TYPE
+        case LongType => if (field.metadata.contains("binarylong"))
+          BINARY_LONG_TYPE else LONG_TYPE
+        case ShortType => SHORT_TYPE
+        case ByteType => BYTE_TYPE
+        case BooleanType => BOOLEAN_TYPE
+        case _: DecimalType => DECIMAL_TYPE
+        case DoubleType => DOUBLE_TYPE
+        case FloatType => FLOAT_TYPE
+        case DateType => DATE_TYPE
+        case TimestampType => TIMESTAMP_TYPE
+        case BinaryType => BINARY_TYPE
+        case _: ArrayType => ARRAY_TYPE
+        case _: MapType => MAP_TYPE
+        case _: StructType => STRUCT_TYPE
+        case _ => throw new IllegalArgumentException(
+          s"Unsupported field $field")
+      }
+      i += 1
+    }
+    result
   }
 }

--- a/dtests/build.gradle
+++ b/dtests/build.gradle
@@ -65,7 +65,7 @@ dependencies {
     testRuntime project(':snappy-cluster_' + scalaBinaryVersion)
     testCompile project(':snappy-cluster_' + scalaBinaryVersion)
     testCompile 'org.scalatest:scalatest_' + scalaBinaryVersion + ':2.2.1'
-    testRuntime 'org.pegdown:pegdown:1.1.0'
+    testRuntime 'org.pegdown:pegdown:1.6.0'
 //    testRuntime group: 'org.datanucleus', name: 'datanucleus-core', version:'3.2.10'
 
 }


### PR DESCRIPTION
## Changes proposed in this pull request

- CachedBatch creation: Use direct AbstractCompactExecRow.getAs* calls to get final java
  values/objects instead of expensive ExecRow.getColumn().get* calls that create intermediate DVDs
- CachedBatch creation: avoid switch on DataType+metadata for every row. Instead cache the end types
  and use a fast switch on ints (code generation might be overkill and may not buy much)
- Skip stats object (avoids its serialization/deserialization cost) for now in CachedBatch creation
  since it is not being used
- Use SparkShellRowRDD for split mode execution over row tables (currently only
    done for row buffer of a column table)
- Push down only those filters to row tables that can use indexes.
- Added support for push down of more filters like IN, AND, OR, LIKE for
  row tables (those that can use indexes)
- Spark row table iteration: use direct access to internal AbstractCompactExecRow
  where possible with getAs* calls

## Patch testing

precheckin and store precheckin

## ReleaseNotes.txt changes

NA

## Other PRs

Created over previous PR #311 for SNAP-933
