### PR TITLE
CreateTableUsing might be called from createExternalTable. Earlier th…

### DIFF
--- a/core/src/main/scala/org/apache/spark/sql/sources/StoreStrategy.scala
+++ b/core/src/main/scala/org/apache/spark/sql/sources/StoreStrategy.scala
@@ -34,7 +34,7 @@ object StoreStrategy extends Strategy {
         false, opts, partitionColumns, bucketSpec, allowExisting, _) =>
       ExecutedCommandExec(CreateMetastoreTableUsing(tableIdent, None,
         userSpecifiedSchema, None, SnappyContext.getProvider(provider,
-          onlyBuiltIn = false), allowExisting, opts, isBuiltIn = true)) :: Nil
+          onlyBuiltIn = false), allowExisting, opts, isBuiltIn = false)) :: Nil
 
     case CreateTableUsingAsSelect(tableIdent, provider, partitionCols,
         bucketSpec, mode, opts, query) =>


### PR DESCRIPTION
## Changes proposed in this pull request
CreateTableUsing might be called from createExternalTable. Earlier the builtin flag used to be false. But now its true after Spark2.0.

## Patch testing
Ran quickstart tests
## ReleaseNotes.txt changes
NA
## Other PRs 

NA