### PR TITLE
Fix the test for serialization issue.

### DIFF
--- a/core/src/main/scala/io/snappydata/SnappyTableStatsProviderService.scala
+++ b/core/src/main/scala/io/snappydata/SnappyTableStatsProviderService.scala
@@ -105,7 +105,7 @@ object SnappyTableStatsProviderService extends Logging {
   def getAggregatedTableStatsOnDemand(sc: SparkContext):
   Map[String, SnappyRegionStats] = {
     val serverStats = getTableStatsFromAllServers
-    val aggregatedStats = collection.mutable.Map[String, SnappyRegionStats]()
+    val aggregatedStats = scala.collection.mutable.Map[String, SnappyRegionStats]()
     val snc = SnappyContext(sc)
     val samples = getSampleTableList(snc)
     serverStats.foreach(stat => {


### PR DESCRIPTION
## Changes proposed in this pull request
SnappyRegionStat is not serializable anymore. Fixed the test so that it does not create an RDD of SnappyRegionStat for test verifacation purpose

## Patch testing
executed the SnappyRegionStat DUnit test

## ReleaseNotes.txt changes

(Does this change require an entry in ReleaseNotes.txt? If yes, has it been added to it?)

## Other PRs 
yes.
https://github.com/SnappyDataInc/snappy-store/pull/121
(Does this change require changes in other projects- store, spark, spark-jobserver, aqp? Add the links of PR of the other subprojects that are related to this change)

