### PR TITLE
Snap 293

### DIFF
--- a/cluster/src/dunit/scala/org/apache/scala/DynamicJarInstallationDUnitTest.scala
+++ b/cluster/src/dunit/scala/org/apache/scala/DynamicJarInstallationDUnitTest.scala
@@ -1,0 +1,150 @@
+/*
+ * Copyright (c) 2016 SnappyData, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License. You
+ * may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License. See accompanying
+ * LICENSE file.
+ */
+
+
+package org.apache.spark
+
+import java.io.File
+import java.net.URL
+import java.sql.{Connection, DriverManager}
+import _root_.io.snappydata.cluster.ClusterManagerTestBase
+import _root_.io.snappydata.test.dunit.AvailablePortHelper
+import org.apache.spark.sql.SnappyContext
+import org.apache.spark.sql.collection.{Utils => Utility}
+import org.apache.spark.util.Utils
+
+class DynamicJarInstallationDUnitTest(val s: String)
+    extends ClusterManagerTestBase(s) {
+
+
+  override def tearDown2(): Unit = {
+    Array(vm3, vm2, vm1, vm0).foreach(_.invoke(getClass, "stopNetworkServers"))
+    bootProps.clear()
+  }
+
+  private def getANetConnection(netPort: Int): Connection = {
+    val driver = "com.pivotal.gemfirexd.jdbc.ClientDriver"
+    // scalastyle:off classforname
+    Class.forName(driver).newInstance
+    val url = "jdbc:snappydata://localhost:" + netPort + "/"
+    DriverManager.getConnection(url)
+  }
+
+
+  def verifyClassOnExecutors(snc: SnappyContext, className: String,
+      version: String, count: Int): Unit = {
+    val countInstances = Utility.mapExecutors(snc,
+      () => {
+        if (DynamicJarInstallationDUnitTest.loadClass(className, version)) {
+          Seq(1).iterator
+        } else Iterator.empty
+      }).count
+
+    assert(countInstances == count)
+  }
+
+  def testJarDeployementWithThinClient(): Unit = {
+    val snc = SnappyContext(sc)
+    val sqlJars = DynamicJarInstallationDUnitTest.createJarWithClasses(
+      classNames = Seq("FakeClass1", "FakeClass2", "FakeClass3"),
+      toStringValue = "1",
+      Seq.empty, Seq.empty,
+      "testJar_SNAPPY_JOB_SERVER_JAR_%s.jar".format(System.currentTimeMillis()))
+
+
+    val replaceJars = DynamicJarInstallationDUnitTest.createJarWithClasses(
+      classNames = Seq("FakeClass1", "FakeClass2", "FakeClass4"),
+      toStringValue = "2",
+      Seq.empty, Seq.empty,
+      "testJar_SNAPPY_JOB_SERVER_JAR_%s.jar".format(System.currentTimeMillis()))
+
+    val netPort1 = AvailablePortHelper.getRandomAvailableTCPPort
+    vm2.invoke(classOf[ClusterManagerTestBase], "startNetServer", netPort1)
+
+    val conn = getANetConnection(netPort1)
+
+    val stmt = conn.createStatement()
+
+    stmt.executeUpdate("call sqlj.install_jar('" + sqlJars.getPath + "', 'app.sqlJars', 0)")
+
+    // look for jar inside the executors
+    verifyClassOnExecutors(snc, "FakeClass1", "1", 3)
+    verifyClassOnExecutors(snc, "FakeClass2", "1", 3)
+    verifyClassOnExecutors(snc, "FakeClass3", "1", 3)
+
+
+    // replace  the jar and check again
+    stmt.executeUpdate("call sqlj.replace_jar('" + replaceJars.getPath + "', 'app.sqlJars')")
+    // look for jar inside the executors
+    verifyClassOnExecutors(snc, "FakeClass1", "2", 3)
+    verifyClassOnExecutors(snc, "FakeClass2", "2", 3)
+    verifyClassOnExecutors(snc, "FakeClass4", "2", 3)
+    verifyClassOnExecutors(snc, "FakeClass3", "", 0)
+
+    // remove the jar and check
+
+    stmt.executeUpdate("call sqlj.remove_jar('app.sqlJars', 0)")
+    verifyClassOnExecutors(snc, "FakeClass1", "", 0)
+    verifyClassOnExecutors(snc, "FakeClass2", "", 0)
+    verifyClassOnExecutors(snc, "FakeClass3", "", 0)
+    verifyClassOnExecutors(snc, "FakeClass4", "", 0)
+  }
+}
+
+
+object DynamicJarInstallationDUnitTest {
+
+  def createJarWithClasses(
+      classNames: Seq[String],
+      toStringValue: String = "",
+      classNamesWithBase: Seq[(String, String)] = Seq(),
+      classpathUrls: Seq[URL] = Seq(),
+      jarName: String = ""
+  ): URL = {
+    val tempDir = Utils.createTempDir()
+    val files1 = for (name <- classNames) yield {
+      TestUtils.createCompiledClass(name, tempDir, toStringValue, classpathUrls = classpathUrls)
+    }
+    val files2 = for ((childName, baseName) <- classNamesWithBase) yield {
+      TestUtils.createCompiledClass(childName, tempDir, toStringValue, baseName, classpathUrls)
+    }
+    val jarFile = if (jarName.isEmpty) {
+      new File(tempDir, "testJar-%s.jar".format(System.currentTimeMillis()))
+    }
+    else new File(tempDir, jarName.format(System.currentTimeMillis()))
+    TestUtils.createJar(files1 ++ files2, jarFile)
+  }
+
+
+  @throws[ClassNotFoundException]
+  def loadClass(className: String,
+      version: String = ""): Boolean = {
+    val catchExpectedException: Boolean = version.isEmpty
+    val loader = Thread.currentThread().getContextClassLoader
+    assert(loader != null)
+    try {
+      val fakeClass = loader.loadClass(className).newInstance()
+      assert(fakeClass != null)
+      assert(fakeClass.toString.equals(version))
+      true
+    } catch {
+      case cnfe: ClassNotFoundException =>
+        if (!catchExpectedException) throw cnfe
+        else false
+    }
+  }
+}

