### PR TITLE
Modified a test to add testing for unsupported op for update/delete.

### DIFF
--- a/cluster/src/dunit/scala/io/snappydata/cluster/QueryRoutingDUnitTest.scala
+++ b/cluster/src/dunit/scala/io/snappydata/cluster/QueryRoutingDUnitTest.scala
@@ -24,6 +24,7 @@ import com.pivotal.gemfirexd.internal.engine.Misc
 import com.pivotal.gemfirexd.internal.engine.distributed.utils.GemFireXDUtils
 import io.snappydata.Constant._
 import io.snappydata.test.dunit.{AvailablePortHelper, SerializableRunnable}
+import junit.framework.TestCase
 import org.apache.commons.io.FileUtils
 import org.junit.Assert
 
@@ -170,6 +171,27 @@ class QueryRoutingDUnitTest(val s: String)
     // actualResult.foreach(println)
     assert(expectedResult.sorted.sameElements(actualResult))
     setDMLMaxChunkSize(default_chunk_size)
+
+    // Check that update and delete on column table returns exception
+    try {
+      s.executeUpdate("update TEST.ColumnTableQR set col1 = 10")
+      TestCase.fail("update on column table should have failed")
+    } catch {
+      case sqe: SQLException =>
+        if ("42Y62" != sqe.getSQLState) {
+          throw sqe
+        }
+    }
+
+    try {
+      s.executeUpdate("delete from TEST.ColumnTableQR")
+      TestCase.fail("delete on column table should have failed")
+    } catch {
+      case sqe: SQLException =>
+        if ("42Y62" != sqe.getSQLState) {
+          throw sqe
+        }
+    }
 
     conn.close()
   }


### PR DESCRIPTION
## Changes proposed in this pull request

Test enhanced to show that update/delete on column tables are unsupported.

## Patch testing



## ReleaseNotes.txt changes

(Does this change require an entry in ReleaseNotes.txt? If yes, has it been added to it?)

## Other PRs 

(Does this change require changes in other projects- store, spark, spark-jobserver, aqp? Add the links of PR of the other subprojects that are related to this change)

