### PR TITLE
Put a check to avoid flusing sample reservoir if no datastore is pres…

### DIFF
--- a/cluster/src/main/scala/io/snappydata/impl/LeadImpl.scala
+++ b/cluster/src/main/scala/io/snappydata/impl/LeadImpl.scala
@@ -29,6 +29,7 @@ import com.gemstone.gemfire.distributed.internal.DistributionConfig
 import com.gemstone.gemfire.distributed.internal.locks.{DLockService, DistributedMemberLock}
 import com.gemstone.gemfire.internal.cache.GemFireCacheImpl
 import com.pivotal.gemfirexd.FabricService.State
+import com.pivotal.gemfirexd.internal.engine.distributed.utils.GemFireXDUtils
 import com.pivotal.gemfirexd.internal.engine.store.ServerGroupUtils
 import com.pivotal.gemfirexd.{FabricService, NetworkInterface}
 import com.typesafe.config.{Config, ConfigFactory}
@@ -234,7 +235,10 @@ class LeadImpl extends ServerImpl with Lead with Logging {
 
   @throws[SQLException]
   override def stop(shutdownCredentials: Properties): Unit = {
-    SnappyContext.flushSampleTables();
+    val servers = GemFireXDUtils.getGfxdAdvisor.adviseDataStores(null)
+    if (servers.size() > 0) {
+      SnappyContext.flushSampleTables();
+    }
     assert(sparkContext != null, "Mix and match of LeadService api " +
         "and SparkContext is unsupported.")
     if (!sparkContext.isStopped) {


### PR DESCRIPTION
## Changes proposed in this pull request

 Put a check to avoid flushing sample reservoir if no datastore is present.

## Patch testing

Have been tested by pre-checkin in merge branch.
ran cluster scala test .

## ReleaseNotes.txt changes

NA

## Other PRs 

NA