### PR TITLE
Changes for SNAP-653

### DIFF
--- a/core/src/dunit/scala/io/snappydata/cluster/SplitClusterDUnitTest.scala
+++ b/core/src/dunit/scala/io/snappydata/cluster/SplitClusterDUnitTest.scala
@@ -17,6 +17,7 @@
 package io.snappydata.cluster
 
 import java.io.PrintWriter
+import java.net.InetAddress
 import java.nio.file.{Files, Paths}
 import java.sql.{Blob, Clob, Connection, DriverManager, ResultSet, Statement, Timestamp}
 import java.util.Properties
@@ -32,6 +33,8 @@ import io.snappydata.Constant
 import io.snappydata.test.dunit.{AvailablePortHelper, DistributedTestBase, Host, VM}
 import org.junit.Assert
 
+import org.apache.spark.sql.SnappySession
+import org.apache.spark.{SparkContext, SparkConf}
 import org.apache.spark.sql.types.Decimal
 import org.apache.spark.util.collection.OpenHashSet
 
@@ -134,6 +137,27 @@ object SplitClusterDUnitTest extends SplitClusterDUnitTestObject {
 
   private def getConnection(netPort: Int) = DriverManager.getConnection(
     s"jdbc:${Constant.JDBC_URL_PREFIX}localhost:$netPort")
+
+  override def assertTableNotCachedInHiveCatalog(tableName: String): Unit = {
+    val hostName = InetAddress.getLocalHost.getHostName
+    val conf = new SparkConf()
+        .setAppName("test Application")
+        .setMaster(s"spark://$hostName:7077")
+        .set("spark.executor.extraClassPath",
+          getEnvironmentVariable("SNAPPY_DIST_CLASSPATH"))
+
+    val sc = SparkContext.getOrCreate(conf)
+    val catalog = SnappySession.getOrCreate(sc).sessionCatalog
+    val t = catalog.newQualifiedTableName(tableName)
+    try {
+      catalog.getCachedHiveTable(t)
+      assert(assertion = false, s"Table $tableName should not exist in the " +
+          s"cached Hive catalog")
+    } catch {
+      // expected exception
+      case e: org.apache.spark.sql.TableNotFoundException =>
+    }
+  }
 
   override def createTablesAndInsertData(tableType: String): Unit = {
     val conn = getConnection(locatorNetPort)

--- a/core/src/main/scala/org/apache/spark/sql/execution/columnar/ExternalStoreUtils.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/columnar/ExternalStoreUtils.scala
@@ -493,7 +493,7 @@ object ExternalStoreUtils {
     }
   }
 
-  private def removeCachedObjects(table: String): () => Iterator[Unit] = () => {
+  def removeCachedObjects(table: String): () => Iterator[Unit] = () => {
     ConnectionPool.removePoolReference(table)
     CodeGeneration.removeCache(table)
     Iterator.empty

--- a/core/src/main/scala/org/apache/spark/sql/execution/columnar/impl/StoreCallbacksImpl.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/columnar/impl/StoreCallbacksImpl.scala
@@ -16,6 +16,7 @@
  */
 package org.apache.spark.sql.execution.columnar.impl
 
+import java.lang
 import java.util.{Collections, UUID}
 
 import scala.collection.concurrent.TrieMap
@@ -24,18 +25,19 @@ import com.gemstone.gemfire.internal.cache.{BucketRegion, LocalRegion}
 import com.gemstone.gemfire.internal.snappy.{CallbackFactoryProvider, StoreCallbacks}
 import com.pivotal.gemfirexd.internal.engine.Misc
 import com.pivotal.gemfirexd.internal.engine.distributed.utils.GemFireXDUtils
-import com.pivotal.gemfirexd.internal.engine.store.{AbstractCompactExecRow, GemFireContainer}
+import com.pivotal.gemfirexd.internal.engine.store.{GemFireStore, AbstractCompactExecRow, GemFireContainer}
 import com.pivotal.gemfirexd.internal.iapi.sql.conn.LanguageConnectionContext
 import com.pivotal.gemfirexd.internal.iapi.store.access.{ScanController, TransactionController}
 import com.pivotal.gemfirexd.internal.impl.jdbc.EmbedConnection
 import io.snappydata.Constant
 
 import org.apache.spark.internal.Logging
-import org.apache.spark.sql.SQLContext
-import org.apache.spark.sql.execution.columnar.{CachedBatchCreator, ExternalStore}
+import org.apache.spark.sql.{SnappySession, SnappyContext, SQLContext}
+import org.apache.spark.sql.execution.ConnectionPool
+import org.apache.spark.sql.execution.columnar.{ExternalStoreUtils, CachedBatchCreator, ExternalStore}
 import org.apache.spark.sql.execution.joins.HashedRelationCache
 import org.apache.spark.sql.hive.SnappyStoreHiveCatalog
-import org.apache.spark.sql.store.StoreHashFunction
+import org.apache.spark.sql.store.{StoreUtils, CodeGeneration, StoreHashFunction}
 import org.apache.spark.sql.types._
 
 object StoreCallbacksImpl extends StoreCallbacks with Logging with Serializable {
@@ -139,6 +141,27 @@ object StoreCallbacksImpl extends StoreCallbacks with Logging with Serializable 
   override def invalidateReplicatedTableCache(region: LocalRegion): Unit = {
     HashedRelationCache.clear()
   }
+
+  override def cleanUpCachedObjects(table: String,
+      sentFromExternalCluster: lang.Boolean): Unit = {
+    if (sentFromExternalCluster) {
+      // cleanup invoked on embedded mode nodes
+      // from external cluster (in split mode) driver
+      ExternalStoreUtils.removeCachedObjects(table)
+      stores.remove(table)
+      // clean up cached hive relations on lead node
+      if (GemFireXDUtils.getGfxdAdvisor.getMyProfile.hasSparkURL) {
+        SnappyStoreHiveCatalog.registerRelationDestroy()
+      }
+    } else {
+      // clean up invoked on external cluster driver (in split mode)
+      // from embedded mode lead
+      StoreUtils.removeCachedObjects(SnappySession.
+          getOrCreate(SnappyContext.globalSparkContext).sqlContext, table, true)
+    }
+
+  }
+
 }
 
 trait StoreCallback extends Serializable {

--- a/core/src/main/scala/org/apache/spark/sql/hive/SnappyHiveMetaStoreEventListener.scala
+++ b/core/src/main/scala/org/apache/spark/sql/hive/SnappyHiveMetaStoreEventListener.scala
@@ -62,7 +62,7 @@ class SnappyHiveMetaStoreEventListener(config: Configuration)
           val table = getTableName(tableEvent)
           log.debug(s"onDropTable invoked for $table")
           val args = SnappyRemoveCachedObjectsFunction.
-              newArgs(table.toUpperCase, false)
+              newArgs(table, false)
           FunctionService.onMembers(accessors).withArgs(args).
               execute(SnappyRemoveCachedObjectsFunction.ID)
         }
@@ -75,7 +75,7 @@ class SnappyHiveMetaStoreEventListener(config: Configuration)
           val table = getTableName(tableEvent)
           log.debug(s"onDropTable invoked for $table")
           val args = SnappyRemoveCachedObjectsFunction.
-              newArgs(table.toUpperCase, true)
+              newArgs(table, true)
           FunctionService.onMembers(otherMembers).withArgs(args).
               execute(SnappyRemoveCachedObjectsFunction.ID)
         }

--- a/core/src/main/scala/org/apache/spark/sql/hive/SnappyHiveMetaStoreEventListener.scala
+++ b/core/src/main/scala/org/apache/spark/sql/hive/SnappyHiveMetaStoreEventListener.scala
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2016 SnappyData, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License. You
+ * may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License. See accompanying
+ * LICENSE file.
+ */
+package org.apache.spark.sql.hive
+
+import scala.util.control.NonFatal
+
+import com.gemstone.gemfire.cache.execute.FunctionService
+import com.pivotal.gemfirexd.internal.engine.Misc
+import com.pivotal.gemfirexd.internal.engine.distributed.utils.GemFireXDUtils
+import com.pivotal.gemfirexd.internal.engine.distributed.{GfxdMessage, SnappyRemoveCachedObjectsFunction}
+import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.hive.metastore.MetaStoreEventListener
+import org.apache.hadoop.hive.metastore.api.MetaException
+import org.apache.hadoop.hive.metastore.events.DropTableEvent
+
+import org.apache.spark.Logging
+import org.apache.spark.sql._
+
+class SnappyHiveMetaStoreEventListener(config: Configuration)
+    extends MetaStoreEventListener(config) with Logging {
+
+  /**
+   * Callback function invoked when a table is dropped from Hive Metastore.
+   * In a split cluster deployment, this cleans up any cached objects in
+   * embedded mode cluster when a table is dropped from an external cluster
+   * and vice-a-versa
+   * @param tableEvent
+   */
+  @throws(classOf[MetaException])
+  override def onDropTable(tableEvent: DropTableEvent): Unit = {
+    try {
+      handleDropTableEvent(tableEvent)
+    } catch {
+      case NonFatal(e) =>
+        log.error("onDropTable: exception ", e)
+    }
+  }
+
+  private def handleDropTableEvent(tableEvent: DropTableEvent): Unit = {
+    SnappyContext.
+        getClusterMode(SparkSession.getActiveSession.get.sparkContext) match {
+      case SnappyEmbeddedMode(_, _) =>
+        // table is dropped on embedded lead so send message to external
+        // cluster driver
+        val accessors = GemFireXDUtils.getGfxdAdvisor.adviseAccessors(null)
+        accessors.remove(Misc.getMyId)
+        if (accessors.size > 0) {
+          val table = getTableName(tableEvent)
+          log.debug(s"onDropTable invoked for $table")
+          val args = SnappyRemoveCachedObjectsFunction.
+              newArgs(table.toUpperCase, false)
+          FunctionService.onMembers(accessors).withArgs(args).
+              execute(SnappyRemoveCachedObjectsFunction.ID)
+        }
+
+      case SplitClusterMode(_, _) =>
+        // table is dropped on external cluster so send message to
+        // embedded mode nodes
+        val otherMembers = GfxdMessage.getOtherMembers
+        if (otherMembers.size > 0) {
+          val table = getTableName(tableEvent)
+          log.debug(s"onDropTable invoked for $table")
+          val args = SnappyRemoveCachedObjectsFunction.
+              newArgs(table.toUpperCase, true)
+          FunctionService.onMembers(otherMembers).withArgs(args).
+              execute(SnappyRemoveCachedObjectsFunction.ID)
+        }
+
+      case _ => // do nothing
+    }
+  }
+
+  private def getTableName(tableEvent: DropTableEvent): String = {
+    val sqlConf = SparkSession.getActiveSession.get.sqlContext.conf
+    val table = tableEvent.getTable.getDbName + "." +
+        tableEvent.getTable.getTableName
+    SnappyStoreHiveCatalog.processTableIdentifier(table, sqlConf)
+  }
+}

--- a/core/src/main/scala/org/apache/spark/sql/hive/SnappyStoreHiveCatalog.scala
+++ b/core/src/main/scala/org/apache/spark/sql/hive/SnappyStoreHiveCatalog.scala
@@ -248,6 +248,8 @@ class SnappyStoreHiveCatalog(externalCatalog: ExternalCatalog,
       logInfo("Using Hive metastore database, dbURL = " +
           metadataConf.getVar(HiveConf.ConfVars.METASTORECONNECTURLKEY))
     }
+    metadataConf.setVar(HiveConf.ConfVars.METASTORE_EVENT_LISTENERS,
+      "org.apache.spark.sql.hive.SnappyHiveMetaStoreEventListener")
 
     val allConfig = metadataConf.asScala.map(e =>
       e.getKey -> e.getValue).toMap ++ configure
@@ -392,7 +394,7 @@ class SnappyStoreHiveCatalog(externalCatalog: ExternalCatalog,
 
   private var relationDestroyVersion = 0
 
-  private def getCachedHiveTable(table: QualifiedTableName): LogicalRelation = {
+  def getCachedHiveTable(table: QualifiedTableName): LogicalRelation = {
     val sync = SnappyStoreHiveCatalog.relationDestroyLock.readLock()
     sync.lock()
     try {


### PR DESCRIPTION
## Changes proposed in this pull request
+ Registered SnappyHiveMetaStoreEventListener and process onDropTable callback in it (invoked when table dropped from Hive metastore). This callback will be invoked on either embedded snappy lead or external cluster driver (i.e depending on from where the table is dropped)

+ When a table is dropped in on external cluster driver send a message (SnappyRemoveCachedObjectsFunction) to all nodes in embedded cluster to do the clean up. Similarly send a message from embedded lead to external driver if table dropped in embedded mode

## Patch testing
Modified SplitClusterDUnitTest to assert that cached relation is removed from SnappyStoreHiveCatalog after a table drop from external table (in testColumnTableCreation())

Ran precheckin(known failures in streaming tests and ColumnTableDUnitTest#testTableCreationWithHA

## ReleaseNotes.txt changes


## Other PRs 
Store side changes for this PR
https://github.com/SnappyDataInc/snappy-store/pull/102


