### PR TITLE
[SNAP-1007] Add support for non-reserved keywords

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -74,6 +74,7 @@ allprojects {
   tasks.withType(ScalaCompile) {
     // scalaCompileOptions.optimize = true
     // scalaCompileOptions.useAnt = false
+    scalaCompileOptions.fork = false
     scalaCompileOptions.deprecation = false
     scalaCompileOptions.additionalParameters = [ '-feature' ]
     options.encoding = 'UTF-8'

--- a/core/src/main/scala/org/apache/spark/sql/SnappyBaseParser.scala
+++ b/core/src/main/scala/org/apache/spark/sql/SnappyBaseParser.scala
@@ -136,7 +136,7 @@ abstract class SnappyBaseParser(session: SnappySession) extends Parser {
   }
 
   /**
-   * A strictIdentifier is more restricted that an identifier in that neither
+   * A strictIdentifier is more restricted than an identifier in that neither
    * any of the SQL reserved keywords nor non-reserved keywords will be
    * interpreted as a strictIdentifier.
    */
@@ -144,8 +144,7 @@ abstract class SnappyBaseParser(session: SnappySession) extends Parser {
     atomic(capture(CharPredicate.Alpha ~ SnappyParserConsts.identifier.*)) ~
         delimiter ~> { (s: String) =>
       val ucase = Utils.toUpperCase(s)
-      test(!SnappyParserConsts.reservedKeywords.contains(ucase) &&
-          !SnappyParserConsts.nonReservedKeywords.contains(ucase)) ~
+      test(!SnappyParserConsts.allKeywords.contains(ucase)) ~
           push(if (caseSensitive) s else ucase)
     } |
     quotedIdentifier
@@ -290,10 +289,10 @@ object SnappyParserConsts {
 
   final val reservedKeywords: mutable.Set[String] = mutable.Set[String]()
 
-  final val nonReservedKeywords: mutable.Set[String] = mutable.Set[String]()
+  final val allKeywords: mutable.Set[String] = mutable.Set[String]()
 
   /**
-   * Registering a Keyword with this method marks it as a reserved keyword,
+   * Registering a Keyword with this method marks it a reserved keyword,
    * i.e. it is interpreted as a keyword wherever it may appear and is never
    * interpreted as an identifier (except if quoted).
    * <p>
@@ -302,21 +301,22 @@ object SnappyParserConsts {
   private[sql] def reservedKeyword(s: String): Keyword = {
     val k = new Keyword(s)
     reservedKeywords += k.upper
+    allKeywords += k.upper
     k
   }
 
   /**
-   * Registering a Keyword with this method marks it as a non-reserved keyword.
+   * Registering a Keyword with this method marks it a non-reserved keyword.
    * These can be interpreted as identifiers as per the parsing rules,
    * but never interpreted as a "strictIdentifier". In other words, use
    * "strictIdentifier" in parsing rules where there can be an ambiguity
-   * between an identifier or a non-reserved keyword.
+   * between an identifier and a non-reserved keyword.
    * <p>
    * Use this for all SQL keywords used by grammar that are not reserved.
    */
   private[sql] def nonReservedKeyword(s: String): Keyword = {
     val k = new Keyword(s)
-    nonReservedKeywords += k.upper
+    allKeywords += k.upper
     k
   }
 

--- a/core/src/main/scala/org/apache/spark/sql/SnappyBaseParser.scala
+++ b/core/src/main/scala/org/apache/spark/sql/SnappyBaseParser.scala
@@ -73,6 +73,10 @@ abstract class SnappyBaseParser(session: SnappySession) extends Parser {
     quiet(&(SnappyParserConsts.delimiters)) ~ ws | EOI
   }
 
+  protected final def commaSep: Rule0 = rule {
+    ',' ~ ws
+  }
+
   protected final def digits: Rule1[String] = rule {
     capture(CharPredicate.Digit. +) ~ ws
   }
@@ -113,9 +117,13 @@ abstract class SnappyBaseParser(session: SnappySession) extends Parser {
     atomic(capture(CharPredicate.Alpha ~ SnappyParserConsts.identifier.*)) ~
         delimiter ~> { (s: String) =>
       val ucase = Utils.toUpperCase(s)
-      test(!SnappyParserConsts.keywords.contains(ucase)) ~
+      test(!SnappyParserConsts.reservedKeywords.contains(ucase)) ~
           push(if (caseSensitive) s else ucase)
     } |
+    quotedIdentifier
+  }
+
+  protected final def quotedIdentifier: Rule1[String] = rule {
     atomic('"' ~ capture((noneOf("\"") | "\"\""). +) ~ '"') ~
         ws ~> { (s: String) =>
       val id = if (s.indexOf("\"\"") >= 0) s.replace("\"\"", "\"") else s
@@ -125,6 +133,22 @@ abstract class SnappyBaseParser(session: SnappySession) extends Parser {
       val id = if (s.indexOf("``") >= 0) s.replace("``", "`") else s
       if (caseSensitive) id else Utils.toUpperCase(id)
     }
+  }
+
+  /**
+   * A strictIdentifier is more restricted that an identifier in that neither
+   * any of the SQL reserved keywords nor non-reserved keywords will be
+   * interpreted as a strictIdentifier.
+   */
+  protected final def strictIdentifier: Rule1[String] = rule {
+    atomic(capture(CharPredicate.Alpha ~ SnappyParserConsts.identifier.*)) ~
+        delimiter ~> { (s: String) =>
+      val ucase = Utils.toUpperCase(s)
+      test(!SnappyParserConsts.reservedKeywords.contains(ucase) &&
+          !SnappyParserConsts.nonReservedKeywords.contains(ucase)) ~
+          push(if (caseSensitive) s else ucase)
+    } |
+    quotedIdentifier
   }
 
   // DataTypes
@@ -159,7 +183,7 @@ abstract class SnappyBaseParser(session: SnappySession) extends Parser {
   final def VARCHAR: Rule0 = newDataType(SnappyParserConsts.VARCHAR)
 
   protected final def fixedDecimalType: Rule1[DataType] = rule {
-    (DECIMAL | NUMERIC) ~ '(' ~ ws ~ digits ~ ',' ~ ws ~ digits ~ ')' ~ ws ~>
+    (DECIMAL | NUMERIC) ~ '(' ~ ws ~ digits ~ commaSep ~ digits ~ ')' ~ ws ~>
         ((precision: String, scale: String) =>
           DecimalType(precision.toInt, scale.toInt))
   }
@@ -204,7 +228,7 @@ abstract class SnappyBaseParser(session: SnappySession) extends Parser {
   }
 
   protected final def mapType: Rule1[DataType] = rule {
-    MAP ~ '<' ~ ws ~ dataType ~ ',' ~ ws ~ dataType ~ '>' ~ ws ~>
+    MAP ~ '<' ~ ws ~ dataType ~ commaSep ~ dataType ~ '>' ~ ws ~>
         ((t1: DataType, t2: DataType) => MapType(t1, t2))
   }
 
@@ -214,7 +238,7 @@ abstract class SnappyBaseParser(session: SnappySession) extends Parser {
   }
 
   protected final def structType: Rule1[DataType] = rule {
-    STRUCT ~ '<' ~ ws ~ (structField * (',' ~ ws)) ~ '>' ~ ws ~>
+    STRUCT ~ '<' ~ ws ~ (structField * commaSep) ~ '>' ~ ws ~>
         ((f: Any) => StructType(f.asInstanceOf[Seq[StructField]].toArray))
   }
 
@@ -236,7 +260,7 @@ abstract class SnappyBaseParser(session: SnappySession) extends Parser {
   }
 }
 
-final class Keyword(s: String) {
+final class Keyword private[sql] (s: String) {
   val lower = Utils.toLowerCase(s)
   val upper = Utils.toUpperCase(s)
 }
@@ -264,165 +288,197 @@ object SnappyParserConsts {
 
   final val falseFn: () => Boolean = () => false
 
-  final val keywords: mutable.Set[String] = mutable.Set[String]()
+  final val reservedKeywords: mutable.Set[String] = mutable.Set[String]()
 
-  private[sql] def keyword(s: String): Keyword = {
+  final val nonReservedKeywords: mutable.Set[String] = mutable.Set[String]()
+
+  /**
+   * Registering a Keyword with this method marks it as a reserved keyword,
+   * i.e. it is interpreted as a keyword wherever it may appear and is never
+   * interpreted as an identifier (except if quoted).
+   * <p>
+   * Use this only for SQL reserved keywords.
+   */
+  private[sql] def reservedKeyword(s: String): Keyword = {
     val k = new Keyword(s)
-    keywords += k.upper
+    reservedKeywords += k.upper
+    k
+  }
+
+  /**
+   * Registering a Keyword with this method marks it as a non-reserved keyword.
+   * These can be interpreted as identifiers as per the parsing rules,
+   * but never interpreted as a "strictIdentifier". In other words, use
+   * "strictIdentifier" in parsing rules where there can be an ambiguity
+   * between an identifier or a non-reserved keyword.
+   * <p>
+   * Use this for all SQL keywords used by grammar that are not reserved.
+   */
+  private[sql] def nonReservedKeyword(s: String): Keyword = {
+    val k = new Keyword(s)
+    nonReservedKeywords += k.upper
     k
   }
 
   // reserved keywords
-  final val ALL = keyword("all")
-  final val AND = keyword("and")
-  final val AS = keyword("as")
-  final val ASC = keyword("asc")
-  final val BETWEEN = keyword("between")
-  final val BY = keyword("by")
-  final val CASE = keyword("case")
-  final val CREATE = keyword("create")
-  final val CURRENT = keyword("current")
-  final val DELETE = keyword("delete")
-  final val DESC = keyword("desc")
-  final val DISTINCT = keyword("distinct")
-  final val DROP = keyword("drop")
-  final val ELSE = keyword("else")
-  final val EXCEPT = keyword("except")
-  final val EXISTS = keyword("exists")
-  final val FALSE = keyword("false")
-  final val FROM = keyword("from")
-  final val GROUP = keyword("group")
-  final val HAVING = keyword("having")
-  final val IN = keyword("in")
-  final val INNER = keyword("inner")
-  final val INSERT = keyword("insert")
-  final val INTERSECT = keyword("intersect")
-  final val INTO = keyword("into")
-  final val IS = keyword("is")
-  final val JOIN = keyword("join")
-  final val LEFT = keyword("left")
-  final val LIKE = keyword("like")
-  final val NOT = keyword("not")
-  final val NULL = keyword("null")
-  final val ON = keyword("on")
-  final val OR = keyword("or")
-  final val ORDER = keyword("order")
-  final val OUTER = keyword("outer")
-  final val RIGHT = keyword("right")
-  final val SCHEMA = keyword("schema")
-  final val SELECT = keyword("select")
-  final val SET = keyword("set")
-  final val TABLE = keyword("table")
-  final val THEN = keyword("then")
-  final val TO = keyword("to")
-  final val TRUE = keyword("true")
-  final val UNION = keyword("union")
-  final val UNIQUE = keyword("unique")
-  final val UPDATE = keyword("update")
-  final val WHEN = keyword("when")
-  final val WHERE = keyword("where")
-  final val WITH = keyword("with")
+  final val ALL = reservedKeyword("all")
+  final val AND = reservedKeyword("and")
+  final val AS = reservedKeyword("as")
+  final val ASC = reservedKeyword("asc")
+  final val BETWEEN = reservedKeyword("between")
+  final val BY = reservedKeyword("by")
+  final val CASE = reservedKeyword("case")
+  final val CAST = reservedKeyword("cast")
+  final val CREATE = reservedKeyword("create")
+  final val CURRENT = reservedKeyword("current")
+  final val CURRENT_DATE = reservedKeyword("current_date")
+  final val CURRENT_TIMESTAMP = reservedKeyword("current_timestamp")
+  final val DELETE = reservedKeyword("delete")
+  final val DESC = reservedKeyword("desc")
+  final val DISTINCT = reservedKeyword("distinct")
+  final val DROP = reservedKeyword("drop")
+  final val ELSE = reservedKeyword("else")
+  final val EXCEPT = reservedKeyword("except")
+  final val EXISTS = reservedKeyword("exists")
+  final val FALSE = reservedKeyword("false")
+  final val FROM = reservedKeyword("from")
+  final val GROUP = reservedKeyword("group")
+  final val HAVING = reservedKeyword("having")
+  final val IN = reservedKeyword("in")
+  final val INNER = reservedKeyword("inner")
+  final val INSERT = reservedKeyword("insert")
+  final val INTERSECT = reservedKeyword("intersect")
+  final val INTO = reservedKeyword("into")
+  final val IS = reservedKeyword("is")
+  final val JOIN = reservedKeyword("join")
+  final val LEFT = reservedKeyword("left")
+  final val LIKE = reservedKeyword("like")
+  final val NOT = reservedKeyword("not")
+  final val NULL = reservedKeyword("null")
+  final val ON = reservedKeyword("on")
+  final val OR = reservedKeyword("or")
+  final val ORDER = reservedKeyword("order")
+  final val OUTER = reservedKeyword("outer")
+  final val RIGHT = reservedKeyword("right")
+  final val SCHEMA = reservedKeyword("schema")
+  final val SELECT = reservedKeyword("select")
+  final val SET = reservedKeyword("set")
+  final val TABLE = reservedKeyword("table")
+  final val THEN = reservedKeyword("then")
+  final val TO = reservedKeyword("to")
+  final val TRUE = reservedKeyword("true")
+  final val UNION = reservedKeyword("union")
+  final val UNIQUE = reservedKeyword("unique")
+  final val UPDATE = reservedKeyword("update")
+  final val WHEN = reservedKeyword("when")
+  final val WHERE = reservedKeyword("where")
+  final val WITH = reservedKeyword("with")
 
   // non-reserved keywords
-  final val ANTI = new Keyword("anti")
-  final val CACHE = new Keyword("cache")
-  final val CAST = new Keyword("cast")
-  final val CLEAR = new Keyword("clear")
-  final val CLUSTER = new Keyword("cluster")
-  final val COMMENT = new Keyword("comment")
-  final val CURRENT_DATE = new Keyword("current_date")
-  final val CURRENT_TIMESTAMP = new Keyword("current_timestamp")
-  final val DESCRIBE = new Keyword("describe")
-  final val DISTRIBUTE = new Keyword("distribute")
-  final val END = new Keyword("end")
-  final val EXTENDED = new Keyword("extended")
-  final val EXTERNAL = new Keyword("external")
-  final val FULL = new Keyword("full")
-  final val FUNCTION = new Keyword("function")
-  final val FUNCTIONS = new Keyword("functions")
-  final val GLOBAL = new Keyword("global")
-  final val HASH = new Keyword("hash")
-  final val IF = new Keyword("if")
-  final val INDEX = new Keyword("index")
-  final val INIT = new Keyword("init")
-  final val INTERVAL = new Keyword("interval")
-  final val LAZY = new Keyword("lazy")
-  final val LIMIT = new Keyword("limit")
-  final val NATURAL = new Keyword("natural")
-  final val OPTIONS = new Keyword("options")
-  final val OVERWRITE = new Keyword("overwrite")
-  final val PARTITION = new Keyword("partition")
-  final val PUT = new Keyword("put")
-  final val REFRESH = new Keyword("refresh")
-  final val REGEXP = new Keyword("regexp")
-  final val RLIKE = new Keyword("rlike")
-  final val SEMI = new Keyword("semi")
-  final val SHOW = new Keyword("show")
-  final val SORT = new Keyword("sort")
-  final val START = new Keyword("start")
-  final val STOP = new Keyword("stop")
-  final val STREAM = new Keyword("stream")
-  final val STREAMING = new Keyword("streaming")
-  final val TABLES = new Keyword("tables")
-  final val TEMPORARY = new Keyword("temporary")
-  final val TRUNCATE = new Keyword("truncate")
-  final val UNCACHE = new Keyword("uncache")
-  final val USING = new Keyword("using")
+  final val ANTI = nonReservedKeyword("anti")
+  final val CACHE = nonReservedKeyword("cache")
+  final val CLEAR = nonReservedKeyword("clear")
+  final val CLUSTER = nonReservedKeyword("cluster")
+  final val COMMENT = nonReservedKeyword("comment")
+  final val DESCRIBE = nonReservedKeyword("describe")
+  final val DISTRIBUTE = nonReservedKeyword("distribute")
+  final val END = nonReservedKeyword("end")
+  final val EXTENDED = nonReservedKeyword("extended")
+  final val EXTERNAL = nonReservedKeyword("external")
+  final val FULL = nonReservedKeyword("full")
+  final val FUNCTION = nonReservedKeyword("function")
+  final val FUNCTIONS = nonReservedKeyword("functions")
+  final val GLOBAL = nonReservedKeyword("global")
+  final val HASH = nonReservedKeyword("hash")
+  final val IF = nonReservedKeyword("if")
+  final val INDEX = nonReservedKeyword("index")
+  final val INIT = nonReservedKeyword("init")
+  final val INTERVAL = nonReservedKeyword("interval")
+  final val LAZY = nonReservedKeyword("lazy")
+  final val LIMIT = nonReservedKeyword("limit")
+  final val NATURAL = nonReservedKeyword("natural")
+  final val OPTIONS = nonReservedKeyword("options")
+  final val OVERWRITE = nonReservedKeyword("overwrite")
+  final val PARTITION = nonReservedKeyword("partition")
+  final val PUT = nonReservedKeyword("put")
+  final val REFRESH = nonReservedKeyword("refresh")
+  final val REGEXP = nonReservedKeyword("regexp")
+  final val RLIKE = nonReservedKeyword("rlike")
+  final val SEMI = nonReservedKeyword("semi")
+  final val SHOW = nonReservedKeyword("show")
+  final val SORT = nonReservedKeyword("sort")
+  final val START = nonReservedKeyword("start")
+  final val STOP = nonReservedKeyword("stop")
+  final val STREAM = nonReservedKeyword("stream")
+  final val STREAMING = nonReservedKeyword("streaming")
+  final val TABLES = nonReservedKeyword("tables")
+  final val TEMPORARY = nonReservedKeyword("temporary")
+  final val TRUNCATE = nonReservedKeyword("truncate")
+  final val UNCACHE = nonReservedKeyword("uncache")
+  final val USING = nonReservedKeyword("using")
 
   // Window analytical functions are non-reserved
-  final val DURATION = new Keyword("duration")
-  final val FOLLOWING = new Keyword("following")
-  final val OVER = new Keyword("over")
-  final val PRECEDING = new Keyword("preceding")
-  final val RANGE = new Keyword("range")
-  final val ROW = new Keyword("row")
-  final val ROWS = new Keyword("rows")
-  final val SLIDE = new Keyword("slide")
-  final val UNBOUNDED = new Keyword("unbounded")
-  final val WINDOW = new Keyword("window")
+  final val DURATION = nonReservedKeyword("duration")
+  final val FOLLOWING = nonReservedKeyword("following")
+  final val OVER = nonReservedKeyword("over")
+  final val PRECEDING = nonReservedKeyword("preceding")
+  final val RANGE = nonReservedKeyword("range")
+  final val ROW = nonReservedKeyword("row")
+  final val ROWS = nonReservedKeyword("rows")
+  final val SLIDE = nonReservedKeyword("slide")
+  final val UNBOUNDED = nonReservedKeyword("unbounded")
+  final val WINDOW = nonReservedKeyword("window")
 
   // interval units are not reserved
-  final val DAY = new Keyword("day")
-  final val HOUR = new Keyword("hour")
-  final val MICROSECOND = new Keyword("microsecond")
-  final val MILLISECOND = new Keyword("millisecond")
-  final val MINUTE = new Keyword("minute")
-  final val MONTH = new Keyword("month")
-  final val SECOND = new Keyword("seconds")
-  final val WEEK = new Keyword("week")
-  final val YEAR = new Keyword("year")
+  final val DAY = nonReservedKeyword("day")
+  final val HOUR = nonReservedKeyword("hour")
+  final val MICROSECOND = nonReservedKeyword("microsecond")
+  final val MILLISECOND = nonReservedKeyword("millisecond")
+  final val MINUTE = nonReservedKeyword("minute")
+  final val MONTH = nonReservedKeyword("month")
+  final val SECOND = nonReservedKeyword("seconds")
+  final val WEEK = nonReservedKeyword("week")
+  final val YEAR = nonReservedKeyword("year")
 
   // cube, rollup, grouping sets are not reserved
-  final val CUBE = new Keyword("cube")
-  final val ROLLUP = new Keyword("rollup")
-  final val GROUPING = new Keyword("grouping")
-  final val SETS = new Keyword("sets")
+  final val CUBE = nonReservedKeyword("cube")
+  final val ROLLUP = nonReservedKeyword("rollup")
+  final val GROUPING = nonReservedKeyword("grouping")
+  final val SETS = nonReservedKeyword("sets")
 
   // datatypes are not reserved
-  final val ARRAY = new Keyword("array")
-  final val BIGINT = new Keyword("bigint")
-  final val BINARY = new Keyword("binary")
-  final val BLOB = new Keyword("blob")
-  final val BOOLEAN = new Keyword("boolean")
-  final val BYTE = new Keyword("byte")
-  final val CHAR = new Keyword("char")
-  final val CLOB = new Keyword("clob")
-  final val DATE = new Keyword("date")
-  final val DECIMAL = new Keyword("decimal")
-  final val DOUBLE = new Keyword("double")
-  final val FLOAT = new Keyword("float")
-  final val INT = new Keyword("int")
-  final val INTEGER = new Keyword("integer")
-  final val LONG = new Keyword("long")
-  final val MAP = new Keyword("map")
-  final val NUMERIC = new Keyword("numeric")
-  final val REAL = new Keyword("real")
-  final val SHORT = new Keyword("short")
-  final val SMALLINT = new Keyword("smallint")
-  final val STRING = new Keyword("string")
-  final val STRUCT = new Keyword("struct")
-  final val TIMESTAMP = new Keyword("timestamp")
-  final val TINYINT = new Keyword("tinyint")
-  final val VARBINARY = new Keyword("varbinary")
-  final val VARCHAR = new Keyword("varchar")
+  final val ARRAY = nonReservedKeyword("array")
+  final val BIGINT = nonReservedKeyword("bigint")
+  final val BINARY = nonReservedKeyword("binary")
+  final val BLOB = nonReservedKeyword("blob")
+  final val BOOLEAN = nonReservedKeyword("boolean")
+  final val BYTE = nonReservedKeyword("byte")
+  final val CHAR = nonReservedKeyword("char")
+  final val CLOB = nonReservedKeyword("clob")
+  final val DATE = nonReservedKeyword("date")
+  final val DECIMAL = nonReservedKeyword("decimal")
+  final val DOUBLE = nonReservedKeyword("double")
+  final val FLOAT = nonReservedKeyword("float")
+  final val INT = nonReservedKeyword("int")
+  final val INTEGER = nonReservedKeyword("integer")
+  final val LONG = nonReservedKeyword("long")
+  final val MAP = nonReservedKeyword("map")
+  final val NUMERIC = nonReservedKeyword("numeric")
+  final val REAL = nonReservedKeyword("real")
+  final val SHORT = nonReservedKeyword("short")
+  final val SMALLINT = nonReservedKeyword("smallint")
+  final val STRING = nonReservedKeyword("string")
+  final val STRUCT = nonReservedKeyword("struct")
+  final val TIMESTAMP = nonReservedKeyword("timestamp")
+  final val TINYINT = nonReservedKeyword("tinyint")
+  final val VARBINARY = nonReservedKeyword("varbinary")
+  final val VARCHAR = nonReservedKeyword("varchar")
+
+  // for AQP
+  final val ERROR = nonReservedKeyword("error")
+  final val ESTIMATE = nonReservedKeyword("estimate")
+  final val CONFIDENCE = nonReservedKeyword("confidence")
+  final val BEHAVIOR = nonReservedKeyword("behavior")
+  final val SAMPLE = nonReservedKeyword("sample")
+  final val TOPK = nonReservedKeyword("topk")
 }

--- a/core/src/main/scala/org/apache/spark/sql/SnappyDDLParser.scala
+++ b/core/src/main/scala/org/apache/spark/sql/SnappyDDLParser.scala
@@ -46,8 +46,11 @@ abstract class SnappyDDLParser(session: SnappySession)
   final def BETWEEN: Rule0 = rule { keyword(Consts.BETWEEN) }
   final def BY: Rule0 = rule { keyword(Consts.BY) }
   final def CASE: Rule0 = rule { keyword(Consts.CASE) }
+  final def CAST: Rule0 = rule { keyword(Consts.CAST) }
   final def CREATE: Rule0 = rule { keyword(Consts.CREATE) }
   final def CURRENT: Rule0 = rule { keyword(Consts.CURRENT) }
+  final def CURRENT_DATE: Rule0 = rule { keyword(Consts.CURRENT_DATE) }
+  final def CURRENT_TIMESTAMP: Rule0 = rule { keyword(Consts.CURRENT_TIMESTAMP) }
   final def DELETE: Rule0 = rule { keyword(Consts.DELETE) }
   final def DESC: Rule0 = rule { keyword(Consts.DESC) }
   final def DISTINCT: Rule0 = rule { keyword(Consts.DISTINCT) }
@@ -92,12 +95,9 @@ abstract class SnappyDDLParser(session: SnappySession)
   // non-reserved keywords
   final def ANTI: Rule0 = rule { keyword(Consts.ANTI) }
   final def CACHE: Rule0 = rule { keyword(Consts.CACHE) }
-  final def CAST: Rule0 = rule { keyword(Consts.CAST) }
   final def CLEAR: Rule0 = rule { keyword(Consts.CLEAR) }
   final def CLUSTER: Rule0 = rule { keyword(Consts.CLUSTER) }
   final def COMMENT: Rule0 = rule { keyword(Consts.COMMENT) }
-  final def CURRENT_DATE: Rule0 = rule { keyword(Consts.CURRENT_DATE) }
-  final def CURRENT_TIMESTAMP: Rule0 = rule { keyword(Consts.CURRENT_TIMESTAMP) }
   final def DESCRIBE: Rule0 = rule { keyword(Consts.DESCRIBE) }
   final def DISTRIBUTE: Rule0 = rule { keyword(Consts.DISTRIBUTE) }
   final def END: Rule0 = rule { keyword(Consts.END) }
@@ -162,7 +162,7 @@ abstract class SnappyDDLParser(session: SnappySession)
   final def WEEK: Rule0 = rule { intervalUnit(Consts.WEEK) }
   final def YEAR: Rule0 = rule { intervalUnit(Consts.YEAR) }
 
-  //cube, rollup, grouping sets
+  // cube, rollup, grouping sets
   final def CUBE: Rule0 = rule { keyword(Consts.CUBE) }
   final def ROLLUP: Rule0 = rule { keyword(Consts.ROLLUP) }
   final def GROUPING: Rule0 = rule { keyword(Consts.GROUPING) }
@@ -432,7 +432,7 @@ abstract class SnappyDDLParser(session: SnappySession)
   protected final def colsWithDirection: Rule1[Map[String,
       Option[SortDirection]]] = rule {
     '(' ~ ws ~ (identifier ~ sortDirection.? ~> ((id: Any, direction: Any) =>
-      (id, direction))).*(',' ~ ws) ~ ')' ~ ws ~> ((cols: Any) =>
+      (id, direction))).*(commaSep) ~ ')' ~ ws ~> ((cols: Any) =>
       cols.asInstanceOf[Seq[(String, Option[SortDirection])]].toMap)
   }
 
@@ -480,7 +480,7 @@ abstract class SnappyDDLParser(session: SnappySession)
   }
 
   protected final def tableCols: Rule1[Seq[StructField]] = rule {
-    '(' ~ ws ~ (column + (',' ~ ws)) ~ ')' ~ ws
+    '(' ~ ws ~ (column + commaSep) ~ ')' ~ ws
   }
 
   protected final def tableColsOrNone: Rule1[Option[Seq[StructField]]] = rule {
@@ -492,7 +492,7 @@ abstract class SnappyDDLParser(session: SnappySession)
   }
 
   protected final def options: Rule1[Map[String, String]] = rule {
-    '(' ~ ws ~ (pair * (',' ~ ws)) ~ ')' ~ ws ~>
+    '(' ~ ws ~ (pair * commaSep) ~ ')' ~ ws ~>
         ((pairs: Any) => pairs.asInstanceOf[Seq[(String, String)]].toMap)
   }
 


### PR DESCRIPTION
## Changes proposed in this pull request

As per SNAP-1007, this primarily adds support for non-reserved keywords which are not allowed in some places in the SQL grammar where otherwise any identifier is allowed.

 - marked all keywords as either reserved or non-reserved
 - added a "strictIdentifier" which can be neither of reserved or non-reserved;
   mark all aliases to use "strictIdentifier" (but identifier when with AS)
 - refactored to add "commaSep" rule for all uses of comma followed by whitespace
 - marked CAST, CURRENT_DATE/TIMESTAMP as reserved due to ambiguities otherwise
 - some formatting corrections

## Patch testing

precheckin (no new failures)

## ReleaseNotes.txt changes

NA

## Other PRs 

NA