### PR TITLE
[SNAP-1008] Pause zeppelin scala interpreter when critical up event i…

### DIFF
--- a/cluster/src/main/java/io/snappydata/gemxd/LeadNodeMemoryListener.java
+++ b/cluster/src/main/java/io/snappydata/gemxd/LeadNodeMemoryListener.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2016 SnappyData, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License. You
+ * may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License. See accompanying
+ * LICENSE file.
+ */
+package io.snappydata.gemxd;
+
+import com.gemstone.gemfire.internal.cache.control.MemoryEvent;
+import com.gemstone.gemfire.internal.cache.control.ResourceListener;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ *
+ */
+public class LeadNodeMemoryListener implements ResourceListener<MemoryEvent> {
+
+  public static Logger logger = LoggerFactory.getLogger(LeadNodeMemoryListener.class);
+
+  @Override
+  public void onEvent(MemoryEvent event) {
+
+    if (event.getState().isCritical()) {
+      MemoryNotificationFactory.notifyCriticalUp();
+    }
+    if (event.getState().isEviction()) {
+      MemoryNotificationFactory.notifyEvictionUp();
+    }
+  }
+}

--- a/cluster/src/main/java/io/snappydata/gemxd/MemoryNotificationFactory.java
+++ b/cluster/src/main/java/io/snappydata/gemxd/MemoryNotificationFactory.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2016 SnappyData, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License. You
+ * may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License. See accompanying
+ * LICENSE file.
+ */
+package io.snappydata.gemxd;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Created by sachin on 24/8/16.
+ */
+public class MemoryNotificationFactory {
+  private static List<MemoryNotificationListener> notificationListeners = new ArrayList<MemoryNotificationListener>();
+
+
+  public static void attachListener(MemoryNotificationListener listener) {
+    notificationListeners.add(listener);
+  }
+
+
+  public static void notifyCriticalUp() {
+    for (MemoryNotificationListener mnl : notificationListeners) {
+      mnl.notifyCriticalUp();
+    }
+  }
+
+  public static void notifyEvictionUp() {
+    for (MemoryNotificationListener mnl : notificationListeners) {
+      mnl.notifyEvictionUp();
+    }
+  }
+
+
+}

--- a/cluster/src/main/java/io/snappydata/gemxd/MemoryNotificationListener.java
+++ b/cluster/src/main/java/io/snappydata/gemxd/MemoryNotificationListener.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2016 SnappyData, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License. You
+ * may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License. See accompanying
+ * LICENSE file.
+ */
+package io.snappydata.gemxd;
+
+/**
+ * Created by sachin on 24/8/16.
+ */
+public interface MemoryNotificationListener {
+  public void notifyCriticalUp();
+  public void notifyEvictionUp();
+}

--- a/cluster/src/main/scala/io/snappydata/impl/LeadImpl.scala
+++ b/cluster/src/main/scala/io/snappydata/impl/LeadImpl.scala
@@ -28,10 +28,12 @@ import akka.actor.ActorSystem
 import com.gemstone.gemfire.distributed.internal.DistributionConfig
 import com.gemstone.gemfire.distributed.internal.locks.{DLockService, DistributedMemberLock}
 import com.gemstone.gemfire.internal.cache.GemFireCacheImpl
+import com.gemstone.gemfire.internal.cache.control.InternalResourceManager
 import com.pivotal.gemfirexd.FabricService.State
 import com.pivotal.gemfirexd.internal.engine.store.ServerGroupUtils
 import com.pivotal.gemfirexd.{FabricService, NetworkInterface}
 import com.typesafe.config.{Config, ConfigFactory}
+import io.snappydata.gemxd.LeadNodeMemoryListener
 import io.snappydata.util.ServiceUtils
 import io.snappydata.{Constant, Lead, LocalizedMessages, Property, ServiceManager}
 import org.apache.thrift.transport.TTransportException
@@ -436,9 +438,9 @@ class LeadImpl extends ServerImpl with Lead with Logging {
               tTransportException.getMessage)
       }
       // Add memory listener for zeppelin will need it for zeppelin
-      // val listener = new LeadNodeMemoryListener();
-      // GemFireCacheImpl.getInstance().getResourceManager().
-      //   addResourceListener(InternalResourceManager.ResourceType.ALL, listener)
+      val listener = new LeadNodeMemoryListener();
+      GemFireCacheImpl.getInstance().getResourceManager().
+          addResourceListener(InternalResourceManager.ResourceType.ALL, listener)
 
     }
   }


### PR DESCRIPTION
## Changes proposed in this pull request
* This PR addresses the first part of SNAP-1008 used to monitor memory of lead node which is used to pause zeppelin interpreter

## Patch testing
Ran precheckin some tests fail which are not related to this PR

## ReleaseNotes.txt changes
No
## Other PRs 
N/A
…s triggered