### PR TITLE
[AQP-252] Fix for AQP-252 to allow reservior to be flushed before clu…

### DIFF
--- a/cluster/src/main/scala/io/snappydata/impl/LeadImpl.scala
+++ b/cluster/src/main/scala/io/snappydata/impl/LeadImpl.scala
@@ -234,6 +234,7 @@ class LeadImpl extends ServerImpl with Lead with Logging {
 
   @throws[SQLException]
   override def stop(shutdownCredentials: Properties): Unit = {
+    SnappyContext.flushSampleTables();
     assert(sparkContext != null, "Mix and match of LeadService api " +
         "and SparkContext is unsupported.")
     if (!sparkContext.isStopped) {

--- a/core/src/main/scala/org/apache/spark/sql/SnappyContext.scala
+++ b/core/src/main/scala/org/apache/spark/sql/SnappyContext.scala
@@ -17,6 +17,7 @@
 package org.apache.spark.sql
 
 import java.io.{Externalizable, ObjectInput, ObjectOutput}
+import java.lang.reflect.Method
 
 import scala.collection.JavaConverters._
 import scala.collection.concurrent.TrieMap
@@ -40,8 +41,9 @@ import org.apache.spark.sql.execution.datasources.CaseInsensitiveMap
 import org.apache.spark.sql.execution.datasources.csv.CSVFileFormat
 import org.apache.spark.sql.execution.joins.HashedRelationCache
 import org.apache.spark.sql.execution.ui.SnappyStatsTab
-import org.apache.spark.sql.hive.{QualifiedTableName, SnappyStoreHiveCatalog}
+import org.apache.spark.sql.hive.{ExternalTableType, QualifiedTableName, SnappyStoreHiveCatalog}
 import org.apache.spark.sql.internal.SnappySessionState
+import org.apache.spark.sql.sources.SamplingRelation
 import org.apache.spark.sql.store.CodeGeneration
 import org.apache.spark.sql.streaming._
 import org.apache.spark.sql.types.StructType
@@ -1056,6 +1058,20 @@ object SnappyContext extends Logging {
     builtinSources.getOrElse(providerName,
       if (onlyBuiltIn) throw new AnalysisException(
         s"Failed to find a builtin provider $providerName") else providerName)
+  }
+
+
+  def flushSampleTables(): Unit = {
+    val sampleRelations = _anySNContext.sessionState.catalog.
+    getDataSourceRelations[AnyRef](Seq(ExternalTableType.Sample),None)
+    val clazz = org.apache.spark.util.Utils.classForName(
+      "org.apache.spark.sql.sampling.ColumnFormatSamplingRelation")
+    val method: Method = clazz.getDeclaredMethod("flushReservior")
+    println(sampleRelations.size)
+    for (s <- sampleRelations) {
+      method.invoke(s)
+    }
+
   }
 }
 

--- a/core/src/main/scala/org/apache/spark/sql/SnappyContext.scala
+++ b/core/src/main/scala/org/apache/spark/sql/SnappyContext.scala
@@ -1063,12 +1063,12 @@ object SnappyContext extends Logging {
 
   def flushSampleTables(): Unit = {
     val sampleRelations = _anySNContext.sessionState.catalog.
-    getDataSourceRelations[AnyRef](Seq(ExternalTableType.Sample),None)
+      getDataSourceRelations[AnyRef](Seq(ExternalTableType.Sample), None)
     val clazz = org.apache.spark.util.Utils.classForName(
       "org.apache.spark.sql.sampling.ColumnFormatSamplingRelation")
     val method: Method = clazz.getDeclaredMethod("flushReservior")
-    println(sampleRelations.size)
     for (s <- sampleRelations) {
+      method.setAccessible(true)
       method.invoke(s)
     }
 


### PR DESCRIPTION
## Changes proposed in this pull request
* Flush Reservior data of all sample tables before cluster shutdonw

## Patch testing
* Ran precheckin some tests related to streaming failed but were not related to this patch
* Manually tested 

## ReleaseNotes.txt changes

(Does this change require an entry in ReleaseNotes.txt? If yes, has it been added to it?)
 No
## Other PRs 


…ster stops