### PR TITLE
[SNAP-1036] optimized generated code iteration for row tables

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -233,9 +233,16 @@ subprojects {
     // top-level default is single process run since scalatest does not
     // spawn separate JVMs
     maxParallelForks = 1
+    minHeapSize '4g'
     maxHeapSize '4g'
-    jvmArgs '-XX:+HeapDumpOnOutOfMemoryError','-XX:+UseConcMarkSweepGC',
-            '-XX:+CMSClassUnloadingEnabled',  '-XX:MaxPermSize=512m', '-ea'
+    jvmArgs '-ea', '-XX:+HeapDumpOnOutOfMemoryError','-XX:+UseConcMarkSweepGC', '-XX:MaxNewSize=1g',
+            '-XX:+UseParNewGC', '-XX:+CMSClassUnloadingEnabled', '-XX:MaxPermSize=512m'
+    // for benchmarking
+    // minHeapSize '12g'
+    // maxHeapSize '12g'
+    // jvmArgs '-XX:+HeapDumpOnOutOfMemoryError','-XX:+UseConcMarkSweepGC', '-XX:MaxNewSize=2g',
+    //        '-XX:+UseParNewGC', '-XX:+CMSClassUnloadingEnabled', '-XX:MaxPermSize=512m'
+
     testLogging.exceptionFormat = 'full'
 
     List<String> suites = []
@@ -245,15 +252,15 @@ subprojects {
 
     def result = new StringBuilder()
     extensions.add(com.github.maiflai.ScalaTestAction.TESTRESULT, result)
-    extensions.add('testResult', { String name -> result.append(name) } )
+    extensions.add('testResult', { String name -> result.setLength(0); result.append(name) } )
 
     def output = new StringBuilder()
     extensions.add(com.github.maiflai.ScalaTestAction.TESTOUTPUT, output)
-    extensions.add('testOutput', { String name -> output.append(name) } )
+    extensions.add('testOutput', { String name -> output.setLength(0); output.append(name) } )
 
     def errorOutput = new StringBuilder()
     extensions.add(com.github.maiflai.ScalaTestAction.TESTERROR, errorOutput)
-    extensions.add('testError', { String name -> errorOutput.append(name) } )
+    extensions.add('testError', { String name -> errorOutput.setLength(0); errorOutput.append(name) } )
 
     // running a single scala suite
     if (rootProject.hasProperty('singleSuite')) {
@@ -271,8 +278,8 @@ subprojects {
   test {
     maxParallelForks = (2 * Runtime.getRuntime().availableProcessors())
     maxHeapSize '2g'
-    jvmArgs '-XX:+HeapDumpOnOutOfMemoryError','-XX:+UseConcMarkSweepGC',
-            '-XX:+CMSClassUnloadingEnabled', '-XX:MaxPermSize=384m', '-ea'
+    jvmArgs '-ea', '-XX:+HeapDumpOnOutOfMemoryError','-XX:+UseConcMarkSweepGC',
+            '-XX:+UseParNewGC', '-XX:+CMSClassUnloadingEnabled', '-XX:MaxPermSize=512m'
     testLogging.exceptionFormat = 'full'
 
     include '**/*.class'

--- a/cluster/build.gradle
+++ b/cluster/build.gradle
@@ -53,6 +53,9 @@ dependencies {
     compile project(':snappy-spark:snappy-spark-yarn_' + scalaBinaryVersion)
     compile project(':snappy-spark:snappy-spark-graphx_' + scalaBinaryVersion)
     compile project(':snappy-spark:snappy-spark-hive-thriftserver_' + scalaBinaryVersion)
+
+    testCompile project(path: ':snappy-spark:snappy-spark-sql_' + scalaBinaryVersion,
+        configuration: 'testOutput')
   } else {
     compile 'io.snappydata:snappy-spark-core_' + scalaBinaryVersion + ':' + snappySparkVersion
     compile 'io.snappydata:snappy-spark-catalyst_' + scalaBinaryVersion + ':' + snappySparkVersion
@@ -66,6 +69,9 @@ dependencies {
     compile 'io.snappydata:snappy-spark-yarn_' + scalaBinaryVersion + ':' + snappySparkVersion
     compile 'io.snappydata:snappy-spark-graphx_' + scalaBinaryVersion + ':' + snappySparkVersion
     compile 'io.snappydata:snappy-spark-hive-thriftserver_' + scalaBinaryVersion + ':' + snappySparkVersion
+
+    testCompile group: 'io.snappydata', name: 'snappy-spark-sql_' + scalaBinaryVersion,
+                version: snappySparkVersion, classfier: 'tests'
   }
 
   if (new File(rootDir, 'store/build.gradle').exists()) {

--- a/cluster/src/dunit/scala/io/snappydata/externalstore/ColumnTableDUnitTest.scala
+++ b/cluster/src/dunit/scala/io/snappydata/externalstore/ColumnTableDUnitTest.scala
@@ -16,13 +16,13 @@
  */
 package io.snappydata.externalstore
 
-import scala.collection.JavaConversions
+import scala.collection.JavaConverters._
 import scala.util.Random
 
 import com.gemstone.gemfire.internal.cache.{GemFireCacheImpl, PartitionedRegion}
 import com.pivotal.gemfirexd.internal.engine.Misc
 import io.snappydata.cluster.ClusterManagerTestBase
-import io.snappydata.test.dunit.{SerializableRunnable, SerializableCallable}
+import io.snappydata.test.dunit.{SerializableCallable, SerializableRunnable}
 
 import org.apache.spark.sql.execution.columnar.impl.ColumnFormatRelation
 import org.apache.spark.sql.{Row, SaveMode, SnappyContext}
@@ -209,7 +209,7 @@ class ColumnTableDUnitTest(s: String) extends ClusterManagerTestBase(s) {
           buckets = buckets + x
         }
         val iter = pr.getAppropriateLocalEntriesIterator(
-          JavaConversions.setAsJavaSet(buckets), false, false, true, pr, true)
+          buckets.asJava, false, false, true, pr, true)
         var count = 0
         while (iter.hasNext) {
           iter.next

--- a/cluster/src/dunit/scala/org/apache/spark/sql/NorthWindDUnitTest.scala
+++ b/cluster/src/dunit/scala/org/apache/spark/sql/NorthWindDUnitTest.scala
@@ -17,8 +17,9 @@
 package org.apache.spark.sql
 
 import io.snappydata.cluster.ClusterManagerTestBase
+
 import org.apache.spark.sql.execution.joins._
-import org.apache.spark.sql.execution.{LocalTableScanExec, ProjectExec, PartitionedPhysicalRDD}
+import org.apache.spark.sql.execution.{LocalTableScanExec, PartitionedPhysicalScan, PartitionedPhysicalScan$, ProjectExec}
 
 class NorthWindDUnitTest(s: String) extends ClusterManagerTestBase(s) {
 
@@ -81,7 +82,7 @@ class NorthWindDUnitTest(s: String) extends ClusterManagerTestBase(s) {
       // case j: Sort => j
       case j: ProjectExec => j
       // case j: TungstenAggregate => j
-      case j: PartitionedPhysicalRDD => j
+      case j: PartitionedPhysicalScan => j
       case j: LocalTableScanExec => j
     }
     //    if (operators(0).getClass() != c) {
@@ -135,23 +136,23 @@ class NorthWindDUnitTest(s: String) extends ClusterManagerTestBase(s) {
   private def validateReplicatedTableQueries(snc: SnappyContext): Unit = {
     for (q <- NWQueries.queries) {
       q._1 match {
-        case "Q1" => assertQuery(snc, NWQueries.Q1, 8, 1) // classOf[PartitionedPhysicalRDD])
-        case "Q2" => assertQuery(snc, NWQueries.Q2, 91, 1) //, classOf[PartitionedPhysicalRDD])
-        case "Q3" => assertQuery(snc, NWQueries.Q3, 830, 1) //, classOf[PartitionedPhysicalRDD])
-        case "Q4" => assertQuery(snc, NWQueries.Q4, 8, 1) //, classOf[PartitionedPhysicalRDD])
+        case "Q1" => assertQuery(snc, NWQueries.Q1, 8, 1) // classOf[RowTableScan])
+        case "Q2" => assertQuery(snc, NWQueries.Q2, 91, 1) //, classOf[RowTableScan])
+        case "Q3" => assertQuery(snc, NWQueries.Q3, 830, 1) //, classOf[RowTableScan])
+        case "Q4" => assertQuery(snc, NWQueries.Q4, 8, 1) //, classOf[RowTableScan])
         case "Q5" => assertQuery(snc, NWQueries.Q5, 8, 1) //, classOf[Sort])
         case "Q6" => assertQuery(snc, NWQueries.Q6, 8, 1) //, classOf[Sort])
         case "Q7" => assertQuery(snc, NWQueries.Q7, 8, 1) //, classOf[Sort])
-        case "Q8" => assertQuery(snc, NWQueries.Q8, 5, 1) // classOf[PartitionedPhysicalRDD])
+        case "Q8" => assertQuery(snc, NWQueries.Q8, 5, 1) // classOf[RowTableScan])
         case "Q9" => assertQuery(snc, NWQueries.Q9, 3, 1) //, classOf[Project])
-        case "Q10" => assertQuery(snc, NWQueries.Q10, 2, 1) //, classOf[PartitionedPhysicalRDD])
+        case "Q10" => assertQuery(snc, NWQueries.Q10, 2, 1) //, classOf[RowTableScan])
         case "Q11" => assertQuery(snc, NWQueries.Q11, 0, 1) //, classOf[Project])
         case "Q12" => assertQuery(snc, NWQueries.Q12, 2, 1) //, classOf[Sort])
         case "Q13" => assertQuery(snc, NWQueries.Q13, 0, 4) //, classOf[LocalTableScan])
         case "Q14" => assertQuery(snc, NWQueries.Q14, 91, 1) //, classOf[Sort])
-        case "Q15" => assertQuery(snc, NWQueries.Q15, 5, 1) //, classOf[PartitionedPhysicalRDD])
-        case "Q16" => assertQuery(snc, NWQueries.Q16, 7, 1) //, classOf[PartitionedPhysicalRDD])
-        case "Q17" => assertQuery(snc, NWQueries.Q17, 3, 1) //, classOf[PartitionedPhysicalRDD])
+        case "Q15" => assertQuery(snc, NWQueries.Q15, 5, 1) //, classOf[RowTableScan])
+        case "Q16" => assertQuery(snc, NWQueries.Q16, 7, 1) //, classOf[RowTableScan])
+        case "Q17" => assertQuery(snc, NWQueries.Q17, 3, 1) //, classOf[RowTableScan])
         case "Q18" => assertQuery(snc, NWQueries.Q18, 8, 1) // classOf[Project])
         case "Q19" => assertQuery(snc, NWQueries.Q19, 13, 1) // classOf[Project])
         case "Q20" => assertQuery(snc, NWQueries.Q20, 1, 1) //, classOf[TungstenAggregate])
@@ -240,23 +241,23 @@ class NorthWindDUnitTest(s: String) extends ClusterManagerTestBase(s) {
   private def validatePartitionedRowTableQueries(snc: SnappyContext): Unit = {
     for (q <- NWQueries.queries) {
       q._1 match {
-        case "Q1" => assertQuery(snc, NWQueries.Q1, 8, 1) //, classOf[PartitionedPhysicalRDD])
-        case "Q2" => assertQuery(snc, NWQueries.Q2, 91, 1) //, classOf[PartitionedPhysicalRDD])
-        case "Q3" => assertQuery(snc, NWQueries.Q3, 830, 4) //, classOf[PartitionedPhysicalRDD])
-        case "Q4" => assertQuery(snc, NWQueries.Q4, 8, 1) //, classOf[PartitionedPhysicalRDD])
+        case "Q1" => assertQuery(snc, NWQueries.Q1, 8, 1) //, classOf[RowTableScan])
+        case "Q2" => assertQuery(snc, NWQueries.Q2, 91, 1) //, classOf[RowTableScan])
+        case "Q3" => assertQuery(snc, NWQueries.Q3, 830, 4) //, classOf[RowTableScan])
+        case "Q4" => assertQuery(snc, NWQueries.Q4, 8, 1) //, classOf[RowTableScan])
         case "Q5" => assertQuery(snc, NWQueries.Q5, 8, 1) //, classOf[Sort])
         case "Q6" => assertQuery(snc, NWQueries.Q6, 8, 1) //, classOf[Sort])
         case "Q7" => assertQuery(snc, NWQueries.Q7, 8, 1) //, classOf[Sort])
-        case "Q8" => assertQuery(snc, NWQueries.Q8, 5, 1) //, classOf[PartitionedPhysicalRDD])
+        case "Q8" => assertQuery(snc, NWQueries.Q8, 5, 1) //, classOf[RowTableScan])
         case "Q9" => assertQuery(snc, NWQueries.Q9, 3, 1) // , classOf[Project])
-        case "Q10" => assertQuery(snc, NWQueries.Q10, 2, 1) //, classOf[PartitionedPhysicalRDD])
+        case "Q10" => assertQuery(snc, NWQueries.Q10, 2, 1) //, classOf[RowTableScan])
         case "Q11" => assertQuery(snc, NWQueries.Q11, 0, 1) //, classOf[Project])
         case "Q12" => assertQuery(snc, NWQueries.Q12, 2, 1) //, classOf[Sort])
         case "Q13" => assertQuery(snc, NWQueries.Q13, 0, 4) //, classOf[LocalTableScan])
         case "Q14" => assertQuery(snc, NWQueries.Q14, 91, 1) //, classOf[Sort])
-        case "Q15" => assertQuery(snc, NWQueries.Q15, 5, 1) //, classOf[PartitionedPhysicalRDD])
-        case "Q16" => assertQuery(snc, NWQueries.Q16, 7, 1) //, classOf[PartitionedPhysicalRDD])
-        case "Q17" => assertQuery(snc, NWQueries.Q17, 3, 1) //, classOf[PartitionedPhysicalRDD])
+        case "Q15" => assertQuery(snc, NWQueries.Q15, 5, 1) //, classOf[RowTableScan])
+        case "Q16" => assertQuery(snc, NWQueries.Q16, 7, 1) //, classOf[RowTableScan])
+        case "Q17" => assertQuery(snc, NWQueries.Q17, 3, 1) //, classOf[RowTableScan])
         case "Q18" => assertQuery(snc, NWQueries.Q18, 8, 1) //, classOf[Project])
         case "Q19" => assertQuery(snc, NWQueries.Q19, 13, 4) //, classOf[Project])
         case "Q20" => assertQuery(snc, NWQueries.Q20, 1, 1) //, classOf[TungstenAggregate])
@@ -345,23 +346,23 @@ class NorthWindDUnitTest(s: String) extends ClusterManagerTestBase(s) {
 
     for (q <- NWQueries.queries) {
       q._1 match {
-        case "Q1" => assertQuery(snc, NWQueries.Q1, 8, 1) //, classOf[PartitionedPhysicalRDD])
-        case "Q2" => assertQuery(snc, NWQueries.Q2, 91, 1) //, classOf[PartitionedPhysicalRDD])
-        case "Q3" => assertQuery(snc, NWQueries.Q3, 830, 4) //, classOf[PartitionedPhysicalRDD])
-        case "Q4" => assertQuery(snc, NWQueries.Q4, 8, 4) //, classOf[PartitionedPhysicalRDD])
+        case "Q1" => assertQuery(snc, NWQueries.Q1, 8, 1) //, classOf[ColumnTableScan])
+        case "Q2" => assertQuery(snc, NWQueries.Q2, 91, 1) //, classOf[ColumnTableScan])
+        case "Q3" => assertQuery(snc, NWQueries.Q3, 830, 4) //, classOf[ColumnTableScan])
+        case "Q4" => assertQuery(snc, NWQueries.Q4, 8, 4) //, classOf[ColumnTableScan])
         case "Q5" => assertQuery(snc, NWQueries.Q5, 8, 9) //, classOf[Sort])
         case "Q6" => assertQuery(snc, NWQueries.Q6, 8, 2) //, classOf[Sort])
         case "Q7" => assertQuery(snc, NWQueries.Q7, 8, 9) //, classOf[Sort])
-        case "Q8" => assertQuery(snc, NWQueries.Q8, 5, 4) //, classOf[PartitionedPhysicalRDD])
+        case "Q8" => assertQuery(snc, NWQueries.Q8, 5, 4) //, classOf[ColumnTableScan])
         case "Q9" => assertQuery(snc, NWQueries.Q9, 3, 4) //, classOf[Project])
-        case "Q10" => assertQuery(snc, NWQueries.Q10, 2, 4) //, classOf[PartitionedPhysicalRDD])
+        case "Q10" => assertQuery(snc, NWQueries.Q10, 2, 4) //, classOf[ColumnTableScan])
         case "Q11" => assertQuery(snc, NWQueries.Q11, 0, 24) //, classOf[Project])
         case "Q12" => assertQuery(snc, NWQueries.Q12, 2, 3) //, classOf[Sort])
         case "Q13" => assertQuery(snc, NWQueries.Q13, 0, 4) //, classOf[LocalTableScan])
         case "Q14" => assertQuery(snc, NWQueries.Q14, 91, 1) //, classOf[Sort])
-        case "Q15" => assertQuery(snc, NWQueries.Q15, 5, 4) //, classOf[PartitionedPhysicalRDD])
-        case "Q16" => assertQuery(snc, NWQueries.Q16, 7, 4) //, classOf[PartitionedPhysicalRDD])
-        case "Q17" => assertQuery(snc, NWQueries.Q17, 3, 4) //, classOf[PartitionedPhysicalRDD])
+        case "Q15" => assertQuery(snc, NWQueries.Q15, 5, 4) //, classOf[ColumnTableScan])
+        case "Q16" => assertQuery(snc, NWQueries.Q16, 7, 4) //, classOf[ColumnTableScan])
+        case "Q17" => assertQuery(snc, NWQueries.Q17, 3, 4) //, classOf[ColumnTableScan])
         case "Q18" => assertQuery(snc, NWQueries.Q18, 8, 4) //, classOf[Project])
         case "Q19" => assertQuery(snc, NWQueries.Q19, 13, 4) //, classOf[Project])
         case "Q20" => assertQuery(snc, NWQueries.Q20, 1, 1) //, classOf[TungstenAggregate])
@@ -456,23 +457,23 @@ class NorthWindDUnitTest(s: String) extends ClusterManagerTestBase(s) {
 
     for (q <- NWQueries.queries) {
       q._1 match {
-        case "Q1" => assertQuery(snc, NWQueries.Q1, 8, 1) //, classOf[PartitionedPhysicalRDD])
-        case "Q2" => assertQuery(snc, NWQueries.Q2, 91, 4) //, classOf[PartitionedPhysicalRDD])
-        case "Q3" => assertQuery(snc, NWQueries.Q3, 830, 4) //, classOf[PartitionedPhysicalRDD])
-        case "Q4" => assertQuery(snc, NWQueries.Q4, 8, 3) //, classOf[PartitionedPhysicalRDD])
+        case "Q1" => assertQuery(snc, NWQueries.Q1, 8, 1) //, classOf[ColumnTableScan])
+        case "Q2" => assertQuery(snc, NWQueries.Q2, 91, 4) //, classOf[ColumnTableScan])
+        case "Q3" => assertQuery(snc, NWQueries.Q3, 830, 4) //, classOf[ColumnTableScan])
+        case "Q4" => assertQuery(snc, NWQueries.Q4, 8, 3) //, classOf[ColumnTableScan])
         case "Q5" => assertQuery(snc, NWQueries.Q5, 8, 9) //, classOf[Sort])
         case "Q6" => assertQuery(snc, NWQueries.Q6, 8, 2) //, classOf[Sort])
         case "Q7" => assertQuery(snc, NWQueries.Q7, 8, 9) //, classOf[Sort])
-        case "Q8" => assertQuery(snc, NWQueries.Q8, 5, 3) //, classOf[PartitionedPhysicalRDD])
+        case "Q8" => assertQuery(snc, NWQueries.Q8, 5, 3) //, classOf[ColumnTableScan])
         case "Q9" => assertQuery(snc, NWQueries.Q9, 3, 3) //, classOf[Project])
-        case "Q10" => assertQuery(snc, NWQueries.Q10, 2, 3) //, classOf[PartitionedPhysicalRDD])
+        case "Q10" => assertQuery(snc, NWQueries.Q10, 2, 3) //, classOf[ColumnTableScan])
         case "Q11" => assertQuery(snc, NWQueries.Q11, 0, 3) //, classOf[Project])
         case "Q12" => assertQuery(snc, NWQueries.Q12, 2, 3) //, classOf[Sort])
         case "Q13" => assertQuery(snc, NWQueries.Q13, 0, 4) //, classOf[LocalTableScan])
         case "Q14" => assertQuery(snc, NWQueries.Q14, 91, 92) //, classOf[Sort])
-        case "Q15" => assertQuery(snc, NWQueries.Q15, 5, 3) //, classOf[PartitionedPhysicalRDD])
-        case "Q16" => assertQuery(snc, NWQueries.Q16, 7, 3) //, classOf[PartitionedPhysicalRDD])
-        case "Q17" => assertQuery(snc, NWQueries.Q17, 3, 3) //, classOf[PartitionedPhysicalRDD])
+        case "Q15" => assertQuery(snc, NWQueries.Q15, 5, 3) //, classOf[ColumnTableScan])
+        case "Q16" => assertQuery(snc, NWQueries.Q16, 7, 3) //, classOf[ColumnTableScan])
+        case "Q17" => assertQuery(snc, NWQueries.Q17, 3, 3) //, classOf[ColumnTableScan])
         case "Q18" => assertQuery(snc, NWQueries.Q18, 8, 3) //, classOf[Project])
         case "Q19" => assertQuery(snc, NWQueries.Q19, 13, 4) //, classOf[Project])
         case "Q20" => assertQuery(snc, NWQueries.Q20, 1, 1) //, classOf[TungstenAggregate])

--- a/cluster/src/main/scala/org/apache/spark/scheduler/cluster/SnappyEmbeddedModeClusterManager.scala
+++ b/cluster/src/main/scala/org/apache/spark/scheduler/cluster/SnappyEmbeddedModeClusterManager.scala
@@ -71,7 +71,7 @@ class SnappyEmbeddedModeClusterManager extends ExternalClusterManager {
 
   override def createSchedulerBackend(sc: SparkContext, masterURL: String,
       scheduler: TaskScheduler): SchedulerBackend = {
-    sc.addSparkListener(new BlockManagerIdListener)
+    sc.addSparkListener(new BlockManagerIdListener(sc))
     schedulerBackend = new SnappyCoarseGrainedSchedulerBackend(
       scheduler.asInstanceOf[TaskSchedulerImpl], sc.env.rpcEnv)
 

--- a/cluster/src/test/scala/org/apache/spark/sql/NWQueries.scala
+++ b/cluster/src/test/scala/org/apache/spark/sql/NWQueries.scala
@@ -73,7 +73,7 @@ object NWQueries extends SnappyFunSuite{
   // Using the WHERE clause to check for equality or inequality
   val Q13: String = "SELECT OrderDate, ShippedDate, CustomerID, Freight" +
       " FROM Orders " +
-      " WHERE OrderDate = '19-May-1997'"
+      " WHERE OrderDate = '1997-05-19'"
 
   // Using WHERE and ORDER BY Together
   val Q14: String = "SELECT CompanyName, ContactName, Fax" +
@@ -130,7 +130,7 @@ object NWQueries extends SnappyFunSuite{
       "(SELECT CustomerID FROM Orders WHERE OrderID = 10290)"
 
   val Q26: String = "SELECT CompanyName FROM Customers  WHERE CustomerID IN (SELECT CustomerID " +
-      "FROM Orders WHERE OrderDate BETWEEN '1-Jan-1997' AND '31-Dec-1997')"
+      "FROM Orders WHERE OrderDate BETWEEN '1997-01-01' AND '1997-12-31')"
 
   val Q27: String = "SELECT ProductName, SupplierID FROM Products WHERE SupplierID" +
       " IN (SELECT SupplierID FROM Suppliers WHERE CompanyName IN" +
@@ -156,7 +156,7 @@ object NWQueries extends SnappyFunSuite{
       " FROM Orders o" +
       " JOIN Employees e ON (e.EmployeeID = o.EmployeeID)" +
       " JOIN Customers c ON (c.CustomerID = o.CustomerID)" +
-      " WHERE o.ShippedDate > o.RequiredDate AND o.OrderDate > '1-Jan-1998'" +
+      " WHERE o.ShippedDate > o.RequiredDate AND o.OrderDate > '1998-01-01'" +
       " ORDER BY c.CompanyName"
 
   val Q33: String = "SELECT e.FirstName, e.LastName, o.OrderID" +
@@ -214,7 +214,7 @@ object NWQueries extends SnappyFunSuite{
       " order by y.OrderID" +
       " ) c on c.ProductID = b.ProductID" +
       " inner join Orders d on d.OrderID = c.OrderID" +
-      " where d.OrderDate > '1997/1/1' and d.OrderDate < '1997/12/31'" +
+      " where d.OrderDate > '1997-01-01' and d.OrderDate < '1997-12-31'" +
       " group by a.CategoryID, a.CategoryName, b.ProductName" +
       " order by a.CategoryName, b.ProductName, ProductSales"
 

--- a/cluster/src/test/scala/org/apache/spark/sql/NorthWindTest.scala
+++ b/cluster/src/test/scala/org/apache/spark/sql/NorthWindTest.scala
@@ -21,6 +21,7 @@ import org.scalatest.{BeforeAndAfter, BeforeAndAfterAll}
 
 import org.apache.spark.Logging
 import org.apache.spark.sql.execution._
+import org.apache.spark.sql.execution.columnar.ColumnTableScan
 import org.apache.spark.sql.execution.joins._
 
 class NorthWindTest
@@ -69,7 +70,7 @@ class NorthWindTest
       case j: CartesianProductExec => j
       case j: SortMergeJoinExec => j
       case j: ShuffledHashJoinExec => j
-      case j: PartitionedPhysicalRDD => j
+      case j: PartitionedPhysicalScan => j
 
     }
     if (operators(0).getClass() != c) {
@@ -95,7 +96,7 @@ class NorthWindTest
       case j: ProjectExec => j
       // case j: TungstenAggregate => j
       case j: PartitionedDataSourceScan => j
-      case j: PartitionedPhysicalRDD => j
+      case j: PartitionedPhysicalScan => j
       case j: LocalTableScanExec => j
       case j: CoalesceExec => j
       case j: FilterExec => j
@@ -157,19 +158,19 @@ class NorthWindTest
   private def validateReplicatedTableQueries(snc: SnappyContext): Unit = {
     for (q <- NWQueries.queries) {
       q._1 match {
-        case "Q1" => assertQuery(snc, NWQueries.Q1, 8, 1, classOf[PartitionedPhysicalRDD])
-        case "Q2" => assertQuery(snc, NWQueries.Q2, 91, 1, classOf[PartitionedPhysicalRDD])
-        case "Q3" => assertQuery(snc, NWQueries.Q3, 830, 1, classOf[PartitionedPhysicalRDD])
-        case "Q4" => assertQuery(snc, NWQueries.Q4, 9, 1, classOf[PartitionedPhysicalRDD])
-        case "Q5" => assertQuery(snc, NWQueries.Q5, 9, 1, classOf[PartitionedPhysicalRDD])
-        case "Q6" => assertQuery(snc, NWQueries.Q6, 9, 1, classOf[PartitionedPhysicalRDD])
-        case "Q7" => assertQuery(snc, NWQueries.Q7, 9, 1, classOf[PartitionedPhysicalRDD])
+        case "Q1" => assertQuery(snc, NWQueries.Q1, 8, 1, classOf[RowTableScan])
+        case "Q2" => assertQuery(snc, NWQueries.Q2, 91, 1, classOf[RowTableScan])
+        case "Q3" => assertQuery(snc, NWQueries.Q3, 830, 1, classOf[RowTableScan])
+        case "Q4" => assertQuery(snc, NWQueries.Q4, 9, 1, classOf[RowTableScan])
+        case "Q5" => assertQuery(snc, NWQueries.Q5, 9, 1, classOf[RowTableScan])
+        case "Q6" => assertQuery(snc, NWQueries.Q6, 9, 1, classOf[RowTableScan])
+        case "Q7" => assertQuery(snc, NWQueries.Q7, 9, 1, classOf[RowTableScan])
         case "Q8" => assertQuery(snc, NWQueries.Q8, 6, 1, classOf[FilterExec])
         case "Q9" => assertQuery(snc, NWQueries.Q9, 3, 1, classOf[ProjectExec])
         case "Q10" => assertQuery(snc, NWQueries.Q10, 2, 1, classOf[FilterExec])
         case "Q11" => assertQuery(snc, NWQueries.Q11, 0, 1 , classOf[ProjectExec])
         case "Q12" => assertQuery(snc, NWQueries.Q12, 2, 1 , classOf[FilterExec])
-        case "Q13" => assertQuery(snc, NWQueries.Q13, 0, 1, classOf[FilterExec])
+        case "Q13" => assertQuery(snc, NWQueries.Q13, 2, 1, classOf[FilterExec])
         case "Q14" => assertQuery(snc, NWQueries.Q14, 91, 1 , classOf[FilterExec])
         case "Q15" => assertQuery(snc, NWQueries.Q15, 5, 1 , classOf[FilterExec])
         case "Q16" => assertQuery(snc, NWQueries.Q16, 8, 1 , classOf[FilterExec])
@@ -177,23 +178,23 @@ class NorthWindTest
         case "Q18" => assertQuery(snc, NWQueries.Q18, 9, 1, classOf[ProjectExec])
         case "Q19" => assertQuery(snc, NWQueries.Q19, 13, 1, classOf[ProjectExec])
         case "Q20" => assertQuery(snc, NWQueries.Q20, 1, 1, classOf[ProjectExec])
-        case "Q21" => assertQuery(snc, NWQueries.Q21, 1, 1, classOf[PartitionedPhysicalRDD])
+        case "Q21" => assertQuery(snc, NWQueries.Q21, 1, 1, classOf[RowTableScan])
         case "Q22" => assertQuery(snc, NWQueries.Q22, 1, 1, classOf[ProjectExec])
-        case "Q23" => assertQuery(snc, NWQueries.Q23, 1, 1, classOf[PartitionedPhysicalRDD])
+        case "Q23" => assertQuery(snc, NWQueries.Q23, 1, 1, classOf[RowTableScan])
         case "Q24" => assertQuery(snc, NWQueries.Q24, 4, 1, classOf[ProjectExec])
-        case "Q25" => assertJoin(snc, NWQueries.Q25, 1, 1, classOf[PartitionedPhysicalRDD])
-        case "Q26" => assertJoin(snc, NWQueries.Q26, 89, 1, classOf[SortMergeJoinExec])
+        case "Q25" => assertJoin(snc, NWQueries.Q25, 1, 1, classOf[RowTableScan])
+        case "Q26" => assertJoin(snc, NWQueries.Q26, 86, 1, classOf[SortMergeJoinExec])
         case "Q27" => assertJoin(snc, NWQueries.Q27, 9, 1, classOf[SortMergeJoinExec])
-        case "Q28" => assertJoin(snc, NWQueries.Q28, 12, 1, classOf[PartitionedPhysicalRDD])
+        case "Q28" => assertJoin(snc, NWQueries.Q28, 12, 1, classOf[RowTableScan])
         case "Q29" => assertJoin(snc, NWQueries.Q29, 8, 1, classOf[SortMergeJoinExec])
         case "Q30" => assertJoin(snc, NWQueries.Q30, 8, 1, classOf[SortMergeJoinExec])
         case "Q31" => assertJoin(snc, NWQueries.Q31, 830, 1, classOf[LocalJoin])
-        case "Q32" => assertJoin(snc, NWQueries.Q32, 37, 1, classOf[LocalJoin])
+        case "Q32" => assertJoin(snc, NWQueries.Q32, 8, 1, classOf[LocalJoin])
         case "Q33" => assertJoin(snc, NWQueries.Q33, 37, 1, classOf[LocalJoin])
         case "Q34" => assertJoin(snc, NWQueries.Q34, 5, 1, classOf[LocalJoin])
         case "Q35" => assertJoin(snc, NWQueries.Q35, 3, 4, classOf[LocalJoin])
-        case "Q36" => assertJoin(snc, NWQueries.Q36, 292, 1, classOf[LocalJoin])
-        case "Q37" => assertJoin(snc, NWQueries.Q37, 0, 1, classOf[LocalJoin]) // 77
+        case "Q36" => assertJoin(snc, NWQueries.Q36, 290, 1, classOf[LocalJoin])
+        case "Q37" => assertJoin(snc, NWQueries.Q37, 77, 1, classOf[LocalJoin])
         //case "Q38" => assertJoin(snc, NWQueries.Q38, 2155, 1, classOf[LocalJoin]) // NPE LocalJoin
         case "Q39" => assertJoin(snc, NWQueries.Q39, 9, 1, classOf[LocalJoin])
         case "Q40" => assertJoin(snc, NWQueries.Q40, 830, 1, classOf[LocalJoin])
@@ -268,19 +269,19 @@ class NorthWindTest
   private def validatePartitionedRowTableQueries(snc: SnappyContext): Unit = {
     for (q <- NWQueries.queries) {
       q._1 match {
-        case "Q1" => assertQuery(snc, NWQueries.Q1, 8, 1, classOf[PartitionedPhysicalRDD])
-        case "Q2" => assertQuery(snc, NWQueries.Q2, 91, 1, classOf[PartitionedPhysicalRDD])
-        case "Q3" => assertQuery(snc, NWQueries.Q3, 830, 4, classOf[PartitionedPhysicalRDD])
-        case "Q4" => assertQuery(snc, NWQueries.Q4, 9, 1, classOf[PartitionedPhysicalRDD])
-        case "Q5" => assertQuery(snc, NWQueries.Q5, 9, 1, classOf[PartitionedPhysicalRDD])
-        case "Q6" => assertQuery(snc, NWQueries.Q6, 9, 1, classOf[PartitionedPhysicalRDD])
-        case "Q7" => assertQuery(snc, NWQueries.Q7, 9, 1, classOf[PartitionedPhysicalRDD])
+        case "Q1" => assertQuery(snc, NWQueries.Q1, 8, 1, classOf[RowTableScan])
+        case "Q2" => assertQuery(snc, NWQueries.Q2, 91, 1, classOf[RowTableScan])
+        case "Q3" => assertQuery(snc, NWQueries.Q3, 830, 4, classOf[RowTableScan])
+        case "Q4" => assertQuery(snc, NWQueries.Q4, 9, 1, classOf[RowTableScan])
+        case "Q5" => assertQuery(snc, NWQueries.Q5, 9, 1, classOf[RowTableScan])
+        case "Q6" => assertQuery(snc, NWQueries.Q6, 9, 1, classOf[RowTableScan])
+        case "Q7" => assertQuery(snc, NWQueries.Q7, 9, 1, classOf[RowTableScan])
         case "Q8" => assertQuery(snc, NWQueries.Q8, 6, 1, classOf[FilterExec])
         case "Q9" => assertQuery(snc, NWQueries.Q9, 3, 1, classOf[ProjectExec])
         case "Q10" => assertQuery(snc, NWQueries.Q10, 2, 1, classOf[FilterExec])
         case "Q11" => assertQuery(snc, NWQueries.Q11, 0, 1 , classOf[ProjectExec])
         case "Q12" => assertQuery(snc, NWQueries.Q12, 2, 1 , classOf[FilterExec])
-        case "Q13" => assertQuery(snc, NWQueries.Q13, 0, 4, classOf[FilterExec])
+        case "Q13" => assertQuery(snc, NWQueries.Q13, 2, 4, classOf[FilterExec])
         case "Q14" => assertQuery(snc, NWQueries.Q14, 91, 1 , classOf[FilterExec])
         case "Q15" => assertQuery(snc, NWQueries.Q15, 5, 1 , classOf[FilterExec])
         case "Q16" => assertQuery(snc, NWQueries.Q16, 8, 1 , classOf[FilterExec])
@@ -288,14 +289,14 @@ class NorthWindTest
         case "Q18" => assertQuery(snc, NWQueries.Q18, 9, 1, classOf[ProjectExec])
         case "Q19" => assertQuery(snc, NWQueries.Q19, 13, 4, classOf[ProjectExec])
         case "Q20" => assertQuery(snc, NWQueries.Q20, 1, 1, classOf[ProjectExec])
-        case "Q21" => assertQuery(snc, NWQueries.Q21, 1, 1, classOf[PartitionedPhysicalRDD])
+        case "Q21" => assertQuery(snc, NWQueries.Q21, 1, 1, classOf[RowTableScan])
         case "Q22" => assertQuery(snc, NWQueries.Q22, 1, 1, classOf[ProjectExec])
-        case "Q23" => assertQuery(snc, NWQueries.Q23, 1, 1, classOf[PartitionedPhysicalRDD])
+        case "Q23" => assertQuery(snc, NWQueries.Q23, 1, 1, classOf[RowTableScan])
         case "Q24" => assertQuery(snc, NWQueries.Q24, 4, 5, classOf[ProjectExec])
-        case "Q25" => assertJoin(snc, NWQueries.Q25, 1, 1, classOf[PartitionedPhysicalRDD])
+        case "Q25" => assertJoin(snc, NWQueries.Q25, 1, 1, classOf[RowTableScan])
 //        case "Q26" => assertJoin(snc, NWQueries.Q26, 89, 1, classOf[BroadcastHashJoinExec])
 //        case "Q27" => assertJoin(snc, NWQueries.Q27, 9, 4, classOf[BroadcastHashJoinExec])
-//        case "Q28" => assertJoin(snc, NWQueries.Q28, 12, 4, classOf[PartitionedPhysicalRDD])
+//        case "Q28" => assertJoin(snc, NWQueries.Q28, 12, 4, classOf[RowTableScan])
 //        case "Q29" => assertJoin(snc, NWQueries.Q29, 8, 4, classOf[BroadcastHashJoinExec])
 //        case "Q30" => assertJoin(snc, NWQueries.Q30, 8, 4, classOf[BroadcastHashJoinExec])
 //        case "Q31" => assertJoin(snc, NWQueries.Q31, 830, 200, classOf[LocalJoin])
@@ -379,19 +380,19 @@ class NorthWindTest
 
     for (q <- NWQueries.queries) {
       q._1 match {
-        case "Q1" => assertQuery(snc, NWQueries.Q1, 8, 1, classOf[PartitionedPhysicalRDD])
-        case "Q2" => assertQuery(snc, NWQueries.Q2, 91, 1, classOf[PartitionedPhysicalRDD])
-        case "Q3" => assertQuery(snc, NWQueries.Q3, 830, 4, classOf[PartitionedPhysicalRDD])
-        case "Q4" => assertQuery(snc, NWQueries.Q4, 9, 4, classOf[PartitionedPhysicalRDD])
-        case "Q5" => assertQuery(snc, NWQueries.Q5, 9, 10, classOf[PartitionedPhysicalRDD])
-        case "Q6" => assertQuery(snc, NWQueries.Q6, 9, 10, classOf[PartitionedPhysicalRDD])
-        case "Q7" => assertQuery(snc, NWQueries.Q7, 9, 10, classOf[PartitionedPhysicalRDD])
+        case "Q1" => assertQuery(snc, NWQueries.Q1, 8, 1, classOf[RowTableScan])
+        case "Q2" => assertQuery(snc, NWQueries.Q2, 91, 1, classOf[RowTableScan])
+        case "Q3" => assertQuery(snc, NWQueries.Q3, 830, 4, classOf[ColumnTableScan])
+        case "Q4" => assertQuery(snc, NWQueries.Q4, 9, 4, classOf[ColumnTableScan])
+        case "Q5" => assertQuery(snc, NWQueries.Q5, 9, 10, classOf[ColumnTableScan])
+        case "Q6" => assertQuery(snc, NWQueries.Q6, 9, 10, classOf[ColumnTableScan])
+        case "Q7" => assertQuery(snc, NWQueries.Q7, 9, 10, classOf[ColumnTableScan])
         case "Q8" => assertQuery(snc, NWQueries.Q8, 6, 4, classOf[FilterExec])
         case "Q9" => assertQuery(snc, NWQueries.Q9, 3, 4, classOf[ProjectExec])
         case "Q10" => assertQuery(snc, NWQueries.Q10, 2, 4, classOf[FilterExec])
         case "Q11" => assertQuery(snc, NWQueries.Q11, 0, 4, classOf[ProjectExec])
         case "Q12" => assertQuery(snc, NWQueries.Q12, 2, 3, classOf[FilterExec])
-        case "Q13" => assertQuery(snc, NWQueries.Q13, 0, 4, classOf[FilterExec])
+        case "Q13" => assertQuery(snc, NWQueries.Q13, 2, 4, classOf[FilterExec])
         case "Q14" => assertQuery(snc, NWQueries.Q14, 91, 1, classOf[FilterExec])
         case "Q15" => assertQuery(snc, NWQueries.Q15, 5, 4, classOf[FilterExec])
         case "Q16" => assertQuery(snc, NWQueries.Q16, 8, 4, classOf[FilterExec])
@@ -399,14 +400,14 @@ class NorthWindTest
         case "Q18" => assertQuery(snc, NWQueries.Q18, 9, 4, classOf[ProjectExec])
         case "Q19" => assertQuery(snc, NWQueries.Q19, 13, 4, classOf[ProjectExec])
         case "Q20" => assertQuery(snc, NWQueries.Q20, 1, 1, classOf[ProjectExec])
-        case "Q21" => assertQuery(snc, NWQueries.Q21, 1, 1, classOf[PartitionedPhysicalRDD])
+        case "Q21" => assertQuery(snc, NWQueries.Q21, 1, 1, classOf[ColumnTableScan])
         case "Q22" => assertQuery(snc, NWQueries.Q22, 1, 2, classOf[ProjectExec])
-        case "Q23" => assertQuery(snc, NWQueries.Q23, 1, 1, classOf[PartitionedPhysicalRDD])
+        case "Q23" => assertQuery(snc, NWQueries.Q23, 1, 1, classOf[ColumnTableScan])
         case "Q24" => assertQuery(snc, NWQueries.Q24, 4, 5, classOf[ProjectExec])
-        case "Q25" => assertJoin(snc, NWQueries.Q25, 1, 1, classOf[PartitionedPhysicalRDD])
+        case "Q25" => assertJoin(snc, NWQueries.Q25, 1, 1, classOf[RowTableScan])
 //        case "Q26" => assertJoin(snc, NWQueries.Q26, 89, 200, classOf[SortMergeJoinExec])
 //        case "Q27" => assertJoin(snc, NWQueries.Q27, 9, 4, classOf[BroadcastHashJoinExec])
-//        case "Q28" => assertJoin(snc, NWQueries.Q28, 12, 200, classOf[PartitionedPhysicalRDD])
+//        case "Q28" => assertJoin(snc, NWQueries.Q28, 12, 200, classOf[ColumnTableScan])
 //        case "Q29" => assertJoin(snc, NWQueries.Q29, 8, 200, classOf[SortMergeJoinExec])
 //        case "Q30" => assertJoin(snc, NWQueries.Q30, 8, 200, classOf[SortMergeJoinExec])
 //        case "Q31" => assertJoin(snc, NWQueries.Q31, 830, 200, classOf[LocalJoin])
@@ -496,19 +497,19 @@ class NorthWindTest
 
     for (q <- NWQueries.queries) {
       q._1 match {
-        case "Q1" => assertQuery(snc, NWQueries.Q1, 8, 1, classOf[PartitionedPhysicalRDD])
-        case "Q2" => assertQuery(snc, NWQueries.Q2, 91, 4, classOf[PartitionedPhysicalRDD])
-        case "Q3" => assertQuery(snc, NWQueries.Q3, 830, 4, classOf[PartitionedPhysicalRDD])
-        case "Q4" => assertQuery(snc, NWQueries.Q4, 9, 3, classOf[PartitionedPhysicalRDD])
-        case "Q5" => assertQuery(snc, NWQueries.Q5, 9, 10, classOf[PartitionedPhysicalRDD])
-        case "Q6" => assertQuery(snc, NWQueries.Q6, 9, 10, classOf[PartitionedPhysicalRDD])
-        case "Q7" => assertQuery(snc, NWQueries.Q7, 9, 10, classOf[PartitionedPhysicalRDD])
+        case "Q1" => assertQuery(snc, NWQueries.Q1, 8, 1, classOf[RowTableScan])
+        case "Q2" => assertQuery(snc, NWQueries.Q2, 91, 4, classOf[ColumnTableScan])
+        case "Q3" => assertQuery(snc, NWQueries.Q3, 830, 4, classOf[RowTableScan])
+        case "Q4" => assertQuery(snc, NWQueries.Q4, 9, 3, classOf[RowTableScan])
+        case "Q5" => assertQuery(snc, NWQueries.Q5, 9, 10, classOf[RowTableScan])
+        case "Q6" => assertQuery(snc, NWQueries.Q6, 9, 10, classOf[RowTableScan])
+        case "Q7" => assertQuery(snc, NWQueries.Q7, 9, 10, classOf[RowTableScan])
         case "Q8" => assertQuery(snc, NWQueries.Q8, 6, 3, classOf[FilterExec])
         case "Q9" => assertQuery(snc, NWQueries.Q9, 3, 3, classOf[ProjectExec])
         case "Q10" => assertQuery(snc, NWQueries.Q10, 2, 3, classOf[FilterExec])
         case "Q11" => assertQuery(snc, NWQueries.Q11, 0, 3, classOf[ProjectExec])
         case "Q12" => assertQuery(snc, NWQueries.Q12, 2, 3, classOf[FilterExec])
-        case "Q13" => assertQuery(snc, NWQueries.Q13, 0, 4, classOf[FilterExec])
+        case "Q13" => assertQuery(snc, NWQueries.Q13, 2, 4, classOf[FilterExec])
         case "Q14" => assertQuery(snc, NWQueries.Q14, 91, 92, classOf[FilterExec])
         case "Q15" => assertQuery(snc, NWQueries.Q15, 5, 3, classOf[FilterExec])
         case "Q16" => assertQuery(snc, NWQueries.Q16, 8, 3, classOf[FilterExec])
@@ -516,14 +517,14 @@ class NorthWindTest
         case "Q18" => assertQuery(snc, NWQueries.Q18, 9, 3, classOf[ProjectExec])
         case "Q19" => assertQuery(snc, NWQueries.Q19, 13, 4, classOf[ProjectExec])
         case "Q20" => assertQuery(snc, NWQueries.Q20, 1, 1, classOf[ProjectExec])
-        case "Q21" => assertQuery(snc, NWQueries.Q21, 1, 1, classOf[PartitionedPhysicalRDD])
+        case "Q21" => assertQuery(snc, NWQueries.Q21, 1, 1, classOf[RowTableScan])
         case "Q22" => assertQuery(snc, NWQueries.Q22, 1, 2, classOf[ProjectExec])
-        case "Q23" => assertQuery(snc, NWQueries.Q23, 1, 1, classOf[PartitionedPhysicalRDD])
+        case "Q23" => assertQuery(snc, NWQueries.Q23, 1, 1, classOf[RowTableScan])
         case "Q24" => assertQuery(snc, NWQueries.Q24, 4, 5, classOf[ProjectExec])
-        case "Q25" => assertJoin(snc, NWQueries.Q25, 1, 4, classOf[PartitionedPhysicalRDD])
-        case "Q26" => assertJoin(snc, NWQueries.Q26, 89, 4, classOf[BroadcastHashJoinExec])
+        case "Q25" => assertJoin(snc, NWQueries.Q25, 1, 4, classOf[ColumnTableScan])
+        case "Q26" => assertJoin(snc, NWQueries.Q26, 86, 4, classOf[BroadcastHashJoinExec])
 //       // case "Q27" => assertJoin(snc, NWQueries.Q27, 9, 4, classOf[SortMergeJoinExec])
-//        case "Q28" => assertJoin(snc, NWQueries.Q28, 12, 4, classOf[PartitionedPhysicalRDD])
+//        case "Q28" => assertJoin(snc, NWQueries.Q28, 12, 4, classOf[ColumnTableScan])
 //        case "Q29" => assertJoin(snc, NWQueries.Q29, 8, 4, classOf[BroadcastHashJoinExec])
 //        case "Q30" => assertJoin(snc, NWQueries.Q30, 8, 4, classOf[BroadcastHashJoinExec])
 //        case "Q31" => assertJoin(snc, NWQueries.Q31, 830, 200, classOf[BroadcastHashJoinExec])

--- a/cluster/src/test/scala/org/apache/spark/sql/execution/benchmark/ColumnCacheBenchmark.scala
+++ b/cluster/src/test/scala/org/apache/spark/sql/execution/benchmark/ColumnCacheBenchmark.scala
@@ -1,0 +1,229 @@
+/*
+ * Adapted from https://github.com/apache/spark/pull/13899 having the below
+ * license.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/*
+ * Changes for SnappyData data platform.
+ *
+ * Portions Copyright (c) 2016 SnappyData, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License. You
+ * may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License. See accompanying
+ * LICENSE file.
+ */
+
+package org.apache.spark.sql.execution.benchmark
+
+import io.snappydata.SnappyFunSuite
+
+import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.types.StructType
+import org.apache.spark.sql.{DataFrame, QueryTest, Row}
+import org.apache.spark.util.Benchmark
+import org.apache.spark.{SparkConf, SparkEnv}
+
+
+class ColumnCacheBenchmark extends SnappyFunSuite {
+
+  override protected def newSparkConf(
+      addOn: SparkConf => SparkConf = null): SparkConf = {
+    val conf = new SparkConf()
+        .setIfMissing("spark.master", "local[1]")
+        .setAppName("microbenchmark")
+    conf.set("snappy.store.optimization", "true")
+    conf.set("spark.sql.shuffle.partitions", "1")
+    conf.set(SQLConf.COLUMN_BATCH_SIZE.key, "100000")
+    // conf.set("spark.sql.autoBroadcastJoinThreshold", "1")
+    if (addOn != null) {
+      addOn(conf)
+    }
+    conf
+  }
+
+  private val snappySession = snc.snappySession
+
+  ignore("cache with randomized keys - end-to-end") {
+    benchmarkRandomizedKeys(size = 20 << 18, readPathOnly = false)
+  }
+
+  test("cache with randomized keys - read path only") {
+    benchmarkRandomizedKeys(size = 20 << 21, readPathOnly = true)
+  }
+
+  /**
+   * Call collect on a [[DataFrame]] after deleting all existing temporary files.
+   * This also checks whether the collected result matches the expected answer.
+   */
+  private def collect(df: DataFrame, expectedAnswer: Seq[Row]): Unit = {
+    QueryTest.checkAnswer(df, expectedAnswer) match {
+      case Some(errMessage) => throw new RuntimeException(errMessage)
+      case None => // all good
+    }
+  }
+
+  def addCaseWithCleanup(
+      benchmark: Benchmark,
+      name: String,
+      numIters: Int = 0,
+      prepare: () => Unit,
+      cleanup: () => Unit,
+      testCleanup: () => Unit)(f: Int => Unit): Unit = {
+    val timedF = (timer: Benchmark.Timer) => {
+      timer.startTiming()
+      f(timer.iteration)
+      timer.stopTiming()
+      testCleanup()
+    }
+    benchmark.benchmarks += Benchmark.Case(name, timedF, numIters, prepare, cleanup)
+  }
+
+  private def doGC(): Unit = {
+    System.gc()
+    System.runFinalization()
+    System.gc()
+    System.runFinalization()
+  }
+
+  /**
+   * Benchmark caching randomized keys created from a range.
+   *
+   * NOTE: When running this benchmark, you will get a lot of WARN logs complaining that the
+   * shuffle files do not exist. This is intentional; we delete the shuffle files manually
+   * after every call to `collect` to avoid the next run to reuse shuffle files written by
+   * the previous run.
+   */
+  private def benchmarkRandomizedKeys(size: Int, readPathOnly: Boolean): Unit = {
+    val numIters = 10
+    val benchmark = new Benchmark("Cache random keys", size)
+    snappySession.sql("drop table if exists test")
+    var testDF = snappySession.range(size)
+        .selectExpr("id", "floor(rand() * 10000) as k")
+    // var testDF = snappySession.range(size)
+    //    .selectExpr("id", "concat('val', cast((id % 100) as string)) as k")
+    testDF.createOrReplaceTempView("test")
+    val query = "select avg(k), avg(id) from test"
+    val expectedAnswer = snappySession.sql(query).collect().toSeq
+
+    /**
+     * Add a benchmark case, optionally specifying whether to cache the dataset.
+     */
+    def addBenchmark(name: String, cache: Boolean, params: Map[String, String] = Map(),
+        snappy: Boolean = false, nullable: Boolean = true): Unit = {
+      val defaults = params.keys.flatMap { k => snappySession.conf.getOption(k).map((k, _)) }
+      var ds = snappySession.sql(query)
+      def prepare(): Unit = {
+        params.foreach { case (k, v) => snappySession.conf.set(k, v) }
+        if (!nullable) {
+          testDF = snappySession.internalCreateDataFrame(testDF.queryExecution.toRdd,
+            StructType(testDF.schema.fields.map(_.copy(nullable = false))))
+          testDF.createOrReplaceTempView("test")
+          ds = snappySession.sql(query)
+        }
+        doGC()
+        if (cache) {
+          testDF.createOrReplaceTempView("test")
+          snappySession.catalog.cacheTable("test")
+        } else if (snappy) {
+          val nullableStr = if (nullable) "" else " not null"
+          snappySession.sql("drop table if exists test")
+          snappySession.sql(s"create table test (id bigint $nullableStr, " +
+              s"k bigint $nullableStr) using column options(buckets '1')")
+          if (readPathOnly) {
+            testDF.write.insertInto("test")
+            ds = snappySession.sql(query)
+          }
+        }
+        if (readPathOnly) {
+          collect(ds, expectedAnswer)
+          testCleanup()
+        }
+        doGC()
+      }
+      def cleanup(): Unit = {
+        defaults.foreach { case (k, v) => snappySession.conf.set(k, v) }
+        snappySession.catalog.clearCache()
+        snappySession.sql("drop table if exists test")
+        doGC()
+      }
+      def testCleanup(): Unit = {
+        snappySession.sparkContext.parallelize(1 to 10, 10).foreach { _ =>
+          SparkEnv.get.blockManager.diskBlockManager.getAllFiles().foreach { dir =>
+            dir.delete()
+          }
+        }
+      }
+      addCaseWithCleanup(benchmark, name, numIters, prepare, cleanup, testCleanup) { _ =>
+        if (readPathOnly) {
+          collect(ds, expectedAnswer)
+        } else {
+          // also benchmark the time it takes to build the column buffers
+          if (snappy) {
+            snappySession.sql("truncate table test")
+            testDF.write.insertInto("test")
+          }
+          val ds2 = snappySession.sql(query)
+          collect(ds2, expectedAnswer)
+          collect(ds2, expectedAnswer)
+        }
+      }
+    }
+
+    // All of these are codegen = T hashmap = T
+    snappySession.conf.set(SQLConf.WHOLESTAGE_CODEGEN_ENABLED.key, "true")
+    snappySession.conf.set(SQLConf.VECTORIZED_AGG_MAP_MAX_COLUMNS.key, "1024")
+
+    // Benchmark cases:
+    //   (1) No caching
+    //   (2) Caching without compression
+    //   (3) Caching with compression
+    //   (4) Caching with column batches (without compression)
+    // addBenchmark("cache = F", cache = false)
+    addBenchmark("cache = T compress = F nullable = T", cache = true, Map(
+      // SQLConf.CACHE_CODEGEN.key -> "false",
+      SQLConf.COMPRESS_CACHED.key -> "false"
+    ), nullable = true)
+    /*
+    addBenchmark("cache = T compress = F nullable = F", cache = true, Map(
+      // SQLConf.CACHE_CODEGEN.key -> "false",
+      SQLConf.COMPRESS_CACHED.key -> "false"
+    ), nullable = false)
+    addBenchmark("cache = T columnVector = T nullable = T", cache = true,
+      Map(SQLConf.CACHE_CODEGEN.key -> "true"), nullable = false)
+    */
+
+    addBenchmark("cache = F snappyCompress = F nullable = T", cache = false, Map(
+      SQLConf.COMPRESS_CACHED.key -> "false"
+    ), snappy = true, nullable = true)
+    /*
+    addBenchmark("cache = F snappyCompress = T nullable = T", cache = false, Map(
+      SQLConf.COMPRESS_CACHED.key -> "true"
+    ), snappy = true, nullable = true)
+    */
+
+    benchmark.run()
+  }
+}

--- a/cluster/src/test/scala/org/apache/spark/sql/execution/benchmark/TPCETrade.scala
+++ b/cluster/src/test/scala/org/apache/spark/sql/execution/benchmark/TPCETrade.scala
@@ -1,0 +1,208 @@
+/*
+ * Copyright (c) 2016 SnappyData, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License. You
+ * may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License. See accompanying
+ * LICENSE file.
+ */
+package org.apache.spark.sql.execution.benchmark
+
+import io.snappydata.SnappyFunSuite
+
+import org.apache.spark.SparkConf
+import org.apache.spark.sql._
+import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.types.{Decimal, DecimalType, StructType}
+import org.apache.spark.util.Benchmark
+import org.apache.spark.util.random.XORShiftRandom
+
+class TPCETrade extends SnappyFunSuite {
+
+  override protected def newSparkConf(
+      addOn: SparkConf => SparkConf = null): SparkConf = {
+    val numProcessors = Runtime.getRuntime.availableProcessors()
+    val conf = new SparkConf()
+        .setIfMissing("spark.master", s"local[$numProcessors]")
+        .setAppName("microbenchmark")
+    conf.set("spark.sql.shuffle.partitions", numProcessors.toString)
+    conf.set(SQLConf.COLUMN_BATCH_SIZE.key, "100000")
+    conf.set("snappydata.store.eviction-heap-percentage", "90")
+    conf.set("snappydata.store.critical-heap-percentage", "95")
+    if (addOn != null) {
+      addOn(conf)
+    }
+    conf
+  }
+
+  private lazy val snappySession = snc.snappySession
+
+  import snappySession.implicits._
+
+  ignore("cache with random data - read path only") {
+    benchmarkRandomizedKeys(size = 1000000000L, readPathOnly = true)
+  }
+
+  private def collect(df: DataFrame): Unit = {
+    df.collect()
+  }
+
+  def addCaseWithCleanup(
+      benchmark: Benchmark,
+      name: String,
+      numIters: Int = 0,
+      prepare: () => Unit,
+      cleanup: () => Unit,
+      testCleanup: () => Unit)(f: Int => Unit): Unit = {
+    val timedF = (timer: Benchmark.Timer) => {
+      timer.startTiming()
+      f(timer.iteration)
+      timer.stopTiming()
+      testCleanup()
+    }
+    benchmark.benchmarks += Benchmark.Case(name, timedF, numIters, prepare, cleanup)
+  }
+
+  private def doGC(): Unit = {
+    System.gc()
+    System.runFinalization()
+    System.gc()
+    System.runFinalization()
+  }
+
+  /**
+   * Benchmark caching randomized keys created from a range.
+   *
+   * NOTE: When running this benchmark, you will get a lot of WARN logs complaining that the
+   * shuffle files do not exist. This is intentional; we delete the shuffle files manually
+   * after every call to `collect` to avoid the next run to reuse shuffle files written by
+   * the previous run.
+   */
+  private def benchmarkRandomizedKeys(size: Long, readPathOnly: Boolean): Unit = {
+    val numIters = 20
+    val benchmark = new Benchmark("Cache random data", size)
+    snappySession.sql("drop table if exists trade")
+    val tradeDF = snappySession.range(size).mapPartitions { itr =>
+      val rnd = new XORShiftRandom
+      val syms = TPCETrade.SYMBOLS
+      val numSyms = syms.length
+      itr.map(id => Trade(syms(rnd.nextInt(numSyms)),
+        Decimal(rnd.nextInt(10000000), 8, 2)))
+        //rnd.nextDouble()))
+    }
+    val dataDF = snappySession.internalCreateDataFrame(
+      tradeDF.queryExecution.toRdd,
+      StructType(tradeDF.schema.fields.map { f =>
+          f.dataType match {
+            case d: DecimalType =>
+              f.copy(dataType = DecimalType(8, 2), nullable = false)
+            case _ => f.copy(nullable = false)
+          }
+      }))
+    dataDF.createOrReplaceTempView("trade")
+    val query = "select avg(bid) from trade"
+
+    /**
+     * Add a benchmark case, optionally specifying whether to cache the dataset.
+     */
+    def addBenchmark(name: String, cache: Boolean, params: Map[String, String] = Map(),
+        snappy: Boolean = false): Unit = {
+      val defaults = params.keys.flatMap { k => snappySession.conf.getOption(k).map((k, _)) }
+      def prepare(): Unit = {
+        params.foreach { case (k, v) => snappySession.conf.set(k, v) }
+        doGC()
+        if (cache) {
+          dataDF.createOrReplaceTempView("trade")
+          snappySession.catalog.cacheTable("trade")
+        } else if (snappy) {
+          snappySession.sql("drop table if exists trade")
+          snappySession.sql(s"${TPCETrade.sql} using column")
+          if (readPathOnly) {
+            dataDF.write.insertInto("trade")
+          }
+        }
+        if (readPathOnly) {
+          collect(snappySession.sql(query))
+          testCleanup()
+        }
+        doGC()
+      }
+      def cleanup(): Unit = {
+        defaults.foreach { case (k, v) => snappySession.conf.set(k, v) }
+        snappySession.sql("drop table if exists trade")
+        doGC()
+      }
+      def testCleanup(): Unit = {
+      }
+      addCaseWithCleanup(benchmark, name, numIters, prepare, cleanup, testCleanup) { _ =>
+        if (readPathOnly) {
+          collect(snappySession.sql(query))
+        } else {
+          // also benchmark the time it takes to build the column buffers
+          if (snappy) {
+            snappySession.sql("truncate table trade")
+            dataDF.write.insertInto("trade")
+          }
+          val ds2 = snappySession.sql(query)
+          collect(ds2)
+          collect(ds2)
+        }
+      }
+    }
+
+    // All of these are codegen = T hashmap = T
+    snappySession.conf.set(SQLConf.WHOLESTAGE_CODEGEN_ENABLED.key, "true")
+    snappySession.conf.set(SQLConf.VECTORIZED_AGG_MAP_MAX_COLUMNS.key, "1024")
+
+    // Benchmark cases:
+    //   (1) No caching
+    //   (2) Caching without compression
+    //   (3) Caching with compression
+    //   (4) Caching with snappydata without compression
+    //   (5) Caching with snappydata with compression
+    // addBenchmark("cache = F", cache = false)
+    /*
+    addBenchmark("cache = T compress = F", cache = true, Map(
+      // SQLConf.CACHE_CODEGEN.key -> "false",
+      SQLConf.COMPRESS_CACHED.key -> "false"
+    ))
+    addBenchmark("cache = T compress = F", cache = true, Map(
+      // SQLConf.CACHE_CODEGEN.key -> "false",
+      SQLConf.COMPRESS_CACHED.key -> "false"
+    ))
+    */
+
+    /*
+    addBenchmark("cache = F snappyCompress = F", cache = false, Map(
+      SQLConf.COMPRESS_CACHED.key -> "false"
+    ), snappy = true)
+    */
+    addBenchmark("cache = F snappyCompress = T", cache = false, Map(
+      SQLConf.COMPRESS_CACHED.key -> "true"
+    ), snappy = true)
+    benchmark.run()
+  }
+}
+
+case class Trade(sym: String, bid: Decimal)
+
+object TPCETrade {
+  val SYMBOLS: Array[String] = Array("IBM", "YHOO", "GOOG", "MSFT", "AOL",
+    "APPL", "ORCL", "SAP", "DELL", "RHAT", "NOVL", "HP")
+
+  val sql: String =
+    s"""
+       |CREATE TABLE trade (
+       |   sym CHAR(15) NOT NULL,
+       |   bid DECIMAL(8, 2) NOT NULL
+       |)
+     """.stripMargin
+}

--- a/core/src/dunit/scala/io/snappydata/cluster/SplitClusterDUnitTestBase.scala
+++ b/core/src/dunit/scala/io/snappydata/cluster/SplitClusterDUnitTestBase.scala
@@ -33,7 +33,7 @@ import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.collection.{Utils, WrappedInternalRow}
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types.Decimal
-import org.apache.spark.sql.{AnalysisException, SnappyContext, SnappySession}
+import org.apache.spark.sql.{AnalysisException, SnappyContext}
 import org.apache.spark.util.collection.OpenHashSet
 import org.apache.spark.{Logging, SparkConf, SparkContext}
 

--- a/core/src/main/scala/org/apache/spark/sql/SnappyContext.scala
+++ b/core/src/main/scala/org/apache/spark/sql/SnappyContext.scala
@@ -16,6 +16,8 @@
  */
 package org.apache.spark.sql
 
+import java.io.{Externalizable, ObjectInput, ObjectOutput}
+
 import scala.collection.JavaConverters._
 import scala.collection.concurrent.TrieMap
 import scala.language.implicitConversions
@@ -30,9 +32,7 @@ import org.apache.spark.api.java.JavaSparkContext
 import org.apache.spark.internal.Logging
 import org.apache.spark.rdd.RDD
 import org.apache.spark.scheduler.{SparkListener, SparkListenerApplicationEnd}
-import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.SortDirection
-import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.apache.spark.sql.collection.{ToolsCallbackInit, Utils}
 import org.apache.spark.sql.execution.ConnectionPool
 import org.apache.spark.sql.execution.columnar.ExternalStoreUtils
@@ -805,8 +805,39 @@ object SnappyContext extends Logging {
       throw new IllegalStateException("Invalid SparkConf")
   }
 
-  val storeToBlockMap: TrieMap[String, BlockManagerId] =
-    TrieMap.empty[String, BlockManagerId]
+  private[this] val storeToBlockMap: TrieMap[String, BlockAndExecutorId] =
+    TrieMap.empty[String, BlockAndExecutorId]
+
+  def containsBlockId(executorId: String): Boolean = {
+    storeToBlockMap.get(executorId) match {
+      case Some(b) => b.blockId != null
+      case None => false
+    }
+  }
+
+  def getBlockId(executorId: String): Option[BlockAndExecutorId] = {
+    storeToBlockMap.get(executorId) match {
+      case s@Some(b) if b.blockId != null => s
+      case None => None
+    }
+  }
+
+  private[spark] def getBlockIdIfNull(
+      executorId: String): Option[BlockAndExecutorId] =
+    storeToBlockMap.get(executorId)
+
+  private[spark] def addBlockId(executorId: String,
+      blockId: BlockAndExecutorId): Option[BlockAndExecutorId] =
+    storeToBlockMap.put(executorId, blockId)
+
+  private[spark] def removeBlockId(executorId: String): Option[BlockAndExecutorId] =
+    storeToBlockMap.remove(executorId)
+
+  def getAllBlockIds: scala.collection.Map[String, BlockAndExecutorId] = {
+    storeToBlockMap.filter(_._2.blockId != null)
+  }
+
+  private[spark] def clearBlockIds(): Unit = storeToBlockMap.clear()
 
   /** Returns the current SparkContext or null */
   def globalSparkContext: SparkContext = try {
@@ -828,7 +859,8 @@ object SnappyContext extends Logging {
     val cache = Misc.getGemFireCacheNoThrow
     if (cache != null && Utils.isLoner(sc)) {
       storeToBlockMap(cache.getMyId.toString) =
-          SparkEnv.get.blockManager.blockManagerId
+          new BlockAndExecutorId(SparkEnv.get.blockManager.blockManagerId,
+            sc.schedulerBackend.defaultParallelism())
     }
   }
 
@@ -1004,7 +1036,6 @@ object SnappyContext extends Logging {
   def clearStaticArtifacts(): Unit = {
     ConnectionPool.clear()
     CodeGeneration.clearCache()
-    storeToBlockMap.clear()
     HashedRelationCache.close()
     _clusterMode match {
       case m: ExternalClusterMode =>
@@ -1031,6 +1062,37 @@ object SnappyContext extends Logging {
 abstract class ClusterMode {
   val sc: SparkContext
   val url: String
+}
+
+final class BlockAndExecutorId(private[spark] var _blockId: BlockManagerId,
+    private[spark] var _executorCores: Int) extends Externalizable {
+
+  def blockId: BlockManagerId = _blockId
+
+  def executorCores: Int = _executorCores
+
+  override def hashCode: Int = if (blockId != null) blockId.hashCode() else 0
+
+  override def equals(that: Any): Boolean = that match {
+    case b: BlockAndExecutorId => b.blockId == blockId
+    case b: BlockManagerId => b == blockId
+    case _ => false
+  }
+
+  override def writeExternal(out: ObjectOutput): Unit = {
+    _blockId.writeExternal(out)
+    out.writeInt(_executorCores)
+  }
+
+  override def readExternal(in: ObjectInput): Unit = {
+    _blockId.readExternal(in)
+    _executorCores = in.readInt()
+  }
+
+  override def toString: String = if (blockId != null) {
+    s"BlockAndExecutorId(${blockId.executorId}," +
+        s" ${blockId.host}, ${blockId.port}, cores=$executorCores)"
+  } else "BlockAndExecutor()"
 }
 
 /**

--- a/core/src/main/scala/org/apache/spark/sql/SnappyParser.scala
+++ b/core/src/main/scala/org/apache/spark/sql/SnappyParser.scala
@@ -235,7 +235,7 @@ class SnappyParser(session: SnappySession)
     ) ~ ws
   }
 
-  protected final def namedExpression: Rule1[Expression] = rule {
+  final def namedExpression: Rule1[Expression] = rule {
     expression ~ (
         AS ~ identifier ~> ((e: Expression, a: String) => Alias(e, a)()) |
         strictIdentifier ~> ((e: Expression, a: String) => Alias(e, a)()) |
@@ -243,7 +243,7 @@ class SnappyParser(session: SnappySession)
     )
   }
 
-  final def expression: Rule1[Expression] = rule {
+  protected final def expression: Rule1[Expression] = rule {
     andExpression ~ (OR ~ andExpression ~>
         ((e1: Expression, e2: Expression) => Or(e1, e2))).*
   }

--- a/core/src/main/scala/org/apache/spark/sql/SnappySqlParser.scala
+++ b/core/src/main/scala/org/apache/spark/sql/SnappySqlParser.scala
@@ -37,7 +37,7 @@ class SnappySqlParser(session: SnappySession) extends AbstractSqlParser {
 
   /** Creates Expression for a given SQL string. */
   override def parseExpression(sqlText: String): Expression = {
-    sqlParser.parse(sqlText, sqlParser.expression.run())
+    sqlParser.parse(sqlText, sqlParser.namedExpression.run())
   }
 
   /** Creates TableIdentifier for a given SQL string. */

--- a/core/src/main/scala/org/apache/spark/sql/collection/Utils.scala
+++ b/core/src/main/scala/org/apache/spark/sql/collection/Utils.scala
@@ -20,10 +20,8 @@ import java.io.ObjectOutputStream
 import java.nio.ByteBuffer
 import java.sql.DriverManager
 
-import org.apache.spark.storage.BlockManagerId
-
+import scala.annotation.tailrec
 import scala.collection.{mutable, Map => SMap}
-
 import scala.language.existentials
 import scala.reflect.ClassTag
 import scala.util.Sorting
@@ -298,6 +296,12 @@ object Utils {
       // case "boolean" => org.apache.spark.sql.types.BooleanType
       case _ => throw new IllegalArgumentException(s"Invalid type $dataType")
     }
+  }
+
+  @tailrec
+  def getSQLDataType(dataType: DataType): DataType = dataType match {
+    case udt: UserDefinedType[_] => getSQLDataType(udt.sqlType)
+    case _ => dataType
   }
 
   def getClientHostPort(netServer: String): String = {
@@ -659,14 +663,10 @@ class ExecutorLocalPartition(override val index: Int,
 }
 
 class MultiBucketExecutorPartition(override val index: Int,
-                                   val buckets: mutable.HashSet[Int],
-                                   val blockIds: Seq[BlockManagerId]) extends Partition {
+    val buckets: Set[Int], val hostExecutorIds: Seq[String]) extends Partition {
 
-  def hostExecutorIds : Seq[String] = {
-    val execs = blockIds.map(blockId => Utils.getHostExecutorId(blockId))
-    execs
-  }
-  override def toString = s"MultiBucketExecutorPartition($index, $buckets, $blockIds)"
+  override def toString: String =
+    s"MultiBucketExecutorPartition($index, $buckets, $hostExecutorIds)"
 }
 
 
@@ -710,9 +710,10 @@ private[spark] class CoGroupExecutorLocalPartition(
 }
 
 class ExecutorMultiBucketLocalShellPartition(override val index: Int,
-                                             val buckets: mutable.HashSet[Int],
-                                  val hostList: mutable.ArrayBuffer[(String, String)]) extends Partition {
-  override def toString = s"ExecutorMultiBucketLocalShellPartition($index, $buckets, $hostList"
+    val buckets: mutable.HashSet[Int],
+    val hostList: mutable.ArrayBuffer[(String, String)]) extends Partition {
+  override def toString: String =
+    s"ExecutorMultiBucketLocalShellPartition($index, $buckets, $hostList"
 }
 
 object ToolsCallbackInit extends Logging {

--- a/core/src/main/scala/org/apache/spark/sql/execution/CompactExecRowToMutableRow.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/CompactExecRowToMutableRow.scala
@@ -31,23 +31,15 @@ import org.apache.spark.sql.types.{DataType, Decimal, DecimalType, StructType}
 import org.apache.spark.unsafe.Platform
 import org.apache.spark.unsafe.types.UTF8String
 
-trait CompactExecRowToMutableRow extends ResultWasNull {
+abstract class CompactExecRowToMutableRow extends ResultNullHolder {
 
   val schema: StructType
-
-  protected final var wasNull: Boolean = _
-
-  protected final lazy val defaultCal = new GregorianCalendar()
 
   protected final val dataTypes: ArrayBuffer[DataType] =
     new ArrayBuffer[DataType](schema.length)
 
   protected final val fieldTypes = StoreUtils.mapCatalystTypes(
     schema, dataTypes)
-
-  override final def setWasNull(): Unit = {
-    wasNull = true
-  }
 
   protected final def createInternalRow(execRow: AbstractCompactExecRow,
       mutableRow: SpecificMutableRow): InternalRow = {
@@ -222,5 +214,16 @@ trait CompactExecRowToMutableRow extends ResultWasNull {
       i = i + 1
     }
     mutableRow
+  }
+}
+
+class ResultNullHolder extends ResultWasNull {
+
+  final var wasNull: Boolean = _
+
+  final val defaultCal = new GregorianCalendar()
+
+  override final def setWasNull(): Unit = {
+    wasNull = true
   }
 }

--- a/core/src/main/scala/org/apache/spark/sql/execution/CompactExecRowToMutableRow.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/CompactExecRowToMutableRow.scala
@@ -226,4 +226,10 @@ class ResultNullHolder extends ResultWasNull {
   override final def setWasNull(): Unit = {
     wasNull = true
   }
+
+  final def wasNullAndClear(): Boolean = {
+    val result = wasNull
+    wasNull = false
+    result
+  }
 }

--- a/core/src/main/scala/org/apache/spark/sql/execution/ExistingPlans.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/ExistingPlans.scala
@@ -16,115 +16,61 @@
  */
 package org.apache.spark.sql.execution
 
-import scala.collection.AbstractIterator
-
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.InternalRow
-import org.apache.spark.sql.catalyst.expressions.codegen.CodegenContext
-import org.apache.spark.sql.catalyst.expressions.{Attribute, BoundReference, Expression}
+import org.apache.spark.sql.catalyst.expressions.{Attribute, Expression}
 import org.apache.spark.sql.catalyst.plans.physical.{HashPartitioning, Partitioning, SinglePartition}
 import org.apache.spark.sql.collection.ToolsCallbackInit
+import org.apache.spark.sql.execution.columnar.impl.BaseColumnFormatRelation
+import org.apache.spark.sql.execution.columnar.{ColumnTableScan, ConnectionType}
 import org.apache.spark.sql.execution.metric.SQLMetrics
-import org.apache.spark.sql.snappy._
-import org.apache.spark.sql.sources.{BaseRelation, PrunedUnsafeFilteredScan}
-import org.apache.spark.sql.types.StructType
+import org.apache.spark.sql.execution.row.RowFormatRelation
+import org.apache.spark.sql.sources.{BaseRelation, PrunedUnsafeFilteredScan, SamplingRelation}
+import org.apache.spark.sql.types._
 
 /** Physical plan node for scanning data from an DataSource scan RDD.
  * If user knows that the data is partitioned or replicated across
  * all nodes this SparkPla can be used to avoid expensive shuffle
  * and Broadcast joins. This plan overrides outputPartitioning and
  * make it inline with the partitioning of the underlying DataSource */
-private[sql] case class PartitionedPhysicalRDD(
+private[sql] abstract class PartitionedPhysicalRDD(
     output: Seq[Attribute],
-    rdd: RDD[InternalRow],
+    rdd: RDD[Any],
     numPartitions: Int,
     numBuckets: Int,
     partitionColumns: Seq[Expression],
-    extraInformation: String) extends LeafExecNode with CodegenSupport {
+    @transient baseRelation: PartitionedDataSourceScan)
+    extends LeafExecNode with CodegenSupport {
+
+  private val extraInformation = baseRelation.toString
 
   override lazy val schema: StructType = StructType.fromAttributes(output)
 
+  override def inputRDDs(): Seq[RDD[InternalRow]] = {
+    rdd.asInstanceOf[RDD[InternalRow]] :: Nil
+  }
+
   protected override def doExecute(): RDD[InternalRow] = {
-    val numOutputRows = longMetric("numOutputRows")
-    val scanTime = longMetric("scanTime")
-    rdd.mapPartitionsPreserve { itr =>
-      new AbstractIterator[InternalRow] {
-
-        var nRows = 0L
-        val start = System.nanoTime()
-
-        def hasNext: Boolean = {
-          if (itr.hasNext) true
-          else {
-            numOutputRows += nRows
-            scanTime += (System.nanoTime() - start) / 1000000L
-            false
-          }
-        }
-
-        def next(): InternalRow = {
-          nRows += 1
-          itr.next()
-        }
-      }
-    }
+    WholeStageCodegenExec(this).execute()
   }
 
   /** Specifies how data is partitioned across different nodes in the cluster. */
   override lazy val outputPartitioning: Partitioning = {
     if (numPartitions == 1) {
       SinglePartition
-    }
-    else {
+    } else if (partitionColumns.nonEmpty) {
       val callbacks = ToolsCallbackInit.toolsCallback
       if (callbacks != null) {
-        callbacks.getOrderlessHashPartitioning(partitionColumns, numPartitions, numBuckets)
+        callbacks.getOrderlessHashPartitioning(partitionColumns,
+          numPartitions, numBuckets)
       } else {
         HashPartitioning(partitionColumns, numPartitions)
       }
-    }
+    } else super.outputPartitioning
   }
 
   private[sql] override lazy val metrics = Map(
-    "numOutputRows" -> SQLMetrics.createMetric(sparkContext, "number of output rows"),
-    "scanTime" -> SQLMetrics.createTimingMetric(sparkContext, "scan and consume time"))
-
-  override def inputRDDs(): Seq[RDD[InternalRow]] = {
-    rdd :: Nil
-  }
-
-  override def doProduce(ctx: CodegenContext): String = {
-    val numOutputRows = metricTerm(ctx, "numOutputRows")
-    val scanTime = metricTerm(ctx, "scanTime")
-    // PartitionedPhysicalRDD always just has one input
-    val input = ctx.freshName("input")
-    val numRows = ctx.freshName("numRows")
-    val start = ctx.freshName("start")
-    ctx.addMutableState("scala.collection.Iterator", input,
-      s"$input = inputs[0];")
-    val exprRows = output.zipWithIndex.map { case (a, i) =>
-      BoundReference(i, a.dataType, a.nullable)
-    }
-    val row = ctx.freshName("row")
-    ctx.INPUT_ROW = row
-    ctx.currentVars = null
-    val columnsRowInput = exprRows.map(_.genCode(ctx))
-    s"""
-       |long $numRows = 0L;
-       |long $start = System.nanoTime();
-       |try {
-       |  while ($input.hasNext()) {
-       |    InternalRow $row = (InternalRow)$input.next();
-       |    $numRows++;
-       |    ${consume(ctx, columnsRowInput, row).trim}
-       |    if (shouldStop()) return;
-       |  }
-       |} finally {
-       |  $numOutputRows.add($numRows);
-       |  $scanTime.add((System.nanoTime() - $start)/1000000L);
-       |}
-     """.stripMargin
-  }
+    "numOutputRows" -> SQLMetrics.createMetric(sparkContext, "number of output rows"))
 
   override def simpleString: String = "Partitioned Scan " + extraInformation +
       " , Requested Columns = " + output.mkString("[", ",", "]") +
@@ -136,21 +82,38 @@ private[sql] case class PartitionedPhysicalRDD(
 private[sql] object PartitionedPhysicalRDD {
   def createFromDataSource(
       output: Seq[Attribute],
-      numPartition: Int,
+      numPartitions: Int,
       numBuckets: Int,
       partitionColumns: Seq[Expression],
-      rdd: RDD[InternalRow],
-      relation: BaseRelation): PartitionedPhysicalRDD = {
-    PartitionedPhysicalRDD(output, rdd, numPartition, numBuckets, partitionColumns,
-      relation.toString)
-  }
+      rdd: RDD[Any],
+      otherRDDs: Seq[RDD[InternalRow]],
+      relation: PartitionedDataSourceScan): PartitionedPhysicalRDD =
+    relation match {
+      case r: BaseColumnFormatRelation =>
+        ColumnTableScan(output, rdd, otherRDDs, numPartitions, numBuckets,
+          partitionColumns, r.scanAsUnsafeRows, relation)
+      case r: SamplingRelation =>
+        ColumnTableScan(output, rdd, otherRDDs, numPartitions, numBuckets,
+          partitionColumns, r.baseRelation.scanAsUnsafeRows, relation)
+      case _: RowFormatRelation =>
+        if (otherRDDs.nonEmpty) {
+          throw new UnsupportedOperationException(
+            "Row table scan cannot handle other RDDs")
+        }
+        RowTableScan(output, rdd, numPartitions, numBuckets,
+          partitionColumns, relation)
+    }
 }
 
 trait PartitionedDataSourceScan extends PrunedUnsafeFilteredScan {
+
+  def schema: StructType
 
   def numPartitions: Int
 
   def numBuckets: Int
 
   def partitionColumns: Seq[String]
+
+  def connectionType: ConnectionType.Value
 }

--- a/core/src/main/scala/org/apache/spark/sql/execution/RowTableScan.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/RowTableScan.scala
@@ -1,0 +1,356 @@
+/*
+ * Copyright (c) 2016 SnappyData, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License. You
+ * may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License. See accompanying
+ * LICENSE file.
+ */
+package org.apache.spark.sql.execution
+
+import java.util.GregorianCalendar
+
+import com.pivotal.gemfirexd.internal.engine.store.AbstractCompactExecRow
+
+import org.apache.spark.rdd.RDD
+import org.apache.spark.sql.catalyst.expressions.codegen.{CodegenContext, ExprCode}
+import org.apache.spark.sql.catalyst.expressions.{Attribute, Expression}
+import org.apache.spark.sql.execution.row.{ResultSetTraversal, RowFormatScanRDD}
+import org.apache.spark.sql.types._
+
+/**
+ * Physical plan node for scanning data from a SnappyData row table RDD.
+ * If user knows that the data is partitioned or replicated across
+ * all nodes, this SparkPlan can be used to avoid expensive shuffle
+ * and Broadcast joins. This plan overrides outputPartitioning and
+ * makes it inline with the partitioning of the underlying DataSource.
+ */
+private[sql] final case class RowTableScan(
+    output: Seq[Attribute],
+    rdd: RDD[Any],
+    numPartitions: Int,
+    numBuckets: Int,
+    partitionColumns: Seq[Expression],
+    @transient baseRelation: PartitionedDataSourceScan)
+    extends PartitionedPhysicalRDD(output, rdd, numPartitions, numBuckets,
+      partitionColumns, baseRelation) {
+
+  override def doProduce(ctx: CodegenContext): String = {
+    val numOutputRows = metricTerm(ctx, "numOutputRows")
+    // PartitionedPhysicalRDD always just has one input
+    val input = ctx.freshName("input")
+    ctx.addMutableState("scala.collection.Iterator",
+      input, s"$input = inputs[0];")
+    ctx.currentVars = null
+
+    rdd match {
+      case rowRdd: RowFormatScanRDD if !rowRdd.pushProjections =>
+        RowTableScan.doProduceWithoutProjection(ctx, input, numOutputRows,
+          output, baseRelation, this)
+      case _ =>
+        RowTableScan.doProduceWithProjection(ctx, input, numOutputRows,
+          output, baseRelation, this)
+    }
+  }
+}
+
+object RowTableScan {
+
+  def doProduceWithoutProjection(ctx: CodegenContext, input: String,
+      numOutputRows: String, output: Seq[Attribute],
+      baseRelation: PartitionedDataSourceScan,
+      forObject: CodegenSupport): String = {
+    // case of CompactExecRows
+    val numRows = ctx.freshName("numRows")
+    val row = ctx.freshName("row")
+    val holder = ctx.freshName("holder")
+    val holderClass = classOf[ResultNullHolder].getName
+    val compactRowClass = classOf[AbstractCompactExecRow].getName
+    val baseSchema = baseRelation.schema
+    val columnsRowInput = output.map(a => genCodeCompactRowColumn(ctx,
+      row, holder, baseSchema.fieldIndex(a.name), a.dataType, a.nullable))
+    s"""
+       |final $holderClass $holder = new $holderClass();
+       |long $numRows = 0L;
+       |try {
+       |  while ($input.hasNext()) {
+       |    final $compactRowClass $row = ($compactRowClass)$input.next();
+       |    $numRows++;
+       |    ${forObject.consume(ctx, columnsRowInput).trim}
+       |    if (shouldStop()) return;
+       |  }
+       |} catch (RuntimeException re) {
+       |  throw re;
+       |} catch (Exception e) {
+       |  throw new RuntimeException(e);
+       |} finally {
+       |  $numOutputRows.add($numRows);
+       |}
+    """.stripMargin
+  }
+
+  def doProduceWithProjection(ctx: CodegenContext, input: String,
+      numOutputRows: String, output: Seq[Attribute],
+      baseRelation: PartitionedDataSourceScan,
+      forObject: CodegenSupport): String = {
+    // case of ResultSet
+    val numRows = ctx.freshName("numRows")
+    val iterator = ctx.freshName("iterator")
+    val iteratorClass = classOf[ResultSetTraversal].getName
+    val rs = ctx.freshName("resultSet")
+    val baseSchema = baseRelation.schema
+    val columnsRowInput = output.map(a => genCodeResultSetColumn(ctx,
+      rs, iterator, baseSchema.fieldIndex(a.name), a.dataType, a.nullable))
+    s"""
+       |final $iteratorClass $iterator = ($iteratorClass)$input;
+       |final java.sql.ResultSet $rs = $iterator.rs();
+       |long $numRows = 0L;
+       |try {
+       |  while ($rs.next()) {
+       |    $numRows++;
+       |    ${forObject.consume(ctx, columnsRowInput).trim}
+       |    if (shouldStop()) return;
+       |  }
+       |} catch (RuntimeException re) {
+       |  throw re;
+       |} catch (Exception e) {
+       |  throw new RuntimeException(e);
+       |} finally {
+       |  $iterator.close();
+       |  $numOutputRows.add($numRows);
+       |}
+    """.stripMargin
+  }
+
+  private def genCodeCompactRowColumn(ctx: CodegenContext, rowVar: String,
+      holder: String, ordinal: Int, dataType: DataType,
+      nullable: Boolean): ExprCode = {
+    val javaType = ctx.javaType(dataType)
+    val col = ctx.freshName("col")
+    val pos = ordinal + 1
+    val code = dataType match {
+      case IntegerType =>
+        s"final $javaType $col = $rowVar.getAsInt($pos, $holder);"
+      case StringType =>
+        // TODO: SW: optimize to store same full UTF8 format in GemXD
+        s"""
+          final $javaType $col = UTF8String.fromString($rowVar.getAsString(
+            $pos, $holder));
+        """
+      case LongType =>
+        s"final $javaType $col = $rowVar.getAsLong($pos, $holder);"
+      case BooleanType =>
+        s"final $javaType $col = $rowVar.getAsBoolean($pos, $holder);"
+      case ShortType =>
+        s"final $javaType $col = $rowVar.getAsShort($pos, $holder);"
+      case ByteType =>
+        s"final $javaType $col = $rowVar.getAsByte($pos, $holder);"
+      case FloatType =>
+        s"final $javaType $col = $rowVar.getAsFloat($pos, $holder);"
+      case DoubleType =>
+        s"final $javaType $col = $rowVar.getAsDouble($pos, $holder);"
+      case d: DecimalType =>
+        val decVar = ctx.freshName("dec")
+        s"""
+          final java.math.BigDecimal $decVar = $rowVar.getAsBigDecimal(
+            $pos, $holder);
+          final $javaType $col = $decVar != null ? Decimal.apply($decVar,
+            ${d.precision}, ${d.scale}) : null;
+        """
+      case DateType =>
+        // TODO: optimize to avoid Date object and instead get millis
+        val cal = ctx.freshName("cal")
+        val date = ctx.freshName("date")
+        val calClass = classOf[GregorianCalendar].getName
+        s"""
+          final $calClass $cal = $holder.defaultCal();
+          $cal.clear();
+          final java.sql.Date $date = $rowVar.getAsDate($pos, $cal, $holder);
+          final $javaType $col = $date != null ? org.apache.spark.sql
+            .catalyst.util.DateTimeUtils.fromJavaDate($date) : 0;
+        """
+      case TimestampType =>
+        // TODO: optimize to avoid object and instead get nanoseconds
+        val cal = ctx.freshName("cal")
+        val tsVar = ctx.freshName("ts")
+        val calClass = classOf[GregorianCalendar].getName
+        s"""
+          final $calClass $cal = $holder.defaultCal();
+          $cal.clear();
+          final java.sql.Timestamp $tsVar = $rowVar.getAsTimestamp($pos,
+             $cal, $holder);
+          final $javaType $col = $tsVar != null ? org.apache.spark.sql
+            .catalyst.util.DateTimeUtils.fromJavaTimestamp($tsVar) : 0L;
+        """
+      case BinaryType =>
+        s"final $javaType $col = $rowVar.getAsBytes($pos, $holder);"
+      case _: ArrayType =>
+        val bytes = ctx.freshName("bytes")
+        s"""
+          final byte[] $bytes = $rowVar.getAsBytes($pos, $holder);
+          final $javaType $col;
+          if ($bytes != null) {
+            $col = new UnsafeArrayData();
+            $col.pointTo($bytes, Platform.BYTE_ARRAY_OFFSET, $bytes.length);
+          } else {
+            $col = null;
+          }
+        """
+      case _: MapType =>
+        val bytes = ctx.freshName("bytes")
+        s"""
+          final byte[] $bytes = $rowVar.getAsBytes($pos, $holder);
+          final $javaType $col;
+          if ($bytes != null) {
+            $col = new UnsafeMapData();
+            $col.pointTo($bytes, Platform.BYTE_ARRAY_OFFSET, $bytes.length);
+          } else {
+            $col = null;
+          }
+        """
+      case s: StructType =>
+        val bytes = ctx.freshName("bytes")
+        s"""
+          final byte[] $bytes = $rowVar.getAsBytes($pos, $holder);
+          final $javaType $col;
+          if ($bytes != null) {
+            $col = new UnsafeRow(${s.length});
+            $col.pointTo($bytes, Platform.BYTE_ARRAY_OFFSET, $bytes.length);
+          } else {
+            $col = null;
+          }
+        """
+      case _ =>
+        s"""
+          $javaType $col = ($javaType)$rowVar.getAsObject($pos, $holder);
+        """
+    }
+    if (nullable) {
+      val isNullVar = ctx.freshName("isNull")
+      ExprCode(code + s"\nfinal boolean $isNullVar = $holder.wasNull();",
+        isNullVar, col)
+    } else {
+      ExprCode(code, "false", col)
+    }
+  }
+
+  private def genCodeResultSetColumn(ctx: CodegenContext, rsVar: String,
+      holder: String, ordinal: Int, dataType: DataType,
+      nullable: Boolean): ExprCode = {
+    val javaType = ctx.javaType(dataType)
+    val col = ctx.freshName("col")
+    val pos = ordinal + 1
+    val code = dataType match {
+      case IntegerType =>
+        s"final $javaType $col = $rsVar.getInt($pos);"
+      case StringType =>
+        s"final $javaType $col = UTF8String.fromString($rsVar.getString($pos));"
+      case LongType =>
+        s"final $javaType $col = $rsVar.getLong($pos);"
+      case BooleanType =>
+        s"final $javaType $col = $rsVar.getBoolean($pos);"
+      case ShortType =>
+        s"final $javaType $col = $rsVar.getShort($pos);"
+      case ByteType =>
+        s"final $javaType $col = $rsVar.getByte($pos);"
+      case FloatType =>
+        s"final $javaType $col = $rsVar.getFloat($pos);"
+      case DoubleType =>
+        s"final $javaType $col = $rsVar.getDouble($pos);"
+      case d: DecimalType =>
+        // When connecting with Oracle DB, the precision and scale of
+        // BigDecimal object returned by ResultSet.getBigDecimal is not
+        // correctly matched to the table schema reported by
+        // ResultSetMetaData.getPrecision and ResultSetMetaData.getScale.
+        // If inserting values like 19999 into a column with NUMBER(12, 2)
+        // type, you get through a BigDecimal object with scale as 0.
+        // But the DataFrame schema has correct type as DecimalType(12, 2).
+        // Thus, after saving the DataFrame into parquet file and then
+        // retrieve it, you will get wrong result 199.99. So it is needed
+        // to set precision and scale for Decimal based on metadata.
+        val decVar = ctx.freshName("dec")
+        s"""
+          final java.math.BigDecimal $decVar = $rsVar.getBigDecimal($pos);
+          final $javaType $col = $decVar != null ? Decimal.apply($decVar,
+            ${d.precision}, ${d.scale}) : null;
+        """
+      case DateType =>
+        val cal = ctx.freshName("cal")
+        val date = ctx.freshName("date")
+        val calClass = classOf[GregorianCalendar].getName
+        s"""
+          final $calClass $cal = $holder.defaultCal();
+          $cal.clear();
+          final java.sql.Date $date = $rsVar.getDate($pos, $cal);
+          final $javaType $col = $date != null ? org.apache.spark.sql
+            .catalyst.util.DateTimeUtils.fromJavaDate($date) : 0;
+        """
+      case TimestampType =>
+        val cal = ctx.freshName("cal")
+        val tsVar = ctx.freshName("ts")
+        val calClass = classOf[GregorianCalendar].getName
+        s"""
+          final $calClass $cal = $holder.defaultCal();
+          $cal.clear();
+          final java.sql.Timestamp $tsVar = $rsVar.getTimestamp($pos, $cal);
+          final $javaType $col = $tsVar != null ? org.apache.spark.sql
+            .catalyst.util.DateTimeUtils.fromJavaTimestamp($tsVar) : 0L;
+        """
+      case BinaryType =>
+        s"final $javaType $col = $rsVar.getBytes($pos);"
+      case _: ArrayType =>
+        val bytes = ctx.freshName("bytes")
+        s"""
+          final byte[] $bytes = $rsVar.getBytes($pos);
+          final $javaType $col;
+          if ($bytes != null) {
+            $col = new UnsafeArrayData();
+            $col.pointTo($bytes, Platform.BYTE_ARRAY_OFFSET, $bytes.length);
+          } else {
+            $col = null;
+          }
+        """
+      case _: MapType =>
+        val bytes = ctx.freshName("bytes")
+        s"""
+          final byte[] $bytes = $rsVar.getBytes($pos);
+          final $javaType $col;
+          if ($bytes != null) {
+            $col = new UnsafeMapData();
+            $col.pointTo($bytes, Platform.BYTE_ARRAY_OFFSET, $bytes.length);
+          } else {
+            $col = null;
+          }
+        """
+      case s: StructType =>
+        val bytes = ctx.freshName("bytes")
+        s"""
+          final byte[] $bytes = $rsVar.getBytes($pos);
+          final $javaType $col;
+          if ($bytes != null) {
+            $col = new UnsafeRow(${s.length});
+            $col.pointTo($bytes, Platform.BYTE_ARRAY_OFFSET, $bytes.length);
+          } else {
+            $col = null;
+          }
+        """
+      case _ =>
+        s"final $javaType $col = ($javaType)$rsVar.getObject($pos);"
+    }
+    if (nullable) {
+      val isNullVar = ctx.freshName("isNull")
+      ExprCode(code + s"\nfinal boolean $isNullVar = $rsVar.wasNull();",
+        isNullVar, col)
+    } else {
+      ExprCode(code, "false", col)
+    }
+  }
+}

--- a/core/src/main/scala/org/apache/spark/sql/execution/RowTableScan.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/RowTableScan.scala
@@ -236,7 +236,7 @@ object RowTableScan {
     }
     if (nullable) {
       val isNullVar = ctx.freshName("isNull")
-      ExprCode(code + s"\nfinal boolean $isNullVar = $holder.wasNull();",
+      ExprCode(s"$code\nfinal boolean $isNullVar = $holder.wasNullAndClear();",
         isNullVar, col)
     } else {
       ExprCode(code, "false", col)

--- a/core/src/main/scala/org/apache/spark/sql/execution/columnar/ColumnTableScan.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/columnar/ColumnTableScan.scala
@@ -1,0 +1,496 @@
+/*
+ * Copyright (c) 2016 SnappyData, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License. You
+ * may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License. See accompanying
+ * LICENSE file.
+ */
+/*
+ * UnionScanRDD taken from Spark's UnionRDD having the license below.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.columnar
+
+import scala.collection.mutable.ArrayBuffer
+import scala.reflect.ClassTag
+
+import com.pivotal.gemfirexd.internal.engine.distributed.utils.GemFireXDUtils
+import com.pivotal.gemfirexd.internal.engine.store.{OffHeapCompactExecRowWithLobs, ResultWasNull, RowFormatter}
+
+import org.apache.spark.rdd.{RDD, UnionPartition}
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.expressions.codegen.{CodegenContext, ExprCode}
+import org.apache.spark.sql.catalyst.expressions.{Attribute, Expression}
+import org.apache.spark.sql.collection.Utils
+import org.apache.spark.sql.execution.columnar.encoding.ColumnEncoding
+import org.apache.spark.sql.execution.metric.SQLMetrics
+import org.apache.spark.sql.execution.row.{ResultSetEncodingAdapter, ResultSetTraversal, UnsafeRowEncodingAdapter, UnsafeRowHolder}
+import org.apache.spark.sql.execution.{PartitionedDataSourceScan, PartitionedPhysicalScan}
+import org.apache.spark.sql.sources.BaseRelation
+import org.apache.spark.sql.types._
+import org.apache.spark.{Dependency, Partition, RangeDependency, SparkContext, TaskContext}
+
+/**
+ * Physical plan node for scanning data from a SnappyData column table RDD.
+ * If user knows that the data is partitioned across all nodes, this SparkPlan
+ * can be used to avoid expensive shuffle and Broadcast joins.
+ * This plan overrides outputPartitioning and makes it inline with the
+ * partitioning of the underlying DataSource.
+ */
+private[sql] final case class ColumnTableScan(
+    output: Seq[Attribute],
+    dataRDD: RDD[Any],
+    otherRDDs: Seq[RDD[InternalRow]],
+    numPartitions: Int,
+    numBuckets: Int,
+    partitionColumns: Seq[Expression],
+    @transient baseRelation: PartitionedDataSourceScan)
+    extends PartitionedPhysicalScan(output, dataRDD, numPartitions, numBuckets,
+      partitionColumns, baseRelation.asInstanceOf[BaseRelation]) {
+
+  private[sql] override lazy val metrics = Map(
+    "numOutputRows" -> SQLMetrics.createMetric(sparkContext,
+      "number of output rows"),
+    "numRowsBufferOutput" -> SQLMetrics.createMetric(sparkContext,
+      "number of output rows from row buffer")) ++ (
+      if (otherRDDs.isEmpty) Map.empty
+      else Map("numRowsOtherRDDs" -> SQLMetrics.createMetric(sparkContext,
+        "number of output rows from other RDDs")))
+
+  private val allRDDs = if (otherRDDs.isEmpty) rdd
+  else new UnionScanRDD(rdd.sparkContext, (Seq(rdd) ++ otherRDDs)
+      .asInstanceOf[Seq[RDD[Any]]])
+
+  private val isOffHeap = GemFireXDUtils.getGemFireContainer(
+    baseRelation.table, true).isOffHeap
+
+  private val otherRDDsPartitionIndex = rdd.getNumPartitions
+
+  override def inputRDDs(): Seq[RDD[InternalRow]] = {
+    allRDDs.asInstanceOf[RDD[InternalRow]] :: Nil
+  }
+
+  override def doProduce(ctx: CodegenContext): String = {
+    val numOutputRows = metricTerm(ctx, "numOutputRows")
+    val numRowsBufferOutput = metricTerm(ctx, "numRowsBufferOutput")
+    val numRowsOtherOutput =
+      if (otherRDDs.isEmpty) null else metricTerm(ctx, "numRowsOtherRDDs")
+    val isEmbedded = baseRelation.connectionType match {
+      case ConnectionType.Embedded => true
+      case _ => false
+    }
+    // PartitionedPhysicalRDD always has one input.
+    // It returns an iterator of iterators (row + column)
+    // except when doing union with multiple RDDs where other
+    // RDDs return iterator of UnsafeRows.
+    val rowInput = ctx.freshName("rowInput")
+    val colInput = ctx.freshName("colInput")
+    val input = ctx.freshName("input")
+    val inputIsRow = s"${input}IsRow"
+    val inputIsOtherRDD = s"${input}IsOtherRDD"
+    val rs = ctx.freshName("resultSet")
+    val rsIterClass = classOf[ResultSetTraversal].getName
+    val unsafeHolder = if (otherRDDs.isEmpty) null
+    else ctx.freshName("unsafeHolder")
+    val unsafeHolderClass = classOf[UnsafeRowHolder].getName
+
+    val colItrClass = if (!isEmbedded) classOf[CachedBatchIteratorOnRS].getName
+    else if (isOffHeap) classOf[OffHeapLobsIteratorOnScan].getName
+    else classOf[ByteArraysIteratorOnScan].getName
+
+    if (otherRDDs.isEmpty) {
+      ctx.addMutableState("scala.collection.Iterator",
+        rowInput, s"$rowInput = (scala.collection.Iterator)inputs[0].next();")
+      ctx.addMutableState(colItrClass, colInput,
+        s"$colInput = ($colItrClass)inputs[0].next();")
+      ctx.addMutableState("java.sql.ResultSet", rs,
+        s"$rs = (($rsIterClass)$rowInput).rs();")
+    } else {
+      ctx.addMutableState("boolean", inputIsOtherRDD,
+        s"$inputIsOtherRDD = (partitionIndex >= $otherRDDsPartitionIndex);")
+      ctx.addMutableState("scala.collection.Iterator", rowInput,
+        s"""
+            $rowInput = $inputIsOtherRDD ? inputs[0]
+                : (scala.collection.Iterator)inputs[0].next();
+        """)
+      ctx.addMutableState(colItrClass, colInput,
+        s"$colInput = $inputIsOtherRDD ? null : ($colItrClass)inputs[0].next();")
+      ctx.addMutableState("java.sql.ResultSet", rs,
+        s"$rs = $inputIsOtherRDD ? null : (($rsIterClass)$rowInput).rs();")
+      ctx.addMutableState(unsafeHolderClass, unsafeHolder,
+        s"$unsafeHolder = new $unsafeHolderClass();")
+    }
+    ctx.addMutableState("scala.collection.Iterator", input,
+      s"$input = $rowInput;")
+    ctx.addMutableState("boolean", inputIsRow, s"$inputIsRow = true;")
+
+    ctx.currentVars = null
+    val cachedBatchClass = classOf[CachedBatch].getName
+    val execRowClass = classOf[OffHeapCompactExecRowWithLobs].getName
+    val decoderClass = classOf[ColumnEncoding].getName
+    val wasNullClass = classOf[ResultWasNull].getName
+    val rsAdapterClass = classOf[ResultSetEncodingAdapter].getName
+    val rowAdapterClass = classOf[UnsafeRowEncodingAdapter].getName
+    val rowFormatterClass = classOf[RowFormatter].getName
+    val batch = ctx.freshName("batch")
+    val numBatchRows = s"${batch}NumRows"
+    val batchIndex = s"${batch}Index"
+    val buffers = s"${batch}Buffers"
+    val rowFormatter = s"${batch}RowFormatter"
+
+    val numRowsBuffer = ctx.freshName("numRowsBuffer")
+    val numRowsOther = s"${numRowsBuffer}Other"
+
+    ctx.addMutableState("byte[][]", buffers, s"$buffers = null;")
+    ctx.addMutableState("int", numBatchRows, s"$numBatchRows = 0;")
+    ctx.addMutableState("int", batchIndex, s"$batchIndex = 0;")
+
+    // need DataType and nullable to get decoder in generated code
+    val fields = ctx.addReferenceObj("fields", output.toArray, "Attribute[]")
+    val columnBufferInitCode = new StringBuilder
+    val bufferInitCode = new StringBuilder
+    val cursorUpdateCode = new StringBuilder
+    val moveNextCode = new StringBuilder
+
+    val nextRowSnippet = if (otherRDDs.isEmpty) s"$rowInput.next();"
+    else {
+      s"""
+        if ($inputIsOtherRDD) {
+          $unsafeHolder.setRow((UnsafeRow)$rowInput.next());
+        } else {
+          $rowInput.next();
+        }
+      """
+    }
+    val incrementNumRowsSnippet = if (otherRDDs.isEmpty) s"$numRowsBuffer++;"
+    else {
+      s"""
+        if ($inputIsOtherRDD) {
+          $numRowsOther++;
+        } else {
+          $numRowsBuffer++;
+        }
+      """
+    }
+    val incrementOtherRows = if (otherRDDs.isEmpty) ""
+    else {
+      s"""
+        $numOutputRows.add($numRowsOther);
+        $numRowsOtherOutput.add($numRowsOther);
+      """
+    }
+
+    val columnsInput = output.zipWithIndex.map { case (a, index) =>
+      val decoder = ctx.freshName("decoder")
+      val cursor = s"${decoder}Cursor"
+      val buffer = ctx.freshName("buffer")
+      val cursorVar = s"cursor$index"
+      val decoderVar = s"decoder$index"
+      val bufferVar = s"buffer$index"
+      // projections are not pushed in embedded mode for optimized access
+      val baseIndex = baseRelation.schema.fieldIndex(a.name)
+      val rsPosition = if (isEmbedded) baseIndex + 1 else index + 1
+
+      val bufferPosition = baseIndex + PartitionedPhysicalScan.CT_COLUMN_START
+
+      ctx.addMutableState("byte[]", buffer, s"$buffer = null;")
+      if (otherRDDs.isEmpty) {
+        ctx.addMutableState(decoderClass, decoder,
+          s"$decoder = new $rsAdapterClass($rs, $rsPosition);")
+      } else {
+        ctx.addMutableState(decoderClass, decoder,
+          s"""
+            if ($inputIsOtherRDD) {
+              $decoder = new $rowAdapterClass($unsafeHolder, $baseIndex);
+            } else {
+              $decoder = new $rsAdapterClass($rs, $rsPosition);
+            }
+          """
+        )
+      }
+      ctx.addMutableState("long", cursor, s"$cursor = 0L;")
+      if (!isEmbedded) {
+        columnBufferInitCode.append(s"$buffer = $buffers[$index];")
+      } else if (isOffHeap) {
+        columnBufferInitCode.append(
+          s"""
+            $buffer = $batch.getAsBytes($bufferPosition, ($wasNullClass)null);
+          """)
+      } else {
+        columnBufferInitCode.append(
+          s"$buffer = $rowFormatter.getLob($buffers, $bufferPosition);")
+      }
+      columnBufferInitCode.append(
+        s"""
+          $decoder = $decoderClass.getColumnDecoder($buffer,
+            $fields[$index]);
+          // intialize the decoder and store the starting cursor position
+          $cursor = $decoder.initializeDecoding($buffer, $fields[$index]);
+        """)
+      bufferInitCode.append(
+        s"""
+          final $decoderClass $decoderVar = $decoder;
+          final byte[] $bufferVar = $buffer;
+          long $cursorVar = $cursor;
+        """
+      )
+      cursorUpdateCode.append(s"$cursor = $cursorVar;\n")
+      val notNullVar = if (a.nullable) ctx.freshName("notNull") else null
+      moveNextCode.append(genCodeColumnNext(ctx, decoderVar, bufferVar,
+        cursorVar, "batchOrdinal", a.dataType, notNullVar)).append('\n')
+      genCodeColumnBuffer(ctx, decoderVar, bufferVar, cursorVar,
+        a.dataType, notNullVar)
+    }
+
+    val batchInit = if (!isEmbedded) {
+      s"""
+        final $cachedBatchClass $batch = ($cachedBatchClass)$colInput.next();
+        $buffers = $batch.buffers();
+        $numBatchRows = $batch.numRows();
+      """
+    } else if (isOffHeap) {
+      s"""
+        final $execRowClass $batch = ($execRowClass)$colInput.next();
+        $numBatchRows = $batch.getAsInt(
+          ${PartitionedPhysicalScan.CT_NUMROWS_POSITION}, ($wasNullClass)null);
+      """
+    } else {
+      s"""
+        final $rowFormatterClass $rowFormatter = $colInput.rowFormatter();
+        $buffers = (byte[][])$colInput.next();
+        $numBatchRows = $rowFormatter.getAsInt(
+          ${PartitionedPhysicalScan.CT_NUMROWS_POSITION}, $buffers[0],
+          ($wasNullClass)null);
+      """
+    }
+    val nextBatch = ctx.freshName("nextBatch")
+    ctx.addNewFunction(nextBatch,
+      s"""
+         |private boolean $nextBatch() throws Exception {
+         |  if ($buffers != null) return true;
+         |  // get next batch or row (latter for non-batch source iteration)
+         |  if ($input == null) return false;
+         |  if (!$input.hasNext()) {
+         |    if ($input == $rowInput) {
+         |      $input = $colInput;
+         |      $inputIsRow = false;
+         |      if ($input == null || !$input.hasNext()) {
+         |        return false;
+         |      }
+         |    } else {
+         |      return false;
+         |    }
+         |  }
+         |  if ($inputIsRow) {
+         |    $nextRowSnippet
+         |    $numBatchRows = 1;
+         |  } else {
+         |    $batchInit
+         |    $numOutputRows.add($numBatchRows);
+         |    // initialize the column buffers and decoders
+         |    ${columnBufferInitCode.toString()}
+         |  }
+         |  $batchIndex = 0;
+         |  return true;
+         |}
+      """.stripMargin)
+
+    s"""
+       |// Combined iterator for cached batches from column table
+       |// and ResultSet from row buffer. Also takes care of otherRDDs
+       |// case when partition is of otherRDDs by iterating over it
+       |// using an UnsafeRow adapter.
+       |long $numRowsBuffer = 0L;
+       |long $numRowsOther = 0L;
+       |try {
+       |  while ($nextBatch()) {
+       |    final int numRows = $numBatchRows;
+       |    ${bufferInitCode.toString()}
+       |    final boolean isRow = $inputIsRow;
+       |    for (int batchOrdinal = $batchIndex; batchOrdinal < numRows;
+       |         batchOrdinal++) {
+       |      ${moveNextCode.toString()}
+       |      if (isRow) {
+       |        $incrementNumRowsSnippet
+       |      }
+       |      ${consume(ctx, columnsInput).trim}
+       |      if (shouldStop()) {
+       |        // increment index for premature return
+       |        $batchIndex = batchOrdinal + 1;
+       |        // set the cursors
+       |        ${cursorUpdateCode.toString()}
+       |        return;
+       |      }
+       |    }
+       |    $buffers = null;
+       |  }
+       |} catch (RuntimeException re) {
+       |  throw re;
+       |} catch (Exception e) {
+       |  throw new RuntimeException(e);
+       |} finally {
+       |  $numOutputRows.add($numRowsBuffer);
+       |  $numRowsBufferOutput.add($numRowsBuffer);
+       |  $incrementOtherRows
+       |}
+    """.stripMargin
+  }
+
+  private def genCodeColumnNext(ctx: CodegenContext, decoder: String,
+      buffer: String, cursorVar: String, batchOrdinal: String,
+      dataType: DataType, notNullVar: String): String = {
+    val sqlType = Utils.getSQLDataType(dataType)
+    val jt = ctx.javaType(sqlType)
+    val moveNext = sqlType match {
+      case _ if ctx.isPrimitiveType(jt) =>
+        val typeName = ctx.primitiveTypeName(jt)
+        s"$cursorVar = $decoder.next$typeName($buffer, $cursorVar);"
+      case StringType =>
+        s"$cursorVar = $decoder.nextUTF8String($buffer, $cursorVar);"
+      case d: DecimalType if d.precision <= Decimal.MAX_LONG_DIGITS =>
+        s"$cursorVar = $decoder.nextLong($buffer, $cursorVar);"
+      case _: DecimalType =>
+        s"$cursorVar = $decoder.nextDecimal($buffer, $cursorVar);"
+      case CalendarIntervalType =>
+        s"$cursorVar = $decoder.nextInterval($buffer, $cursorVar);"
+      case BinaryType | _: ArrayType | _: MapType | _: StructType =>
+        s"$cursorVar = $decoder.nextBinary($buffer, $cursorVar);"
+      case NullType => ""
+      case _ =>
+        throw new UnsupportedOperationException(s"unknown type $sqlType")
+    }
+    if (notNullVar != null) {
+      val nullCode =
+        s"final int $notNullVar = $decoder.notNull($buffer, $batchOrdinal);"
+      if (moveNext.isEmpty) nullCode
+      else s"$nullCode\nif ($notNullVar == 1) $moveNext"
+    } else moveNext
+  }
+
+  private def genCodeColumnBuffer(ctx: CodegenContext, decoder: String,
+      buffer: String, cursorVar: String, dataType: DataType,
+      notNullVar: String): ExprCode = {
+    val sqlType = Utils.getSQLDataType(dataType)
+    val jt = ctx.javaType(sqlType)
+    val extract = sqlType match {
+      case DateType => s"$decoder.readDate($buffer, $cursorVar)"
+      case TimestampType => s"$decoder.readTimestamp($buffer, $cursorVar)"
+      case _ if ctx.isPrimitiveType(jt) =>
+        s"$decoder.read${ctx.primitiveTypeName(jt)}($buffer, $cursorVar)"
+      case StringType => s"$decoder.readUTF8String($buffer, $cursorVar)"
+      case d: DecimalType if d.precision <= Decimal.MAX_LONG_DIGITS =>
+        s"$decoder.readLongDecimal($buffer, ${d.precision}, ${d.scale}, " +
+            s"$cursorVar)"
+      case d: DecimalType =>
+        s"$decoder.readDecimal($buffer, ${d.precision}, ${d.scale}, $cursorVar)"
+      case BinaryType => s"$decoder.readBinary($buffer, $cursorVar)"
+      case CalendarIntervalType => s"$decoder.readInterval($buffer, $cursorVar)"
+      case _: ArrayType => s"$decoder.readArray($buffer, $cursorVar)"
+      case _: MapType => s"$decoder.readMap($buffer, $cursorVar)"
+      case t: StructType =>
+        s"$decoder.readStruct($buffer, ${t.size}, $cursorVar)"
+      case NullType => "null"
+      case _ =>
+        throw new UnsupportedOperationException(s"unknown type $sqlType")
+    }
+    val col = ctx.freshName("col")
+    if (notNullVar != null) {
+      val nullVar = ctx.freshName("nullVal")
+      // For ResultSets wasNull() is always a post-facto operation
+      // i.e. works only after get has been invoked. However, for column
+      // table buffers as well as UnsafeRow adapter, this is not the case
+      // and nonNull() should be invoked before get (and get not invoked
+      //   at all if nonNull was false). Hence notNull uses tri-state to
+      // indicate (true/false/use wasNull) and code below is a tri-switch.
+      val code =
+        s"""
+          final $jt $col;
+          final boolean $nullVar;
+          if ($notNullVar == 1) {
+            $col = $extract;
+            $nullVar = false;
+          } else {
+            if ($notNullVar == 0) {
+              $col = ${ctx.defaultValue(jt)};
+              $nullVar = true;
+            } else {
+              $col = $extract;
+              $nullVar = $decoder.wasNull();
+            }
+          }
+        """
+      ExprCode(code, nullVar, col)
+    } else {
+      ExprCode(s"final $jt $col = $extract;", "false", col)
+    }
+  }
+}
+
+/**
+ * This class is a simplified copy of Spark's UnionRDD. The reason for
+ * having this is to ensure that partition IDs are always assigned in order
+ * (which may possibly change in future versions of Spark's UnionRDD)
+ * so that a compute on executor can tell owner RDD of the current partition.
+ */
+private[sql] final class UnionScanRDD[T: ClassTag](
+    sc: SparkContext,
+    var rdds: Seq[RDD[T]])
+    extends RDD[T](sc, Nil) {
+
+  override def getPartitions: Array[Partition] = {
+    val array = new Array[Partition](rdds.map(_.getNumPartitions).sum)
+    var pos = 0
+    for ((rdd, rddIndex) <- rdds.zipWithIndex; split <- rdd.partitions) {
+      array(pos) = new UnionPartition(pos, rdd, rddIndex, split.index)
+      pos += 1
+    }
+    array
+  }
+
+  override def getDependencies: Seq[Dependency[_]] = {
+    val deps = new ArrayBuffer[Dependency[_]]
+    var pos = 0
+    for (rdd <- rdds) {
+      deps += new RangeDependency(rdd, 0, pos, rdd.getNumPartitions)
+      pos += rdd.getNumPartitions
+    }
+    deps
+  }
+
+  override def compute(s: Partition, context: TaskContext): Iterator[T] = {
+    val part = s.asInstanceOf[UnionPartition[T]]
+    parent[T](part.parentRddIndex).iterator(part.parentPartition, context)
+  }
+
+  override def getPreferredLocations(s: Partition): Seq[String] =
+    s.asInstanceOf[UnionPartition[T]].preferredLocations()
+
+  override def clearDependencies() {
+    super.clearDependencies()
+    rdds = null
+  }
+}

--- a/core/src/main/scala/org/apache/spark/sql/execution/columnar/JDBCSourceAsStore.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/columnar/JDBCSourceAsStore.scala
@@ -25,10 +25,15 @@ import scala.language.implicitConversions
 import scala.reflect.ClassTag
 import scala.util.Random
 
+import com.gemstone.gemfire.internal.cache.{NonLocalRegionEntry, OffHeapRegionEntry}
+import com.pivotal.gemfirexd.internal.engine.store.{GemFireContainer, OffHeapCompactExecRowWithLobs, RegionEntryUtils, RowFormatter}
+import com.pivotal.gemfirexd.internal.iapi.types.RowLocation
+
 import org.apache.spark.internal.Logging
 import org.apache.spark.rdd.RDD
-import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.expressions.UnsafeRow
 import org.apache.spark.sql.execution.ConnectionPool
+import org.apache.spark.sql.execution.row.PRValuesIterator
 import org.apache.spark.sql.sources.ConnectionProperties
 import org.apache.spark.{Partition, SparkContext, TaskContext}
 
@@ -73,9 +78,8 @@ class JDBCSourceAsStore(override val connProperties: ConnectionProperties,
         stmt.setInt(2, partitionId)
         stmt.setInt(3, batch.numRows)
         // TODO: set to null since stats are currently not being used
-        // Need to use them for partition/CachedBatch pruning but also
-        // add more efficient custom serialization below (shows perf impact)
-        // stmt.setBytes(4, SparkSqlSerializer.serialize(batch.stats))
+        // Need to use them for partition/CachedBatch pruning.
+        // Use UnsafeRow for efficient serialization else shows perf impact.
         stmt.setNull(4, java.sql.Types.BLOB)
         var columnIndex = 5
         batch.buffers.foreach(buffer => {
@@ -144,8 +148,6 @@ abstract class ResultSetIterator[A](conn: Connection,
   override final def hasNext: Boolean = {
     var success = false
     try {
-      // TODO: see if optimization using rs.lightWeightNext
-      // and explicit context pop in close possible (was causing trouble)
       if (doMove && hasNextValue) {
         success = rs.next()
         doMove = false
@@ -212,10 +214,65 @@ final class CachedBatchIteratorOnRS(conn: Connection,
       colBuffers(i) = rs.getBytes(i + 1)
       i += 1
     }
-    // val stats = SparkSqlSerializer.deserialize[InternalRow](rs.getBytes("stats"))
-    val stats: InternalRow = null
+    // val statsBytes = rs.getBytes("stats")
+    val stats: UnsafeRow = null
     val numRows = rs.getInt("numRows")
     CachedBatch(numRows, colBuffers, stats)
+  }
+}
+
+final class ByteArraysIteratorOnScan(container: GemFireContainer,
+    bucketIds: scala.collection.Set[Int])
+    extends PRValuesIterator[Array[Array[Byte]]](container, bucketIds) {
+
+  assert(!container.isOffHeap,
+    s"Unexpected byte[][] iterator call for off-heap $container")
+
+  protected var currentVal: Array[Array[Byte]] = _
+
+  var rowFormatter: RowFormatter = _
+
+  override protected def moveNext(): Unit = {
+    while (itr.hasNext) {
+      val rl = itr.next().asInstanceOf[RowLocation]
+      val owner = itr.getHostedBucketRegion
+      if ((owner ne null) || rl.isInstanceOf[NonLocalRegionEntry]) {
+        val v = RegionEntryUtils.getValueWithoutFaultInOrOffHeapEntry(owner, rl)
+        if (v ne null) {
+          currentVal = v.asInstanceOf[Array[Array[Byte]]]
+          rowFormatter = container.getRowFormatter(currentVal(0))
+          return
+        }
+      }
+    }
+    hasNextValue = false
+  }
+}
+
+final class OffHeapLobsIteratorOnScan(container: GemFireContainer,
+    bucketIds: scala.collection.Set[Int])
+    extends PRValuesIterator[OffHeapCompactExecRowWithLobs](container,
+      bucketIds) {
+
+  assert(container.isOffHeap,
+    s"Unexpected off-heap iterator call for on-heap $container")
+
+  override protected val currentVal: OffHeapCompactExecRowWithLobs = container
+      .newTemplateRow().asInstanceOf[OffHeapCompactExecRowWithLobs]
+
+  override protected def moveNext(): Unit = {
+    while (itr.hasNext) {
+      val rl = itr.next().asInstanceOf[RowLocation]
+      val owner = itr.getHostedBucketRegion
+      if ((owner ne null) || rl.isInstanceOf[NonLocalRegionEntry]) {
+        val v = RegionEntryUtils.getValueWithoutFaultInOrOffHeapEntry(owner, rl)
+        if ((v ne null) && (RegionEntryUtils.fillRowUsingAddress(container, owner,
+          v.asInstanceOf[OffHeapRegionEntry], currentVal, false) ne null)) {
+          return
+        }
+      }
+    }
+    hasNextValue = false
   }
 }
 

--- a/core/src/main/scala/org/apache/spark/sql/execution/columnar/JDBCSourceAsStore.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/columnar/JDBCSourceAsStore.scala
@@ -139,19 +139,19 @@ abstract class ResultSetIterator[A](conn: Connection,
     try {
       // TODO: see if optimization using rs.lightWeightNext
       // and explicit context pop in close possible (was causing trouble)
-      if (doMove) {
+      if (doMove && hasNextValue) {
         success = rs.next()
         doMove = false
-        return success
+        success
       } else {
         success = hasNextValue
+        success
       }
     } finally {
       if (!success) {
         close()
       }
     }
-    hasNextValue
   }
 
   override final def next(): A = {

--- a/core/src/main/scala/org/apache/spark/sql/execution/columnar/encoding/BooleanBitSetEncoding.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/columnar/encoding/BooleanBitSetEncoding.scala
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2016 SnappyData, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License. You
+ * may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License. See accompanying
+ * LICENSE file.
+ */
+package org.apache.spark.sql.execution.columnar.encoding
+
+import org.apache.spark.sql.catalyst.expressions.Attribute
+import org.apache.spark.sql.types.{BooleanType, DataType}
+
+final class BooleanBitSetEncoding
+    extends BooleanBitSetEncodingBase with NotNullColumn
+
+final class BooleanBitSetEncodingNullable
+    extends BooleanBitSetEncodingBase with NullableColumn
+
+abstract class BooleanBitSetEncodingBase extends ColumnEncoding {
+
+  private[this] var byteCursor = 0L
+  private[this] var currentWord = 0L
+
+  override final def typeId: Int = 3
+
+  override final def supports(dataType: DataType): Boolean =
+    dataType == BooleanType
+
+  override def initializeDecoding(columnBytes: AnyRef,
+      field: Attribute): Long = {
+    val cursor = super.initializeDecoding(columnBytes, field)
+    // read the count but its not used since CachedBatch has numRows
+    ColumnEncoding.readInt(columnBytes, cursor)
+    byteCursor = cursor + 4
+    // return current bit index as the cursor so that is used and
+    // incremented in the next call; the byte position will happen once
+    // every 64 calls so that can be a member variable;
+    // return max to force reading word in first nextBoolean call
+    ColumnEncoding.BITS_PER_LONG
+  }
+
+  override final def nextBoolean(columnBytes: AnyRef, cursor: Long): Long = {
+    var currentBitIndex = cursor
+    currentBitIndex += 1
+    if (currentBitIndex < ColumnEncoding.BITS_PER_LONG) currentBitIndex
+    else {
+      currentWord = ColumnEncoding.readLong(columnBytes, byteCursor)
+      byteCursor += 8
+      0L
+    }
+  }
+
+  override final def readBoolean(columnBytes: AnyRef, cursor: Long): Boolean =
+    ((currentWord >> cursor) & 1) != 0
+}

--- a/core/src/main/scala/org/apache/spark/sql/execution/columnar/encoding/ColumnEncoding.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/columnar/encoding/ColumnEncoding.scala
@@ -1,0 +1,450 @@
+/*
+ * Copyright (c) 2016 SnappyData, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License. You
+ * may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License. See accompanying
+ * LICENSE file.
+ */
+package org.apache.spark.sql.execution.columnar.encoding
+
+import java.lang.reflect.Field
+import java.nio.ByteOrder
+
+import org.apache.spark.sql.catalyst.expressions.{Attribute, UnsafeArrayData, UnsafeMapData, UnsafeRow}
+import org.apache.spark.sql.collection.Utils
+import org.apache.spark.sql.types._
+import org.apache.spark.unsafe.Platform
+import org.apache.spark.unsafe.types.{CalendarInterval, UTF8String}
+import org.apache.spark.util.collection.BitSet
+
+abstract class ColumnEncoding {
+
+  def typeId: Int
+
+  def supports(dataType: DataType): Boolean
+
+  protected def initializeNulls(columnBytes: AnyRef,
+      field: Attribute): Long
+
+  def initializeDecoding(columnBytes: AnyRef, field: Attribute): Long = {
+    val cursor = initializeNulls(columnBytes, field)
+    val dataType = Utils.getSQLDataType(field.dataType)
+    // no typeId for complex types
+    dataType match {
+      case d: DecimalType =>
+        if (d.precision > Decimal.MAX_LONG_DIGITS) cursor else cursor + 4
+      case BinaryType | _: ArrayType | _: MapType | _: StructType => cursor
+      case _ => cursor + 4
+    }
+  }
+
+  /**
+   * Returns 1 to indicate that column value was not-null,
+   * 0 to indicate that it was null and -1 to indicate that
+   * <code>wasNull()</code> needs to be invoked after the
+   * appropriate read method.
+   */
+  def notNull(columnBytes: AnyRef, ordinal: Int): Int
+
+  def nextBoolean(columnBytes: AnyRef, cursor: Long): Long =
+    throw new UnsupportedOperationException(s"nextBoolean for $toString")
+
+  def readBoolean(columnBytes: AnyRef, cursor: Long): Boolean =
+    throw new UnsupportedOperationException(s"readBoolean for $toString")
+
+  def nextByte(columnBytes: AnyRef, cursor: Long): Long =
+    throw new UnsupportedOperationException(s"nextByte for $toString")
+
+  def readByte(columnBytes: AnyRef, cursor: Long): Byte =
+    throw new UnsupportedOperationException(s"readByte for $toString")
+
+  def nextShort(columnBytes: AnyRef, cursor: Long): Long =
+    throw new UnsupportedOperationException(s"nextShort for $toString")
+
+  def readShort(columnBytes: AnyRef, cursor: Long): Short =
+    throw new UnsupportedOperationException(s"readShort for $toString")
+
+  def nextInt(columnBytes: AnyRef, cursor: Long): Long =
+    throw new UnsupportedOperationException(s"nextInt for $toString")
+
+  def readInt(columnBytes: AnyRef, cursor: Long): Int =
+    throw new UnsupportedOperationException(s"readInt for $toString")
+
+  def nextLong(columnBytes: AnyRef, cursor: Long): Long =
+    throw new UnsupportedOperationException(s"nextLong for $toString")
+
+  def readLong(columnBytes: AnyRef, cursor: Long): Long =
+    throw new UnsupportedOperationException(s"readLong for $toString")
+
+  def nextFloat(columnBytes: AnyRef, cursor: Long): Long =
+    throw new UnsupportedOperationException(s"nextFloat for $toString")
+
+  def readFloat(columnBytes: AnyRef, cursor: Long): Float =
+    throw new UnsupportedOperationException(s"readFloat for $toString")
+
+  def nextDouble(columnBytes: AnyRef, cursor: Long): Long =
+    throw new UnsupportedOperationException(s"nextDouble for $toString")
+
+  def readDouble(columnBytes: AnyRef, cursor: Long): Double =
+    throw new UnsupportedOperationException(s"readDouble for $toString")
+
+  def readLongDecimal(columnBytes: AnyRef, precision: Int,
+      scale: Int, cursor: Long): Decimal =
+    throw new UnsupportedOperationException(s"readLongDecimal for $toString")
+
+  def nextDecimal(columnBytes: AnyRef, cursor: Long): Long =
+    throw new UnsupportedOperationException(s"nextDecimal for $toString")
+
+  def readDecimal(columnBytes: AnyRef, precision: Int,
+      scale: Int, cursor: Long): Decimal =
+    throw new UnsupportedOperationException(s"readDecimal for $toString")
+
+  def nextUTF8String(columnBytes: AnyRef, cursor: Long): Long =
+    throw new UnsupportedOperationException(s"nextUTF8String for $toString")
+
+  def readUTF8String(columnBytes: AnyRef, cursor: Long): UTF8String =
+    throw new UnsupportedOperationException(s"readUTF8String for $toString")
+
+  def readDate(columnBytes: AnyRef, cursor: Long): Int =
+    readInt(columnBytes, cursor)
+
+  def readTimestamp(columnBytes: AnyRef, cursor: Long): Long =
+    readLong(columnBytes, cursor)
+
+  def nextInterval(columnBytes: AnyRef, cursor: Long): Long =
+    throw new UnsupportedOperationException(s"nextInterval for $toString")
+
+  def readInterval(columnBytes: AnyRef, cursor: Long): CalendarInterval =
+    throw new UnsupportedOperationException(s"readInterval for $toString")
+
+  def nextBinary(columnBytes: AnyRef, cursor: Long): Long =
+    throw new UnsupportedOperationException(s"nextBinary for $toString")
+
+  def readBinary(columnBytes: AnyRef, cursor: Long): Array[Byte] =
+    throw new UnsupportedOperationException(s"readBinary for $toString")
+
+  def readArray(columnBytes: AnyRef, cursor: Long): UnsafeArrayData =
+    throw new UnsupportedOperationException(s"readArray for $toString")
+
+  def readMap(columnBytes: AnyRef, cursor: Long): UnsafeMapData =
+    throw new UnsupportedOperationException(s"readMap for $toString")
+
+  def readStruct(columnBytes: AnyRef, numFields: Int,
+      cursor: Long): UnsafeRow =
+    throw new UnsupportedOperationException(s"readStruct for $toString")
+
+  /**
+   * Only to be used for implementations (ResultSet adapter) that need to check
+   * for null after having invoked the appropriate read method.
+   * The <code>notNull</code> method should return -1 for such implementations.
+   */
+  def wasNull(): Boolean = false
+
+  def initializeEncoding(dataType: DataType, batchSize: Int): AnyRef =
+    throw new UnsupportedOperationException(s"initializeEncoding for $toString")
+
+  def writeBoolean(columnBytes: AnyRef, value: Boolean): Unit =
+    throw new UnsupportedOperationException(s"writeBoolean for $toString")
+
+  def writeByte(columnBytes: AnyRef, value: Byte): Unit =
+    throw new UnsupportedOperationException(s"writeByte for $toString")
+
+  def writeShort(columnBytes: AnyRef, value: Short): Unit =
+    throw new UnsupportedOperationException(s"writeShort for $toString")
+
+  def writeInt(columnBytes: AnyRef, value: Int): Unit =
+    throw new UnsupportedOperationException(s"writeInt for $toString")
+
+  def writeLong(columnBytes: AnyRef, value: Long): Unit =
+    throw new UnsupportedOperationException(s"writeLong for $toString")
+
+  def writeFloat(columnBytes: AnyRef, value: Float): Unit =
+    throw new UnsupportedOperationException(s"writeFloat for $toString")
+
+  def writeDouble(columnBytes: AnyRef, value: Double): Unit =
+    throw new UnsupportedOperationException(s"writeDouble for $toString")
+
+  def writeLongDecimal(columnBytes: AnyRef, value: Decimal,
+      precision: Int): Unit =
+    throw new UnsupportedOperationException(s"writeLongDecimal for $toString")
+
+  def writeDecimal(columnBytes: AnyRef, value: Decimal,
+      precision: Int): Unit =
+    throw new UnsupportedOperationException(s"writeDecimal for $toString")
+
+  def writeUTF8String(columnBytes: AnyRef,
+      value: UTF8String): Unit =
+    throw new UnsupportedOperationException(s"writeUTF8String for $toString")
+
+  def writeBinary(columnBytes: AnyRef, value: Array[Byte]): Unit =
+    throw new UnsupportedOperationException(s"writeBinary for $toString")
+
+  def writeInterval(columnBytes: AnyRef,
+      value: CalendarInterval): Unit =
+    throw new UnsupportedOperationException(s"writeInterval for $toString")
+
+  def writeArray(columnBytes: AnyRef,
+      value: UnsafeArrayData): Unit =
+    throw new UnsupportedOperationException(s"writeArray for $toString")
+
+  def writeMap(columnBytes: AnyRef, value: UnsafeMapData): Unit =
+    throw new UnsupportedOperationException(s"writeMap for $toString")
+
+  def writeStruct(columnBytes: AnyRef, value: UnsafeRow): Unit =
+    throw new UnsupportedOperationException(s"writeStruct for $toString")
+}
+
+object ColumnEncoding {
+
+  private[columnar] val bitSetWords: Field = {
+    val f = classOf[BitSet].getDeclaredField("words")
+    f.setAccessible(true)
+    f
+  }
+
+  private[columnar] val BITS_PER_LONG = 64
+
+  val littleEndian: Boolean = ByteOrder.nativeOrder == ByteOrder.LITTLE_ENDIAN
+
+  val allEncodings: Array[(AnyRef, DataType, Boolean) => ColumnEncoding] = Array(
+    createPassThrough,
+    createRunLengthEncoding,
+    createDictionaryEncoding,
+    createBooleanBitSetEncoding,
+    createIntDeltaEncoding,
+    createLongDeltaEncoding
+  )
+
+  def getColumnDecoder(columnBytes: Array[Byte],
+      field: Attribute): ColumnEncoding = {
+    // read and skip null values array at the start, then read the typeId
+    var cursor = Platform.BYTE_ARRAY_OFFSET
+    val nullValuesSize = readInt(columnBytes, cursor) << 2
+    cursor += (4 + nullValuesSize)
+
+    val dataType = Utils.getSQLDataType(field.dataType)
+    // no typeId for complex types
+    val typeId = dataType match {
+      case d: DecimalType if d.precision > Decimal.MAX_LONG_DIGITS => 0
+      case BinaryType | _: ArrayType | _: MapType | _: StructType => 0
+      case _ => readInt(columnBytes, cursor)
+    }
+    if (typeId >= allEncodings.length) {
+      throw new IllegalStateException(s"Unknown encoding typeId = $typeId " +
+          s"for $dataType($field) bytes: ${columnBytes.toSeq}")
+    }
+    val encoding = allEncodings(typeId)(columnBytes, dataType,
+      // use NotNull version if field is marked so or no nulls in the batch
+      field.nullable && nullValuesSize > 0)
+    if (encoding.typeId != typeId) {
+      throw new IllegalStateException(s"typeId for $encoding = " +
+          s"${encoding.typeId} does not match $typeId in global registration")
+    }
+    if (!encoding.supports(dataType)) {
+      throw new IllegalStateException("Encoder bug? Unsupported type " +
+          s"$dataType for encoding $encoding")
+    }
+    encoding
+  }
+
+  private[columnar] def createPassThrough(columnBytes: AnyRef,
+      dataType: DataType, nullable: Boolean): ColumnEncoding =
+    if (nullable) new UncompressedNullable else new Uncompressed
+
+  private[columnar] def createRunLengthEncoding(columnBytes: AnyRef,
+      dataType: DataType, nullable: Boolean): ColumnEncoding = dataType match {
+    case BooleanType | ByteType | ShortType |
+         IntegerType | DateType | LongType | TimestampType | StringType =>
+      if (nullable) new RunLengthEncodingNullable else new RunLengthEncoding
+    case _ => throw new UnsupportedOperationException(
+      s"RunLengthEncoding not supported for $dataType")
+  }
+
+  private[columnar] def createDictionaryEncoding(columnBytes: AnyRef,
+      dataType: DataType, nullable: Boolean): ColumnEncoding = dataType match {
+    case StringType | IntegerType | DateType | LongType | TimestampType =>
+      if (nullable) new DictionaryEncodingNullable
+      else new DictionaryEncoding
+    case _ => throw new UnsupportedOperationException(
+      s"DictionaryEncoding not supported for $dataType")
+  }
+
+  private[columnar] def createBooleanBitSetEncoding(columnBytes: AnyRef,
+      dataType: DataType, nullable: Boolean): ColumnEncoding = dataType match {
+    case BooleanType =>
+      if (nullable) new BooleanBitSetEncodingNullable
+      else new BooleanBitSetEncoding
+    case _ => throw new UnsupportedOperationException(
+      s"BooleanBitSetEncoding not supported for $dataType")
+  }
+
+  private[columnar] def createIntDeltaEncoding(columnBytes: AnyRef,
+      dataType: DataType, nullable: Boolean): ColumnEncoding = dataType match {
+    case IntegerType | DateType =>
+      if (nullable) new IntDeltaEncodingNullable else new IntDeltaEncoding
+    case _ => throw new UnsupportedOperationException(
+      s"IntDeltaEncoding not supported for $dataType")
+  }
+
+  private[columnar] def createLongDeltaEncoding(columnBytes: AnyRef,
+      dataType: DataType, nullable: Boolean): ColumnEncoding = dataType match {
+    case LongType | TimestampType =>
+      if (nullable) new LongDeltaEncodingNullable else new LongDeltaEncoding
+    case _ => throw new UnsupportedOperationException(
+      s"LongDeltaEncoding not supported for $dataType")
+  }
+
+  private[columnar] final def readShort(columnBytes: AnyRef,
+      cursor: Long): Int = if (littleEndian) {
+    Platform.getShort(columnBytes, cursor)
+  } else {
+    java.lang.Short.reverseBytes(Platform.getShort(columnBytes, cursor))
+  }
+
+  private[columnar] final def readInt(columnBytes: AnyRef,
+      cursor: Long): Int = if (littleEndian) {
+    Platform.getInt(columnBytes, cursor)
+  } else {
+    java.lang.Integer.reverseBytes(Platform.getInt(columnBytes, cursor))
+  }
+
+  private[columnar] final def readLong(columnBytes: AnyRef,
+      cursor: Long): Long = if (littleEndian) {
+    Platform.getLong(columnBytes, cursor)
+  } else {
+    java.lang.Long.reverseBytes(Platform.getLong(columnBytes, cursor))
+  }
+
+  private[columnar] final def readUTF8String(columnBytes: AnyRef,
+      cursor: Long): UTF8String = {
+    val size = readInt(columnBytes, cursor)
+    UTF8String.fromAddress(columnBytes, cursor + 4, size)
+  }
+}
+
+trait NotNullColumn extends ColumnEncoding {
+
+  override protected final def initializeNulls(
+      columnBytes: AnyRef, field: Attribute): Long = {
+    val cursor = Platform.BYTE_ARRAY_OFFSET
+    val numNullValues = ColumnEncoding.readInt(columnBytes, cursor)
+    if (numNullValues != 0) {
+      throw new IllegalStateException(
+        s"$numNullValues null values found in NOT NULL column $field")
+    }
+    cursor + 4 // skip numNullValues
+  }
+
+  override final def notNull(columnBytes: AnyRef, ordinal: Int): Int = 1
+}
+
+trait NullableColumn extends ColumnEncoding {
+
+  protected final var nullValues: Array[Byte] = _
+  // protected final var nullValuesBitSet: BitSet = _
+  protected final var nextNullOrdinal = 0
+  protected final var nextNullCursor = 0
+  protected final var nextNullCursorEnd = 0
+  // protected final var nullValuesType: Byte = 0
+
+  private final def updateNextNullOrdinal() {
+    if (nextNullCursor < nextNullCursorEnd) {
+      nextNullOrdinal = ColumnEncoding.readInt(nullValues, nextNullCursor)
+      nextNullCursor += 4
+    } else nextNullOrdinal = -1
+    /*
+    nullValuesType match {
+      case 0 =>
+        // 0 indicates bytes for null indexes
+        if (nextNullCursor < nextNullCursorEnd) {
+          nextNullOrdinal = nullValues(nextNullCursor)
+          nextNullCursor += 1
+        } else nextNullOrdinal = -1
+      case 1 =>
+        // 1 indicates shorts for null indexes
+        if (nextNullCursor < nextNullCursorEnd) {
+          val s1 = nullValues(nextNullCursor)
+          nextNullCursor += 1
+          nextNullOrdinal = (s1 << 8) + nullValues(nextNullCursor)
+          nextNullCursor += 1
+        } else nextNullOrdinal = -1
+      case _ =>
+        // 2 indicates a bit map
+        nextNullOrdinal = nullValuesBitSet.nextSetBit(nextNullOrdinal)
+    }
+    */
+  }
+
+  override protected final def initializeNulls(
+      columnBytes: AnyRef, field: Attribute): Long = {
+    val cursor = Platform.BYTE_ARRAY_OFFSET
+    val nullValuesSize = ColumnEncoding.readInt(columnBytes, cursor) << 2
+    if (nullValuesSize > 0) {
+      // copying instead of keeping pointer will help in better cache alignment
+      nullValues = new Array[Byte](nullValuesSize)
+      Platform.copyMemory(columnBytes, cursor + 4, nullValues,
+        Platform.BYTE_ARRAY_OFFSET, nullValuesSize)
+      nextNullCursor = Platform.BYTE_ARRAY_OFFSET
+      nextNullCursorEnd = nextNullCursor + nullValuesSize
+      updateNextNullOrdinal()
+    } else nextNullOrdinal = -1
+    cursor + 4 + nullValuesSize
+    /*
+    nullValuesType = columnBytes(0)
+    cursor = Platform.BYTE_ARRAY_OFFSET + 1
+    // copying instead of keeping pointer will help in better cache alignment
+    // since these are at the start of the byte array
+    if (nullValuesType <= 1) {
+      nullValues = readBinary(columnBytes, 0)
+      nullValuesBitSet = null
+      if (nullValues.length > 0) {
+        nullCursorEnd = nullValues.length
+        updateNextNullOrdinal()
+      }
+      else {
+        nullValues = null
+        nextNullOrdinal = -1
+      }
+    } else {
+      nullValues = null
+      nullValuesBitSet = null
+      val numWords = ColumnEncoding.readInt(columnBytes, cursor)
+      cursor += 4
+      if (numWords > 0) {
+        try {
+          nullValuesBitSet = new BitSet(numWords << 6)
+          // set the internal words field of BitSet directly
+          val words = ColumnEncodingBase.bitSetWords.get(
+            nullValuesBitSet).asInstanceOf[Array[Long]]
+          var index = 0
+          while (index < numWords) {
+            words(index) = ColumnEncoding.readLong(columnBytes, cursor)
+            cursor += 8
+            index += 1
+          }
+          nextNullOrdinal = nullValuesBitSet.nextSetBit(0)
+        } catch {
+          case e: IllegalAccessException => throw new RuntimeException(e)
+        }
+      } else nextNullOrdinal = -1
+    }
+    */
+  }
+
+  override final def notNull(columnBytes: AnyRef, ordinal: Int): Int = {
+    if (ordinal != nextNullOrdinal) 1
+    else {
+      updateNextNullOrdinal()
+      0
+    }
+  }
+}

--- a/core/src/main/scala/org/apache/spark/sql/execution/columnar/encoding/DictionaryEncoding.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/columnar/encoding/DictionaryEncoding.scala
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2016 SnappyData, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License. You
+ * may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License. See accompanying
+ * LICENSE file.
+ */
+package org.apache.spark.sql.execution.columnar.encoding
+
+import org.apache.spark.sql.catalyst.expressions.Attribute
+import org.apache.spark.sql.collection.Utils
+import org.apache.spark.sql.types.{DataType, DateType, IntegerType, LongType, StringType, TimestampType}
+import org.apache.spark.unsafe.types.UTF8String
+
+final class DictionaryEncoding
+    extends DictionaryEncodingBase with NotNullColumn
+
+final class DictionaryEncodingNullable
+    extends DictionaryEncodingBase with NullableColumn
+
+abstract class DictionaryEncodingBase extends ColumnEncoding {
+
+  override final def typeId: Int = 2
+
+  override final def supports(dataType: DataType): Boolean = dataType match {
+    case StringType | IntegerType | DateType | LongType | TimestampType => true
+    case _ => false
+  }
+
+  private[this] final var stringDictionary: Array[UTF8String] = _
+  private[this] final var intDictionary: Array[Int] = _
+  private[this] final var longDictionary: Array[Long] = _
+
+  override def initializeDecoding(columnBytes: AnyRef,
+      field: Attribute): Long = {
+    var cursor = super.initializeDecoding(columnBytes, field)
+    val elementNum = ColumnEncoding.readInt(columnBytes, cursor)
+    cursor += 4
+    Utils.getSQLDataType(field.dataType) match {
+      case StringType =>
+        stringDictionary = new Array[UTF8String](elementNum)
+        (0 until elementNum).foreach { index =>
+          val s = ColumnEncoding.readUTF8String(columnBytes, cursor)
+          stringDictionary(index) = s
+          cursor += (4 + s.numBytes())
+        }
+      case IntegerType | DateType =>
+        intDictionary = new Array[Int](elementNum)
+        (0 until elementNum).foreach { index =>
+          intDictionary(index) = ColumnEncoding.readInt(columnBytes, cursor)
+          cursor += 4
+        }
+      case LongType | TimestampType =>
+        longDictionary = new Array[Long](elementNum)
+        (0 until elementNum).foreach { index =>
+          longDictionary(index) = ColumnEncoding.readLong(columnBytes, cursor)
+          cursor += 8
+        }
+      case _ => throw new UnsupportedOperationException(
+        s"DictionaryEncoding not supported for ${field.dataType}")
+    }
+    cursor - 2 // move cursor back so that first next call increments it
+  }
+
+  override final def nextUTF8String(columnBytes: AnyRef, cursor: Long): Long =
+    cursor + 2
+
+  override final def readUTF8String(columnBytes: AnyRef,
+      cursor: Long): UTF8String =
+    stringDictionary(ColumnEncoding.readShort(columnBytes, cursor))
+
+  override final def nextInt(columnBytes: AnyRef, cursor: Long): Long =
+    cursor + 2
+
+  override final def readInt(columnBytes: AnyRef, cursor: Long): Int =
+    intDictionary(ColumnEncoding.readShort(columnBytes, cursor))
+
+  override final def nextLong(columnBytes: AnyRef, cursor: Long): Long =
+    cursor + 2
+
+  override final def readLong(columnBytes: AnyRef, cursor: Long): Long =
+    longDictionary(ColumnEncoding.readShort(columnBytes, cursor))
+}

--- a/core/src/main/scala/org/apache/spark/sql/execution/columnar/encoding/IntDeltaEncoding.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/columnar/encoding/IntDeltaEncoding.scala
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2016 SnappyData, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License. You
+ * may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License. See accompanying
+ * LICENSE file.
+ */
+package org.apache.spark.sql.execution.columnar.encoding
+
+import org.apache.spark.sql.types.{DataType, DateType, IntegerType}
+import org.apache.spark.unsafe.Platform
+
+final class IntDeltaEncoding extends IntDeltaEncodingBase with NotNullColumn
+
+final class IntDeltaEncodingNullable
+    extends IntDeltaEncodingBase with NullableColumn
+
+abstract class IntDeltaEncodingBase extends ColumnEncoding {
+
+  private[this] final var prev: Int = 0
+
+  override final def typeId: Int = 4
+
+  override final def supports(dataType: DataType): Boolean = dataType match {
+    case IntegerType | DateType => true
+    case _ => false
+  }
+
+  override final def nextInt(columnBytes: AnyRef, cursor: Long): Long = {
+    val delta = Platform.getByte(columnBytes, cursor)
+    if (delta > Byte.MinValue) {
+      prev += delta
+      cursor + 1
+    } else {
+      prev = ColumnEncoding.readInt(columnBytes, cursor + 1)
+      cursor + 5
+    }
+  }
+
+  override final def readInt(columnBytes: AnyRef, cursor: Long): Int = prev
+
+  override final def readDate(columnBytes: AnyRef, cursor: Long): Int = prev
+}

--- a/core/src/main/scala/org/apache/spark/sql/execution/columnar/encoding/LongDeltaEncoding.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/columnar/encoding/LongDeltaEncoding.scala
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2016 SnappyData, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License. You
+ * may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License. See accompanying
+ * LICENSE file.
+ */
+package org.apache.spark.sql.execution.columnar.encoding
+
+import org.apache.spark.sql.types.{DataType, LongType, TimestampType}
+import org.apache.spark.unsafe.Platform
+
+final class LongDeltaEncoding extends LongDeltaEncodingBase with NotNullColumn
+
+final class LongDeltaEncodingNullable
+    extends LongDeltaEncodingBase with NullableColumn
+
+abstract class LongDeltaEncodingBase extends ColumnEncoding {
+
+  private[this] final var prev: Long = 0L
+
+  override final def typeId: Int = 5
+
+  override final def supports(dataType: DataType): Boolean = dataType match {
+    case LongType | TimestampType => true
+    case _ => false
+  }
+
+  override final def nextLong(columnBytes: AnyRef, cursor: Long): Long = {
+    val delta = Platform.getByte(columnBytes, cursor)
+    if (delta > Byte.MinValue) {
+      prev += delta
+      cursor + 1
+    } else {
+      prev = ColumnEncoding.readLong(columnBytes, cursor + 1)
+      cursor + 9
+    }
+  }
+
+  override final def readLong(columnBytes: AnyRef, cursor: Long): Long = prev
+
+  override final def readTimestamp(columnBytes: AnyRef,
+      cursor: Long): Long = prev
+}

--- a/core/src/main/scala/org/apache/spark/sql/execution/columnar/encoding/RunLengthEncoding.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/columnar/encoding/RunLengthEncoding.scala
@@ -1,0 +1,150 @@
+/*
+ * Copyright (c) 2016 SnappyData, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License. You
+ * may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License. See accompanying
+ * LICENSE file.
+ */
+package org.apache.spark.sql.execution.columnar.encoding
+
+import org.apache.spark.sql.catalyst.expressions.Attribute
+import org.apache.spark.sql.types._
+import org.apache.spark.unsafe.Platform
+import org.apache.spark.unsafe.types.UTF8String
+
+final class RunLengthEncoding extends RunLengthEncodingBase with NotNullColumn
+
+final class RunLengthEncodingNullable
+    extends RunLengthEncodingBase with NullableColumn
+
+abstract class RunLengthEncodingBase extends ColumnEncoding {
+
+  private[this] var runLength = 0
+  private[this] var cursorPos = 0L
+  private[this] var currentValueLong: Long = _
+  private[this] var currentValueString: UTF8String = _
+
+  override final def typeId: Int = 1
+
+  override final def supports(dataType: DataType): Boolean = dataType match {
+    case BooleanType | ByteType | ShortType |
+         IntegerType | DateType | LongType | TimestampType | StringType => true
+    case _ => false
+  }
+
+  override def initializeDecoding(columnBytes: AnyRef,
+      field: Attribute): Long = {
+    cursorPos = super.initializeDecoding(columnBytes, field)
+    // use the current count + value for cursor since that will be read and
+    // written most frequently while actual cursor will be less frequently used
+    0L
+  }
+
+  override final def nextByte(columnBytes: AnyRef, countValue: Long): Long = {
+    val count = countValue.toInt
+    if (count != runLength) {
+      countValue + 1
+    } else {
+      val cursor = cursorPos
+      val currentValue: Long = Platform.getByte(columnBytes, cursor)
+      runLength = ColumnEncoding.readInt(columnBytes, cursor + 1)
+      cursorPos = cursor + 5
+      // reset count to 1
+      (currentValue << 32) | 1L
+    }
+  }
+
+  override final def readByte(columnBytes: AnyRef, countValue: Long): Byte =
+    (countValue >> 32).toByte
+
+  override final def nextBoolean(columnBytes: AnyRef, countValue: Long): Long =
+    this.nextByte(columnBytes, countValue)
+
+  override final def readBoolean(columnBytes: AnyRef,
+      countValue: Long): Boolean =
+    (countValue >> 32) == 1
+
+  override final def nextShort(columnBytes: AnyRef, countValue: Long): Long = {
+    val count = countValue.toInt
+    if (count != runLength) {
+      countValue + 1
+    } else {
+      val cursor = cursorPos
+      val currentValue: Long = ColumnEncoding.readShort(columnBytes, cursor)
+      runLength = ColumnEncoding.readInt(columnBytes, cursor + 2)
+      cursorPos = cursor + 6
+      // reset count to 1
+      (currentValue << 32) | 1L
+    }
+  }
+
+  override final def readShort(columnBytes: AnyRef, countValue: Long): Short =
+    (countValue >> 32).toShort
+
+  override final def nextInt(columnBytes: AnyRef, countValue: Long): Long = {
+    val count = countValue.toInt
+    if (count != runLength) {
+      countValue + 1
+    } else {
+      val cursor = cursorPos
+      val currentValue: Long = ColumnEncoding.readInt(columnBytes, cursor)
+      runLength = ColumnEncoding.readInt(columnBytes, cursor + 4)
+      cursorPos = cursor + 8
+      // reset count to 1
+      (currentValue << 32) | 1L
+    }
+  }
+
+  override final def readInt(columnBytes: AnyRef, countValue: Long): Int =
+    (countValue >> 32).toInt
+
+  override final def readDate(columnBytes: AnyRef, countValue: Long): Int =
+    (countValue >> 32).toInt
+
+  override final def nextLong(columnBytes: AnyRef, count: Long): Long = {
+    if (count != runLength) {
+      count + 1
+    } else {
+      val cursor = cursorPos
+      currentValueLong = ColumnEncoding.readLong(columnBytes, cursor)
+      runLength = ColumnEncoding.readInt(columnBytes, cursor + 8)
+      cursorPos = cursor + 12
+      // reset count to 1
+      1L
+    }
+  }
+
+  override final def readLong(columnBytes: AnyRef, count: Long): Long =
+    currentValueLong
+
+  override final def readTimestamp(columnBytes: AnyRef, count: Long): Long =
+    currentValueLong
+
+  override final def nextUTF8String(columnBytes: AnyRef, count: Long): Long = {
+    if (count != runLength) {
+      count + 1
+    } else {
+      var cursor = cursorPos
+      val currentValue = ColumnEncoding.readUTF8String(columnBytes, cursor)
+      cursor += (4 + currentValue.numBytes())
+      runLength = ColumnEncoding.readInt(columnBytes, cursor)
+      cursorPos = cursor + 4
+      currentValueString = currentValue
+      // reset count to 1
+      1L
+    }
+  }
+
+  override final def readUTF8String(columnBytes: AnyRef,
+      count: Long): UTF8String =
+    currentValueString
+}

--- a/core/src/main/scala/org/apache/spark/sql/execution/columnar/encoding/Uncompressed.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/columnar/encoding/Uncompressed.scala
@@ -1,0 +1,304 @@
+/*
+ * Copyright (c) 2016 SnappyData, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License. You
+ * may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License. See accompanying
+ * LICENSE file.
+ */
+package org.apache.spark.sql.execution.columnar.encoding
+
+import java.math.{BigDecimal, BigInteger}
+
+import org.apache.spark.sql.catalyst.expressions.{Attribute, UnsafeArrayData, UnsafeMapData, UnsafeRow}
+import org.apache.spark.sql.collection.Utils
+import org.apache.spark.sql.types._
+import org.apache.spark.unsafe.Platform
+import org.apache.spark.unsafe.types.{CalendarInterval, UTF8String}
+
+final class Uncompressed extends UncompressedBase with NotNullColumn
+
+final class UncompressedNullable extends UncompressedBase with NullableColumn
+
+abstract class UncompressedBase extends ColumnEncoding {
+
+  import ColumnEncoding.littleEndian
+
+  protected final var baseCursor = 0L
+
+  def typeId: Int = 0
+
+  def supports(dataType: DataType): Boolean = true
+
+  override final def initializeDecoding(columnBytes: AnyRef,
+      field: Attribute): Long = {
+    val cursor = initializeNulls(columnBytes, field)
+    // typeId takes 4 bytes for non-complex types else 0;
+    // adjust cursor for the first next call to avoid extra checks in next
+    // accounting for typeId size
+    Utils.getSQLDataType(field.dataType) match {
+      case BooleanType | ByteType => cursor + 3 // (typeIdSize - 1)
+      case ShortType => cursor + 2 // (typeIdSize - 2)
+      case IntegerType | FloatType | DateType => cursor // (typeIdSize - 4)
+      case LongType | DoubleType | TimestampType =>
+        cursor - 4 // (typeIdSize - 8)
+      case CalendarIntervalType => cursor - 8 // (typeIdSize - 12)
+      case StringType =>
+        // this will check for zero value of cursor and adjust in first next
+        baseCursor = cursor + 4 // typeIdSize
+        0L
+      case d: DecimalType if d.precision <= Decimal.MAX_LONG_DIGITS =>
+        cursor - 4 // (typeIdSize - 8)
+      case BinaryType | _: DecimalType |
+           _: ArrayType | _: MapType | _: StructType =>
+        // these will check for zero value of cursor and adjust in first next;
+        // no typeId for complex types
+        baseCursor = cursor
+        0L
+      case NullType => 0L // no role of cursor for NullType
+      case t => throw new UnsupportedOperationException(s"Unsupported type $t")
+    }
+  }
+
+  override def nextBoolean(columnBytes: AnyRef, cursor: Long): Long =
+    cursor + 1
+
+  override def readBoolean(columnBytes: AnyRef, cursor: Long): Boolean =
+    Platform.getByte(columnBytes, cursor) == 1
+
+  override def nextByte(columnBytes: AnyRef, cursor: Long): Long =
+    cursor + 1
+
+  override def readByte(columnBytes: AnyRef, cursor: Long): Byte =
+    Platform.getByte(columnBytes, cursor)
+
+  override def nextShort(columnBytes: AnyRef, cursor: Long): Long =
+    cursor + 2
+
+  override def readShort(columnBytes: AnyRef, cursor: Long): Short =
+    if (littleEndian) Platform.getShort(columnBytes, cursor)
+    else java.lang.Short.reverseBytes(Platform.getShort(columnBytes, cursor))
+
+  override def nextInt(columnBytes: AnyRef, cursor: Long): Long =
+    cursor + 4
+
+  override def readInt(columnBytes: AnyRef, cursor: Long): Int =
+    if (littleEndian) Platform.getInt(columnBytes, cursor)
+    else java.lang.Integer.reverseBytes(Platform.getInt(columnBytes, cursor))
+
+  override def nextLong(columnBytes: AnyRef, cursor: Long): Long =
+    cursor + 8
+
+  override def readLong(columnBytes: AnyRef, cursor: Long): Long = {
+    val result = if (littleEndian) Platform.getLong(columnBytes, cursor)
+    else java.lang.Long.reverseBytes(Platform.getLong(columnBytes, cursor))
+    result
+  }
+
+  override def nextFloat(columnBytes: AnyRef, cursor: Long): Long =
+    cursor + 4
+
+  override def readFloat(columnBytes: AnyRef, cursor: Long): Float =
+    if (littleEndian) Platform.getFloat(columnBytes, cursor)
+    else java.lang.Float.intBitsToFloat(java.lang.Integer.reverseBytes(
+      Platform.getInt(columnBytes, cursor)))
+
+  override def nextDouble(columnBytes: AnyRef, cursor: Long): Long =
+    cursor + 8
+
+  override def readDouble(columnBytes: AnyRef, cursor: Long): Double =
+    if (littleEndian) Platform.getDouble(columnBytes, cursor)
+    else java.lang.Double.longBitsToDouble(java.lang.Long.reverseBytes(
+      Platform.getLong(columnBytes, cursor)))
+
+  override def readLongDecimal(columnBytes: AnyRef, precision: Int,
+      scale: Int, cursor: Long): Decimal =
+    Decimal.createUnsafe(ColumnEncoding.readLong(columnBytes, cursor),
+      precision, scale)
+
+  override def nextDecimal(columnBytes: AnyRef, cursor: Long): Long = {
+    // cursor == 0 indicates first call so don't increment cursor
+    if (cursor != 0) {
+      val size = ColumnEncoding.readInt(columnBytes, cursor)
+      cursor + 4 + size
+    } else {
+      baseCursor
+    }
+  }
+
+  override def readDecimal(columnBytes: AnyRef, precision: Int,
+      scale: Int, cursor: Long): Decimal = {
+    Decimal.apply(new BigDecimal(new BigInteger(readBinary(columnBytes,
+      cursor)), scale), precision, scale)
+  }
+
+  override def nextUTF8String(columnBytes: AnyRef, cursor: Long): Long = {
+    // cursor == 0 indicates first call so don't increment cursor
+    if (cursor != 0) {
+      val size = ColumnEncoding.readInt(columnBytes, cursor)
+      cursor + 4 + size
+    } else {
+      baseCursor
+    }
+  }
+
+  override def readUTF8String(columnBytes: AnyRef, cursor: Long): UTF8String =
+    ColumnEncoding.readUTF8String(columnBytes, cursor)
+
+  override def nextInterval(columnBytes: AnyRef, cursor: Long): Long =
+    cursor + 12
+
+  override def readInterval(columnBytes: AnyRef,
+      cursor: Long): CalendarInterval = {
+    val months = ColumnEncoding.readInt(columnBytes, cursor)
+    val micros = ColumnEncoding.readLong(columnBytes, cursor + 4)
+    new CalendarInterval(months, micros)
+  }
+
+  override def nextBinary(columnBytes: AnyRef, cursor: Long): Long = {
+    // cursor == 0 indicates first call so don't increment cursor
+    if (cursor != 0) {
+      val size = ColumnEncoding.readInt(columnBytes, cursor)
+      cursor + 4 + size
+    } else {
+      baseCursor
+    }
+  }
+
+  override def readBinary(columnBytes: AnyRef, cursor: Long): Array[Byte] = {
+    val size = ColumnEncoding.readInt(columnBytes, cursor)
+    val b = new Array[Byte](size)
+    Platform.copyMemory(columnBytes, cursor + 4, b,
+      Platform.BYTE_ARRAY_OFFSET, size)
+    b
+  }
+
+  override def readArray(columnBytes: AnyRef, cursor: Long): UnsafeArrayData = {
+    val result = new UnsafeArrayData
+    val size = ColumnEncoding.readInt(columnBytes, cursor)
+    result.pointTo(columnBytes, cursor + 4, size)
+    result
+  }
+
+  override def readMap(columnBytes: AnyRef, cursor: Long): UnsafeMapData = {
+    val result = new UnsafeMapData
+    val size = ColumnEncoding.readInt(columnBytes, cursor)
+    result.pointTo(columnBytes, cursor + 4, size)
+    result
+  }
+
+  override def readStruct(columnBytes: AnyRef, numFields: Int,
+      cursor: Long): UnsafeRow = {
+    val result = new UnsafeRow(numFields)
+    val size = ColumnEncoding.readInt(columnBytes, cursor)
+    result.pointTo(columnBytes, cursor + 4, size)
+    result
+  }
+
+  /*
+  override def writeBoolean(columnBytes: AnyRef, value: Boolean): Unit = {
+    Platform.putByte(columnBytes, cursor, if (value) 1 else 0)
+    cursor += 1
+  }
+
+  override def writeByte(columnBytes: AnyRef, value: Byte): Unit = {
+    Platform.putByte(columnBytes, cursor, value)
+    cursor += 1
+  }
+
+  override def writeShort(columnBytes: AnyRef, value: Short): Unit = {
+    if (littleEndian) Platform.putShort(columnBytes, cursor, value)
+    else Platform.putShort(columnBytes, cursor, java.lang.Short.reverseBytes(value))
+    cursor += 2
+  }
+
+  override def writeInt(columnBytes: AnyRef, value: Int): Unit = {
+    if (littleEndian) Platform.putInt(columnBytes, cursor, value)
+    else Platform.putInt(columnBytes, cursor, java.lang.Integer.reverseBytes(value))
+    cursor += 4
+  }
+
+  override def writeLong(columnBytes: AnyRef, value: Long): Unit = {
+    if (littleEndian) Platform.putLong(columnBytes, cursor, value)
+    else Platform.putLong(columnBytes, cursor, java.lang.Long.reverseBytes(value))
+    cursor += 8
+  }
+
+  override def writeDecimal(columnBytes: AnyRef, value: Decimal,
+      precision: Int): Unit = {
+    if (precision <= Decimal.MAX_LONG_DIGITS) {
+      writeLong(columnBytes, value.toUnscaledLong)
+    } else {
+      val b = value.toJavaBigDecimal.unscaledValue.toByteArray
+      writeBinary(columnBytes, b)
+    }
+  }
+
+  override def writeFloat(columnBytes: AnyRef, value: Float): Unit = {
+    if (littleEndian) Platform.putFloat(columnBytes, cursor, value)
+    else Platform.putInt(columnBytes, cursor, java.lang.Integer.reverseBytes(
+      java.lang.Float.floatToIntBits(value)))
+    cursor += 4
+  }
+
+  override def writeDouble(columnBytes: AnyRef, value: Double): Unit = {
+    if (littleEndian) Platform.putDouble(columnBytes, cursor, value)
+    else Platform.putLong(columnBytes, cursor, java.lang.Long.reverseBytes(
+      java.lang.Double.doubleToLongBits(value)))
+    cursor += 8
+  }
+
+  override def writeUTF8String(columnBytes: AnyRef, value: UTF8String): Unit = {
+    val size = value.numBytes
+    writeInt(columnBytes, size)
+    Platform.copyMemory(value.getBaseObject, value.getBaseOffset, columnBytes,
+      cursor, size)
+    cursor += size
+  }
+
+  override def writeBinary(columnBytes: AnyRef, value: Array[Byte]): Unit = {
+    val size = value.length
+    writeInt(columnBytes, size)
+    Platform.copyMemory(value, Platform.BYTE_ARRAY_OFFSET, columnBytes, cursor, size)
+    cursor += size
+  }
+
+  override def writeInterval(columnBytes: AnyRef,
+      value: CalendarInterval): Unit = {
+    writeInt(columnBytes, value.months)
+    writeLong(columnBytes, value.microseconds)
+  }
+
+  override def writeArray(columnBytes: AnyRef, value: UnsafeArrayData): Unit = {
+    val size = value.getSizeInBytes
+    writeInt(columnBytes, size)
+    Platform.copyMemory(value.getBaseObject, value.getBaseOffset, columnBytes,
+      cursor, size)
+    cursor += size
+  }
+
+  override def writeMap(columnBytes: AnyRef, value: UnsafeMapData): Unit = {
+    val size = value.getSizeInBytes
+    writeInt(columnBytes, size)
+    Platform.copyMemory(value.getBaseObject, value.getBaseOffset, columnBytes,
+      cursor, size)
+    cursor += size
+  }
+
+  override def writeStruct(columnBytes: AnyRef, value: UnsafeRow): Unit = {
+    val size = value.getSizeInBytes
+    writeInt(columnBytes, size)
+    Platform.copyMemory(value.getBaseObject, value.getBaseOffset, columnBytes,
+      cursor, size)
+    cursor += size
+  }
+  */
+}

--- a/core/src/main/scala/org/apache/spark/sql/execution/columnar/impl/ColumnFormatRelation.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/columnar/impl/ColumnFormatRelation.scala
@@ -84,7 +84,7 @@ class BaseColumnFormatRelation(
 
   val columnBatchSize = sqlContext.conf.columnBatchSize
 
-  lazy val connectionType = ExternalStoreUtils.getConnectionType(dialect)
+  override val connectionType = ExternalStoreUtils.getConnectionType(dialect)
 
   lazy val rowInsertStr = ExternalStoreUtils.getInsertStringWithColumnName(
     resolvedName, schema)
@@ -110,7 +110,7 @@ class BaseColumnFormatRelation(
   }
 
   override def scanTable(tableName: String, requiredColumns: Array[String],
-      filters: Array[Filter]): RDD[InternalRow] = {
+      filters: Array[Filter]): (RDD[CachedBatch], Array[String]) = {
     super.scanTable(ColumnFormatRelation.cachedBatchTableName(tableName),
       requiredColumns, filters)
   }
@@ -118,8 +118,8 @@ class BaseColumnFormatRelation(
   // TODO: Suranjan currently doesn't apply any filters.
   // will see that later.
   override def buildUnsafeScan(requiredColumns: Array[String],
-      filters: Array[Filter]): RDD[InternalRow] = {
-    val colRdd = scanTable(table, requiredColumns, filters)
+      filters: Array[Filter]): (RDD[Any], Seq[RDD[InternalRow]]) = {
+    val (rdd, _) = scanTable(table, requiredColumns, filters)
     // TODO: Suranjan scanning over column rdd before row will make sure
     // that we don't have duplicates; we may miss some results though
     // [sumedh] In the absence of snapshot isolation, one option is to
@@ -138,16 +138,18 @@ class BaseColumnFormatRelation(
           resolvedName,
           isPartitioned,
           requiredColumns,
+          pushProjections = false,
+          useResultSet = true,
           connProperties,
-          filters,
+          Array.empty[Filter],
           Array.empty[Partition]
         )
 
-        rowRdd.zipPartitions(colRdd) { (leftItr, rightItr) =>
-          leftItr ++ rightItr
+        rowRdd.zipPartitions(rdd) { (leftItr, rightItr) =>
+          Iterator[Any](leftItr, rightItr)
         }
-      case _ =>
 
+      case _ =>
         val rowRdd = new SparkShellRowRDD(
           sqlContext.sparkContext,
           executorConnector,
@@ -159,11 +161,11 @@ class BaseColumnFormatRelation(
           filters
         )
 
-        rowRdd.zipPartitions(colRdd) { (leftItr, rightItr) =>
-          leftItr ++ rightItr
+        rowRdd.zipPartitions(rdd) { (leftItr, rightItr) =>
+          Iterator[Any](leftItr, rightItr)
         }
     }
-    zipped
+    (zipped, Nil)
   }
 
   override def cachedBatchAggregate(batch: CachedBatch): Unit = {
@@ -174,9 +176,11 @@ class BaseColumnFormatRelation(
       externalStore.storeCachedBatch(ColumnFormatRelation.
           cachedBatchTableName(table), batch)
     } else {
-      // TODO: can we do it before compressing. Might save a bit
+      // TODO: can we do it before compressing. Might save a bit.
+      // [sumedh] instead we should add it to a separate CachedBatch
+      // which will be appended with such small pieces in future.
       val unCachedRows = ExternalStoreUtils.cachedBatchesToRows(
-        Iterator(batch), schema.map(_.name).toArray, schema, forScan = true)
+        Iterator(batch), schema.map(_.name).toArray, schema, forScan = false)
       insert(unCachedRows)
     }
   }
@@ -323,7 +327,7 @@ class BaseColumnFormatRelation(
       "createExternalTableForCachedBatches: expected non-empty table name")
 
 
-    val (primarykey, partitionStrategy, concurrency) = dialect match {
+    val (primaryKey, partitionStrategy, concurrency) = dialect match {
       // The driver if not a loner should be an accessor only
       case d: JdbcExtendedDialect =>
         (s"constraint ${tableName}_partitionCheck check (partitionId != -1), " +
@@ -334,11 +338,13 @@ class BaseColumnFormatRelation(
     }
     val colocationClause = s"COLOCATE WITH ($table)"
 
+    // if the numRows or other columns are ever changed here, then change
+    // the hardcoded positions in insert and PartitionedPhysicalRDD.CT_*
     createTable(externalStore, s"create table $tableName (uuid varchar(36) " +
         "not null, partitionId integer, numRows integer not null, stats blob, " +
         schema.fields.map(structField => externalStore.columnPrefix +
         structField.name + " blob").mkString(", ") +
-        s", $primarykey) $partitionStrategy $colocationClause " +
+        s", $primaryKey) $partitionStrategy $colocationClause " +
         s" $concurrency $ddlExtensionForShadowTable",
         tableName, dropIfExists = false)
   }

--- a/core/src/main/scala/org/apache/spark/sql/execution/columnar/impl/JDBCSourceAsColumnarStore.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/columnar/impl/JDBCSourceAsColumnarStore.scala
@@ -19,9 +19,13 @@ package org.apache.spark.sql.execution.columnar.impl
 import java.sql.{Connection, ResultSet, Statement}
 import java.util.UUID
 
+import scala.reflect.ClassTag
+
 import com.gemstone.gemfire.internal.cache.{AbstractRegion, PartitionedRegion}
 import com.pivotal.gemfirexd.internal.engine.Misc
+import com.pivotal.gemfirexd.internal.engine.distributed.utils.GemFireXDUtils
 import io.snappydata.impl.SparkShellRDDHelper
+
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.collection._
 import org.apache.spark.sql.execution.columnar._
@@ -30,8 +34,6 @@ import org.apache.spark.sql.sources.{ConnectionProperties, Filter}
 import org.apache.spark.sql.store.StoreUtils
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.{Partition, SparkContext, TaskContext}
-
-import scala.reflect.ClassTag
 
 /**
  * Column Store implementation for GemFireXD.
@@ -45,7 +47,7 @@ final class JDBCSourceAsColumnarStore(_connProperties: ConnectionProperties,
     connectionType match {
       case ConnectionType.Embedded =>
         new ColumnarStorePartitionedRDD[CachedBatch](sparkContext,
-          tableName, requiredColumns, this)
+          tableName, this).asInstanceOf[RDD[CachedBatch]]
       case _ =>
         // remove the url property from poolProps since that will be
         // partition-specific
@@ -115,33 +117,17 @@ final class JDBCSourceAsColumnarStore(_connProperties: ConnectionProperties,
 }
 
 class ColumnarStorePartitionedRDD[T: ClassTag](_sc: SparkContext,
-    tableName: String, requiredColumns: Array[String],
-    store: JDBCSourceAsColumnarStore) extends RDD[CachedBatch](_sc, Nil) {
+    tableName: String,
+    store: JDBCSourceAsColumnarStore) extends RDD[Any](_sc, Nil) {
 
-  override def compute(split: Partition,
-      context: TaskContext): Iterator[CachedBatch] = {
-    store.tryExecute(tableName,
-      conn => {
-        val resolvedName = ExternalStoreUtils.lookupName(tableName,
-          conn.getSchema)
-        val ps1 = conn.prepareStatement(
-          "call sys.SET_BUCKETS_FOR_LOCAL_EXECUTION(?, ?)")
-        ps1.setString(1, resolvedName)
-        val partition = split.asInstanceOf[MultiBucketExecutorPartition]
-        var bucketString = ""
-        partition.buckets.foreach( bucket => {
-          bucketString = bucketString + bucket + ","
-        })
-        ps1.setString(2, bucketString.substring(0, bucketString.length-1))
-        ps1.execute()
-
-        val ps = conn.prepareStatement("select " + requiredColumns.mkString(
-          ", ") + ", numRows, stats from " + tableName)
-
-        val rs = ps.executeQuery()
-        ps1.close()
-        new CachedBatchIteratorOnRS(conn, requiredColumns, ps, rs, context)
-    }, closeOnSuccess = false, onExecutor = true)
+  override def compute(part: Partition, context: TaskContext): Iterator[Any] = {
+    val container = GemFireXDUtils.getGemFireContainer(tableName, true)
+    val bucketIds = part match {
+      case p: MultiBucketExecutorPartition => p.buckets
+      case _ => Set(part.index)
+    }
+    if (container.isOffHeap) new OffHeapLobsIteratorOnScan(container, bucketIds)
+    else new ByteArraysIteratorOnScan(container, bucketIds)
   }
 
   override def getPreferredLocations(split: Partition): Seq[String] = {
@@ -177,7 +163,7 @@ class SparkShellCachedBatchRDD[T: ClassTag](_sc: SparkContext,
 
   override def getPreferredLocations(split: Partition): Seq[String] = {
     split.asInstanceOf[ExecutorMultiBucketLocalShellPartition]
-        .hostList.map(_._1.asInstanceOf[String]).toSeq
+        .hostList.map(_._1.asInstanceOf[String])
   }
 
   override def getPartitions: Array[Partition] = {
@@ -195,7 +181,8 @@ class SparkShellRowRDD[T: ClassTag](_sc: SparkContext,
     filters: Array[Filter] = Array.empty[Filter],
     partitions: Array[Partition] = Array.empty[Partition])
     extends RowFormatScanRDD(_sc, getConnection, schema, tableName,
-      isPartitioned, columns, connProperties, filters, partitions) {
+      isPartitioned, columns, pushProjections = true, useResultSet = true,
+      connProperties, filters, partitions) {
 
   override def computeResultSet(
       thePart: Partition): (Connection, Statement, ResultSet) = {
@@ -206,16 +193,13 @@ class SparkShellRowRDD[T: ClassTag](_sc: SparkContext,
 
     // TODO: this will fail if no network server is available unless SNAP-365 is
     // fixed with the approach of having an iterator that can fetch from remote
-    if(isPartitioned) {
+    if (isPartitioned) {
       val ps = conn.prepareStatement(
         "call sys.SET_BUCKETS_FOR_LOCAL_EXECUTION(?, ?)")
       ps.setString(1, resolvedName)
       val partition = thePart.asInstanceOf[ExecutorMultiBucketLocalShellPartition]
-      var bucketString = ""
-      partition.buckets.foreach(bucket => {
-        bucketString = bucketString + bucket + ","
-      })
-      ps.setString(2, bucketString.substring(0, bucketString.length - 1))
+      val bucketString = partition.buckets.mkString(",")
+      ps.setString(2, bucketString)
       ps.executeUpdate()
       ps.close()
     }
@@ -237,7 +221,7 @@ class SparkShellRowRDD[T: ClassTag](_sc: SparkContext,
 
   override def getPreferredLocations(split: Partition): Seq[String] = {
     split.asInstanceOf[ExecutorMultiBucketLocalShellPartition]
-        .hostList.map(_._1.asInstanceOf[String]).toSeq
+        .hostList.map(_._1.asInstanceOf[String])
   }
 
   override def getPartitions: Array[Partition] = {

--- a/core/src/main/scala/org/apache/spark/sql/execution/columnar/impl/StoreCallbacksImpl.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/columnar/impl/StoreCallbacksImpl.scala
@@ -27,7 +27,7 @@ import com.pivotal.gemfirexd.internal.engine.Misc
 import com.pivotal.gemfirexd.internal.engine.distributed.utils.GemFireXDUtils
 import com.pivotal.gemfirexd.internal.engine.store.{GemFireStore, AbstractCompactExecRow, GemFireContainer}
 import com.pivotal.gemfirexd.internal.iapi.sql.conn.LanguageConnectionContext
-import com.pivotal.gemfirexd.internal.iapi.store.access.{ScanController, TransactionController}
+import com.pivotal.gemfirexd.internal.iapi.store.access.TransactionController
 import com.pivotal.gemfirexd.internal.impl.jdbc.EmbedConnection
 import io.snappydata.Constant
 import org.apache.spark.SparkException
@@ -95,7 +95,7 @@ object StoreCallbacksImpl extends StoreCallbacks with Logging with Serializable 
         lcc.setExecuteLocally(Collections.singleton(bucketID),
           region.getPartitionedRegion, false, null)
         try {
-          val sc: ScanController = lcc.getTransactionExecute.openScan(
+          val sc = lcc.getTransactionExecute.openScan(
             container.getId.getContainerId, false, 0,
             TransactionController.MODE_RECORD,
             TransactionController.ISOLATION_NOLOCK /* not used */ ,

--- a/core/src/main/scala/org/apache/spark/sql/execution/datasources/StoreDataSourceStrategy.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/datasources/StoreDataSourceStrategy.scala
@@ -42,6 +42,7 @@ private[sql] object StoreDataSourceStrategy extends Strategy {
         l,
         projects,
         filters,
+        isPartitioned = true,
         t.numPartitions,
         t.numBuckets,
         t.partitionColumns,
@@ -52,6 +53,7 @@ private[sql] object StoreDataSourceStrategy extends Strategy {
         l,
         projects,
         filters,
+        isPartitioned = false,
         0,
         0,
         Seq.empty[String],
@@ -64,14 +66,17 @@ private[sql] object StoreDataSourceStrategy extends Strategy {
       relation: LogicalRelation,
       projects: Seq[NamedExpression],
       filterPredicates: Seq[Expression],
+      isPartitioned: Boolean,
       numPartition: Int,
       numBuckets: Int,
       partitionColumns: Seq[String],
-      scanBuilder: (Seq[Attribute], Array[Filter]) => RDD[InternalRow]) = {
+      scanBuilder: (Seq[Attribute], Array[Filter]) =>
+          (RDD[Any], Seq[RDD[InternalRow]])) = {
     pruneFilterProjectRaw(
       relation,
       projects,
       filterPredicates,
+      isPartitioned,
       numPartition,
       numBuckets,
       partitionColumns,
@@ -85,10 +90,12 @@ private[sql] object StoreDataSourceStrategy extends Strategy {
       relation: LogicalRelation,
       projects: Seq[NamedExpression],
       filterPredicates: Seq[Expression],
+      isPartitioned: Boolean,
       numPartition: Int,
       numBuckets: Int,
       partitionColumns: Seq[String],
-      scanBuilder: (Seq[Attribute], Seq[Expression], Seq[Filter]) => RDD[InternalRow]) = {
+      scanBuilder: (Seq[Attribute], Seq[Expression], Seq[Filter]) =>
+          (RDD[Any], Seq[RDD[InternalRow]])) = {
 
     val projectSet = AttributeSet(projects.flatMap(_.references))
     val filterSet = AttributeSet(filterPredicates.flatMap(_.references))
@@ -103,8 +110,8 @@ private[sql] object StoreDataSourceStrategy extends Strategy {
     val (unhandledPredicates, pushedFilters) =
       selectFilters(relation.relation, candidatePredicates)
 
-    // A set of column attributes that are only referenced by pushed down filters.  We can eliminate
-    // them from requested columns.
+    // A set of column attributes that are only referenced by pushed down
+    // filters. We can eliminate them from requested columns.
     val handledSet = {
       val handledPredicates = filterPredicates.filterNot(unhandledPredicates.contains)
       val unhandledSet = AttributeSet(unhandledPredicates.flatMap(_.references))
@@ -112,8 +119,8 @@ private[sql] object StoreDataSourceStrategy extends Strategy {
           (projectSet ++ unhandledSet).map(relation.attributeMap)
     }
 
-    // Combines all Catalyst filter `Expression`s that are either not convertible to data source
-    // `Filter`s or cannot be handled by `relation`.
+    // Combines all Catalyst filter `Expression`s that are either not
+    // convertible to data source `Filter`s or cannot be handled by `relation`.
     val filterCondition = unhandledPredicates.reduceLeftOption(expressions.And)
 
     // Get the partition column attribute INFO from relation schema
@@ -134,7 +141,8 @@ private[sql] object StoreDataSourceStrategy extends Strategy {
       pairs.toMap
     }
 
-    if (projects.map(_.toAttribute) == projects &&
+    val mappedProjects = projects.map(_.toAttribute)
+    if (mappedProjects == projects &&
         projectSet.size == projects.size &&
         filterSet.subsetOf(projectSet)) {
       // When it is possible to just use column pruning to get the right projection and
@@ -146,18 +154,22 @@ private[sql] object StoreDataSourceStrategy extends Strategy {
           // Don't request columns that are only referenced by pushed filters.
           .filterNot(handledSet.contains)
 
-      val scan = if (numPartition > 0) {
-        execution.PartitionedPhysicalRDD.createFromDataSource(
-          projects.map(_.toAttribute),
+      val scan = if (isPartitioned) {
+        val (rdd, otherRDDs) = scanBuilder(requestedColumns,
+          candidatePredicates, pushedFilters)
+        execution.PartitionedPhysicalScan.createFromDataSource(
+          mappedProjects,
           numPartition,
           numBuckets,
           joinedCols,
-          scanBuilder(requestedColumns, candidatePredicates, pushedFilters),
-          relation.relation)
+          rdd,
+          otherRDDs,
+          relation.relation.asInstanceOf[PartitionedDataSourceScan])
       } else {
         execution.DataSourceScanExec.create(
-          projects.map(_.toAttribute),
-          scanBuilder(requestedColumns, candidatePredicates, pushedFilters),
+          mappedProjects,
+          scanBuilder(requestedColumns, candidatePredicates,
+            pushedFilters)._1.asInstanceOf[RDD[InternalRow]],
           relation.relation, metadata, relation.metastoreTableIdentifier)
       }
       filterCondition.map(execution.FilterExec(_, scan)).getOrElse(scan)
@@ -166,18 +178,22 @@ private[sql] object StoreDataSourceStrategy extends Strategy {
       val requestedColumns = (projectSet ++ filterSet -- handledSet).map(
         relation.attributeMap).toSeq
 
-      val scan = if (numPartition > 0) {
-        execution.PartitionedPhysicalRDD.createFromDataSource(
+      val scan = if (isPartitioned) {
+        val (rdd, otherRDDs) = scanBuilder(requestedColumns,
+          candidatePredicates, pushedFilters)
+        execution.PartitionedPhysicalScan.createFromDataSource(
           requestedColumns,
           numPartition,
           numBuckets,
           joinedCols,
-          scanBuilder(requestedColumns, candidatePredicates, pushedFilters),
-          relation.relation)
+          rdd,
+          otherRDDs,
+          relation.relation.asInstanceOf[PartitionedDataSourceScan])
       } else {
         execution.DataSourceScanExec.create(
           requestedColumns,
-          scanBuilder(requestedColumns, candidatePredicates, pushedFilters),
+          scanBuilder(requestedColumns, candidatePredicates,
+            pushedFilters)._1.asInstanceOf[RDD[InternalRow]],
           relation.relation, metadata, relation.metastoreTableIdentifier)
       }
       execution.ProjectExec(projects,

--- a/core/src/main/scala/org/apache/spark/sql/execution/row/ResultSetEncodingAdapter.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/row/ResultSetEncodingAdapter.scala
@@ -1,0 +1,160 @@
+/*
+ * Copyright (c) 2016 SnappyData, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License. You
+ * may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License. See accompanying
+ * LICENSE file.
+ */
+package org.apache.spark.sql.execution.row
+
+import java.sql.ResultSet
+import java.util.GregorianCalendar
+
+import org.apache.spark.sql.catalyst.expressions.{Attribute, UnsafeArrayData, UnsafeMapData, UnsafeRow}
+import org.apache.spark.sql.catalyst.util.DateTimeUtils
+import org.apache.spark.sql.execution.columnar.encoding.ColumnEncoding
+import org.apache.spark.sql.types.{DataType, Decimal}
+import org.apache.spark.unsafe.Platform
+import org.apache.spark.unsafe.types.{CalendarInterval, UTF8String}
+
+/**
+ * An adapter for a ResultSet to pose as ColumnEncoding so that the same
+ * generated code can be used for both row buffer and column data access.
+ */
+final class ResultSetEncodingAdapter(rs: ResultSet, columnPosition: Int)
+    extends ColumnEncoding {
+
+  private[this] val defaultCal = new GregorianCalendar()
+
+  override def typeId: Int = -1
+
+  override def supports(dataType: DataType): Boolean = true
+
+  override protected def initializeNulls(columnBytes: AnyRef,
+      field: Attribute): Long = 0L
+
+  override def initializeDecoding(columnBytes: AnyRef,
+      field: Attribute): Long = 0L
+
+  override def nextBoolean(columnBytes: AnyRef, cursor: Long): Long = 0L
+
+  override def nextByte(columnBytes: AnyRef, cursor: Long): Long = 0L
+
+  override def nextShort(columnBytes: AnyRef, cursor: Long): Long = 0L
+
+  override def nextInt(columnBytes: AnyRef, cursor: Long): Long = 0L
+
+  override def nextLong(columnBytes: AnyRef, cursor: Long): Long = 0L
+
+  override def nextFloat(columnBytes: AnyRef, cursor: Long): Long = 0L
+
+  override def nextDouble(columnBytes: AnyRef, cursor: Long): Long = 0L
+
+  override def nextDecimal(columnBytes: AnyRef, cursor: Long): Long = 0L
+
+  override def nextUTF8String(columnBytes: AnyRef, cursor: Long): Long = 0L
+
+  override def nextInterval(columnBytes: AnyRef, cursor: Long): Long = 0L
+
+  override def nextBinary(columnBytes: AnyRef, cursor: Long): Long = 0L
+
+  override def notNull(columnBytes: AnyRef, ordinal: Int): Int = -1
+
+  override def readBoolean(columnBytes: AnyRef, cursor: Long): Boolean =
+    rs.getBoolean(columnPosition)
+
+  override def readByte(columnBytes: AnyRef, cursor: Long): Byte =
+    rs.getByte(columnPosition)
+
+  override def readShort(columnBytes: AnyRef, cursor: Long): Short =
+    rs.getShort(columnPosition)
+
+  override def readInt(columnBytes: AnyRef, cursor: Long): Int =
+    rs.getInt(columnPosition)
+
+  override def readLong(columnBytes: AnyRef, cursor: Long): Long =
+    rs.getLong(columnPosition)
+
+  override def readFloat(columnBytes: AnyRef, cursor: Long): Float =
+    rs.getFloat(columnPosition)
+
+  override def readDouble(columnBytes: AnyRef, cursor: Long): Double =
+    rs.getDouble(columnPosition)
+
+  override def readLongDecimal(columnBytes: AnyRef, precision: Int,
+      scale: Int, cursor: Long): Decimal = {
+    val longValue = rs.getLong(columnPosition)
+    Decimal.createUnsafe(longValue, precision, scale)
+  }
+
+  override def readDecimal(columnBytes: AnyRef, precision: Int, scale: Int,
+      cursor: Long): Decimal = {
+    val dec = rs.getBigDecimal(columnPosition)
+    if (dec != null) {
+      Decimal.apply(dec, precision, scale)
+    } else {
+      null
+    }
+  }
+
+  override def readUTF8String(columnBytes: AnyRef, cursor: Long): UTF8String =
+    UTF8String.fromString(rs.getString(columnPosition))
+
+  override def readDate(columnBytes: AnyRef, cursor: Long): Int = {
+    defaultCal.clear()
+    val date = rs.getDate(columnPosition, defaultCal)
+    DateTimeUtils.fromJavaDate(date)
+  }
+
+  override def readTimestamp(columnBytes: AnyRef, cursor: Long): Long = {
+    defaultCal.clear()
+    val timestamp = rs.getTimestamp(columnPosition, defaultCal)
+    DateTimeUtils.fromJavaTimestamp(timestamp)
+  }
+
+  override def readBinary(columnBytes: AnyRef, cursor: Long): Array[Byte] =
+    rs.getBytes(columnPosition)
+
+  override def readInterval(columnBytes: AnyRef,
+      cursor: Long): CalendarInterval =
+    new CalendarInterval(0, rs.getLong(columnPosition))
+
+  override def readArray(columnBytes: AnyRef, cursor: Long): UnsafeArrayData = {
+    val b = rs.getBytes(columnPosition)
+    if (b != null) {
+      val result = new UnsafeArrayData
+      result.pointTo(b, Platform.BYTE_ARRAY_OFFSET, b.length)
+      result
+    } else null
+  }
+
+  override def readMap(columnBytes: AnyRef, cursor: Long): UnsafeMapData = {
+    val b = rs.getBytes(columnPosition)
+    if (b != null) {
+      val result = new UnsafeMapData
+      result.pointTo(b, Platform.BYTE_ARRAY_OFFSET, b.length)
+      result
+    } else null
+  }
+
+  override def readStruct(columnBytes: AnyRef, numFields: Int,
+      cursor: Long): UnsafeRow = {
+    val b = rs.getBytes(columnPosition)
+    if (b != null) {
+      val result = new UnsafeRow(numFields)
+      result.pointTo(b, Platform.BYTE_ARRAY_OFFSET, b.length)
+      result
+    } else null
+  }
+
+  override def wasNull(): Boolean = rs.wasNull()
+}

--- a/core/src/main/scala/org/apache/spark/sql/execution/row/RowFormatScanRDD.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/row/RowFormatScanRDD.scala
@@ -28,17 +28,12 @@ import com.pivotal.gemfirexd.internal.iapi.types.RowLocation
 import com.pivotal.gemfirexd.internal.impl.jdbc.EmbedResultSet
 
 import org.apache.spark.rdd.RDD
-import org.apache.spark.sql.catalyst.InternalRow
-import org.apache.spark.sql.catalyst.expressions.{SpecificMutableRow, UnsafeArrayData, UnsafeMapData, UnsafeProjection, UnsafeRow}
-import org.apache.spark.sql.catalyst.util.DateTimeUtils
 import org.apache.spark.sql.collection.MultiBucketExecutorPartition
 import org.apache.spark.sql.execution.ConnectionPool
 import org.apache.spark.sql.execution.columnar.{ExternalStoreUtils, ResultSetIterator}
 import org.apache.spark.sql.sources._
 import org.apache.spark.sql.store.StoreUtils
 import org.apache.spark.sql.types._
-import org.apache.spark.unsafe.Platform
-import org.apache.spark.unsafe.types.UTF8String
 import org.apache.spark.{Partition, SparkContext, TaskContext}
 
 /**
@@ -266,177 +261,6 @@ final class ResultSetTraversal(conn: Connection,
   val defaultCal: GregorianCalendar = new GregorianCalendar()
 
   override protected def getCurrentValue: Void = null
-}
-
-final class InternalRowIteratorOnRS(conn: Connection,
-    stmt: Statement, rs: ResultSet, context: TaskContext, schema: StructType)
-    extends ResultSetIterator[InternalRow](conn, stmt, rs, context) {
-
-  private[this] lazy val defaultCal = new GregorianCalendar()
-
-  private[this] val dataTypes: ArrayBuffer[DataType] =
-    new ArrayBuffer[DataType](schema.length)
-
-  private[this] val fieldTypes = StoreUtils.mapCatalystTypes(schema, dataTypes)
-
-  private[this] val unsafeproj = UnsafeProjection.create(
-    schema.map(_.dataType).toArray)
-
-  private[this] val mutableRow = new SpecificMutableRow(dataTypes)
-
-  override protected def getCurrentValue: InternalRow = {
-    var i = 0
-    while (i < schema.length) {
-      val pos = i + 1
-      fieldTypes(i) match {
-        case StoreUtils.STRING_TYPE =>
-          val v = rs.getString(pos)
-          if (v != null) {
-            mutableRow.update(i, UTF8String.fromString(v))
-          } else {
-            mutableRow.setNullAt(i)
-          }
-        case StoreUtils.INT_TYPE =>
-          val v = rs.getInt(pos)
-          if (v != 0 || !rs.wasNull()) {
-            mutableRow.setInt(i, v)
-          } else {
-            mutableRow.setNullAt(i)
-          }
-        case StoreUtils.LONG_TYPE =>
-          val v = rs.getLong(pos)
-          if (v != 0L || !rs.wasNull()) {
-            mutableRow.setLong(i, v)
-          } else {
-            mutableRow.setNullAt(i)
-          }
-        case StoreUtils.BINARY_LONG_TYPE =>
-          val bytes = rs.getBytes(pos)
-          if (bytes != null) {
-            var v = 0L
-            var j = 0
-            val numBytes = bytes.size
-            while (j < numBytes) {
-              v = 256 * v + (255 & bytes(j))
-              j = j + 1
-            }
-            mutableRow.setLong(i, v)
-          } else {
-            mutableRow.setNullAt(i)
-          }
-        case StoreUtils.SHORT_TYPE =>
-          val v = rs.getShort(pos)
-          if (v != 0 || !rs.wasNull()) {
-            mutableRow.setShort(i, v)
-          } else {
-            mutableRow.setNullAt(i)
-          }
-        case StoreUtils.BYTE_TYPE =>
-          val v = rs.getByte(pos)
-          if (v != 0 || !rs.wasNull()) {
-            mutableRow.setByte(i, v)
-          } else {
-            mutableRow.setNullAt(i)
-          }
-        case StoreUtils.BOOLEAN_TYPE =>
-          val v = rs.getBoolean(pos)
-          if (!rs.wasNull()) {
-            mutableRow.setBoolean(i, v)
-          } else {
-            mutableRow.setNullAt(i)
-          }
-        case StoreUtils.DECIMAL_TYPE =>
-          // When connecting with Oracle DB through JDBC, the precision and
-          // scale of BigDecimal object returned by ResultSet.getBigDecimal
-          // is not correctly matched to the table schema reported by
-          // ResultSetMetaData.getPrecision and ResultSetMetaData.getScale.
-          // If inserting values like 19999 into a column with NUMBER(12, 2)
-          // type, you get through a BigDecimal object with scale as 0.
-          // But the dataframe schema has correct type as DecimalType(12, 2).
-          // Thus, after saving the dataframe into parquet file and then
-          // retrieve it, you will get wrong result 199.99. So it is needed
-          // to set precision and scale for Decimal based on JDBC metadata.
-          val v = rs.getBigDecimal(pos)
-          if (v != null) {
-            val d = schema.fields(i).dataType.asInstanceOf[DecimalType]
-            mutableRow.update(i, Decimal(v, d.precision, d.scale))
-          } else {
-            mutableRow.setNullAt(i)
-          }
-        case StoreUtils.DOUBLE_TYPE =>
-          val v = rs.getDouble(pos)
-          if (!rs.wasNull()) {
-            mutableRow.setDouble(i, v)
-          } else {
-            mutableRow.setNullAt(i)
-          }
-        case StoreUtils.FLOAT_TYPE =>
-          val v = rs.getFloat(pos)
-          if (!rs.wasNull()) {
-            mutableRow.setFloat(i, v)
-          } else {
-            mutableRow.setNullAt(i)
-          }
-        case StoreUtils.DATE_TYPE =>
-          val cal = this.defaultCal
-          cal.clear()
-          val v = rs.getDate(pos, cal)
-          if (v != null) {
-            mutableRow.setInt(i, DateTimeUtils.fromJavaDate(v))
-          } else {
-            mutableRow.setNullAt(i)
-          }
-        case StoreUtils.TIMESTAMP_TYPE =>
-          val cal = this.defaultCal
-          cal.clear()
-          val v = rs.getTimestamp(pos, cal)
-          if (v != null) {
-            mutableRow.setLong(i, DateTimeUtils.fromJavaTimestamp(v))
-          } else {
-            mutableRow.setNullAt(i)
-          }
-        case StoreUtils.BINARY_TYPE =>
-          val v = rs.getBytes(pos)
-          if (v != null) {
-            mutableRow.update(i, v)
-          } else {
-            mutableRow.setNullAt(i)
-          }
-        case StoreUtils.ARRAY_TYPE =>
-          val v = rs.getBytes(pos)
-          if (v != null) {
-            val array = new UnsafeArrayData
-            array.pointTo(v, Platform.BYTE_ARRAY_OFFSET, v.length)
-            mutableRow.update(i, array)
-          } else {
-            mutableRow.setNullAt(i)
-          }
-        case StoreUtils.MAP_TYPE =>
-          val v = rs.getBytes(pos)
-          if (v != null) {
-            val map = new UnsafeMapData
-            map.pointTo(v, Platform.BYTE_ARRAY_OFFSET, v.length)
-            mutableRow.update(i, map)
-          } else {
-            mutableRow.setNullAt(i)
-          }
-        case StoreUtils.STRUCT_TYPE =>
-          val v = rs.getBytes(pos)
-          if (v != null) {
-            val s = schema.fields(i).dataType.asInstanceOf[StructType]
-            val row = new UnsafeRow(s.fields.length)
-            row.pointTo(v, Platform.BYTE_ARRAY_OFFSET, v.length)
-            mutableRow.update(i, row)
-          } else {
-            mutableRow.setNullAt(i)
-          }
-        case _ => throw new IllegalArgumentException(
-          s"Unsupported field ${schema.fields(i)}")
-      }
-      i = i + 1
-    }
-    unsafeproj.apply(mutableRow)
-  }
 }
 
 final class CompactExecRowIteratorOnRS(conn: Connection,

--- a/core/src/main/scala/org/apache/spark/sql/execution/row/UnsafeRowEncodingAdapter.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/row/UnsafeRowEncodingAdapter.scala
@@ -1,0 +1,117 @@
+/*
+ * Copyright (c) 2016 SnappyData, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License. You
+ * may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License. See accompanying
+ * LICENSE file.
+ */
+package org.apache.spark.sql.execution.row
+
+import org.apache.spark.sql.catalyst.expressions.{Attribute, UnsafeArrayData, UnsafeMapData, UnsafeRow}
+import org.apache.spark.sql.execution.columnar.encoding.ColumnEncoding
+import org.apache.spark.sql.types.{DataType, Decimal}
+import org.apache.spark.unsafe.types.{CalendarInterval, UTF8String}
+
+final class UnsafeRowEncodingAdapter(holder: UnsafeRowHolder, columnIndex: Int)
+    extends ColumnEncoding {
+
+  override def typeId: Int = -2
+
+  override def supports(dataType: DataType): Boolean = true
+
+  override protected def initializeNulls(columnBytes: AnyRef,
+      field: Attribute): Long = 0L
+
+  override def initializeDecoding(columnBytes: AnyRef,
+      field: Attribute): Long = 0L
+
+  override def nextBoolean(columnBytes: AnyRef, cursor: Long): Long = 0L
+
+  override def nextByte(columnBytes: AnyRef, cursor: Long): Long = 0L
+
+  override def nextShort(columnBytes: AnyRef, cursor: Long): Long = 0L
+
+  override def nextInt(columnBytes: AnyRef, cursor: Long): Long = 0L
+
+  override def nextLong(columnBytes: AnyRef, cursor: Long): Long = 0L
+
+  override def nextFloat(columnBytes: AnyRef, cursor: Long): Long = 0L
+
+  override def nextDouble(columnBytes: AnyRef, cursor: Long): Long = 0L
+
+  override def nextDecimal(columnBytes: AnyRef, cursor: Long): Long = 0L
+
+  override def nextUTF8String(columnBytes: AnyRef, cursor: Long): Long = 0L
+
+  override def nextInterval(columnBytes: AnyRef, cursor: Long): Long = 0L
+
+  override def nextBinary(columnBytes: AnyRef, cursor: Long): Long = 0L
+
+  override def notNull(columnBytes: AnyRef, ordinal: Int): Int =
+    if (holder.row.isNullAt(columnIndex)) 0 else 1
+
+  override def readBoolean(columnBytes: AnyRef, cursor: Long): Boolean =
+    holder.row.getBoolean(columnIndex)
+
+  override def readByte(columnBytes: AnyRef, cursor: Long): Byte =
+    holder.row.getByte(columnIndex)
+
+  override def readShort(columnBytes: AnyRef, cursor: Long): Short =
+    holder.row.getShort(columnIndex)
+
+  override def readInt(columnBytes: AnyRef, cursor: Long): Int =
+    holder.row.getInt(columnIndex)
+
+  override def readLong(columnBytes: AnyRef, cursor: Long): Long =
+    holder.row.getLong(columnIndex)
+
+  override def readFloat(columnBytes: AnyRef, cursor: Long): Float =
+    holder.row.getFloat(columnIndex)
+
+  override def readDouble(columnBytes: AnyRef, cursor: Long): Double =
+    holder.row.getDouble(columnIndex)
+
+  override def readLongDecimal(columnBytes: AnyRef, precision: Int, scale: Int,
+      cursor: Long): Decimal = {
+    val longValue = holder.row.getLong(columnIndex)
+    Decimal.createUnsafe(longValue, precision, scale)
+  }
+
+  override def readDecimal(columnBytes: AnyRef, precision: Int, scale: Int,
+      cursor: Long): Decimal =
+    holder.row.getDecimal(columnIndex, precision, scale)
+
+  override def readUTF8String(columnBytes: AnyRef, cursor: Long): UTF8String =
+    holder.row.getUTF8String(columnIndex)
+
+  override def readBinary(columnBytes: AnyRef, cursor: Long): Array[Byte] =
+    holder.row.getBinary(columnIndex)
+
+  override def readInterval(columnBytes: AnyRef, cursor: Long): CalendarInterval =
+    holder.row.getInterval(columnIndex)
+
+  override def readArray(columnBytes: AnyRef, cursor: Long): UnsafeArrayData =
+    holder.row.getArray(columnIndex)
+
+  override def readMap(columnBytes: AnyRef, cursor: Long): UnsafeMapData =
+    holder.row.getMap(columnIndex)
+
+  override def readStruct(columnBytes: AnyRef, numFields: Int,
+      cursor: Long): UnsafeRow =
+    holder.row.getStruct(columnIndex, numFields)
+}
+
+final class UnsafeRowHolder {
+  private[row] var row: UnsafeRow = _
+
+  def setRow(row: UnsafeRow): Unit = this.row = row
+}

--- a/core/src/main/scala/org/apache/spark/sql/row/JDBCMutableRelation.scala
+++ b/core/src/main/scala/org/apache/spark/sql/row/JDBCMutableRelation.scala
@@ -151,8 +151,8 @@ case class JDBCMutableRelation(
     connProperties, forExecutor = true)
 
   override def buildUnsafeScan(requiredColumns: Array[String],
-    filters: Array[Filter]): RDD[InternalRow] = {
-    new JDBCRDD(
+    filters: Array[Filter]): (RDD[Any], Seq[RDD[InternalRow]]) = {
+    val rdd = new JDBCRDD(
       sqlContext.sparkContext,
       executorConnector,
       ExternalStoreUtils.pruneSchema(schemaFields, requiredColumns),
@@ -161,7 +161,8 @@ case class JDBCMutableRelation(
       filters.filterNot(ExternalStoreUtils.unhandledFilter),
       parts,
       connProperties.url,
-      connProperties.executorConnProps)
+      connProperties.executorConnProps).asInstanceOf[RDD[Any]]
+    (rdd, Nil)
   }
 
   final lazy val rowInsertStr = ExternalStoreUtils.getInsertString(table, schema)

--- a/core/src/main/scala/org/apache/spark/sql/sources/interfaces.scala
+++ b/core/src/main/scala/org/apache/spark/sql/sources/interfaces.scala
@@ -21,6 +21,7 @@ import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.{Attribute, SortDirection}
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
+import org.apache.spark.sql.execution.columnar.impl.BaseColumnFormatRelation
 import org.apache.spark.sql.hive.{QualifiedTableName, SnappyStoreHiveCatalog}
 import org.apache.spark.sql.{DataFrame, Row, SQLContext, SaveMode}
 
@@ -141,6 +142,11 @@ trait SamplingRelation extends DependentRelation with SchemaInsertableRelation {
    * The QCS columns for the sample.
    */
   def qcs: Array[String]
+
+  /**
+   * The underlying column table used to store data.
+   */
+  def baseRelation: BaseColumnFormatRelation
 }
 
 @DeveloperApi
@@ -279,5 +285,7 @@ trait ExternalSchemaRelationProvider {
   */
 @DeveloperApi
 trait PrunedUnsafeFilteredScan {
-  def buildUnsafeScan(requiredColumns: Array[String], filters: Array[Filter]): RDD[InternalRow]
+
+  def buildUnsafeScan(requiredColumns: Array[String],
+      filters: Array[Filter]): (RDD[Any], Seq[RDD[InternalRow]])
 }

--- a/core/src/test/scala/io/snappydata/core/LocalTestData.scala
+++ b/core/src/test/scala/io/snappydata/core/LocalTestData.scala
@@ -82,7 +82,7 @@ object LocalSparkConf {
         setIfMissing("spark.master", "local[4]").
         setAppName(getClass.getName)
     conf.set("snappy.store.optimization", "true")
-    conf.set("spark.sql.inMemoryColumnarStorage.batchSize", "3")
+    conf.set("spark.sql.inMemoryColumnarStorage.batchSize", "4")
     if (addOn != null) {
       addOn(conf)
     }

--- a/core/src/test/scala/org/apache/spark/sql/store/ColumnTableInternalValidationTest.scala
+++ b/core/src/test/scala/org/apache/spark/sql/store/ColumnTableInternalValidationTest.scala
@@ -115,7 +115,7 @@ class ColumnTableInternalValidationTest extends SnappyFunSuite
         cachedBatchTableName("COLUMNTABLE7").toUpperCase,
       true).asInstanceOf[PartitionedRegion]
 
-    val data = Seq(Seq(1, 2), Seq(7, 8), Seq(9, 2)) // Seq(4, 2), Seq(5, 6))
+    val data = Seq(Seq(1, 2), Seq(7, 8), Seq(9, 2), Seq(4, 2)) // Seq(5, 6))
 
     val rdd = sc.parallelize(data, data.length).map(
       s => MyTestData(s.head, s(1)))
@@ -131,12 +131,12 @@ class ColumnTableInternalValidationTest extends SnappyFunSuite
 
     val result = snc.sql("SELECT * FROM  COLUMNTABLE7")
     val r = result.collect()
-    assert(r.length == 3)
+    assert(r.length == 4)
 
     val rCopy = region.getPartitionAttributes.getRedundantCopies
     assert(rCopy == 2)
 
-    assert(GemFireCacheImpl.getColumnBatchSize == 3)
+    assert(GemFireCacheImpl.getColumnBatchSize == 4)
 
     assert(region.size == 0)
     assert(shadowRegion.size == 1)
@@ -225,8 +225,8 @@ class ColumnTableInternalValidationTest extends SnappyFunSuite
 
     // assert(GemFireCacheImpl.getColumnBatchSize == 2)
     // sometimes sizes may be different depending on how are the rows distributed
-    if (GemFireCacheImpl.getColumnBatchSize == 3) {
-      assert(region.size == 2)
+    if (GemFireCacheImpl.getColumnBatchSize == 4) {
+      assert(region.size == 1)
       assert(shadowRegion.size == 1)
     }
     else {

--- a/core/src/test/scala/org/apache/spark/sql/store/SnappyJoinSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/store/SnappyJoinSuite.scala
@@ -23,7 +23,7 @@ import org.scalatest.BeforeAndAfterAll
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.apache.spark.sql.execution.exchange.Exchange
 import org.apache.spark.sql.execution.joins.{LocalJoin, SortMergeJoinExec}
-import org.apache.spark.sql.execution.{PartitionedPhysicalRDD, QueryExecution, RowDataSourceScanExec}
+import org.apache.spark.sql.execution.{PartitionedPhysicalScan, QueryExecution, RowDataSourceScanExec}
 import org.apache.spark.sql.{SaveMode, SnappyContext}
 
 class SnappyJoinSuite extends SnappyFunSuite with BeforeAndAfterAll {
@@ -196,7 +196,7 @@ class SnappyJoinSuite extends SnappyFunSuite with BeforeAndAfterAll {
     } else {
       lj.foreach(a => a.child.collect {
         // this means no Exhange should have child as PartitionedPhysicalRDD
-        case p: PartitionedPhysicalRDD => sys.error(
+        case p: PartitionedPhysicalScan => sys.error(
           s"Did not expect exchange with partitioned scan with same partitions")
         case p: RowDataSourceScanExec => sys.error(
           s"Did not expect RowDataSourceScanExec with PartitionedDataSourceScan")


### PR DESCRIPTION
## Changes proposed in this pull request

Avoid creation of UnsafeRow copies in generated code for row table iterators.

- in embedded mode, don't push down any projections; push down filters when there are relevant indexes as before
- optimized iterators for: a) directly using Region iteration when no projections or filters, b) on CompactExecRows when filters, c) on ResultSet directly when projections
- adding a RowTableScan plan which uses the above classes to set column variables directly (iterator either returns CompactExecRows or a resultset which is iterated)
- fixed ResultSet iteration to keep two separate variables: doMove and hasNextValue

## Patch testing

precheckin with store ongoing

## ReleaseNotes.txt changes

NA

## Other PRs 

https://github.com/SnappyDataInc/snappy-store/pull/107