### PR TITLE
 saved the locURL so that later server can be

### DIFF
--- a/cluster/src/dunit/scala/io/snappydata/HiveMetastoreClientAccessDUnitTest.scala
+++ b/cluster/src/dunit/scala/io/snappydata/HiveMetastoreClientAccessDUnitTest.scala
@@ -46,7 +46,7 @@ class HiveMetastoreClientAccessDUnitTest(val s: String)
   def _testOne(): Unit = {
     val serverNetPort = AvailablePortHelper.getRandomAvailableTCPPort
 
-    val locStr = "localhost[" + locatorPort + ']'
+    val locStr = "localhost[" + ClusterManagerTestBase.locatorPort + ']'
     vm2.invoke(this.getClass, "startDriverApp",
       Array(locStr.asInstanceOf[AnyRef]))
 

--- a/cluster/src/dunit/scala/io/snappydata/cluster/ClusterManagerTestBase.scala
+++ b/cluster/src/dunit/scala/io/snappydata/cluster/ClusterManagerTestBase.scala
@@ -63,9 +63,6 @@ class ClusterManagerTestBase(s: String) extends DistributedTestBase(s) {
     vm3 = host.getVM(3)
   }
 
-  final def locatorPort: Int = DistributedTestBase.getDUnitLocatorPort
-  final val locPort: Int = locatorPort
-
   protected final def startArgs =
     Array(locatorPort, bootProps).asInstanceOf[Array[AnyRef]]
 
@@ -76,24 +73,11 @@ class ClusterManagerTestBase(s: String) extends DistributedTestBase(s) {
   // this can be used only by jobs running on Lead node
   def sc: SparkContext = SnappyContext.globalSparkContext
 
-  val startNode = new SerializableRunnable() {
-    override def run(): Unit = {
-      val node = ServiceManager.currentFabricServiceInstance
-      if (node == null || node.status != FabricService.State.RUNNING) {
-        startSnappyServer(locPort, bootProps)
-      }
-      assert(ServiceManager.currentFabricServiceInstance.status ==
-          FabricService.State.RUNNING)
-
-      val logger = LoggerFactory.getLogger(getClass)
-      logger.info("\n\n\n  STARTING TESTS IN " + getClass.getName + "\n\n")
-    }
-  }
-
   override def beforeClass(): Unit = {
     super.beforeClass()
     val locNetPort = locatorNetPort
     val locNetProps = locatorNetProps
+    val locPort = ClusterManagerTestBase.locPort
     DistributedTestBase.invokeInLocator(new SerializableRunnable() {
       override def run(): Unit = {
         val loc: Locator = ServiceManager.getLocatorInstance
@@ -110,6 +94,21 @@ class ClusterManagerTestBase(s: String) extends DistributedTestBase(s) {
         logger.info("\n\n\n  STARTING TESTS IN " + getClass.getName + "\n\n")
       }
     })
+
+    val nodeProps = bootProps
+    val startNode = new SerializableRunnable() {
+      override def run(): Unit = {
+        val node = ServiceManager.currentFabricServiceInstance
+        if (node == null || node.status != FabricService.State.RUNNING) {
+          startSnappyServer(locPort, nodeProps)
+        }
+        assert(ServiceManager.currentFabricServiceInstance.status ==
+            FabricService.State.RUNNING)
+
+        val logger = LoggerFactory.getLogger(getClass)
+        logger.info("\n\n\n  STARTING TESTS IN " + getClass.getName + "\n\n")
+      }
+    }
 
     vm0.invoke(startNode)
     vm1.invoke(startNode)
@@ -172,6 +171,8 @@ class ClusterManagerTestBase(s: String) extends DistributedTestBase(s) {
  */
 object ClusterManagerTestBase {
   val logger = LoggerFactory.getLogger(getClass)
+  final def locatorPort: Int = DistributedTestBase.getDUnitLocatorPort
+  final val locPort: Int = locatorPort
 
   /* SparkContext is initialized on the lead node and hence,
   this can be used only by jobs running on Lead node */

--- a/cluster/src/dunit/scala/io/snappydata/externalstore/ColumnTableDUnitTest.scala
+++ b/cluster/src/dunit/scala/io/snappydata/externalstore/ColumnTableDUnitTest.scala
@@ -22,8 +22,7 @@ import scala.util.Random
 import com.gemstone.gemfire.internal.cache.{GemFireCacheImpl, PartitionedRegion}
 import com.pivotal.gemfirexd.internal.engine.Misc
 import io.snappydata.cluster.ClusterManagerTestBase
-import io.snappydata.cluster.ClusterManagerTestBase._
-import io.snappydata.test.dunit.SerializableCallable
+import io.snappydata.test.dunit.{SerializableRunnable, SerializableCallable}
 
 import org.apache.spark.sql.execution.columnar.impl.ColumnFormatRelation
 import org.apache.spark.sql.{Row, SaveMode, SnappyContext}
@@ -51,9 +50,12 @@ class ColumnTableDUnitTest(s: String) extends ClusterManagerTestBase(s) {
 
     val props = bootProps
     val port = currenyLocatorPort
-    val args = Array(port , props).asInstanceOf[Array[AnyRef]]
 
-    vm2.invoke(classOf[ClusterManagerTestBase] , "startSnappyServer" , args)
+    val restartServer = new SerializableRunnable() {
+      override def run(): Unit = ClusterManagerTestBase.startSnappyServer(port, props)
+    }
+
+    vm2.invoke(restartServer)
 
     verifyTableData(snc , tableName)
     dropTable(snc, tableName)

--- a/cluster/src/dunit/scala/io/snappydata/externalstore/ColumnTableDUnitTest.scala
+++ b/cluster/src/dunit/scala/io/snappydata/externalstore/ColumnTableDUnitTest.scala
@@ -44,7 +44,8 @@ class ColumnTableDUnitTest(s: String) extends ClusterManagerTestBase(s) {
     createTable(snc, tableName, Map("BUCKETS" -> "1", "PERSISTENT" -> "async"))
     verifyTableData(snc , tableName)
     vm2.invoke(this.getClass, "stopAny")
-    vm2.invoke(startNode)
+    val args = Array(ClusterManagerTestBase.locPort , bootProps).asInstanceOf[Array[AnyRef]]
+    vm2.invoke(classOf[ClusterManagerTestBase] , "startSnappyServer" , args)
     dropTable(snc, tableName)
     createTable(snc, tableName , Map("BUCKETS" -> "1", "PERSISTENT" -> "sync"))
     verifyTableData(snc, tableName)

--- a/cluster/src/dunit/scala/io/snappydata/externalstore/ExecutorMessageDUnitTest.scala
+++ b/cluster/src/dunit/scala/io/snappydata/externalstore/ExecutorMessageDUnitTest.scala
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2016 SnappyData, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License. You
+ * may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License. See accompanying
+ * LICENSE file.
+ */
+
 package io.snappydata.externalstore
 
 import scala.util.Random
@@ -88,7 +105,7 @@ class ExecutorMessageDUnitTest(s: String) extends ClusterManagerTestBase(s) with
 
   def restartSpark(): Unit = {
     ClusterManagerTestBase.stopSpark()
-    ClusterManagerTestBase.startSnappyLead(locatorPort, bootProps)
+    ClusterManagerTestBase.startSnappyLead(ClusterManagerTestBase.locatorPort, bootProps)
   }
 
   def verifyTable (snc: SnappyContext): Unit = {


### PR DESCRIPTION
## Changes proposed in this pull request
Fixed the TaskNotSerializable Exception  in the AQP test cases

## Patch testing

aqp dunit and cluster dunits

## ReleaseNotes.txt changes

(Does this change require an entry in ReleaseNotes.txt? If yes, has it been added to it?)

## Other PRs 

(Does this change require changes in other projects- store, spark, spark-jobserver, aqp? Add the links of PR of the other subprojects that are related to this change)

 started with the same locator port.