### PR TITLE
Snap 1154

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -585,7 +585,7 @@ task product(type: Zip) {
     def coreProject = project(":snappy-core_${scalaBinaryVersion}")
     def examplesProject = project(":snappy-examples_${scalaBinaryVersion}")
     String coreName = "snappydata-core_${scalaBinaryVersion}-${version}.jar"
-    String exampleArchiveName = "quickstart-${version}.jar"
+    String exampleArchiveName = "quickstart.jar"
 
     // copy all runtime dependencies of snappy-cluster, itself and AQP
     copy {
@@ -812,7 +812,7 @@ def writeToFile(def fileName) {
 
 def runSubmitQuery(def jobName, def appName, def workDir) {
   println "Running job ${jobName}"
-  String exampleArchiveName = "quickstart-${version}.jar"
+  String exampleArchiveName = "quickstart.jar"
   String submitjobairline = runScript("${snappyProductDir}/bin/snappy-job.sh", workDir,
       ['submit', '--lead', 'localhost:8090', '--app-name', appName + System.currentTimeMillis(),
        '--class', jobName, '--app-jar',
@@ -858,7 +858,7 @@ task runQuickstart {
   dependsOn cleanQuickstart
   dependsOn product
   mustRunAfter 'buildAll'
-  def exampleArchiveName = "quickstart-${version}.jar"
+  def exampleArchiveName = "quickstart.jar"
   String workingDir = "${testResultsBase}/quickstart"
   doLast {
     try {

--- a/examples/build.gradle
+++ b/examples/build.gradle
@@ -50,7 +50,7 @@ task productExamples(dependsOn: 'jar') << {
 
   def productDir = file("${rootProject.buildDir}/snappy")
   productDir.mkdirs()
-  def exampleArchiveName = "quickstart-${version}.jar"
+  def exampleArchiveName = "quickstart.jar"
   copy {
     from "${project.buildDir}/libs"
     into "${productDir}/lib"

--- a/examples/quickstart/scripts/run-streaming-example
+++ b/examples/quickstart/scripts/run-streaming-example
@@ -45,7 +45,7 @@ fi
 JAR_PATH="${SPARK_PREFIX}/lib"
 
 JAR_COUNT=0
-for f in "${JAR_PATH}"/quickstart-*.jar; do
+for f in "${JAR_PATH}"/quickstart.jar; do
   if [[ ! -e "$f" ]]; then
     echo "Failed to find snappy examples assembly in ${SPARK_PREFIX}/lib" 1>&2
     echo "You need to build snappydata before running this program" 1>&2
@@ -57,7 +57,7 @@ done
 
 if [ "$JAR_COUNT" -gt "1" ]; then
   echo "Found multiple snappy examples assembly jars in ${JAR_PATH}" 1>&2
-  ls "${JAR_PATH}"/quickstart-*.jar 1>&2
+  ls "${JAR_PATH}"/quickstart.jar 1>&2
   echo "Please remove all but one jar." 1>&2
   exit 1
 fi

--- a/examples/src/main/java/io/snappydata/examples/JavaAirlineDataJob.java
+++ b/examples/src/main/java/io/snappydata/examples/JavaAirlineDataJob.java
@@ -16,11 +16,23 @@ import org.apache.spark.sql.types.StructType;
 /**
  * Creates and loads Airline data from parquet files in row and column
  * tables. Also samples the data and stores it in a column table.
+ *
+ *
+ * Run this on your local machine:
+ * Start snappy cluster
+ * `$ sbin/snappy-start-all.sh`
+ * Start spark cluster
+ * `$ sbin/start-all.sh`
+ *
+ * `$./bin/spark-submit --class io.snappydata.examples.JavaAirlineDataJob \
+ * --master spark://<hostname>:7077 --conf snappydata.store.locators=localhost:10334 \
+ * $SNAPPY_HOME/examples/jars/quickstart.jar`
+ *
  */
 public class JavaAirlineDataJob {
 
-  private static String airlinefilePath = "examples/quickstart/data/airlineParquetData";
-  private static String airlinereftablefilePath = "examples/quickstart/data/airportcodeParquetData";
+  private static String airlinefilePath = "quickstart/data/airlineParquetData";
+  private static String airlinereftablefilePath = "quickstart/data/airportcodeParquetData";
   private static final String colTable = "AIRLINE";
   private static final String rowTable = "AIRLINEREF";
   private static final String sampleTable = "AIRLINE_SAMPLE";
@@ -54,7 +66,7 @@ public class JavaAirlineDataJob {
 
     // Populate the table in snappy store
     airlineDF.write().mode(SaveMode.Append).saveAsTable(colTable);
-    System.out.println("Created and imported data in $colTable table.");
+    System.out.println("Created and imported data in " + colTable + " table.");
 
     // Create a DF from the airline ref data file
     Dataset<Row> airlinerefDF = snc.read().load(airlinereftablefilePath);
@@ -70,7 +82,7 @@ public class JavaAirlineDataJob {
 
     // Create a sample table sampling parameters.
     options.clear();
-    options.put("buckets", "7");
+    options.put("buckets", "11");
     options.put("qcs", "UniqueCarrier, Year_, Month_");
     options.put("fraction", "0.03");
     options.put("strataReservoirSize", "50");

--- a/examples/src/main/java/io/snappydata/examples/JavaAirlineDataJob.java
+++ b/examples/src/main/java/io/snappydata/examples/JavaAirlineDataJob.java
@@ -1,8 +1,3 @@
-
-/*  CURRENTLY THERE IS NO SUPPORT FOR QUERIES ON SAMPLING TABLE IN SPLIT MODE.(AQP-257)
- *  NOT SUPPORTED FOR NOW.
- */
-
 package io.snappydata.examples;
 
 import java.util.Collections;
@@ -19,6 +14,10 @@ import org.apache.spark.sql.types.StructField;
 import org.apache.spark.sql.types.StructType;
 
 /**
+ * NOTE :
+ * CURRENTLY THERE IS NO SUPPORT FOR QUERIES ON SAMPLING TABLE IN SPLIT MODE.(AQP-257)
+ * NOT SUPPORTED FOR NOW.
+ *
  * Creates and loads Airline data from parquet files in row and column
  * tables. Also samples the data and stores it in a column table.
  *
@@ -26,11 +25,11 @@ import org.apache.spark.sql.types.StructType;
  * Run this on your local machine:
  * <p/>
  * Start snappy cluster
- * <p/>
+ *
  * `$ sbin/snappy-start-all.sh`
  * <p/>
  * Start spark cluster
- * <p/>
+ *
  * `$ sbin/start-all.sh`
  * <p/>
  * `$./bin/spark-submit --class io.snappydata.examples.JavaAirlineDataJob \

--- a/examples/src/main/java/io/snappydata/examples/JavaAirlineDataJob.java
+++ b/examples/src/main/java/io/snappydata/examples/JavaAirlineDataJob.java
@@ -1,3 +1,8 @@
+
+/*  CURRENTLY THERE IS NO SUPPORT FOR QUERIES ON SAMPLING TABLE IN SPLIT MODE.(AQP-257)
+ *  NOT SUPPORTED FOR NOW.
+ */
+
 package io.snappydata.examples;
 
 import java.util.Collections;

--- a/examples/src/main/java/io/snappydata/examples/JavaAirlineDataJob.java
+++ b/examples/src/main/java/io/snappydata/examples/JavaAirlineDataJob.java
@@ -19,16 +19,21 @@ import org.apache.spark.sql.types.StructType;
  *
  *
  * Run this on your local machine:
+ * <p/>
  * Start snappy cluster
+ * <p/>
  * `$ sbin/snappy-start-all.sh`
+ * <p/>
  * Start spark cluster
+ * <p/>
  * `$ sbin/start-all.sh`
- *
+ * <p/>
  * `$./bin/spark-submit --class io.snappydata.examples.JavaAirlineDataJob \
  * --master spark://<hostname>:7077 --conf snappydata.store.locators=localhost:10334 \
  * $SNAPPY_HOME/examples/jars/quickstart.jar`
  *
  */
+
 public class JavaAirlineDataJob {
 
   private static String airlinefilePath = "quickstart/data/airlineParquetData";
@@ -82,7 +87,7 @@ public class JavaAirlineDataJob {
 
     // Create a sample table sampling parameters.
     options.clear();
-    options.put("buckets", "11");
+    options.put("buckets", "7");
     options.put("qcs", "UniqueCarrier, Year_, Month_");
     options.put("fraction", "0.03");
     options.put("strataReservoirSize", "50");

--- a/examples/src/main/java/io/snappydata/examples/JavaCreateAndLoadAirlineDataJob.java
+++ b/examples/src/main/java/io/snappydata/examples/JavaCreateAndLoadAirlineDataJob.java
@@ -15,7 +15,21 @@ import org.apache.spark.sql.types.StructType;
 /**
  * Creates and loads Airline data from parquet files in row and column
  * tables. Also samples the data and stores it in a column table.
+ *
+ *
+ * Run this on your local machine:
+ * <p/>
+ * `$ sbin/snappy-start-all.sh`
+ * <p/>
+ *
+ * <p/>
+ * `$ ./bin/snappy-job.sh submit --lead localhost:8090 \
+ * --app-name JavaCreateAndLoadAirlineDataJob --class io.snappydata.examples.JavaCreateAndLoadAirlineDataJob \
+ * --app-jar $SNAPPY_HOME/examples/jars/quickstart.jar`
+ * <p/>
  */
+
+
 public class JavaCreateAndLoadAirlineDataJob extends JavaSnappySQLJob {
 
   private String airlinefilePath = null;

--- a/examples/src/main/java/io/snappydata/examples/JavaCreateAndLoadAirlineDataJob.java
+++ b/examples/src/main/java/io/snappydata/examples/JavaCreateAndLoadAirlineDataJob.java
@@ -21,12 +21,9 @@ import org.apache.spark.sql.types.StructType;
  * <p/>
  * `$ sbin/snappy-start-all.sh`
  * <p/>
- *
- * <p/>
  * `$ ./bin/snappy-job.sh submit --lead localhost:8090 \
  * --app-name JavaCreateAndLoadAirlineDataJob --class io.snappydata.examples.JavaCreateAndLoadAirlineDataJob \
  * --app-jar $SNAPPY_HOME/examples/jars/quickstart.jar`
- * <p/>
  */
 
 

--- a/examples/src/main/java/io/snappydata/examples/JavaTwitterPopularTagsJob.java
+++ b/examples/src/main/java/io/snappydata/examples/JavaTwitterPopularTagsJob.java
@@ -32,7 +32,7 @@ import static org.apache.spark.sql.types.DataTypes.createStructField;
  * <p/>
  * `$ ./bin/snappy-job.sh submit --lead localhost:8090 \
  * --app-name JavaTwitterPopularTagsJob --class io.snappydata.examples.JavaTwitterPopularTagsJob \
- * --app-jar $SNAPPY_HOME/lib/quickstart-0.1.0-SNAPSHOT.jar --stream`
+ * --app-jar $SNAPPY_HOME/examples/jars/quickstart.jar --stream`
  * <p/>
  * To run with stored twitter data, run simulateTwitterStream after the Job is submitted:
  * `$ ./quickstart/scripts/simulateTwitterStream`

--- a/examples/src/main/scala/io/snappydata/examples/AirlineDataJob.scala
+++ b/examples/src/main/scala/io/snappydata/examples/AirlineDataJob.scala
@@ -32,7 +32,22 @@ import org.apache.spark.sql.{SnappyJobValid, DataFrame, SnappyContext, SnappyJob
  * comparison. Sample airline table and persist it in Snappy store.
  * Run a aggregate query on all the three tables and return the results in
  * a Map.This Map will be sent over REST.
+ *
+ * Run this on your local machine:
+ * `$ sbin/snappy-start-all.sh`
+ *
+ * Create tables
+ * `$ ./bin/snappy-job.sh submit --lead localhost:8090 \
+ * --app-name CreateAndLoadAirlineDataJob --class io.snappydata.examples.CreateAndLoadAirlineDataJob \
+ * --app-jar $SNAPPY_HOME/examples/jars/quickstart.jar`
+ *
+ *
+ *  `$ ./bin/snappy-job.sh submit --lead localhost:8090 \
+ * --app-name AirlineDataJob --class io.snappydata.examples.AirlineDataJob \
+ * --app-jar $SNAPPY_HOME/examples/jars/quickstart.jar`
+ *
  */
+
 object AirlineDataJob extends SnappySQLJob {
 
   override def runSnappyJob(snc: SnappyContext, jobConfig: Config): Any = {

--- a/examples/src/main/scala/io/snappydata/examples/AirlineDataJob.scala
+++ b/examples/src/main/scala/io/snappydata/examples/AirlineDataJob.scala
@@ -34,15 +34,17 @@ import org.apache.spark.sql.{SnappyJobValid, DataFrame, SnappyContext, SnappyJob
  * a Map.This Map will be sent over REST.
  *
  * Run this on your local machine:
+ * <p/>
  * `$ sbin/snappy-start-all.sh`
- *
+ * <p/>
  * Create tables
+ *
  * `$ ./bin/snappy-job.sh submit --lead localhost:8090 \
  * --app-name CreateAndLoadAirlineDataJob --class io.snappydata.examples.CreateAndLoadAirlineDataJob \
  * --app-jar $SNAPPY_HOME/examples/jars/quickstart.jar`
  *
  *
- *  `$ ./bin/snappy-job.sh submit --lead localhost:8090 \
+ * `$ ./bin/snappy-job.sh submit --lead localhost:8090 \
  * --app-name AirlineDataJob --class io.snappydata.examples.AirlineDataJob \
  * --app-jar $SNAPPY_HOME/examples/jars/quickstart.jar`
  *

--- a/examples/src/main/scala/io/snappydata/examples/AirlineDataSparkApp.scala
+++ b/examples/src/main/scala/io/snappydata/examples/AirlineDataSparkApp.scala
@@ -26,17 +26,22 @@ import org.apache.spark.{SparkContext, SparkConf}
  * using Scala APIs in a Spark App.
  *
  * Run this on your local machine:
+ * <p/>
  * Start snappy cluster
- * `$ sbin/snappy-start-all.sh`
- * Start spark cluster
- * `$ sbin/start-all.sh`
  *
+ * `$ sbin/snappy-start-all.sh`
+ * <p/>
+ * Start spark cluster
+ *
+ * `$ sbin/start-all.sh`
+ * <p/>
  * Create tables
+ *
  * `$ ./bin/snappy-job.sh submit --lead localhost:8090 \
  * --app-name CreateAndLoadAirlineDataJob --class io.snappydata.examples.CreateAndLoadAirlineDataJob \
  * --app-jar $SNAPPY_HOME/examples/jars/quickstart.jar`
  *
- *
+ * <p/>
  * `$ ./bin/spark-submit --class io.snappydata.examples.AirlineDataSparkApp \
  * --master spark://<hostname>:7077 --conf snappydata.store.locators=localhost:10334 \
  * $SNAPPY_HOME/examples/jars/quickstart.jar`

--- a/examples/src/main/scala/io/snappydata/examples/AirlineDataSparkApp.scala
+++ b/examples/src/main/scala/io/snappydata/examples/AirlineDataSparkApp.scala
@@ -24,6 +24,24 @@ import org.apache.spark.{SparkContext, SparkConf}
  * This application depicts how a Spark cluster can
  * connect to a Snappy cluster to fetch and query the tables
  * using Scala APIs in a Spark App.
+ *
+ * Run this on your local machine:
+ * Start snappy cluster
+ * `$ sbin/snappy-start-all.sh`
+ * Start spark cluster
+ * `$ sbin/start-all.sh`
+ *
+ * Create tables
+ * `$ ./bin/snappy-job.sh submit --lead localhost:8090 \
+ * --app-name CreateAndLoadAirlineDataJob --class io.snappydata.examples.CreateAndLoadAirlineDataJob \
+ * --app-jar $SNAPPY_HOME/examples/jars/quickstart.jar`
+ *
+ *
+ * `$ ./bin/spark-submit --class io.snappydata.examples.AirlineDataSparkApp \
+ * --master spark://<hostname>:7077 --conf snappydata.store.locators=localhost:10334 \
+ * $SNAPPY_HOME/examples/jars/quickstart.jar`
+ *
+ *
  */
 object AirlineDataSparkApp {
 

--- a/examples/src/main/scala/io/snappydata/examples/CreateAndLoadAirlineDataJob.scala
+++ b/examples/src/main/scala/io/snappydata/examples/CreateAndLoadAirlineDataJob.scala
@@ -29,14 +29,14 @@ import org.apache.spark.sql.{SaveMode, SnappyContext, SnappyJobInvalid, SnappyJo
 /**
  * Creates and loads Airline data from parquet files in row and column
  * tables. Also samples the data and stores it in a column table.
- *
+ * <p/>
  * Run this on your local machine:
- * `$ sbin/snappy-start-all.sh`
  *
+ * `$ sbin/snappy-start-all.sh`
+ * <p/>
  * `$ ./bin/snappy-job.sh submit --lead localhost:8090 \
  * --app-name CreateAndLoadAirlineDataJob --class io.snappydata.examples.CreateAndLoadAirlineDataJob \
  * --app-jar $SNAPPY_HOME/examples/jars/quickstart.jar`
- *
  *
  */
 object CreateAndLoadAirlineDataJob extends SnappySQLJob {

--- a/examples/src/main/scala/io/snappydata/examples/CreateAndLoadAirlineDataJob.scala
+++ b/examples/src/main/scala/io/snappydata/examples/CreateAndLoadAirlineDataJob.scala
@@ -29,6 +29,15 @@ import org.apache.spark.sql.{SaveMode, SnappyContext, SnappyJobInvalid, SnappyJo
 /**
  * Creates and loads Airline data from parquet files in row and column
  * tables. Also samples the data and stores it in a column table.
+ *
+ * Run this on your local machine:
+ * `$ sbin/snappy-start-all.sh`
+ *
+ * `$ ./bin/snappy-job.sh submit --lead localhost:8090 \
+ * --app-name CreateAndLoadAirlineDataJob --class io.snappydata.examples.CreateAndLoadAirlineDataJob \
+ * --app-jar $SNAPPY_HOME/examples/jars/quickstart.jar`
+ *
+ *
  */
 object CreateAndLoadAirlineDataJob extends SnappySQLJob {
 

--- a/examples/src/main/scala/io/snappydata/examples/TwitterPopularTagsJob.scala
+++ b/examples/src/main/scala/io/snappydata/examples/TwitterPopularTagsJob.scala
@@ -29,18 +29,21 @@ import org.apache.spark.streaming.dstream.DStream
 
 /**
  * Run this on your local machine:
- *
+ * <p/>
  * `$ sbin/snappy-start-all.sh`
- *
+ * <p/>
  * To run with live twitter streaming, export twitter credentials
+ *
  * `$ export APP_PROPS="consumerKey=<consumerKey>,consumerSecret=<consumerSecret>, \
  * accessToken=<accessToken>,accessTokenSecret=<accessTokenSecret>"`
  *
+ *  <p/>
  * `$ ./bin/snappy-job.sh submit --lead localhost:8090 \
  * --app-name TwitterPopularTagsJob --class io.snappydata.examples.TwitterPopularTagsJob \
  * --app-jar $SNAPPY_HOME/examples/jars/quickstart.jar --stream`
- *
+ * <p/>
  * To run with stored twitter data, run simulateTwitterStream after the Job is submitted:
+ *
  * `$ ./quickstart/scripts/simulateTwitterStream`
  */
 

--- a/examples/src/main/scala/io/snappydata/examples/TwitterPopularTagsJob.scala
+++ b/examples/src/main/scala/io/snappydata/examples/TwitterPopularTagsJob.scala
@@ -38,7 +38,7 @@ import org.apache.spark.streaming.dstream.DStream
  *
  * `$ ./bin/snappy-job.sh submit --lead localhost:8090 \
  * --app-name TwitterPopularTagsJob --class io.snappydata.examples.TwitterPopularTagsJob \
- * --app-jar $SNAPPY_HOME/lib/quickstart-0.1.0-SNAPSHOT.jar --stream`
+ * --app-jar $SNAPPY_HOME/examples/jars/quickstart.jar --stream`
  *
  * To run with stored twitter data, run simulateTwitterStream after the Job is submitted:
  * `$ ./quickstart/scripts/simulateTwitterStream`


### PR DESCRIPTION
## Changes proposed in this pull request
- Removed version from the quickstart jar name - Currently we include the snappydata version in the qucikstart jar name, so after every release, it will become mandatory to modify the examples to point correct quickstart jar. By removing the version from jar name, the above overhead will be eliminated 
- Changed quickstart jar path and name of jar in the examples - The current path for the quickstart jar mentioned in the examples in incorrect, hence need to modify the path point to correct location.
- Added run commands to the examples, where it was missing - Adding run commands as guidelines to the users.
- Fixed few issues observed while running the examples.

## Patch testing
Ran examples individually.
Ran runQuickstart task.

## ReleaseNotes.txt changes

(Does this change require an entry in ReleaseNotes.txt? If yes, has it been added to it?)

## Other PRs 
SNAP-1150 - Documentation changes required to be done as per the modified quickstart jar name.