### PR TITLE
SNAP-1035

### DIFF
--- a/core/src/main/scala/org/apache/spark/sql/execution/columnar/impl/ColumnFormatRelation.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/columnar/impl/ColumnFormatRelation.scala
@@ -38,7 +38,7 @@ import org.apache.spark.sql.row.GemFireXDDialect
 import org.apache.spark.sql.sources._
 import org.apache.spark.sql.store.{CodeGeneration, StoreUtils}
 import org.apache.spark.sql.types.StructType
-import org.apache.spark.sql.{DataFrame, Row, SQLContext, SaveMode, SnappySession}
+import org.apache.spark.sql._
 
 /**
  * This class acts as a DataSource provider for column format tables provided Snappy.
@@ -192,7 +192,12 @@ class BaseColumnFormatRelation(
       truncate()
     }
     JdbcExtendedUtils.saveTable(data, table, schema, connProperties)
-    flushRowBuffer()
+
+    SnappyContext.getClusterMode(_context.sparkContext) match {
+      case SnappyEmbeddedMode(_, _) => flushRowBuffer()
+      case LocalMode(_, _) => flushRowBuffer()
+      case _ =>
+    }
   }
 
   /**


### PR DESCRIPTION
## Changes proposed in this pull request

Disabled ColumnFormatRelation.flushRowBuffer for split mode, as no GemFireCache available on Executors

We recently added an optimization of flushing row buffer for the df.write.insertInto case, so that the remaining rows will also be flushed to column store. 
Since ColumnFormatRelation.flushLocalBuckets is executed on Executors, there won't be any GemFireCache available in split mode. 

## Patch testing

Added split mode dunit tests with df.insertInto using northwind schema 

## ReleaseNotes.txt changes

No change

## Other PRs 

No other PR
