### PR TITLE
[SNAP-959] Fix for SNAP-959

### DIFF
--- a/core/src/main/scala/org/apache/spark/sql/collection/Utils.scala
+++ b/core/src/main/scala/org/apache/spark/sql/collection/Utils.scala
@@ -359,6 +359,13 @@ object Utils {
     }: _*)
   }
 
+  def getSchemaFields(schema: StructType): Map[String, StructField] = {
+    Map(schema.fields.flatMap { f =>
+      Iterator((f.name, f))
+    }: _*)
+  }
+
+
   def getFields(o: Any): Map[String, Any] = {
     val fieldsAsPairs = for (field <- o.getClass.getDeclaredFields) yield {
       field.setAccessible(true)

--- a/core/src/main/scala/org/apache/spark/sql/execution/columnar/ExternalStoreUtils.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/columnar/ExternalStoreUtils.scala
@@ -386,9 +386,9 @@ object ExternalStoreUtils {
     val sb = new StringBuilder(s"INSERT INTO $table (")
     val schemaFields = rddSchema.fields
     (0 until (schemaFields.length - 1)).foreach { i =>
-      sb.append(Utils.fieldName(schemaFields(i))).append(',')
+      sb.append(schemaFields(i).name).append(',')
     }
-    sb.append(Utils.fieldName(schemaFields(schemaFields.length - 1)))
+    sb.append((schemaFields(schemaFields.length - 1).name))
     sb.append(") VALUES (")
 
     (1 until rddSchema.length).foreach { _ =>

--- a/core/src/main/scala/org/apache/spark/sql/execution/columnar/JDBCAppendableRelation.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/columnar/JDBCAppendableRelation.scala
@@ -78,7 +78,7 @@ case class JDBCAppendableRelation(
 
   protected final def dialect = connProperties.dialect
 
-  val schemaFields = Utils.schemaFields(schema)
+  val schemaFields = Utils.getSchemaFields(schema)
 
   final lazy val executorConnector = ExternalStoreUtils.getConnector(table,
     connProperties, forExecutor = true)


### PR DESCRIPTION
## Changes proposed in this pull request
* As per the jira SNAP-959 when we execute "Create table as Select" statement with column alias the column alias name should be used to create and insert the data in the table. To fix this issue we used StructField.name instead of StructField.metadata.name as StructField.name contains the column alias name

## Patch testing
- Written scala test for this fix and ran precheckin.All test related to this fix passed

## ReleaseNotes.txt changes
No
## Other PRs 
N/A
