### PR TITLE
Snap 1043

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -776,7 +776,7 @@ def runScript(def execName, def workDir, def param) {
     workingDir = workDir
     args (param)
     standardOutput = stdout
-    environment 'PYTHONPATH', "${snappyProductDir}/python/lib/py4j-0.9-src.zip:${snappyProductDir}/python"
+    environment 'PYTHONPATH', "${snappyProductDir}/python/lib/py4j-0.10.1-src.zip:${snappyProductDir}/python"
   }
   return "${stdout}"
 }
@@ -860,7 +860,7 @@ task runQuickstart {
 
       runSQLScript('create_and_load_row_table.sql', workingDir)
 
-      runSQLScript('create_and_load_sample_table.sql', workingDir)
+     /* runSQLScript('create_and_load_sample_table.sql', workingDir)
 
       runSQLScript('status_queries.sql', workingDir)
 
@@ -876,14 +876,14 @@ task runQuickstart {
           'createJob', workingDir)
 
       runSubmitQuery('io.snappydata.examples.AirlineDataJob',
-          'processjob', workingDir)
+          'processjob', workingDir)*/
 
       String startSparkResult = runScript("${snappyProductDir}/sbin/start-all.sh",
           workingDir, [])
       println startSparkResult
 
       String hostname = 'hostname'.execute().text.trim()
-      String airlineappresult = runScript("${snappyProductDir}/bin/spark-submit", workingDir,
+      /*String airlineappresult = runScript("${snappyProductDir}/bin/spark-submit", workingDir,
               ['--class', 'io.snappydata.examples.AirlineDataSparkApp', '--master', "spark://${hostname}:7077",
                '--conf', 'snappydata.store.locators=localhost:10334', '--conf', 'spark.ui.port=4041',
                "${snappyProductDir}/examples/jars/${exampleArchiveName}"])
@@ -891,13 +891,13 @@ task runQuickstart {
       println airlineappresult
       if (airlineappresult.toLowerCase().contains('exception')) {
         throw new GradleException('Failed to submit AirlineDataSparkApp')
-      }
+      }*/
 
       def examplesdir = project(":snappy-examples_${scalaBinaryVersion}")
 
       String airlinepythonappresult = runScript("${snappyProductDir}/bin/spark-submit", workingDir,
           ['--master', "spark://${hostname}:7077", '--conf', 'snappydata.store.locators=localhost:10334',
-           '--conf', 'spark.ui.port=4042', "${snappyProductDir}/python/examples/AirlineDataPythonApp.py"])
+           '--conf', 'spark.ui.port=4042', "${snappyProductDir}/quickstart/python/AirlineDataPythonApp.py"])
 
       println airlinepythonappresult
       if (airlinepythonappresult.toLowerCase().contains('exception')) {

--- a/build.gradle
+++ b/build.gradle
@@ -860,7 +860,7 @@ task runQuickstart {
 
       runSQLScript('create_and_load_row_table.sql', workingDir)
 
-     /* runSQLScript('create_and_load_sample_table.sql', workingDir)
+      runSQLScript('create_and_load_sample_table.sql', workingDir)
 
       runSQLScript('status_queries.sql', workingDir)
 
@@ -876,14 +876,14 @@ task runQuickstart {
           'createJob', workingDir)
 
       runSubmitQuery('io.snappydata.examples.AirlineDataJob',
-          'processjob', workingDir)*/
+          'processjob', workingDir)
 
       String startSparkResult = runScript("${snappyProductDir}/sbin/start-all.sh",
           workingDir, [])
       println startSparkResult
 
       String hostname = 'hostname'.execute().text.trim()
-      /*String airlineappresult = runScript("${snappyProductDir}/bin/spark-submit", workingDir,
+      String airlineappresult = runScript("${snappyProductDir}/bin/spark-submit", workingDir,
               ['--class', 'io.snappydata.examples.AirlineDataSparkApp', '--master', "spark://${hostname}:7077",
                '--conf', 'snappydata.store.locators=localhost:10334', '--conf', 'spark.ui.port=4041',
                "${snappyProductDir}/examples/jars/${exampleArchiveName}"])
@@ -891,7 +891,7 @@ task runQuickstart {
       println airlineappresult
       if (airlineappresult.toLowerCase().contains('exception')) {
         throw new GradleException('Failed to submit AirlineDataSparkApp')
-      }*/
+      }
 
       def examplesdir = project(":snappy-examples_${scalaBinaryVersion}")
 

