### PR TITLE
[SNAP-977] Fix for SNAP-977 to allow used to specify configuration on…

### DIFF
--- a/cluster/bin/snappy-job.sh
+++ b/cluster/bin/snappy-job.sh
@@ -21,9 +21,9 @@
 
 usage=$'Usage: 
        # Create a new context using the provided context factory
-       snappy-job.sh newcontext <context-name> --factory <factory class name> [--lead <hostname:port>] [--app-jar <jar-path> --app-name <app-name>]
+       snappy-job.sh newcontext <context-name> --factory <factory class name> [--lead <hostname:port>] [--app-jar <jar-path> --app-name <app-name>] [--conf <property=value>]
        # Submit a job, optionally with a provided context or create a streaming-context and use it with the job
-       snappy-job.sh submit --lead <hostname:port> --app-name <app-name> --class <job-class> [--app-jar <jar-path>] [--context <context-name> | --stream]
+       snappy-job.sh submit --lead <hostname:port> --app-name <app-name> --class <job-class> [--app-jar <jar-path>] [--context <context-name> | --stream] [--conf <property=value>]
        # Get status of the job with the given job-id
        snappy-job.sh status --lead <hostname:port> --job-id <job-id>
        # Stop a job with the given job-id
@@ -48,6 +48,7 @@ contextName=
 contextFactory=
 newContext=
 TOK_EMPTY="EMPTY"
+APP_PROPS=$APP_PROPS
 
 while (( "$#" )); do
   param="$1"
@@ -93,6 +94,14 @@ while (( "$#" )); do
     --context)
       shift
       contextName="${1:-$TOK_EMPTY}"
+    ;;
+    --conf)
+      shift
+      if [[ -z "$APP_PROPS" ]]; then
+        APP_PROPS="${1:-$TOK_EMPTY}"
+      else
+        APP_PROPS=$APP_PROPS",""${1:-$TOK_EMPTY}"
+      fi
     ;;
     --stream)
       if [[ $contextName != "" || $cmd != "jobs" ]]; then

--- a/tests/benchmark/snappy/3_createAndLoadTable.sh
+++ b/tests/benchmark/snappy/3_createAndLoadTable.sh
@@ -2,9 +2,8 @@
 source PerfRun.conf
 
 #export APP_PROPS="dataLocation=$dataDir,Buckets_Order_Lineitem=$buckets_Order_Lineitem,Buckets_Cust_Part_PartSupp=$buckets_Cust_Part_PartSupp,useIndex=$UseIndex"
-export APP_PROPS="dataLocation=$dataDir,Buckets_Order_Lineitem=$buckets_Order_Lineitem,Buckets_Cust_Part_PartSupp=$buckets_Cust_Part_PartSupp,useIndex=$UseIndex,Buckets_Nation_Region_Supp=$buckets_Nation_Region_Supp,Nation_Region_Supp_col=$Nation_Region_Supp_col"
 
 echo "******************start Creating Table******************"
-. $SnappyData/bin/snappy-job.sh submit --lead $leads:8090 --app-name TableCreation --class io.snappydata.benchmark.snappy.TPCH_Snappy_Tables --app-jar $TPCHJar
+. $SnappyData/bin/snappy-job.sh submit --lead $leads:8090 --app-name TableCreation --class io.snappydata.benchmark.snappy.TPCH_Snappy_Tables --app-jar $TPCHJar --conf dataLocation=$dataDir --conf Buckets_Order_Lineitem=$buckets_Order_Lineitem --conf Buckets_Cust_Part_PartSupp=$buckets_Cust_Part_PartSupp --conf useIndex=$UseIndex --conf Buckets_Nation_Region_Supp=$buckets_Nation_Region_Supp --conf Nation_Region_Supp_col=$Nation_Region_Supp_col
 
 #. $SnappyData/bin/snappy-job.sh submit --lead localhost:8090 --app-name myapp --class io.snappydata.cluster.Cluster_TPCH_Snappy_Tables --app-jar $TPCHJar

--- a/tests/benchmark/snappy/5_executeQuery.sh
+++ b/tests/benchmark/snappy/5_executeQuery.sh
@@ -4,10 +4,9 @@ source PerfRun.conf
 #rm -rf $SnappyData/work/$leads-lead-1/*.out
 #> $SnappyData/work/$leads-lead-1/Average.out
 #export APP_PROPS="queries=$queries,queryPlan=$queryPlan,sparkSqlProps=$sparkSqlProperties,useIndex=$UseIndex"
-export APP_PROPS="queries=$queries,sparkSqlProps=$sparkSqlProperties,useIndex=$UseIndex,resultCollection=$ResultCollection,warmUpIterations=$WarmupRuns,actualRuns=$AverageRuns"
 
 echo "******************start Executing Query******************"
-. $SnappyData/bin/snappy-job.sh submit --lead $leads:8090 --app-name QueryExecution --class io.snappydata.benchmark.snappy.TPCH_Snappy_Query --app-jar $TPCHJar
+. $SnappyData/bin/snappy-job.sh submit --lead $leads:8090 --app-name QueryExecution --class io.snappydata.benchmark.snappy.TPCH_Snappy_Query --app-jar $TPCHJar --conf queries=$queries --conf sparkSqlProps=$sparkSqlProperties --conf useIndex=$UseIndex --conf resultCollection=$ResultCollection --conf warmUpIterations=$WarmupRuns --conf actualRuns=$AverageRuns
 
 #. $SnappyData/bin/snappy-job.sh submit --lead localhost:8090 --app-name myapp --class io.snappydata.cluster.Cluster_TPCH_Snappy_Query --app-jar $TPCHJar
 


### PR DESCRIPTION
## Changes proposed in this pull request
* Changes to allow user to specify job configuration in command line while submitting job.The previous behavior is also kept as is i.e using APP_PROPS env variable 

## Patch testing
* Ran precheckin some test failed but were not related to this change
* Manual Testing is also done

## ReleaseNotes.txt changes

(Does this change require an entry in ReleaseNotes.txt? If yes, has it been added to it?) 

## Other PRs 

(Does this change require changes in other projects- store, spark, spark-jobserver, aqp? Add the links of PR of the other subprojects that are related to this change) NA

… commandline while submitting job