### PR TITLE
Snap 1024

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -76,6 +76,7 @@ dependencies {
     exclude(group: 'org.scala-lang', module: 'scala-library')
     exclude(group: 'org.scala-lang', module: 'scala-reflect')
     exclude(group: 'org.scala-lang', module: 'scala-compiler')
+    exclude(group: 'com.univocity', module: 'univocity-parsers')
   }
 
   testCompile project(':dunit')

--- a/core/src/main/scala/org/apache/spark/sql/hive/SnappyStoreHiveCatalog.scala
+++ b/core/src/main/scala/org/apache/spark/sql/hive/SnappyStoreHiveCatalog.scala
@@ -518,6 +518,13 @@ class SnappyStoreHiveCatalog(externalCatalog: ExternalCatalog,
     this.currentSchema = schema
   }
 
+  /**
+   * Return whether a table with the specified name is a temporary table.
+   */
+  def isTemporaryTable(tableIdent: QualifiedTableName): Boolean = synchronized {
+    if(tempTables.contains(tableIdent.table)) true else false
+  }
+
   final def lookupRelation(tableIdent: QualifiedTableName): LogicalPlan = {
     tableIdent.getTableOption(client) match {
       case Some(table) =>

--- a/core/src/main/scala/org/apache/spark/sql/sources/StoreStrategy.scala
+++ b/core/src/main/scala/org/apache/spark/sql/sources/StoreStrategy.scala
@@ -34,7 +34,7 @@ object StoreStrategy extends Strategy {
         false, opts, partitionColumns, bucketSpec, allowExisting, _) =>
       ExecutedCommandExec(CreateMetastoreTableUsing(tableIdent, None,
         userSpecifiedSchema, None, SnappyContext.getProvider(provider,
-          onlyBuiltIn = false), allowExisting, opts, isBuiltIn = true)) :: Nil
+          onlyBuiltIn = false), allowExisting, opts, isBuiltIn = false)) :: Nil
 
     case CreateTableUsingAsSelect(tableIdent, provider, partitionCols,
         bucketSpec, mode, opts, query) =>

--- a/core/src/main/scala/org/apache/spark/sql/sources/StoreStrategy.scala
+++ b/core/src/main/scala/org/apache/spark/sql/sources/StoreStrategy.scala
@@ -34,7 +34,7 @@ object StoreStrategy extends Strategy {
         false, opts, partitionColumns, bucketSpec, allowExisting, _) =>
       ExecutedCommandExec(CreateMetastoreTableUsing(tableIdent, None,
         userSpecifiedSchema, None, SnappyContext.getProvider(provider,
-          onlyBuiltIn = false), allowExisting, opts, isBuiltIn = false)) :: Nil
+          onlyBuiltIn = false), allowExisting, opts, isBuiltIn = true)) :: Nil
 
     case CreateTableUsingAsSelect(tableIdent, provider, partitionCols,
         bucketSpec, mode, opts, query) =>

--- a/core/src/test/scala/org/apache/spark/sql/SnappyTempTableTest.scala
+++ b/core/src/test/scala/org/apache/spark/sql/SnappyTempTableTest.scala
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2016 SnappyData, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License. You
+ * may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License. See accompanying
+ * LICENSE file.
+ */
+package org.apache.spark.sql
+
+import io.snappydata.SnappyFunSuite
+import io.snappydata.core.Data
+import org.scalatest.BeforeAndAfter
+
+import org.apache.spark.Logging
+import org.apache.spark.sql.execution.datasources.LogicalRelation
+
+
+class SnappyTempTableTest extends SnappyFunSuite
+with Logging
+with BeforeAndAfter {
+
+  val tableName: String = "TestTempTable"
+  val props = Map.empty[String, String]
+
+  after {
+    snc.dropTable(tableName, true)
+  }
+
+
+  test("test drop table from a simple source") {
+    val data = Seq(Seq(1, 2, 3), Seq(7, 8, 9), Seq(9, 2, 3), Seq(4, 2, 3), Seq(5, 6, 7))
+    val rdd = sc.parallelize(data, data.length).map(s => new Data(s(0), s(1), s(2)))
+    val df = snc.createDataFrame(rdd)
+
+    df.createOrReplaceTempView(tableName)
+
+    val catalog = snc.sessionState.catalog
+    val qName = catalog.newQualifiedTableName(tableName)
+    val plan = catalog.lookupRelation(qName)
+    plan match {
+      case LogicalRelation(br, _, _) => fail(" A RDD based temp table " +
+          "should have been matched with LogicalPlan")
+      case _ =>
+    }
+
+    val scan = snc.sql(s"select * from $tableName")
+
+    assert(scan.count == 5)
+
+    snc.sql(s"drop table $tableName")
+
+    assert(!snc.sessionState.catalog.tableExists(tableName))
+  }
+
+  test("test drop table from a relational source") {
+    val file = getClass.getResource("/airlineCode_Lookup.csv").getPath
+    val df  = snc.read
+            .format("com.databricks.spark.csv") // CSV to DF package
+            .option("header", "true") // Use first line of all files as header
+            .option("inferSchema", "true") // Automatically infer data types
+            .load(file)
+
+    df.createOrReplaceTempView(tableName)
+    val catalog = snc.sessionState.catalog
+    val qName = catalog.newQualifiedTableName(tableName)
+    val plan = catalog.lookupRelation(qName)
+    plan match {
+      case LogicalRelation(br, _, _) =>
+      case _ => fail("A CSV relation temp table should have been " +
+          "matched with LogicalRelation")
+    }
+    val scan = snc.sql(s"select * from $tableName")
+    scan.count
+
+    snc.sql(s"drop table $tableName")
+
+    assert(!snc.sessionState.catalog.tableExists(tableName))
+  }
+}


### PR DESCRIPTION
## Changes proposed in this pull request
a) In Spark 1.6 temp tables were stored against LogicalPlan of the DataFrame. Our catalog makes several assumptions regarding this to consider it as a temp table e.g. while dropping table.

However Spark2.0 analyses the logical plan and converts it to a LogicalRelation before storing that into catalog. Hence the assumptions break.

b) Excluded Univocity Parsers from snappy-core, as this library is already in compile time dependency of spark.sql


## Patch testing

Add a test. Running precheckin

## ReleaseNotes.txt changes

NA

## Other PRs 

NA
