### PR TITLE
Fix for SNAP-1049

### DIFF
--- a/core/src/main/scala/org/apache/spark/sql/collection/Utils.scala
+++ b/core/src/main/scala/org/apache/spark/sql/collection/Utils.scala
@@ -601,7 +601,7 @@ class ExecutorLocalRDD[T: ClassTag](_sc: SparkContext,
 
   override def getPartitions: Array[Partition] = {
     val numberedPeers = Utils.getAllExecutorsMemoryStatus(sparkContext).
-        keySet.zipWithIndex
+        keySet.toList.zipWithIndex
 
     if (numberedPeers.nonEmpty) {
       numberedPeers.map {

--- a/core/src/main/scala/org/apache/spark/sql/store/StoreInitRDD.scala
+++ b/core/src/main/scala/org/apache/spark/sql/store/StoreInitRDD.scala
@@ -83,7 +83,8 @@ class StoreInitRDD(@transient private val sqlContext: SQLContext,
 
   def getPeerPartitions: Array[Partition] = {
     val numberedPeers = org.apache.spark.sql.collection.Utils.
-        getAllExecutorsMemoryStatus(sqlContext.sparkContext).keySet.zipWithIndex
+        getAllExecutorsMemoryStatus(sqlContext.sparkContext)
+        .keySet.toList.zipWithIndex
 
     if (numberedPeers.nonEmpty) {
       numberedPeers.map {


### PR DESCRIPTION
## Changes proposed in this pull request

Fixing a logical bug which was showing up when the number of servers were high ( 6 or more ). The issue was in iterating the keyset of a map.

Patch from Sumedh.

Explanation from him:

The keySet.zipWithIndex will create another set which can be hashed differently from original set due to different capacities (which is why error with only some number of servers). The zipWithIndex will be an iterator on the original set assigning indexes in its iteration order, while the numberedPeers.map will be iterator on the new set that can be in different order if the capacities of the two are different. So numberedPeers.map iteration can return something like (part1, 1), (part0, 0), (part2, 2)

But then the toArray will assume it is in order and return part1 at index 0, part0 at index 1 and so on. One option can be to create an array and then place in that position like:

val partitions = new Array[Partition](numberedPeers.length)
numberedPeers.foreach { case (bid, idx) =>
  partitions(idx) = createPartition(idx, bid)
}

Using toList to order is easier and this is not performance sensitive portion of code so new list is fine.

## Patch testing

precheckin + manual testing

## ReleaseNotes.txt changes

(Does this change require an entry in ReleaseNotes.txt? If yes, has it been added to it?)

## Other PRs 