--- a/core/src/main/scala/org/apache/spark/sql/SnappyContext.scala
+++ b/core/src/main/scala/org/apache/spark/sql/SnappyContext.scala
@@ -821,7 +821,6 @@ object SnappyContext extends Logging {
     if (_anySNContext == null) {
       _anySNContext = snc
     }
-    initMemberBlockMap(sc)
     snc
   }
 
@@ -948,6 +947,7 @@ object SnappyContext extends Logging {
           invokeServices(sc)
           sc.addSparkListener(new SparkContextListener)
           sc.ui.foreach(new SnappyStatsTab(_))
+          initMemberBlockMap(sc)
           _globalSNContextInitialized = true
         }
       }

--- a/core/src/main/scala/org/apache/spark/sql/SnappySession.scala
+++ b/core/src/main/scala/org/apache/spark/sql/SnappySession.scala
@@ -58,6 +58,10 @@ class SnappySession(@transient private val sc: SparkContext,
 
   self =>
 
+  private[sql] def this(sc: SparkContext) {
+    this(sc, None)
+  }
+
   // initialize GemFireXDDialect so that it gets registered
 
   GemFireXDDialect.init()

--- a/core/src/test/scala/io/snappydata/SnappyFunSuite.scala
+++ b/core/src/test/scala/io/snappydata/SnappyFunSuite.scala
@@ -125,9 +125,6 @@ abstract class SnappyFunSuite
     try {
       TestUtils.dropAllTables(this.snc)
     } finally {
-      if (clearStoreToBlockMap) {
-        SnappyContext.storeToBlockMap.clear()
-      }
       dirCleanup()
     }
   }

--- a/examples/src/main/python/AirlineDataPythonApp.py
+++ b/examples/src/main/python/AirlineDataPythonApp.py
@@ -7,7 +7,7 @@ from pyspark.sql.dataframe import DataFrame
 from pyspark.sql.functions import col
 import time
 import sys
-
+import exceptions
 # This application depicts how a Spark cluster can
 # connect to a Snappy cluster to fetch and query the tables
 # using Python APIs in a Spark App.
@@ -19,48 +19,22 @@ COLUMN_TABLE_NAME = "airline"
 ROW_TABLE_NAME = "airlineref"
 
 
-def main(sqlContext):
-    sqlContext.sql("set spark.sql.shuffle.partitions=6")
-    # Get the tables that were created using sql scripts via snappy-shell
-    airlineDF = sqlContext.table(COLUMN_TABLE_NAME)
-    airlineCodeDF = sqlContext.table(ROW_TABLE_NAME)
-
-    # Data Frame query :Which Airlines Arrive On Schedule? JOIN with reference table
-    colResult = airlineDF.alias('airlineDF') \
-        .join(airlineCodeDF.alias('airlineCodeDF'), col('airlineDF.UniqueCarrier') == col('airlineCodeDF.CODE')) \
-        .groupBy(col('airlineDF.UniqueCarrier'), col('airlineCodeDF.Description')) \
-        .agg({"ArrDelay": "avg"}). \
-        orderBy("avg(ArrDelay)")
-
-    print("Airline arrival schedule")
-    start = int(time.time() * 1000)
-    colResult.show()
-    totalTimeCol = int(time.time() * 1000) - start
-    print("Query time: %dms" % totalTimeCol)
-
-    # Suppose a particular Airline company say 'Delta Air Lines Inc.'
-    # re-brands itself as 'Delta America'.Update the row table.
-    query = " CODE ='DL'"
-    newColumnValues = ["Delta America Renewed"]
-    sqlContext.update(ROW_TABLE_NAME, query, newColumnValues, ["DESCRIPTION"])
-
-    # Data Frame query :Which Airlines Arrive On Schedule? JOIN with reference table
-    colResultAftUpd = airlineDF.alias('airlineDF') \
-        .join(airlineCodeDF.alias('airlineCodeDF'), col('airlineDF.UniqueCarrier') == col('airlineCodeDF.CODE')) \
-        .groupBy(col('airlineDF.UniqueCarrier'), col('airlineCodeDF.Description')) \
-        .agg({"ArrDelay": "avg"}). \
-        orderBy("avg(ArrDelay)")
-
-    print("Airline arrival schedule after Updated values:")
-
-    startColUpd = int(time.time() * 1000)
-    colResultAftUpd.show()
-    totalTimeColUpd = int(time.time() * 1000) - startColUpd
-    print("Query time:%dms" % totalTimeColUpd)
 
 if __name__ == "__main__":
     # Configure Spark
     conf = SparkConf().setAppName(APP_NAME)
     sc = SparkContext(conf=conf)
