### PR TITLE
 [SNAP-1000][SNAP-1001] Code generation for LocalJoin, PartitionedPhysicalRDD

### DIFF
--- a/core/src/main/scala/io/snappydata/Literals.scala
+++ b/core/src/main/scala/io/snappydata/Literals.scala
@@ -78,6 +78,8 @@ object Constant {
   // Property to specify the port on which zeppelin interpreter
   // should be started
   val ZEPPELIN_INTERPRETER_PORT = "zeppelin.interpreter.port"
+
+  val DEFAULT_CACHE_TIMEOUT_SECS = 10
 }
 
 /**
@@ -153,6 +155,8 @@ object Property extends Enumeration {
 
   val MetastoreDriver = Val(s"${Constant.PROPERTY_PREFIX}metastore-db-driver",
     Constant.SPARK_PREFIX)
+
+  val LocalCacheTimeout = Val(s"${Constant.SPARK_PREFIX}sql.cacheTimeout")
 }
 
 /**

--- a/core/src/main/scala/org/apache/spark/sql/collection/GenerateFlatIterator.scala
+++ b/core/src/main/scala/org/apache/spark/sql/collection/GenerateFlatIterator.scala
@@ -73,7 +73,7 @@ final class SlicedIterator[A](val iter: Iterator[A]) extends Iterator[A] {
     }
   }
 
-  override def hasNext = remaining > 0 && iter.hasNext
+  override def hasNext: Boolean = remaining > 0 && iter.hasNext
 
   override def next(): A =
     if (remaining > 0) {

--- a/core/src/main/scala/org/apache/spark/sql/collection/SegmentMap.scala
+++ b/core/src/main/scala/org/apache/spark/sql/collection/SegmentMap.scala
@@ -52,7 +52,7 @@ trait ChangeValue[K, V] {
 
   def segmentEnd(segment: SegmentMap[K, V]) {}
 
-  def segmentAbort(segment: SegmentMap[K, V]) = false
+  def segmentAbort(segment: SegmentMap[K, V]): Boolean = false
 }
 
 object SegmentMap {

--- a/core/src/main/scala/org/apache/spark/sql/execution/ExistingPlans.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/ExistingPlans.scala
@@ -84,7 +84,7 @@ private[sql] case class PartitionedPhysicalRDD(
 
   private[sql] override lazy val metrics = Map(
     "numOutputRows" -> SQLMetrics.createMetric(sparkContext, "number of output rows"),
-    "scanTime" -> SQLMetrics.createTimingMetric(sparkContext, "scan time"))
+    "scanTime" -> SQLMetrics.createTimingMetric(sparkContext, "scan and consume time"))
 
   override def inputRDDs(): Seq[RDD[InternalRow]] = {
     rdd :: Nil

--- a/core/src/main/scala/org/apache/spark/sql/execution/ExistingPlans.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/ExistingPlans.scala
@@ -16,29 +16,58 @@
  */
 package org.apache.spark.sql.execution
 
+import scala.collection.AbstractIterator
+
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.InternalRow
-import org.apache.spark.sql.catalyst.expressions.{UnsafeProjection, Attribute, Expression}
+import org.apache.spark.sql.catalyst.expressions.codegen.CodegenContext
+import org.apache.spark.sql.catalyst.expressions.{Attribute, BoundReference, Expression}
 import org.apache.spark.sql.catalyst.plans.physical.{HashPartitioning, Partitioning, SinglePartition}
 import org.apache.spark.sql.collection.ToolsCallbackInit
-import org.apache.spark.sql.sources.{PrunedUnsafeFilteredScan, BaseRelation}
+import org.apache.spark.sql.execution.metric.SQLMetrics
+import org.apache.spark.sql.snappy._
+import org.apache.spark.sql.sources.{BaseRelation, PrunedUnsafeFilteredScan}
 import org.apache.spark.sql.types.StructType
 
 /** Physical plan node for scanning data from an DataSource scan RDD.
-  * If user knows that the data is partitioned or replicated across
-  * all nodes this SparkPla can be used to avoid expensive shuffle
-  * and Broadcast joins. This plan overrides outputPartitioning and
-  * make it inline with the partitioning of the underlying DataSource */
+ * If user knows that the data is partitioned or replicated across
+ * all nodes this SparkPla can be used to avoid expensive shuffle
+ * and Broadcast joins. This plan overrides outputPartitioning and
+ * make it inline with the partitioning of the underlying DataSource */
 private[sql] case class PartitionedPhysicalRDD(
     output: Seq[Attribute],
     rdd: RDD[InternalRow],
     numPartitions: Int,
     partitionColumns: Seq[Expression],
-    extraInformation: String) extends LeafExecNode {
+    extraInformation: String) extends LeafExecNode with CodegenSupport {
 
   override lazy val schema: StructType = StructType.fromAttributes(output)
 
-  protected override def doExecute(): RDD[InternalRow] = rdd
+  protected override def doExecute(): RDD[InternalRow] = {
+    val numOutputRows = longMetric("numOutputRows")
+    val scanTime = longMetric("scanTime")
+    rdd.mapPartitionsPreserve { itr =>
+      new AbstractIterator[InternalRow] {
+
+        var nRows = 0L
+        val start = System.nanoTime()
+
+        def hasNext: Boolean = {
+          if (itr.hasNext) true
+          else {
+            numOutputRows += nRows
+            scanTime += (System.nanoTime() - start) / 1000000L
+            false
+          }
+        }
+
+        def next(): InternalRow = {
+          nRows += 1
+          itr.next()
+        }
+      }
+    }
+  }
 
   /** Specifies how data is partitioned across different nodes in the cluster. */
   override lazy val outputPartitioning: Partitioning = {
@@ -51,6 +80,47 @@ private[sql] case class PartitionedPhysicalRDD(
         HashPartitioning(partitionColumns, numPartitions)
       }
     }
+  }
+
+  private[sql] override lazy val metrics = Map(
+    "numOutputRows" -> SQLMetrics.createMetric(sparkContext, "number of output rows"),
+    "scanTime" -> SQLMetrics.createTimingMetric(sparkContext, "scan time"))
+
+  override def inputRDDs(): Seq[RDD[InternalRow]] = {
+    rdd :: Nil
+  }
+
+  override def doProduce(ctx: CodegenContext): String = {
+    val numOutputRows = metricTerm(ctx, "numOutputRows")
+    val scanTime = metricTerm(ctx, "scanTime")
+    // PartitionedPhysicalRDD always just has one input
+    val input = ctx.freshName("input")
+    val numRows = ctx.freshName("numRows")
+    val start = ctx.freshName("start")
+    ctx.addMutableState("scala.collection.Iterator", input,
+      s"$input = inputs[0];")
+    val exprRows = output.zipWithIndex.map { case (a, i) =>
+      BoundReference(i, a.dataType, a.nullable)
+    }
+    val row = ctx.freshName("row")
+    ctx.INPUT_ROW = row
+    ctx.currentVars = null
+    val columnsRowInput = exprRows.map(_.genCode(ctx))
+    s"""
+       |long $numRows = 0L;
+       |long $start = System.nanoTime();
+       |try {
+       |  while ($input.hasNext()) {
+       |    InternalRow $row = (InternalRow)$input.next();
+       |    $numRows++;
+       |    ${consume(ctx, columnsRowInput, row).trim}
+       |    if (shouldStop()) return;
+       |  }
+       |} finally {
+       |  $numOutputRows.add($numRows);
+       |  $scanTime.add((System.nanoTime() - $start)/1000000L);
+       |}
+     """.stripMargin
   }
 
   override def simpleString: String = "Partitioned Scan " + extraInformation +