--- a/cluster/src/main/java/org/apache/spark/streaming/JavaSnappyStreamingJob.java
+++ b/cluster/src/main/java/org/apache/spark/streaming/JavaSnappyStreamingJob.java
@@ -25,6 +25,7 @@ import org.apache.spark.streaming.api.java.JavaSnappyStreamingContext;
 import spark.jobserver.SparkJobBase;
 import spark.jobserver.SparkJobValidation;
 import org.apache.spark.util.Utils;
+import org.apache.spark.util.SnappyUtils;
 
 public abstract class JavaSnappyStreamingJob implements SparkJobBase {
 
@@ -35,7 +36,16 @@ public abstract class JavaSnappyStreamingJob implements SparkJobBase {
 
   @Override
   final public SparkJobValidation validate(Object sc, Config config) {
+    ClassLoader parentLoader = Utils.getContextOrSparkClassLoader();
+    ClassLoader currentLoader = SnappyUtils.getSnappyStoreContextLoader(parentLoader);
+    Thread.currentThread().setContextClassLoader(currentLoader);
     return SnappyJobValidate.validate(isValidJob(new JavaSnappyStreamingContext((SnappyStreamingContext)sc), config));
+  }
+
+  @Override
+  final public void addOrReplaceJar(Object sc, String jarName, String jarPath) {
+    SnappyUtils.installOrReplaceJar(jarName, jarPath,
+        ((SnappyStreamingContext)sc).sparkContext());
   }
 
   @Override

--- a/cluster/src/main/scala/org/apache/spark/executor/SnappyCoarseGrainedExecutorBackend.scala
+++ b/cluster/src/main/scala/org/apache/spark/executor/SnappyCoarseGrainedExecutorBackend.scala
@@ -44,6 +44,9 @@ class SnappyCoarseGrainedExecutorBackend(
     super.onStart()
   }
 
+  override protected def registerExecutor: Executor =
+    new SnappyExecutor(executorId, hostName, env, userClassPath, isLocal = false)
+
   /**
    * Snappy addition (Replace System.exit with exitExecutor). We could have
    * added functions calling System.exit to SnappyCoarseGrainedExecutorBackend

--- a/cluster/src/main/scala/org/apache/spark/executor/SnappyExecutor.scala
+++ b/cluster/src/main/scala/org/apache/spark/executor/SnappyExecutor.scala
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2016 SnappyData, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License. You
+ * may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License. See accompanying
+ * LICENSE file.
+ */
+package org.apache.spark.executor
+
+import java.io.File
+import java.net.URL
+
+import com.pivotal.gemfirexd.internal.engine.Misc
+
+import org.apache.spark.SparkEnv
+import org.apache.spark.util.{ChildFirstURLClassLoader, MutableURLClassLoader, Utils}
+
+class SnappyExecutor(
+    executorId: String,
+    executorHostname: String,
+    env: SparkEnv,
+    userClassPath: Seq[URL] = Nil,
+    isLocal: Boolean = false)
+    extends Executor(executorId, executorHostname, env, userClassPath, isLocal) {
+
+  override def createClassLoader(): MutableURLClassLoader = {
+    // Bootstrap the list of jars with the user class path.
+    val now = System.currentTimeMillis()
+    userClassPath.foreach { url =>
+      currentJars(url.getPath().split("/").last) = now
+    }
+
+    val currentLoader = Utils.getContextOrSparkClassLoader
+
+    // For each of the jars in the jarSet, add them to the class loader.
+    // We assume each of the files has already been fetched.
+    val urls = userClassPath.toArray ++ currentJars.keySet.map { uri =>
+      new File(uri.split("/").last).toURI.toURL
+    }
+    if (env.conf.getBoolean("spark.executor.userClassPathFirst", false)) {
+      new SnappyChildFirstURLClassLoader(urls, currentLoader)
+    } else {
+      new SnappyMutableURLClassLoader(urls, currentLoader)
+    }
+  }
+
+}
+
+class SnappyChildFirstURLClassLoader(urls: Array[URL], parent: ClassLoader)
+    extends ChildFirstURLClassLoader(urls, parent) {
+
+  override def loadClass(name: String, resolve: Boolean): Class[_] = {
+    try {
+      Misc.getMemStore.getDatabase.getClassFactory.loadClassFromDB(name)
+    } catch {
+      case e: ClassNotFoundException =>
+        super.loadClass(name, resolve)
+    }
+  }
+}
+
+
+class SnappyMutableURLClassLoader(urls: Array[URL], parent: ClassLoader)
+    extends MutableURLClassLoader(urls, parent) {
+  override def loadClass(name: String, resolve: Boolean): Class[_] = {
+    try {
+      super.loadClass(name, resolve)
+    } catch {
+      case e: ClassNotFoundException =>
+        Misc.getMemStore.getDatabase.getClassFactory.loadClassFromDB(name)
+    }
+  }
+}

--- a/cluster/src/main/scala/org/apache/spark/sql/streaming/SnappyStreamingContextFactory.scala
+++ b/cluster/src/main/scala/org/apache/spark/sql/streaming/SnappyStreamingContextFactory.scala
@@ -24,6 +24,7 @@ import spark.jobserver.{SparkJobValidation, ContextLike, SparkJobBase}
 import org.apache.spark.SparkConf
 import org.apache.spark.sql.{SnappyJobValidation, SnappyJobValidate}
 import org.apache.spark.streaming.{JavaSnappyStreamingJob, Milliseconds, SnappyStreamingContext}
+import org.apache.spark.util.SnappyUtils
 
 abstract class SnappyStreamingJob extends SparkJobBase {
   override type C = SnappyStreamingContext
@@ -33,6 +34,11 @@ abstract class SnappyStreamingJob extends SparkJobBase {
 
   final override def runJob(sc: C, jobConfig: Config): Any = {
     runSnappyJob(sc.asInstanceOf[SnappyStreamingContext], jobConfig)
+  }
+
+  final override def addOrReplaceJar(sc: C, jarName: String, jarPath: String): Unit = {
+    SnappyUtils.installOrReplaceJar(jarName, jarPath,
+      sc.asInstanceOf[SnappyStreamingContext].snappyContext.sparkContext)
   }
 
   def isValidJob(sc: SnappyStreamingContext, config: Config): SnappyJobValidation

--- a/cluster/src/main/scala/org/apache/spark/util/SnappyUtils.scala
+++ b/cluster/src/main/scala/org/apache/spark/util/SnappyUtils.scala
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2016 SnappyData, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License. You
+ * may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License. See accompanying
+ * LICENSE file.
+ */
+
+package org.apache.spark.util
+
+import java.security.SecureClassLoader
+import java.sql.{DriverManager, SQLException}
+
+import _root_.io.snappydata.util.ServiceUtils
+import com.pivotal.gemfirexd.internal.engine.Misc
+
+import org.apache.spark.SparkContext
+
+object SnappyUtils {
+
+  def getSnappyStoreContextLoader(parent: ClassLoader): ClassLoader =
+    new SecureClassLoader(parent) {
+      override def loadClass(name: String): Class[_] = {
+        try {
+          parent.loadClass(name)
+        } catch {
+          case cnfe: ClassNotFoundException =>
+            Misc.getMemStore.getDatabase.getClassFactory.loadClassFromDB(name)
+        }
+      }
+    }
+
+
+  def installOrReplaceJar(jarName: String, jarPath: String, sc: SparkContext): Unit = {
+    // for now using this approach as quickFix, later the add/replace should be called based on
+    // whether the jar is already loaded or not.
+
+    val jarExistsException =
+      executeCall("CALL SQLJ.INSTALL_JAR(?, ?, 0)", jarName, jarPath, sc)
+    if (jarExistsException) executeCall("CALL SQLJ.REPLACE_JAR(?, ?)", jarName, jarPath, sc)
+  }
+
+  private def executeCall(sql: String, jarName: String, jarPath: String,
+      sc: SparkContext): Boolean = {
+    val jar = new java.io.File(jarPath).toURI.toURL.toExternalForm
+    var jarExistsException = false
+    val conn = DriverManager.getConnection(ServiceUtils.getLocatorJDBCURL(sc))
+    try {
+      val cs = conn.prepareCall(sql)
+      cs.setString(1, jar)
+      cs.setString(2, jarName)
+      cs.executeUpdate()
+      cs.close
+    } catch {
+      case se: SQLException => if (!se.getSQLState.equals("X0Y32")) throw se
+      else jarExistsException = true
+    }
+    finally {
+      conn.close
+    }
+
+    jarExistsException
+  }
+}


### PR DESCRIPTION
## Changes proposed in this pull request
 Added support for dynamic Jar loading in snappy. The idea here is to support the existing snappy command for loading the jar file. For that lead node driver and executor class loader are modified in such a way that they look for the jar in the snappy-store if it is not found in regular class path.

Apart form above change there is another problem that once the job is submitted through the job server and if user make any changes to the jar related to submitted application and try to rerun again then executors are not able to pick the new jar. This problem is also resolved by loading the jar to the snappy store.

There are still few open issues with this PR which are logged under https://jira.snappydata.io/browse/SNAP-999

## Patch testing

precheckin , dunit and manual testing for lead node path

## ReleaseNotes.txt changes

(Does this change require an entry in ReleaseNotes.txt? If yes, has it been added to it?)

## Other PRs 

Yes.
https://github.com/SnappyDataInc/snappy-store/pull/88
https://github.com/SnappyDataInc/spark/pull/1
https://github.com/SnappyDataInc/spark-jobserver/pull/2