+    log4jLogger = sc._jvm.org.apache.log4j
+    LOGGER = log4jLogger.LogManager.getLogger(__name__)
+    LOGGER.info("pyspark script logger initialized")
+    print("created spark")
     snc = SnappyContext(sc)
-    main(snc)
+    print("created snappy")
+    snc.sql("set spark.sql.shuffle.partitions=6")
+    # Get the tables that were created using sql scripts via snappy-shell
+    LOGGER.info("Airline arrival schedule1")
+    airlineDF = snc.table(COLUMN_TABLE_NAME)
+
+    LOGGER.info("Airline arrival schedule2")
+    airlineCodeDF = snc.table(ROW_TABLE_NAME)
+    # main(snc, LOGGER)

--- a/examples/src/main/python/AirlineDataPythonApp.py
+++ b/examples/src/main/python/AirlineDataPythonApp.py
@@ -7,7 +7,7 @@ from pyspark.sql.dataframe import DataFrame
 from pyspark.sql.functions import col
 import time
 import sys
-import exceptions
+
 # This application depicts how a Spark cluster can
 # connect to a Snappy cluster to fetch and query the tables
 # using Python APIs in a Spark App.
@@ -19,22 +19,48 @@ COLUMN_TABLE_NAME = "airline"
 ROW_TABLE_NAME = "airlineref"
 
 
+def main(sqlContext):
+    sqlContext.sql("set spark.sql.shuffle.partitions=6")
+    # Get the tables that were created using sql scripts via snappy-shell
+    airlineDF = sqlContext.table(COLUMN_TABLE_NAME)
+    airlineCodeDF = sqlContext.table(ROW_TABLE_NAME)
+
+    # Data Frame query :Which Airlines Arrive On Schedule? JOIN with reference table
+    colResult = airlineDF.alias('airlineDF') \
+        .join(airlineCodeDF.alias('airlineCodeDF'), col('airlineDF.UniqueCarrier') == col('airlineCodeDF.CODE')) \
+        .groupBy(col('airlineDF.UniqueCarrier'), col('airlineCodeDF.Description')) \
+        .agg({"ArrDelay": "avg"}). \
+        orderBy("avg(ArrDelay)")
+
+    print("Airline arrival schedule")
+    start = int(time.time() * 1000)
+    colResult.show()
+    totalTimeCol = int(time.time() * 1000) - start
+    print("Query time: %dms" % totalTimeCol)
+
+    # Suppose a particular Airline company say 'Delta Air Lines Inc.'
+    # re-brands itself as 'Delta America'.Update the row table.
+    query = " CODE ='DL'"
+    newColumnValues = ["Delta America Renewed"]
+    sqlContext.update(ROW_TABLE_NAME, query, newColumnValues, ["DESCRIPTION"])
+
+    # Data Frame query :Which Airlines Arrive On Schedule? JOIN with reference table
+    colResultAftUpd = airlineDF.alias('airlineDF') \
+        .join(airlineCodeDF.alias('airlineCodeDF'), col('airlineDF.UniqueCarrier') == col('airlineCodeDF.CODE')) \
+        .groupBy(col('airlineDF.UniqueCarrier'), col('airlineCodeDF.Description')) \
+        .agg({"ArrDelay": "avg"}). \
+        orderBy("avg(ArrDelay)")
+
+    print("Airline arrival schedule after Updated values:")
+
+    startColUpd = int(time.time() * 1000)
+    colResultAftUpd.show()
+    totalTimeColUpd = int(time.time() * 1000) - startColUpd
+    print("Query time:%dms" % totalTimeColUpd)
 
 if __name__ == "__main__":
     # Configure Spark
     conf = SparkConf().setAppName(APP_NAME)
     sc = SparkContext(conf=conf)