--- a/core/src/main/scala/org/apache/spark/sql/execution/columnar/CachedBatchHolder.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/columnar/CachedBatchHolder.scala
@@ -52,7 +52,7 @@ private[sql] final class CachedBatchHolder(getColumnBuilders: => Array[ColumnBui
     if (rowCount >= batchSize || flush) {
       // create a new CachedBatch and push into the array of
       // CachedBatches so far in this iteration
-      //val stats = InternalRow.fromSeq(columnBuilders.map(
+      // val stats = InternalRow.fromSeq(columnBuilders.map(
       //  _.columnStats.collectedStatistics).flatMap(_.values))
       val stats: InternalRow = null
       // TODO: somehow push into global batchStats

--- a/core/src/main/scala/org/apache/spark/sql/execution/columnar/impl/ColumnFormatRelation.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/columnar/impl/ColumnFormatRelation.scala
@@ -20,6 +20,7 @@ import java.sql.Connection
 
 import com.gemstone.gemfire.internal.cache.PartitionedRegion
 import com.pivotal.gemfirexd.internal.engine.Misc
+import io.snappydata.Constant
 
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.InternalRow
@@ -36,7 +37,6 @@ import org.apache.spark.sql.sources._
 import org.apache.spark.sql.store.{CodeGeneration, StoreUtils}
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.sql.{DataFrame, Row, SQLContext, SaveMode, SnappySession}
-import org.apache.spark.storage.BlockManagerId
 import org.apache.spark.{Logging, Partition}
 
 /**
@@ -156,7 +156,7 @@ class BaseColumnFormatRelation(
   override def cachedBatchAggregate(batch: CachedBatch): Unit = {
     // if number of rows are greater than columnBatchSize then store
     // otherwise store locally
-    if (batch.numRows >= columnBatchSize) {
+    if (batch.numRows >= Constant.COLUMN_MIN_BATCH_SIZE) {
       externalStore.storeCachedBatch(ColumnFormatRelation.
           cachedBatchTableName(table), batch)
     } else {
@@ -179,6 +179,7 @@ class BaseColumnFormatRelation(
       truncate()
     }
     JdbcExtendedUtils.saveTable(data, table, schema, connProperties)
+    flushRowBuffer()
   }
 
   /**
@@ -224,8 +225,8 @@ class BaseColumnFormatRelation(
         connProperties.poolProps, connProps, connProperties.hikariCP)
       try {
         val stmt = connection.prepareStatement(rowInsertStr)
-        val result = CodeGeneration.executeUpdate(table, stmt,
-          rows, multipleRows = true, batchSize, schema.fields, dialect)
+        val result = CodeGeneration.executeUpdate(table, stmt, rows,
+          multipleRows = true, batchSize, schema.fields.map(_.dataType), dialect)
         stmt.close()
         result
       } finally {
@@ -387,13 +388,12 @@ class BaseColumnFormatRelation(
 
   override def flushRowBuffer(): Unit = {
     // force flush all the buckets into the column store
-    (Utils.mapExecutors(sqlContext, () => {
+    Utils.mapExecutors(sqlContext, () => {
       ColumnFormatRelation.flushLocalBuckets(resolvedName)
       Iterator.empty
-    })).count()
+    }).count()
     ColumnFormatRelation.flushLocalBuckets(resolvedName)
   }
-
 }
 
 class ColumnFormatRelation(
@@ -612,11 +612,6 @@ final class DefaultSource extends ColumnarRelationProvider {
 
     StoreUtils.validateConnProps(parameters)
 
-    connProperties.dialect match {
-      case GemFireXDDialect => StoreUtils.initStore(sqlContext, table,
-        Some(schema), partitions, connProperties)
-      case _ =>
-    }
     val schemaString = JdbcExtendedUtils.schemaString(schema,
       connProperties.dialect)
     val schemaExtension = if (schemaString.length > 0) {
@@ -629,9 +624,6 @@ final class DefaultSource extends ColumnarRelationProvider {
 
     val externalStore = new JDBCSourceAsColumnarStore(connProperties,
       partitions)
-
-    ColumnFormatRelation.registerStoreCallbacks(sqlContext, table,
-      schema, externalStore)
 
     var success = false
 
@@ -664,6 +656,13 @@ final class DefaultSource extends ColumnarRelationProvider {
 
     try {
       relation.createTable(mode)
+      ColumnFormatRelation.registerStoreCallbacks(sqlContext, table,
+        schema, externalStore)
+      connProperties.dialect match {
+        case GemFireXDDialect => StoreUtils.initStore(sqlContext, table,
+          Some(schema), partitions, connProperties)
+        case _ =>
+      }
       success = true
       relation
     } finally {

--- a/core/src/main/scala/org/apache/spark/sql/execution/joins/LocalJoin.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/joins/LocalJoin.scala
@@ -440,7 +440,7 @@ case class LocalJoin(leftKeys: Seq[Expression],
        |  ${keyEv.code}
        |  // Check if the key has nulls.
        |  if (!($anyNull)) {
-       |    // Check if the HashedRelation exists.
+       |    // find matches from HashedRelation
        |    UnsafeRow $matched = (UnsafeRow)$relationTerm
        |      .getValue(${keyEv.value});
        |    if ($matched != null) {
@@ -455,7 +455,7 @@ case class LocalJoin(leftKeys: Seq[Expression],
        |  ${keyEv.code}
        |  // Check if the key has nulls.
        |  if (!($anyNull)) {
-       |    // Check if the HashedRelation exists.
+       |    // find matches from HashedRelation
        |    $iteratorCls $matches = ($iteratorCls)$relationTerm
        |      .get(${keyEv.value});
        |    if ($matches != null) {

--- a/core/src/main/scala/org/apache/spark/sql/execution/joins/LocalJoin.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/joins/LocalJoin.scala
@@ -16,29 +16,36 @@
  */
 package org.apache.spark.sql.execution.joins
 
-import java.io.{IOException, ObjectOutputStream}
+import java.util.concurrent.atomic.AtomicLong
+import java.util.concurrent.{Callable, ExecutionException, TimeUnit}
+
+import scala.collection.mutable
+
+import com.google.common.cache.{CacheBuilder, RemovalListener, RemovalNotification}
+import io.snappydata.{Constant, Property}
 
 import org.apache.spark.annotation.DeveloperApi
+import org.apache.spark.memory.TaskMemoryManager
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.InternalRow
-import org.apache.spark.sql.catalyst.expressions.Expression
-import org.apache.spark.sql.catalyst.plans.JoinType
+import org.apache.spark.sql.catalyst.expressions.codegen.{CodegenContext, ExprCode, GenerateUnsafeProjection}
+import org.apache.spark.sql.catalyst.expressions.{BindReferences, BoundReference, Expression, UnsafeRow}
+import org.apache.spark.sql.catalyst.plans._
 import org.apache.spark.sql.catalyst.plans.physical.{Distribution, Partitioning, UnspecifiedDistribution}
 import org.apache.spark.sql.execution.metric.SQLMetrics
-import org.apache.spark.sql.execution.{BinaryExecNode, SparkPlan}
-import org.apache.spark.storage.{RDDBlockId, StorageLevel}
-import org.apache.spark.util.Utils
-import org.apache.spark.{OneToOneDependency, Partition, SparkContext, SparkEnv, TaskContext}
-
+import org.apache.spark.sql.execution.{BinaryExecNode, CodegenSupport, SparkPlan}
+import org.apache.spark.sql.snappy._
+import org.apache.spark.sql.types.{LongType, StructType}
+import org.apache.spark.{Partition, SparkEnv, TaskContext}
 
 /**
-  * :: DeveloperApi ::
-  * Performs an local hash join of two child relations. If a relation
-  * (out of a datasource) is already replicated accross all nodes then rather
-  * than doing a Broadcast join which can be expensive, this join just
-  * scans through the single partition of the replicated relation while
-  * streaming through the other relation.
-  */
+ * :: DeveloperApi ::
+ * Performs an local hash join of two child relations. If a relation
+ * (out of a datasource) is already replicated accross all nodes then rather
+ * than doing a Broadcast join which can be expensive, this join just
+ * scans through the single partition of the replicated relation while
+ * streaming through the other relation.
+ */
 @DeveloperApi
 case class LocalJoin(leftKeys: Seq[Expression],
     rightKeys: Seq[Expression],
@@ -47,166 +54,552 @@ case class LocalJoin(leftKeys: Seq[Expression],
     joinType: JoinType,
     left: SparkPlan,
     right: SparkPlan)
-    extends BinaryExecNode with HashJoin {
-
+    extends BinaryExecNode with HashJoin with CodegenSupport {
 
   override private[sql] lazy val metrics = Map(
-    "numLeftRows" -> SQLMetrics.createMetric(sparkContext, "number of left rows"),
-    "numRightRows" -> SQLMetrics.createMetric(sparkContext, "number of right rows"),
-    "numOutputRows" -> SQLMetrics.createMetric(sparkContext, "number of output rows"))
+    "numOutputRows" -> SQLMetrics.createMetric(sparkContext, "number of output rows"),
+    "buildDataSize" -> SQLMetrics.createSizeMetric(sparkContext, "data size of build side"),
+    "buildTime" -> SQLMetrics.createTimingMetric(sparkContext, "time to build hash map"))
 
   override def outputPartitioning: Partitioning = streamedPlan.outputPartitioning
 
-
   override def requiredChildDistribution: Seq[Distribution] =
     UnspecifiedDistribution :: UnspecifiedDistribution :: Nil
+
+  private lazy val streamRDD = streamedPlan.execute()
+  private lazy val (buildRDD, buildPartition) = {
+    val rdd = buildPlan.execute()
+    assert(rdd.getNumPartitions == 1)
+    (rdd, rdd.partitions(0))
+  }
 
   /**
    * Overridden by concrete implementations of SparkPlan.
    * Produces the result of the query as an RDD[InternalRow]
    */
   override protected def doExecute(): RDD[InternalRow] = {
-    /*
-    val (numBuildRows, numStreamedRows) = buildSide match {
-      case BuildLeft => (longMetric("numLeftRows"), longMetric("numRightRows"))
-      case BuildRight => (longMetric("numRightRows"), longMetric("numLeftRows"))
-    }
-    */
     val numOutputRows = longMetric("numOutputRows")
-    def hashedRelationIter(buildIter: Iterator[InternalRow],
-        context: TaskContext): HashedRelation = {
-      HashedRelation(buildIter, buildKeys,
-        taskMemoryManager = context.taskMemoryManager())
+    val buildDataSize = longMetric("buildDataSize")
+    val buildTime = longMetric("buildTime")
+
+    // materialize dependencies in the entire buildRDD graph for
+    // buildRDD.iterator to work in the compute of mapPartitionsPreserve below
+    materializeDependencies(buildRDD, new mutable.HashSet[RDD[_]]())
+
+    val schema = buildPlan.schema
+    streamRDD.mapPartitionsPreserveWithPartition { (context, split, itr) =>
+      val start = System.nanoTime()
+      val hashed = HashedRelationCache.get(schema, buildKeys, buildRDD,
+        split, context)
+      buildTime += (System.nanoTime() - start) / 1000000L
+      val estimatedSize = hashed.estimatedSize
+      buildDataSize += estimatedSize
+      context.taskMetrics().incPeakExecutionMemory(estimatedSize)
+      context.addTaskCompletionListener(_ => hashed.close())
+      join(itr, hashed, numOutputRows)
     }
+  }
 
-    val buildRDD = buildPlan.execute()
-    val streamRDD = streamedPlan.execute()
+  private[spark] def materializeDependencies[T](rdd: RDD[T],
+      visited: mutable.HashSet[RDD[_]]): Unit = {
+    rdd.dependencies.foreach(dep =>
+      if (visited.add(dep.rdd)) materializeDependencies(dep.rdd, visited))
+  }
 
-    val sc = buildRDD.sparkContext
-    val hashedRDD = new HashRelationRDD(sc, buildRDD,
-      streamRDD.partitions.length, sc.clean(hashedRelationIter))
+  override def inputRDDs(): Seq[RDD[InternalRow]] =
+    streamedPlan.asInstanceOf[CodegenSupport].inputRDDs()
 
-    narrowPartitions(hashedRDD, streamRDD, preservesPartitioning = true) {
-      (hashedIter, streamIter) => {
-        val hashed = hashedIter.next()
-        join(streamIter, hashed, numOutputRows)
+  override def doProduce(ctx: CodegenContext): String = {
+    streamedPlan.asInstanceOf[CodegenSupport].produce(ctx, this)
+  }
+
+  override def doConsume(ctx: CodegenContext, input: Seq[ExprCode],
+      row: ExprCode): String = {
+    // create a name for HashedRelation
+    val relationTerm = ctx.freshName("relation")
+    val buildRDDRef = ctx.addReferenceObj("buildRDD", buildRDD)
+    val buildPartRef = ctx.addReferenceObj("buildPartition", buildPartition)
+    ctx.addMutableState(classOf[HashedRelation].getName, relationTerm,
+      prepareHashedRelation(ctx, relationTerm, buildRDDRef, buildPartRef))
+
+    joinType match {
+      case Inner => codeGenInner(ctx, input, relationTerm)
+      case LeftOuter | RightOuter => codeGenOuter(ctx, input, relationTerm)
+      case LeftSemi => codeGenSemi(ctx, input, relationTerm)
+      case LeftAnti => codeGenAnti(ctx, input, relationTerm)
+      case j: ExistenceJoin => codeGenExistence(ctx, input, relationTerm)
+      case x =>
+        throw new IllegalArgumentException(
+          s"BroadcastHashJoin should not take $x as the JoinType")
+    }
+  }
+
+  /**
+   * Returns code for creating a HashedRelation.
+   */
+  private def prepareHashedRelation(ctx: CodegenContext,
+      relationTerm: String, buildRDDTerm: String,
+      buildPartTerm: String): String = {
+    val startName = ctx.freshName("start")
+    val sizeName = ctx.freshName("estimatedSize")
+    val contextName = ctx.freshName("context")
+    val buildKeysVar = ctx.addReferenceObj("buildKeys", buildKeys)
+    val buildSchemaVar = ctx.addReferenceObj("buildSchema", buildPlan.schema)
+    val buildDataSize = metricTerm(ctx, "buildDataSize")
+    val buildTime = metricTerm(ctx, "buildTime")
+    s"""
+       |final long $startName = System.nanoTime();
+       |final org.apache.spark.TaskContext $contextName =
+       |  org.apache.spark.TaskContext.get();
+       |$relationTerm = org.apache.spark.sql.execution.joins.HashedRelationCache
+       |  .get($buildSchemaVar, $buildKeysVar, $buildRDDTerm, $buildPartTerm,
+       |  $contextName, 1);
+       |$buildTime.add((System.nanoTime() - $startName) / 1000000L);
+       |final long $sizeName = $relationTerm.estimatedSize();
+       |$buildDataSize.add($sizeName);
+       |$contextName.taskMetrics().incPeakExecutionMemory($sizeName);
+    """.stripMargin
+  }
+
+  /**
+   * Returns the code for generating join key for stream side,
+   * and expression of whether the key has any null in it or not.
+   */
+  private def genStreamSideJoinKey(
+      ctx: CodegenContext,
+      input: Seq[ExprCode]): (ExprCode, String) = {
+    ctx.currentVars = input
+    if (streamedKeys.length == 1 && streamedKeys.head.dataType == LongType) {
+      // generate the join key as Long
+      val ev = streamedKeys.head.genCode(ctx)
+      (ev, ev.isNull)
+    } else {
+      // generate the join key as UnsafeRow
+      val ev = GenerateUnsafeProjection.createCode(ctx, streamedKeys)
+      (ev, s"${ev.value}.anyNull()")
+    }
+  }
+
+  /**
+   * Generates the code for variable of build side.
+   */
+  private def genBuildSideVars(ctx: CodegenContext,
+      matched: String): Seq[ExprCode] = {
+    ctx.currentVars = null
+    ctx.INPUT_ROW = matched
+    buildPlan.output.zipWithIndex.map { case (a, i) =>
+      val ev = BoundReference(i, a.dataType, a.nullable).genCode(ctx)
+      if (joinType == Inner) {
+        ev
+      } else {
+        // the variables are needed even there is no matched rows
+        val isNull = ctx.freshName("isNull")
+        val value = ctx.freshName("value")
+        val code =
+          s"""
+             |boolean $isNull = true;
+             |${ctx.javaType(a.dataType)} $value =
+             |  ${ctx.defaultValue(a.dataType)};
+             |if ($matched != null) {
+             |  ${ev.code}
+             |  $isNull = ${ev.isNull};
+             |  $value = ${ev.value};
+             |}
+         """.stripMargin
+        ExprCode(code, isNull, value)
       }
     }
   }
 
-  def narrowPartitions(hashedRDD: RDD[HashedRelation], streamRDD: RDD[InternalRow],
-      preservesPartitioning: Boolean)
-      (f: (Iterator[HashedRelation], Iterator[InternalRow])
-          => Iterator[InternalRow]): NarrowPartitionsRDD = {
-    val sc = hashedRDD.sparkContext
-    new NarrowPartitionsRDD(sc, sc.clean(f),
-      hashedRDD, streamRDD, preservesPartitioning)
+  /**
+   * Generate the (non-equi) condition used to filter joined rows.
+   * This is used in Inner, Left Semi and Left Anti joins.
+   */
+  private def getJoinCondition(
+      ctx: CodegenContext,
+      input: Seq[ExprCode],
+      anti: Boolean = false): (String, String, String, Seq[ExprCode]) = {
+    val matched = ctx.freshName("matched")
+    val buildVars = genBuildSideVars(ctx, matched)
+    val (checkCondition, antiCondition) = if (condition.isDefined) {
+      val expr = condition.get
+      // evaluate the variables from build side that used by condition
+      val eval = evaluateRequiredVariables(buildPlan.output, buildVars,
+        expr.references)
+      // filter the output via condition
+      ctx.currentVars = input ++ buildVars
+      val ev = BindReferences.bindReference(expr,
+        streamedPlan.output ++ buildPlan.output).genCode(ctx)
+      val cond =
+        s"""
+           |$eval
+           |${ev.code}
+           |if (${ev.isNull}|| !${ev.value}) continue;
+        """.stripMargin
+      val antiCond = if (anti) {
+        s"""
+           |$eval
+           |${ev.code}
+           |if (!${ev.isNull} && ${ev.value}) continue;
+        """.stripMargin
+      } else ""
+      (cond, antiCond)
+    } else {
+      ("", "continue;")
+    }
+    (matched, checkCondition, antiCondition, buildVars)
+  }
+
+  /**
+   * Generates the code for Inner join.
+   */
+  private def codeGenInner(ctx: CodegenContext,
+      input: Seq[ExprCode], relationTerm: String): String = {
+    val (keyEv, anyNull) = genStreamSideJoinKey(ctx, input)
+    val (matched, checkCondition, _, buildVars) = getJoinCondition(ctx, input)
+    val numOutput = metricTerm(ctx, "numOutputRows")
+
+    val resultVars = buildSide match {
+      case BuildLeft => buildVars ++ input
+      case BuildRight => input ++ buildVars
+    }
+    ctx.copyResult = true
+    val matches = ctx.freshName("matches")
+    val iteratorCls = classOf[Iterator[UnsafeRow]].getName
+    val consumeResult = consume(ctx, resultVars)
+
+    s"""
+       |if ($relationTerm.keyIsUnique()) {
+       |  // generate join key for stream side
+       |  ${keyEv.code}
+       |  // find matches from HashedRelation
+       |  UnsafeRow $matched = $anyNull ? null : (UnsafeRow)$relationTerm
+       |    .getValue(${keyEv.value});
+       |  if ($matched == null) continue;
+       |  $checkCondition
+       |  $numOutput.add(1);
+       |  $consumeResult
+       |} else {
+       |  // generate join key for stream side
+       |  ${keyEv.code}
+       |  // find matches from HashRelation
+       |  $iteratorCls $matches = $anyNull ? null : ($iteratorCls)$relationTerm
+       |    .get(${keyEv.value});
+       |  if ($matches == null) continue;
+       |  while ($matches.hasNext()) {
+       |    UnsafeRow $matched = (UnsafeRow)$matches.next();
+       |    $checkCondition
+       |    $numOutput.add(1);
+       |    $consumeResult
+       |  }
+       |}
+     """.stripMargin
+  }
+
+  /**
+   * Generates the code for left or right outer join.
+   */
+  private def codeGenOuter(ctx: CodegenContext,
+      input: Seq[ExprCode], relationTerm: String): String = {
+    val (keyEv, anyNull) = genStreamSideJoinKey(ctx, input)
+    val matched = ctx.freshName("matched")
+    val buildVars = genBuildSideVars(ctx, matched)
+    val numOutput = metricTerm(ctx, "numOutputRows")
+
+    // filter the output via condition
+    val conditionPassed = ctx.freshName("conditionPassed")
+    val checkCondition = if (condition.isDefined) {
+      val expr = condition.get
+      // evaluate the variables from build side that used by condition
+      val eval = evaluateRequiredVariables(buildPlan.output, buildVars,
+        expr.references)
+      ctx.currentVars = input ++ buildVars
+      val ev = BindReferences.bindReference(expr,
+        streamedPlan.output ++ buildPlan.output).genCode(ctx)
+      s"""
+         |boolean $conditionPassed = true;
+         |${eval.trim}
+         |${ev.code}
+         |if ($matched != null) {
+         |  $conditionPassed = !${ev.isNull} && ${ev.value};
+         |}
+       """.stripMargin.trim
+    } else {
+      s"final boolean $conditionPassed = true;"
+    }
+
+    val resultVars = buildSide match {
+      case BuildLeft => buildVars ++ input
+      case BuildRight => input ++ buildVars
+    }
+    ctx.copyResult = true
+    val matches = ctx.freshName("matches")
+    val iteratorCls = classOf[Iterator[UnsafeRow]].getName
+    val found = ctx.freshName("found")
+    val consumeResult = consume(ctx, resultVars)
+
+    s"""
+       |if ($relationTerm.keyIsUnique()) {
+       |  // generate join key for stream side
+       |  ${keyEv.code}
+       |  // find matches from HashedRelation
+       |  UnsafeRow $matched = $anyNull ? null: (UnsafeRow)$relationTerm
+       |    .getValue(${keyEv.value});
+       |  $checkCondition
+       |  if (!$conditionPassed) {
+       |    $matched = null;
+       |    // reset the variables those are already evaluated.
+       |    ${buildVars.filter(_.code == "").map(v => s"${v.isNull} = true;")
+              .mkString("\n")}
+       |  }
+       |  $numOutput.add(1);
+       |  $consumeResult
+       |} else {
+       |  // generate join key for stream side
+       |  ${keyEv.code}
+       |  // find matches from HashRelation
+       |  $iteratorCls $matches = $anyNull ? null : ($iteratorCls)$relationTerm
+       |    .get(${keyEv.value});
+       |  boolean $found = false;
+       |  // the last iteration of this loop is to emit an empty row
+       |  // if there is no matched rows.
+       |  while ($matches != null && $matches.hasNext() || !$found) {
+       |    UnsafeRow $matched = $matches != null && $matches.hasNext() ?
+       |      (UnsafeRow) $matches.next() : null;
+       |    $checkCondition
+       |    if (!$conditionPassed) continue;
+       |    $found = true;
+       |    $numOutput.add(1);
+       |    $consumeResult
+       |  }
+       |}
+    """.stripMargin
+  }
+
+  /**
+   * Generates the code for left semi join.
+   */
+  private def codeGenSemi(ctx: CodegenContext,
+      input: Seq[ExprCode], relationTerm: String): String = {
+    val (keyEv, anyNull) = genStreamSideJoinKey(ctx, input)
+    val (matched, checkCondition, _, _) = getJoinCondition(ctx, input)
+    val numOutput = metricTerm(ctx, "numOutputRows")
+    val matches = ctx.freshName("matches")
+    val iteratorCls = classOf[Iterator[UnsafeRow]].getName
+    val found = ctx.freshName("found")
+    val consumeResult = consume(ctx, input)
+
+    s"""
+       |if ($relationTerm.keyIsUnique()) {
+       |  // generate join key for stream side
+       |  ${keyEv.code}
+       |  // find matches from HashedRelation
+       |  UnsafeRow $matched = $anyNull ? null: (UnsafeRow)$relationTerm
+       |    .getValue(${keyEv.value});
+       |  if ($matched == null) continue;
+       |  $checkCondition
+       |  $numOutput.add(1);
+       |  $consumeResult
+       |} else {
+       |  // generate join key for stream side
+       |  ${keyEv.code}
+       |  // find matches from HashRelation
+       |  $iteratorCls $matches = $anyNull ? null : ($iteratorCls)$relationTerm
+       |    .get(${keyEv.value});
+       |  if ($matches == null) continue;
+       |  boolean $found = false;
+       |  while (!$found && $matches.hasNext()) {
+       |    UnsafeRow $matched = (UnsafeRow) $matches.next();
+       |    $checkCondition
+       |    $found = true;
+       |  }
+       |  if (!$found) continue;
+       |  $numOutput.add(1);
+       |  $consumeResult
+       |}
+    """.stripMargin
+  }
+
+  /**
+   * Generates the code for anti join.
+   */
+  private def codeGenAnti(ctx: CodegenContext,
+      input: Seq[ExprCode], relationTerm: String): String = {
+    val (keyEv, anyNull) = genStreamSideJoinKey(ctx, input)
+    val (matched, checkCondition, antiCondition, _) =
+      getJoinCondition(ctx, input, anti = true)
+    val numOutput = metricTerm(ctx, "numOutputRows")
+    val matches = ctx.freshName("matches")
+    val iteratorCls = classOf[Iterator[UnsafeRow]].getName
+    val found = ctx.freshName("found")
+    val consumeResult = consume(ctx, input)
+
+    s"""
+       |if ($relationTerm.keyIsUnique()) {
+       |  // generate join key for stream side
+       |  ${keyEv.code}
+       |  // Check if the key has nulls.
+       |  if (!($anyNull)) {
+       |    // Check if the HashedRelation exists.
+       |    UnsafeRow $matched = (UnsafeRow)$relationTerm
+       |      .getValue(${keyEv.value});
+       |    if ($matched != null) {
+       |      // Evaluate the condition.
+       |      $antiCondition
+       |    }
+       |  }
+       |  $numOutput.add(1);
+       |  $consumeResult
+       |} else {
+       |  // generate join key for stream side
+       |  ${keyEv.code}
+       |  // Check if the key has nulls.
+       |  if (!($anyNull)) {
+       |    // Check if the HashedRelation exists.
+       |    $iteratorCls $matches = ($iteratorCls)$relationTerm
+       |      .get(${keyEv.value});
+       |    if ($matches != null) {
+       |      // Evaluate the condition.
+       |      boolean $found = false;
+       |      while (!$found && $matches.hasNext()) {
+       |        UnsafeRow $matched = (UnsafeRow) $matches.next();
+       |        $checkCondition
+       |        $found = true;
+       |      }
+       |      if ($found) continue;
+       |    }
+       |  }
+       |  $numOutput.add(1);
+       |  $consumeResult
+       |}
+    """.stripMargin
+  }
+
+  /**
+   * Generates the code for existence join.
+   */
+  private def codeGenExistence(ctx: CodegenContext,
+      input: Seq[ExprCode], relationTerm: String): String = {
+    val (keyEv, anyNull) = genStreamSideJoinKey(ctx, input)
+    val numOutput = metricTerm(ctx, "numOutputRows")
+    val existsVar = ctx.freshName("exists")
+
+    val matched = ctx.freshName("matched")
+    val buildVars = genBuildSideVars(ctx, matched)
+    val checkCondition = if (condition.isDefined) {
+      val expr = condition.get
+      // evaluate the variables from build side that used by condition
+      val eval = evaluateRequiredVariables(buildPlan.output, buildVars,
+        expr.references)
+      // filter the output via condition
+      ctx.currentVars = input ++ buildVars
+      val ev = BindReferences.bindReference(expr,
+        streamedPlan.output ++ buildPlan.output).genCode(ctx)
+      s"""
+         |$eval
+         |${ev.code}
+         |$existsVar = !${ev.isNull} && ${ev.value};
+       """.stripMargin
+    } else {
+      s"$existsVar = true;"
+    }
+
+    val resultVar = input ++ Seq(ExprCode("", "false", existsVar))
+    val matches = ctx.freshName("matches")
+    val iteratorCls = classOf[Iterator[UnsafeRow]].getName
+    val consumeResult = consume(ctx, resultVar)
+
+    s"""
+       |if ($relationTerm.keyIsUnique()) {
+       |  // generate join key for stream side
+       |  ${keyEv.code}
+       |  // find matches from HashedRelation
+       |  UnsafeRow $matched = $anyNull ? null: (UnsafeRow)$relationTerm
+       |    .getValue(${keyEv.value});
+       |  boolean $existsVar = false;
+       |  if ($matched != null) {
+       |    $checkCondition
+       |  }
+       |  $numOutput.add(1);
+       |  $consumeResult
+       |} else {
+       |  // generate join key for stream side
+       |  ${keyEv.code}
+       |  // find matches from HashRelation
+       |  $iteratorCls $matches = $anyNull ? null : ($iteratorCls)$relationTerm
+       |    .get(${keyEv.value});
+       |  boolean $existsVar = false;
+       |  if ($matches != null) {
+       |    while (!$existsVar && $matches.hasNext()) {
+       |      UnsafeRow $matched = (UnsafeRow) $matches.next();
+       |      $checkCondition
+       |    }
+       |  }
+       |  $numOutput.add(1);
+       |  $consumeResult
+       |}
+     """.stripMargin
   }
 }
 
-// Helper object jut to take a global sync across tasks.
-// Furture helper methods can come here
-private[spark] object HashRelationRDD
+object HashedRelationCache {
 
-private[spark] class HashRelationRDD(
-    sc: SparkContext,
-    var buildRDD: RDD[InternalRow],
-    val maxPartitions: Int,
-    var f: (Iterator[InternalRow], TaskContext) => HashedRelation
-) extends RDD[HashedRelation](sc, Seq(new OneToOneDependency(buildRDD))) {
+  type KeyType = (StructType, Seq[Expression])
 
-  override def compute(s: Partition,
-      context: TaskContext): Iterator[HashedRelation] = {
-
-    val blockId = RDDBlockId(this.id, s.index)
-
-    val rel1 = SparkEnv.get.blockManager.getSingle(blockId) match {
-      case Some(x) => x.asInstanceOf[HashedRelation]
-      case None =>
-        HashRelationRDD.synchronized {
-          SparkEnv.get.blockManager.getSingle(blockId) match {
-            case Some(x) => x.asInstanceOf[HashedRelation]
-            case None =>
-              val hashedRelation = f(buildRDD.iterator(s, context), context)
-              SparkEnv.get.blockManager.putSingle(blockId, hashedRelation,
-                StorageLevel.MEMORY_AND_DISK_SER, tellMaster = false)
-
-              hashedRelation
+  private[this] val relationCacheSize = new AtomicLong(0L)
+  private[this] lazy val (relationCache, cacheMemoryManager) = {
+    val env = SparkEnv.get
+    val cacheTimeoutSecs = Property.LocalCacheTimeout.getOption(env.conf)
+        .map(_.toInt).getOrElse(Constant.DEFAULT_CACHE_TIMEOUT_SECS)
+    val cache = CacheBuilder.newBuilder()
+        .maximumSize(50)
+        .expireAfterAccess(cacheTimeoutSecs, TimeUnit.SECONDS)
+        .removalListener(new RemovalListener[KeyType, HashedRelation] {
+          override def onRemoval(notification: RemovalNotification[KeyType,
+              HashedRelation]): Unit = {
+            relationCacheSize.decrementAndGet()
+            notification.getValue.close()
           }
+        }).build[KeyType, HashedRelation]()
+    (cache, new TaskMemoryManager(env.memoryManager, -1L))
+  }
 
+  def get(schema: StructType, buildKeys: Seq[Expression], rdd: RDD[InternalRow],
+      split: Partition, context: TaskContext, tries: Int = 1): HashedRelation = {
+    try {
+      relationCache.get(schema -> buildKeys, new Callable[HashedRelation] {
+        override def call(): HashedRelation = {
+            val relation = HashedRelation(rdd.iterator(split, context),
+              buildKeys, taskMemoryManager = cacheMemoryManager)
+            relationCacheSize.incrementAndGet()
+            relation
         }
-    }
-
-    Seq(rel1).iterator
-  }
-
-  override def getPartitions: Array[Partition] = {
-    buildRDD.partitions
-  }
-
-
-  override def getPreferredLocations(s: Partition): Seq[String] = {
-    buildRDD.preferredLocations(s)
-  }
-}
-
-private[spark] class NarrowPartitionsRDD(_sc: SparkContext,
-    var f: (Iterator[HashedRelation], Iterator[InternalRow]) => Iterator[InternalRow],
-    var hashedRDD: RDD[HashedRelation],
-    var streamRDD: RDD[InternalRow],
-    preservesPartitioning: Boolean = false)
-    extends RDD[InternalRow](_sc, Seq(new OneToOneDependency(streamRDD))) {
-
-  override def compute(s: Partition, context: TaskContext): Iterator[InternalRow] = {
-    val partitions = s.asInstanceOf[NarrowPartitionsPartition]
-    f(hashedRDD.iterator(partitions.buildPartition, context),
-      streamRDD.iterator(partitions.streamPartition, context))
-  }
-
-  override def getPartitions: Array[Partition] = {
-    val numParts = streamRDD.partitions.length
-    val part = hashedRDD.partitions.head
-    Array.tabulate[Partition](numParts) { i =>
-      val streamLocs = streamRDD.preferredLocations(streamRDD.partitions(i))
-      val buildLocs = hashedRDD.preferredLocations(part)
-      val exactMatchLocations = streamLocs.intersect(buildLocs)
-      val locs = if (exactMatchLocations.nonEmpty) exactMatchLocations
-      else (streamLocs ++ buildLocs).distinct
-
-      new NarrowPartitionsPartition(part.index, hashedRDD, i, streamRDD, locs)
+      }).asReadOnlyCopy()
+    } catch {
+      case e: ExecutionException =>
+        // in case of OOME from MemoryManager, try after clearing the cache
+        val cause = e.getCause
+        cause match {
+          case _: OutOfMemoryError =>
+            if (tries <= 10 && relationCacheSize.get() > 0) {
+              relationCache.invalidateAll()
+              get(schema, buildKeys, rdd, split, context, tries + 1)
+            } else {
+              throw new RuntimeException(cause.getMessage, cause)
+            }
+          case _ => throw new RuntimeException(cause.getMessage, cause)
+        }
+      case e: Exception => throw new RuntimeException(e.getMessage, e)
     }
   }
 
-  override def getPreferredLocations(s: Partition): Seq[String] = {
-    s.asInstanceOf[NarrowPartitionsPartition].preferredLocations
+  def remove(schema: StructType, buildKeys: Seq[Expression]): Unit = {
+    relationCache.invalidate(schema -> buildKeys)
   }
 
-  override def clearDependencies() {
-    super.clearDependencies()
-    hashedRDD = null
-    streamRDD = null
-    f = null
-  }
-
-}
-
-private[spark] class NarrowPartitionsPartition(
-    buildIdx: Int,
-    @transient var hashedRDD: RDD[HashedRelation],
-    streamIdx: Int,
-    @transient var streamRDD: RDD[InternalRow],
-    @transient val preferredLocations: Seq[String])
-    extends Partition {
-  override val index: Int = streamIdx
-  var buildPartition = hashedRDD.partitions(buildIdx)
-  var streamPartition = streamRDD.partitions(streamIdx)
-
-  @throws[IOException]
-  private def writeObject(oos: ObjectOutputStream): Unit = Utils.tryOrIOException {
-    // Update the reference to parent split at the time of task serialization
-    buildPartition = hashedRDD.partitions(buildIdx)
-    streamPartition = streamRDD.partitions(streamIdx)
-
-    oos.defaultWriteObject()
+  def clear(): Unit = {
+    if (relationCacheSize.get() > 0) {
+      relationCache.invalidateAll()
+    }
   }
 }

--- a/core/src/main/scala/org/apache/spark/sql/row/JDBCMutableRelation.scala
+++ b/core/src/main/scala/org/apache/spark/sql/row/JDBCMutableRelation.scala
@@ -231,11 +231,10 @@ case class JDBCMutableRelation(
     var index = 0
     // not using loop over index below because incoming Seq[...]
     // may not have efficient index lookup
-    updateColumns.foreach { col =>
-      setFields(index) = schemaFields.getOrElse(col, schemaFields.getOrElse(
-        col, throw new AnalysisException(
+    updateColumns.foreach { c =>
+      setFields(index) = schemaFields.getOrElse(c, throw new AnalysisException(
           "JDBCUpdatableRelation: Cannot resolve column name " +
-              s""""$col" among (${schema.fieldNames.mkString(", ")})""")))
+              s""""$c" among (${schema.fieldNames.mkString(", ")})"""))
       index += 1
     }
     val connection = ConnectionPool.getPoolConnection(table, dialect,

--- a/core/src/main/scala/org/apache/spark/sql/store/CodeGeneration.scala
+++ b/core/src/main/scala/org/apache/spark/sql/store/CodeGeneration.scala
@@ -184,7 +184,7 @@ object CodeGeneration extends Logging {
               $buffVar.buffer, $buffVar.totalSize()));
         }"""
       case _ =>
-        s"stmt.setObject(${col + 1}, row.get($col, schema[$col].dataType()));"
+        s"stmt.setObject(${col + 1}, row.get($col, schema[$col]));"
     }
     (nonNullCode, s"stmt.setNull(${col + 1}, " +
         s"${ExternalStoreUtils.getJDBCType(dialect, NullType)});")
@@ -194,12 +194,12 @@ object CodeGeneration extends Logging {
     "bufferHolderForComplexType_" + numFields
 
   private[this] def compilePreparedUpdate(table: String,
-      schema: Array[StructField], dialect: JdbcDialect): GeneratedStatement = {
+      schema: Array[DataType], dialect: JdbcDialect): GeneratedStatement = {
     val ctx = new CodegenContext
     val sb = new StringBuilder()
     schema.indices.foreach { col =>
       val (nonNullCode, nullCode) = getColumnSetterFragment(col,
-        schema(col).dataType, dialect, ctx)
+        schema(col), dialect, ctx)
       sb.append(s"""
         if (!row.isNullAt($col)) {
           $nonNullCode
@@ -384,7 +384,7 @@ object CodeGeneration extends Logging {
 
   private[this] def executeUpdate(name: String, stmt: PreparedStatement,
       rows: java.util.Iterator[InternalRow], multipleRows: Boolean,
-      batchSize: Int, schema: Array[StructField], dialect: JdbcDialect): Int = {
+      batchSize: Int, schema: Array[DataType], dialect: JdbcDialect): Int = {
     val result = cache.get(new ExecuteKey(name, schema, dialect))
     result.executeStatement(stmt, multipleRows, rows, batchSize,
       schema, dialect)
@@ -392,7 +392,7 @@ object CodeGeneration extends Logging {
 
   def executeUpdate(name: String, stmt: PreparedStatement,
       rows: Iterator[InternalRow], multipleRows: Boolean, batchSize: Int,
-      schema: Array[StructField], dialect: JdbcDialect): Int =
+      schema: Array[DataType], dialect: JdbcDialect): Int =
     executeUpdate(name, stmt, rows.asJava, multipleRows, batchSize,
       schema, dialect)
 
@@ -414,14 +414,14 @@ object CodeGeneration extends Logging {
         throw new UnsupportedOperationException("remove not supported")
     }
     executeUpdate(name, stmt, iterator, multipleRows, batchSize,
-      schema, dialect)
+      schema.map(_.dataType), dialect)
   }
 
   def executeUpdate(name: String, stmt: PreparedStatement, row: Row,
       schema: Array[StructField], dialect: JdbcDialect): Int = {
     val encoder = RowEncoder(StructType(schema))
     executeUpdate(name, stmt, Collections.singleton(encoder.toRow(row))
-        .iterator(), multipleRows = false, 0, schema, dialect)
+        .iterator(), multipleRows = false, 0, schema.map(_.dataType), dialect)
   }
 
   def getComplexTypeSerializer(dataType: DataType): SerializeComplexType =
@@ -440,7 +440,7 @@ trait GeneratedStatement {
   @throws[java.sql.SQLException]
   def executeStatement(stmt: PreparedStatement, multipleRows: Boolean,
       rows: java.util.Iterator[InternalRow], batchSize: Int,
-      schema: Array[StructField], dialect: JdbcDialect): Int
+      schema: Array[DataType], dialect: JdbcDialect): Int
 }
 
 trait SerializeComplexType {
@@ -451,12 +451,18 @@ trait SerializeComplexType {
 }
 
 private final class ExecuteKey(val name: String,
-    val schema: Array[StructField], val dialect: JdbcDialect) {
+    val schema: Array[DataType], val dialect: JdbcDialect) {
 
-  override def hashCode(): Int = name.hashCode
+  override def hashCode(): Int = if (schema != null) {
+    scala.util.hashing.MurmurHash3.arrayHash(schema)
+  } else name.hashCode
 
   override def equals(other: Any): Boolean = other match {
-    case o: ExecuteKey => name == o.name
+    case o: ExecuteKey => if (schema != null && o.schema != null) {
+      schema.sameElements(o.schema)
+    } else {
+      name == o.name
+    }
     case s: String => name == s
     case _ => false
   }


### PR DESCRIPTION
## Changes proposed in this pull request

 - add code generation for LocalJoin (some taken from BroadcastHashJoinExec)
 - the build-side replicated table RDD is not code generated due to WholeStageCodegen
   limitation of passing upto 2 RDDs; instead it is passed as reference object and
   normal RDD.iterator is opened to consume and create a HashedRelation
 - added a HashedRelationCache which expires after configured time (10secs by default)
   of no access; also invalidate entire cache in case of any insert/update/delete
   to replicated tables (added flag to store side to mark such user regions)
 - added code generation for PartitionedPhysicalRDD like a simple row source;
   going forward this can be changed to batch source once spark's PRs for InMemoryScan
   batching are merged (SPARK-16196, SPARK-14098)
 - pass in source rdd.schema in JdbcExtendedUtils.savePartition when setting values
   into the PreparedStatement; changed the CodeGeneration to accept source
   StructType accordingly (SNAP-1001)
 - add explicit call to flushBuffer at the end of ColumnFormatRelation.insert, and likewise reduced
   the limit for row buffer insert size to minimum of 200 (can be made configurable)
 - add an overload to MapPartitionsPreserveRDD that allows a function with Partition object
 - renamed CachedRDD.scala to rdds.scala; fixed some scalastyle errors

## Patch testing

TPCH queries, precheckin

## ReleaseNotes.txt changes

NA

## Other PRs 

A small change to snappy-store for setting "replicatedTable" flag will be merged directly.