### PR TITLE
Further fix for AQP-205 . The previous fix took care of the single th…

### DIFF
--- a/core/src/main/scala/org/apache/spark/sql/collection/ConcurrentSegmentedHashMap.scala
+++ b/core/src/main/scala/org/apache/spark/sql/collection/ConcurrentSegmentedHashMap.scala
@@ -225,13 +225,19 @@ private[sql] class ConcurrentSegmentedHashMap[K, V, M <: SegmentMap[K, V] : Clas
                 // need to take the latest reference of segmnet
                 //after segmnetAbort is successful
                 lock.unlock()
+                //Because two threads can concurrently call segmentAbort
+                //& is since locks are released,  there is no guarantee that
+                // one thread would correctly identify if the other has cleared
+                // the segments. So after the changeSegment, it should unconditionally
+                // refresh the segments
                 try {
-                  if (change.segmentAbort(seg)) {
+                //  if (change.segmentAbort(seg)) {
                     // break out of loop when segmentAbort returns true
                     //idx = nhashes
-                    seg = segs(i)
-                    lock = seg.writeLock()
-                  }
+                  change.segmentAbort(seg)
+                  seg = segs(i)
+                  lock = seg.writeLock()
+                //  }
                   idx += 1
 
                 } finally {

--- a/core/src/main/scala/org/apache/spark/sql/collection/ConcurrentSegmentedHashMap.scala
+++ b/core/src/main/scala/org/apache/spark/sql/collection/ConcurrentSegmentedHashMap.scala
@@ -230,19 +230,26 @@ private[sql] class ConcurrentSegmentedHashMap[K, V, M <: SegmentMap[K, V] : Clas
                 // one thread would correctly identify if the other has cleared
                 // the segments. So after the changeSegment, it should unconditionally
                 // refresh the segments
-                try {
+               // try {
                 //  if (change.segmentAbort(seg)) {
                     // break out of loop when segmentAbort returns true
                     //idx = nhashes
                   change.segmentAbort(seg)
                   seg = segs(i)
-                  lock = seg.writeLock()
+                  lock = seg.writeLock
+                  lock.lock()
+                  while(!seg.valid) {
+                    lock.unlock()
+                    seg = segs(i)
+                    lock = seg.writeLock
+                    lock.lock()
+                  }
                 //  }
                   idx += 1
 
-                } finally {
-                  lock.lock()
-                }
+               // } finally {
+                  //lock.lock()
+                //}
               }
             }
           } finally {

--- a/core/src/main/scala/org/apache/spark/sql/collection/SegmentMap.scala
+++ b/core/src/main/scala/org/apache/spark/sql/collection/SegmentMap.scala
@@ -40,6 +40,11 @@ trait SegmentMap[K, V] extends ReentrantReadWriteLock {
   def update(k: K, hash: Int, v: V): Boolean
 
   def changeValue(k: K, hash: Int, change: ChangeValue[K, V]): java.lang.Boolean
+
+  //This flag is toggled only under write lock of clear
+   var valid: Boolean = true
+
+
 }
 
 trait ChangeValue[K, V] {


### PR DESCRIPTION
Addresses the race condition where thread2 acquires the reference of a segment s1 but has not yet locked, while thread1 has just unlocked to initiate abortSegment.  Now thread1 aquires the lock on s1 & clears it ( so the segment is no longer valid).  Meanwhile thread2 ,proceeds by obtaining the lock on stale s1 & adds data to it , thus loosing the sample. 
The fix is to keep a boolean flag indicating if the seqment is valid or not & toggling it in write lock. 

(Fill in the changes here)

## Patch testing

(Fill in the details about how this patch was tested)

## ReleaseNotes.txt changes

(Does this change require an entry in ReleaseNotes.txt? If yes, has it been added to it?)

## Other PRs 

(Does this change require changes in other projects- store, spark, spark-jobserver, aqp? Add the links of PR of the other subprojects that are related to this change)

…readed scenario where the thread doing bulkValue change was calling the clear . This fix addresses the issue of multi threaded bulkValue change. Without this fix , there is a window in which thread 2 may have obtainded the reference of the segment which thread1 has just unlocked, and before thread1 is invoking the clear & hence taking all segment lock