### PR TITLE
SNAP-1113: Remove changes in primitiveType() for parsing STRING as CharType

### DIFF
--- a/cluster/src/dunit/scala/io/snappydata/cluster/StringAsVarcharDUnitTest.scala
+++ b/cluster/src/dunit/scala/io/snappydata/cluster/StringAsVarcharDUnitTest.scala
@@ -38,26 +38,47 @@ class StringAsVarcharDUnitTest(val s: String)
   val varcharSize = 20;
   val charSize = 10;
 
+  /**
+   * Test 'select *' and 'select cast(* as)' queries on a column table, without query hint.
+   */
   def testQueries(): Unit = {
     executeQuery()
   }
 
+  /**
+   * Test 'select *' and 'select cast(* as)' queries on a column table, with query hint with
+   * specific column names.
+   */
   def testQueriesWithHint(): Unit = {
     executeQuery("col_string,col_varchar")
   }
 
+  /**
+   * Test 'select *' and 'select cast(* as)' queries on a column table, with query hint '*'.
+   */
   def testQueriesWithHintAll(): Unit = {
     executeQuery("*")
   }
 
+  /**
+   * Test 'select *' and 'select cast(* as)' queries on a column table, with invalid query hint.
+   */
   def testQueriesWithInvalidHint(): Unit = {
     executeQuery("inv,lid")
   }
 
+  /**
+   * Test select query on join of row table with column table, and 'select cast(* as)' query on a
+   * column table, without query hint.
+   */
   def testJoinQuery(): Unit = {
     executeQuery("FALSE", true)
   }
 
+  /**
+   * Test select query on join of row table with column table, and 'select cast(* as)' query on a
+   * column table, with query hint '*'.
+   */
   def testJoinQueryWithHint(): Unit = {
     executeQuery("*", true)
   }
@@ -69,7 +90,7 @@ class StringAsVarcharDUnitTest(val s: String)
     vm2.invoke(classOf[ClusterManagerTestBase], "startNetServer", netPort1)
     val conn = getANetConnection(netPort1)
 
-    createTableAndInsertData(conn)
+    createTablesAndInsertData(conn)
 
     val s = conn.createStatement()
 
@@ -123,6 +144,15 @@ class StringAsVarcharDUnitTest(val s: String)
     conn.close()
   }
 
+  /**
+   * Verify the metadata of the result set.
+   *
+   * @param rs
+   * @param cols
+   * @param stringType
+   * @param tName
+   * @param join
+   */
   private def verify(rs: java.sql.ResultSet, cols: Int,
       stringType: String, tName: String, join: Boolean = false): Unit = {
     val md = rs.getMetaData
@@ -172,7 +202,13 @@ class StringAsVarcharDUnitTest(val s: String)
     assert(md.getTableName(1).equalsIgnoreCase(tName))
   }
 
-  def createTableAndInsertData(conn: Connection): Unit = {
+  /**
+   * Create a row table and a column table with five columns each. Row table has five entries while
+   * the column table has just two entries.
+   * 
+   * @param conn
+   */
+  def createTablesAndInsertData(conn: Connection): Unit = {
     val snc = SnappyContext(sc)
 
     snc.sql(s"create table $rowTab1 (col_int int, col_string string, " +

--- a/cluster/src/dunit/scala/io/snappydata/cluster/StringAsVarcharDUnitTest.scala
+++ b/cluster/src/dunit/scala/io/snappydata/cluster/StringAsVarcharDUnitTest.scala
@@ -111,6 +111,14 @@ class StringAsVarcharDUnitTest(val s: String)
         }
       }
     }
+    s.executeQuery(s"select cast(col_int as string), cast(col_string as clob), " +
+        s"cast(col_char as varchar(100)) from $colTab1 $affix")
+    val rSet = s.getResultSet
+    var count = 0
+    while (rSet.next()) {
+      count += 1
+    }
+    assert(count == 2)
 
     conn.close()
   }

--- a/core/src/main/scala/org/apache/spark/sql/SnappyBaseParser.scala
+++ b/core/src/main/scala/org/apache/spark/sql/SnappyBaseParser.scala
@@ -190,8 +190,7 @@ abstract class SnappyBaseParser(session: SnappySession) extends Parser {
   }
 
   protected final def primitiveType: Rule1[DataType] = rule {
-    STRING ~> (() =>
-      CharType(Constant.MAX_VARCHAR_SIZE, baseType = "STRING")) |
+    STRING ~> (() => StringType) |
     INTEGER ~> (() => IntegerType) |
     INT ~> (() => IntegerType) |
     BIGINT ~> (() => LongType) |
@@ -226,30 +225,17 @@ abstract class SnappyBaseParser(session: SnappySession) extends Parser {
 
   protected final def arrayType: Rule1[DataType] = rule {
     ARRAY ~ '<' ~ ws ~ dataType ~ '>' ~ ws ~>
-        ((t: DataType) => t match {
-          case CharType(size, baseType) => ArrayType(StringType)
-          case _ => ArrayType(t)
-        })
+        ((t: DataType) => ArrayType(t))
   }
 
   protected final def mapType: Rule1[DataType] = rule {
     MAP ~ '<' ~ ws ~ dataType ~ commaSep ~ dataType ~ '>' ~ ws ~>
-        ((t1: DataType, t2: DataType) =>
-        (t1, t2) match {
-          case (CharType(size1, baseType1), CharType(size2, baseType2)) =>
-            MapType(StringType, StringType)
-          case (CharType(size, baseType), t2) => MapType(StringType, t2)
-          case (t1, CharType(size, baseType)) => MapType(t1, StringType)
-          case (t1, t2) => MapType(t1, t2)
-        })
+        ((t1: DataType, t2: DataType) => MapType(t1, t2))
   }
 
   protected final def structField: Rule1[StructField] = rule {
-    identifier ~ ':' ~ ws ~ dataType ~> ((name: String, t: DataType) => t match {
-      case CharType(size, baseType) =>
-        StructField(name, StringType, nullable = true)
-      case _ => StructField(name, t, nullable = true)
-    })
+    identifier ~ ':' ~ ws ~ dataType ~> ((name: String, t: DataType) =>
+      StructField(name, t, nullable = true))
   }
 
   protected final def structType: Rule1[DataType] = rule {
@@ -261,7 +247,8 @@ abstract class SnappyBaseParser(session: SnappySession) extends Parser {
     VARCHAR ~ '(' ~ ws ~ digits ~ ')' ~ ws ~> ((d: String) =>
       CharType(d.toInt, baseType = "VARCHAR")) |
     CHAR ~ '(' ~ ws ~ digits ~ ')' ~ ws ~> ((d: String) =>
-      CharType(d.toInt, baseType = "CHAR"))
+      CharType(d.toInt, baseType = "CHAR")) |
+    STRING ~> (() => CharType(Constant.MAX_VARCHAR_SIZE, baseType = "STRING"))
   }
 
   final def columnDataType: Rule1[DataType] = rule {


### PR DESCRIPTION
## Changes proposed in this pull request
* Remove changes in primitiveType() which were parsing STRING as CharType instead of StringType.
* Instead do it in columnCharType() which affects only the snappy DDL path.

## Patch testing
* Ran precheckin -Pspark. No new failures.

## ReleaseNotes.txt changes
(Does this change require an entry in ReleaseNotes.txt? If yes, has it been added to it?)

## Other PRs 
NA