### PR TITLE
[SNAP-961] Fix passing of some DDL extension clauses

### DIFF
--- a/cluster/src/dunit/scala/io/snappydata/cluster/DDLRoutingDUnitTest.scala
+++ b/cluster/src/dunit/scala/io/snappydata/cluster/DDLRoutingDUnitTest.scala
@@ -16,7 +16,7 @@
  */
 package io.snappydata.cluster
 
-import java.sql.{Connection, DriverManager}
+import java.sql.{Connection, DriverManager, SQLException}
 
 import com.pivotal.gemfirexd.internal.engine.Misc
 import io.snappydata.test.dunit.{AvailablePortHelper, SerializableRunnable}
@@ -118,11 +118,48 @@ class DDLRoutingDUnitTest(val s: String) extends ClusterManagerTestBase(s) {
     Snap319(conn)
   }
 
-  def createTableXD(conn: Connection, tableName: String, usingStr: String): Unit = {
+  def testHang_SNAP_961(): Unit = {
+    val tableName: String = "TEST.ColumnTableQR"
+    val netPort1 = AvailablePortHelper.getRandomAvailableTCPPort
+    vm2.invoke(classOf[ClusterManagerTestBase], "startNetServer", netPort1)
+    val conn = getANetConnection(netPort1)
+
+    val s = conn.createStatement()
+    var options = "OPTIONS(PERSISTENT 'true', DISKSTORE 'd1')"
+    try {
+      s.execute(s"CREATE TABLE $tableName (Col1 INT, Col2 INT, Col3 INT) " +
+          s"USING column $options")
+    } catch {
+      case sqle: SQLException => if (sqle.getSQLState != "38000" ||
+          !sqle.getMessage.contains("Disk store D1 not found")) throw sqle
+    }
+
+    // should succeed after creating diskstore
+    s.execute("CREATE DISKSTORE d1")
+    s.execute(s"CREATE TABLE $tableName (Col1 INT, Col2 INT, Col3 INT) " +
+        s"USING column $options")
+
+    dropTableXD(conn, tableName)
+
+    // check offheap
+    options = "OPTIONS(OFFHEAP 'true')"
+    try {
+      s.execute(s"CREATE TABLE $tableName (Col1 INT, Col2 INT, Col3 INT) " +
+          s"USING column $options")
+    } catch {
+      case sqle: SQLException => if (sqle.getSQLState != "38000" ||
+          !sqle.getMessage.contains("No off-heap memory")) throw sqle
+    }
+
+    s.execute("DROP DISKSTORE d1")
+  }
+
+  def createTableXD(conn: Connection, tableName: String,
+      usingStr: String): Unit = {
     val s = conn.createStatement()
     val options = ""
-    s.execute("CREATE TABLE " + tableName + " (Col1 INT, Col2 INT, Col3 STRING) " + " USING " + usingStr +
-        " " + options)
+    s.execute(s"CREATE TABLE $tableName (Col1 INT, Col2 INT, Col3 STRING) " +
+        s"USING $usingStr $options")
   }
 
   def createTableByDefaultXD(conn: Connection, tableName: String): Unit = {
@@ -153,20 +190,18 @@ class DDLRoutingDUnitTest(val s: String) extends ClusterManagerTestBase(s) {
     }
   }
 
-  def failCreateTableXD(conn: Connection, tableName: String, doFail: Boolean, usingStr: String): Unit = {
+  def failCreateTableXD(conn: Connection, tableName: String, doFail: Boolean,
+      usingStr: String): Unit = {
     try {
       val s = conn.createStatement()
       val options = ""
-      s.execute("CREATE TABLE " + tableName + " (Col1 INT, Col2 INT, Col3 INT) " + (if (doFail) "fail" orElse "") + " USING " + usingStr
+      s.execute("CREATE TABLE " + tableName + " (Col1 INT, Col2 INT, Col3 INT) "
+          + (if (doFail) "fail" orElse "") + " USING " + usingStr
           + " " + options)
-      //println("Successfully Created ColumnTable = " + tableName)
-    }
-    catch {
+    } catch {
       case e: Exception => println("create: Caught exception " + e.getMessage +
           " for ColumnTable = " + tableName)
-      //println("Exception stack. create. ex=" + e.getMessage + " ,stack=" + ExceptionUtils.getFullStackTrace(e))
     }
-    //println("Created ColumnTable = " + tableName)
   }
 
   def tableMetadataAssertColumnTable(schemaName: String, tableName: String): Unit = {
@@ -210,7 +245,7 @@ class DDLRoutingDUnitTest(val s: String) extends ClusterManagerTestBase(s) {
       val s = conn.createStatement()
       s.execute("CREATE EXTERNAL TABLE airlineRef_temp(Code VARCHAR(25), " +
           "Description VARCHAR(25)) USING parquet OPTIONS()")
-      //println("Successfully Created ColumnTable = " + tableName)
+      // println("Successfully Created ColumnTable = " + tableName)
     }
     catch {
       case e: java.sql.SQLException => //println("create temp: Caught exception " + e.getMessage)

--- a/cluster/src/dunit/scala/io/snappydata/cluster/SplitSnappyClusterDUnitTest.scala
+++ b/cluster/src/dunit/scala/io/snappydata/cluster/SplitSnappyClusterDUnitTest.scala
@@ -24,11 +24,10 @@ import scala.language.postfixOps
 import io.snappydata.core.TestData2
 import io.snappydata.store.ClusterSnappyJoinSuite
 import io.snappydata.test.dunit.AvailablePortHelper
-import org.apache.calcite.DataContext.Variable
 
 import org.apache.spark.sql.store.StoreUtils
 import org.apache.spark.sql.{SaveMode, SnappyContext}
-import org.apache.spark.{SparkConf, SparkContext}
+import org.apache.spark.{Logging, SparkConf, SparkContext}
 
 /**
  * Basic tests for non-embedded mode connections to an embedded cluster.
@@ -104,8 +103,10 @@ class SplitSnappyClusterDUnitTest(s: String)
   }
 }
 
-object SplitSnappyClusterDUnitTest extends SplitClusterDUnitTestObject {
-  def sc = ClusterManagerTestBase.sc
+object SplitSnappyClusterDUnitTest
+    extends SplitClusterDUnitTestObject with Logging {
+
+  def sc: SparkContext = ClusterManagerTestBase.sc
 
   override def createTablesAndInsertData(tableType: String): Unit = {
     val snc = SnappyContext(sc)
@@ -116,7 +117,7 @@ object SplitSnappyClusterDUnitTest extends SplitClusterDUnitTestObject {
     createTableUsingDataSourceAPI(snc, "embeddedModeTable2", tableType)
     selectFromTable(snc, "embeddedModeTable2", 1005)
 
-    println("Successful")
+    logInfo("Successful")
   }
 
   override def createComplexTablesAndInsertData(
@@ -131,7 +132,7 @@ object SplitSnappyClusterDUnitTest extends SplitClusterDUnitTestObject {
       "column", props)
     selectFromTable(snc, "embeddedModeTable2", 1005)
 
-    println("Successful")
+    logInfo("Successful")
   }
 
   override def verifySplitModeOperations(tableType: String, isComplex: Boolean,
@@ -139,8 +140,8 @@ object SplitSnappyClusterDUnitTest extends SplitClusterDUnitTestObject {
     // embeddedModeTable1 is dropped in split mode. recreate it
     val snc = SnappyContext(sc)
     // remove below once SNAP-653 is fixed
-    val numPartitions = props.getOrElse("buckets", "113").toInt
-    StoreUtils.removeCachedObjects(snc, "APP.EMBEDDEDMODETABLE1", numPartitions,
+    // val numPartitions = props.getOrElse("buckets", "113").toInt
+    StoreUtils.removeCachedObjects(snc, "APP.EMBEDDEDMODETABLE1",
       registerDestroy = true)
     if (isComplex) {
       createComplexTableUsingDataSourceAPI(snc, "embeddedModeTable1",
@@ -173,7 +174,7 @@ object SplitSnappyClusterDUnitTest extends SplitClusterDUnitTestObject {
     selectFromTable(snc, "splitModeTable1", 1005)
     snc.dropTable("splitModeTable1", ifExists = true)
 
-    println("Successful")
+    logInfo("Successful")
   }
 
   def createRowTableForCollocatedJoin(): Unit = {
@@ -264,7 +265,6 @@ object SplitSnappyClusterDUnitTest extends SplitClusterDUnitTestObject {
     val testJoins = new ClusterSnappyJoinSuite()
     testJoins.partitionToPartitionJoinAssertions(snc, table1, table2)
 
-    println("Successful")
-
+    logInfo("Successful")
   }
 }

--- a/core/src/dunit/scala/io/snappydata/cluster/SplitClusterDUnitTestBase.scala
+++ b/core/src/dunit/scala/io/snappydata/cluster/SplitClusterDUnitTestBase.scala
@@ -188,7 +188,7 @@ trait SplitClusterDUnitTestObject {
 
     // remove below once SNAP-653 is fixed
     val numPartitions = props.getOrElse("buckets", "113").toInt
-    StoreUtils.removeCachedObjects(snc, "APP.SPLITMODETABLE1", numPartitions,
+    StoreUtils.removeCachedObjects(snc, "APP.SPLITMODETABLE1",
       registerDestroy = true)
 
     // create a table in split mode

--- a/core/src/main/scala/org/apache/spark/sql/execution/columnar/impl/ColumnFormatRelation.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/columnar/impl/ColumnFormatRelation.scala
@@ -18,7 +18,6 @@ package org.apache.spark.sql.execution.columnar.impl
 
 import java.sql.Connection
 
-import com.gemstone.gemfire.distributed.internal.membership.InternalDistributedMember
 import com.gemstone.gemfire.internal.cache.PartitionedRegion
 import com.pivotal.gemfirexd.internal.engine.Misc
 
@@ -37,7 +36,6 @@ import org.apache.spark.sql.sources._
 import org.apache.spark.sql.store.{CodeGeneration, StoreUtils}
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.sql.{DataFrame, Row, SQLContext, SaveMode, SnappyContext}
-import org.apache.spark.storage.BlockManagerId
 import org.apache.spark.{Logging, Partition}
 
 /**
@@ -92,9 +90,7 @@ class BaseColumnFormatRelation(
   @transient protected lazy val region = Misc.getRegionForTable(resolvedName,
     true).asInstanceOf[PartitionedRegion]
 
-  override lazy val numPartitions: Int = {
-    region.getTotalNumberOfBuckets
-  }
+  override lazy val numPartitions: Int = region.getTotalNumberOfBuckets
 
   override def partitionColumns: Seq[String] = {
     partitioningColumns
@@ -261,7 +257,7 @@ class BaseColumnFormatRelation(
     val conn = connFactory()
     try {
       // clean up the connection pool and caches
-      StoreUtils.removeCachedObjects(sqlContext, table, numPartitions)
+      StoreUtils.removeCachedObjects(sqlContext, table)
     } finally {
       try {
         try {

--- a/core/src/main/scala/org/apache/spark/sql/execution/row/RowFormatScanRDD.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/row/RowFormatScanRDD.scala
@@ -21,7 +21,6 @@ import java.util.GregorianCalendar
 
 import scala.collection.mutable.ArrayBuffer
 
-import com.gemstone.gemfire.distributed.internal.membership.InternalDistributedMember
 import com.gemstone.gemfire.internal.cache.{CacheDistributionAdvisee, PartitionedRegion}
 import com.pivotal.gemfirexd.internal.engine.Misc
 import com.pivotal.gemfirexd.internal.engine.store.AbstractCompactExecRow
@@ -37,7 +36,6 @@ import org.apache.spark.sql.execution.{CompactExecRowToMutableRow, ConnectionPoo
 import org.apache.spark.sql.sources._
 import org.apache.spark.sql.store.StoreUtils
 import org.apache.spark.sql.types._
-import org.apache.spark.storage.BlockManagerId
 import org.apache.spark.unsafe.Platform
 import org.apache.spark.unsafe.types.UTF8String
 import org.apache.spark.{Partition, SparkContext, TaskContext}

--- a/core/src/main/scala/org/apache/spark/sql/store/StoreUtils.scala
+++ b/core/src/main/scala/org/apache/spark/sql/store/StoreUtils.scala
@@ -20,10 +20,8 @@ import scala.collection.JavaConverters._
 import scala.collection.generic.Growable
 import scala.collection.mutable
 
-import com.gemstone.gemfire.distributed.internal.membership.InternalDistributedMember
 import com.gemstone.gemfire.internal.cache.{CacheDistributionAdvisee, PartitionedRegion}
 import com.pivotal.gemfirexd.internal.engine.Misc
-import io.snappydata.util.ServiceUtils
 
 import org.apache.spark.sql.collection.{MultiExecutorLocalPartition, Utils}
 import org.apache.spark.sql.execution.columnar.ExternalStoreUtils
@@ -32,7 +30,7 @@ import org.apache.spark.sql.execution.datasources.DDLException
 import org.apache.spark.sql.hive.SnappyStoreHiveCatalog
 import org.apache.spark.sql.sources.ConnectionProperties
 import org.apache.spark.sql.types._
-import org.apache.spark.sql.{SnappyContext, AnalysisException, SQLContext}
+import org.apache.spark.sql.{AnalysisException, SQLContext, SnappyContext}
 import org.apache.spark.{Logging, Partition, SparkContext}
 
 object StoreUtils extends Logging {
@@ -46,6 +44,7 @@ object StoreUtils extends Logging {
   val MAXPARTSIZE = "MAXPARTSIZE"
   val EVICTION_BY = "EVICTION_BY"
   val PERSISTENT = "PERSISTENT"
+  val DISKSTORE = "DISKSTORE"
   val SERVER_GROUPS = "SERVER_GROUPS"
   val OFFHEAP = "OFFHEAP"
   val EXPIRE = "EXPIRE"
@@ -109,7 +108,7 @@ object StoreUtils extends Logging {
       val distMembers = region.getRegionAdvisor.getBucketOwners(p).asScala
       val prefNodes = distMembers.map(
         m => SnappyContext.storeToBlockMap.get(m.toString)
-      ).filter(m => m != None)
+      ).filter(_.isDefined)
       val prefNodeSeq = prefNodes.map(_.get).toSeq
       partitions(p) = new MultiExecutorLocalPartition(p, prefNodeSeq)
     }
@@ -143,7 +142,7 @@ object StoreUtils extends Logging {
   }
 
   def removeCachedObjects(sqlContext: SQLContext, table: String,
-      numPartitions: Int, registerDestroy: Boolean = false): Unit = {
+      registerDestroy: Boolean = false): Unit = {
     ExternalStoreUtils.removeCachedObjects(sqlContext, table, registerDestroy)
     Utils.mapExecutors(sqlContext, () => {
       StoreCallbacksImpl.stores.remove(table)
@@ -175,14 +174,11 @@ object StoreUtils extends Logging {
             val schemaFields = Utils.schemaFields(normalizedSchema)
             val cols = v.split(",") map (_.trim)
             val normalizedCols = cols map { c =>
-                if(context.conf.caseSensitiveAnalysis){
-                  c
-                }else{
-                  if (Utils.hasLowerCase(c))
-                    Utils.toUpperCase(c)
-                  else
-                    c
-                }
+              if (context.conf.caseSensitiveAnalysis) {
+                c
+              } else {
+                if (Utils.hasLowerCase(c)) Utils.toUpperCase(c) else c
+              }
             }
             val prunedSchema = ExternalStoreUtils.pruneSchema(schemaFields, normalizedCols)
 
@@ -215,14 +211,13 @@ object StoreUtils extends Logging {
                 s"sparkhash $PRIMARY_KEY"
               } else {
                 throw new DDLException("Column table cannot be partitioned on" +
-                    " PRIMARY KEY as no primary key")
+                  " PRIMARY KEY as no primary key")
               }
-            case _ =>  s"sparkhash COLUMN($v)"
+            case _ => s"sparkhash COLUMN($v)"
           }
         }
         s"$GEM_PARTITION_BY $parClause "
-      }
-      ).getOrElse(if (isRowTable) EMPTY_STRING
+      }).getOrElse(if (isRowTable) EMPTY_STRING
       else s"$GEM_PARTITION_BY COLUMN ($SHADOW_COLUMN_NAME) "))
     } else {
       parameters.remove(PARTITION_BY).foreach {
@@ -239,9 +234,8 @@ object StoreUtils extends Logging {
 
     parameters.remove(REPLICATE).foreach(v =>
       if (v.toBoolean) sb.append(GEM_REPLICATE).append(' ')
-      else if (!parameters.contains(BUCKETS))
-        sb.append(GEM_BUCKETS).append(' ').append(
-          ExternalStoreUtils.DEFAULT_TABLE_BUCKETS).append(' '))
+      else if (!parameters.contains(BUCKETS)) sb.append(GEM_BUCKETS).append(' ')
+        .append(ExternalStoreUtils.DEFAULT_TABLE_BUCKETS).append(' '))
     sb.append(parameters.remove(BUCKETS).map(v => s"$GEM_BUCKETS $v ")
         .getOrElse(EMPTY_STRING))
 
@@ -279,20 +273,30 @@ object StoreUtils extends Logging {
       sb.append(s"$GEM_OVERFLOW ")
     }
 
+    var isPersistent = false
     parameters.remove(PERSISTENT).foreach { v =>
       if (v.equalsIgnoreCase("async") || v.equalsIgnoreCase("true")) {
         sb.append(s"$GEM_PERSISTENT ASYNCHRONOUS ")
+        isPersistent = true
       } else if (v.equalsIgnoreCase("sync")) {
         sb.append(s"$GEM_PERSISTENT SYNCHRONOUS ")
+        isPersistent = true
       } else if (!v.equalsIgnoreCase("false")) {
-        sb.append(s"$GEM_PERSISTENT $v ")
+        throw new DDLException(s"Invalid value for option '$PERSISTENT' = $v" +
+          s" (expected one of: async, sync, true, false)")
       }
     }
-    sb.append(parameters.remove(SERVER_GROUPS).map(v => s"$GEM_SERVER_GROUPS $v ")
-        .getOrElse(EMPTY_STRING))
-    sb.append(parameters.remove(OFFHEAP).map(v => s"$GEM_OFFHEAP $v ")
-        .getOrElse(EMPTY_STRING))
-
+    parameters.remove(DISKSTORE).foreach { v =>
+      if (isPersistent) sb.append(s"'$v' ")
+      else throw new DDLException(
+        s"Option '$DISKSTORE' requires '$PERSISTENT' option")
+    }
+    sb.append(parameters.remove(SERVER_GROUPS)
+      .map(v => s"$GEM_SERVER_GROUPS ($v) ")
+      .getOrElse(EMPTY_STRING))
+    sb.append(parameters.remove(OFFHEAP).map(v =>
+      if (v.equalsIgnoreCase("true")) s"$GEM_OFFHEAP " else EMPTY_STRING)
+      .getOrElse(EMPTY_STRING))
 
     sb.append(parameters.remove(EXPIRE).map(v => {
       if (!isRowTable) {
@@ -332,8 +336,9 @@ object StoreUtils extends Logging {
       result(i) = dataType match {
         case StringType => STRING_TYPE
         case IntegerType => INT_TYPE
-        case LongType => if (field.metadata.contains("binarylong"))
-          BINARY_LONG_TYPE else LONG_TYPE
+        case LongType =>
+          if (field.metadata.contains("binarylong")) BINARY_LONG_TYPE
+          else LONG_TYPE
         case ShortType => SHORT_TYPE
         case ByteType => BYTE_TYPE
         case BooleanType => BOOLEAN_TYPE


### PR DESCRIPTION
## Changes proposed in this pull request

- corrected formatting for PERSISTENT, OFFHEAP and SERVER_GROUPS in proper
  format as expected by snappydata-store
- split the PERSISTENT property into a new DISKSTORE which just specifies
  the diskstore name; former specifies async/sync persistence or whether it on/off
- don't access numPartitions in ColumnFormatRelation.destroy else it causes
  a RegionDestroyedException in case it is invoked to cleanup create table failure
- added dunit test in DDLRoutingDUnitTest to check for cases of exception for
  above clauses as well as when those are proper (no SERVER_GROUPS test yet)

## Patch testing

precheckin

## ReleaseNotes.txt changes

NA

## Other PRs 

https://github.com/SnappyDataInc/snappy-store/commit/6207f0f407ea8a2fbfd67d9ce0da24f5ccd524df has the store side changes