-    log4jLogger = sc._jvm.org.apache.log4j
-    LOGGER = log4jLogger.LogManager.getLogger(__name__)
-    LOGGER.info("pyspark script logger initialized")
-    print("created spark")
     snc = SnappyContext(sc)
-    print("created snappy")
-    snc.sql("set spark.sql.shuffle.partitions=6")
-    # Get the tables that were created using sql scripts via snappy-shell
-    LOGGER.info("Airline arrival schedule1")
-    airlineDF = snc.table(COLUMN_TABLE_NAME)
-
-    LOGGER.info("Airline arrival schedule2")
-    airlineCodeDF = snc.table(ROW_TABLE_NAME)
-    # main(snc, LOGGER)
+    main(snc)

--- a/python/pyspark/sql/snappy/context.py
+++ b/python/pyspark/sql/snappy/context.py
@@ -52,7 +52,7 @@ class SnappyContext(SQLContext):
                             "./gradlew product ", e)
 
     def _get_snappy_ctx(self):
-        return self._jvm.SnappyContext(self.sparkSession)
+        return self._jvm.SnappyContext(self.sparkSession._jsparkSession)
 
     def createTable(self, tableName, provider=None, schema=None, allowExisting=True, **options):
         """

--- a/python/pyspark/sql/snappy/context.py
+++ b/python/pyspark/sql/snappy/context.py
@@ -17,6 +17,7 @@
 
 from py4j.protocol import Py4JError
 from pyspark.sql.context import SQLContext
+from pyspark.sql.snappy.snappysession import SnappySession
 from pyspark.sql.types import StructType
 from pyspark.sql.dataframe import DataFrame
 
@@ -31,20 +32,14 @@ class SnappyContext(SQLContext):
     """
 
     def __init__(self, sparkContext, snappyContext=None):
-        SQLContext.__init__(self, sparkContext)
+        self._sc = sparkContext
+        self._jsc = self._sc._jsc
+        self._jvm = self._sc._jvm
+        snappySession = SnappySession(sparkContext)
+        SQLContext.__init__(self, sparkContext, snappySession)
         if snappyContext:
             self._scala_SnappyContext = snappyContext
 
-    @classmethod
-    def getOrCreate(cls, sc):
-        """
-        Get the existing SnappyContext or create a new one with given SparkContext.
-        :param sc: SparkContext
-        """
-        if cls._instantiatedContext is None:
-            jsqlContext = sc._jvm.SnappyContext.getOrCreate(sc._jsc.sc())
-            cls(sc, jsqlContext)
-        return cls._instantiatedContext
 
     @property
     def _ssql_ctx(self):
@@ -57,7 +52,7 @@ class SnappyContext(SQLContext):
                             "./gradlew product ", e)
 
     def _get_snappy_ctx(self):
-        return self._jvm.SnappyContext(self._jsc.sc())
+        return self._jvm.SnappyContext(self.sparkSession)
 
     def createTable(self, tableName, provider=None, schema=None, allowExisting=True, **options):
         """

--- a/python/pyspark/sql/snappy/snappysession.py
+++ b/python/pyspark/sql/snappy/snappysession.py
@@ -1,0 +1,29 @@
+#
+# Copyright (c) 2016 SnappyData, Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you
+#
+# may not use this file except in compliance with the License. You
+# may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing
+# permissions and limitations under the License. See accompanying
+# LICENSE file.
+
+from pyspark.sql.session import SparkSession
+
+class SnappySession(SparkSession):
+
+     def __init__(self, sparkContext, jsnappySession=None):
+         """Creates a new SnappySession.
+         """
+         SparkSession.__init__(self, sparkContext)
+         if jsnappySession is None:
+            jsnappySession = self._jvm.SnappySession(self._jsc.sc())
+         self._jsparkSession = jsnappySession
+


### PR DESCRIPTION
## Changes proposed in this pull request
With the changes of SnappySession , most of the Python APIs were broken as they were directly acting on SparkSession and not on SnappySession. 
a) made changes to accommodate SnappySession related changes.
b) changed the version of p4j
c) Added a constructor in SnappySession for easy creation from Python
d) In Local mode we can initialize member block map when global SnappyContext is getting created. 

## Patch testing

precheckin

## ReleaseNotes.txt changes
NA: APIs remain the same. When we will be adding SnappySession as full fledged API , we can change the APIs and docs here. 

## Other PRs 

NA