### PR TITLE
Spark 2.0.2 merge

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -93,7 +93,7 @@ allprojects {
     productName = 'SnappyData'
     scalaBinaryVersion = '2.11'
     scalaVersion = scalaBinaryVersion + '.8'
-    sparkVersion = '2.0.0'
+    sparkVersion = '2.0.2'
     snappySparkVersion = '2.0.2-1'
     sparkDistName = "spark-${sparkVersion}-bin-hadoop2.7"
     log4jVersion = '1.2.17'

--- a/cluster/src/test/scala/org/apache/spark/sql/execution/benchmark/TPCETrade.scala
+++ b/cluster/src/test/scala/org/apache/spark/sql/execution/benchmark/TPCETrade.scala
@@ -368,13 +368,14 @@ object TPCETradeTest extends Logging {
       ), query = queries(queryNumber - 1), snappy = true, init)
     init = false
 
+    /*
     addBenchmark(s"Q$queryNumber: cache = F snappyCompress = T, opt = T",
       cache = false, Map(
         SQLConf.COMPRESS_CACHED.key -> "true",
         HASH_OPTIMIZED -> "true"
       ), query = queries(queryNumber - 1), snappy = true, init)
     init = false
-
+    */
     benchmark.run()
   }
 }

--- a/core/src/main/scala/org/apache/spark/sql/internal/SnappySessionState.scala
+++ b/core/src/main/scala/org/apache/spark/sql/internal/SnappySessionState.scala
@@ -39,7 +39,7 @@ import org.apache.spark.sql.hive.SnappyStoreHiveCatalog
 import org.apache.spark.sql.sources._
 import org.apache.spark.sql.store.StoreUtils
 import org.apache.spark.sql.streaming.{LogicalDStreamPlan, WindowLogicalPlan}
-import org.apache.spark.sql.{AnalysisException, SnappyAggregation, SnappySession, SnappySqlParser, SnappyStrategies, Strategy}
+import org.apache.spark.sql.{AnalysisException, DMLExternalTable, SnappyAggregation, SnappySession, SnappySqlParser, SnappyStrategies, Strategy, _}
 import org.apache.spark.streaming.Duration
 
 
@@ -65,6 +65,7 @@ class SnappySessionState(snappySession: SnappySession)
           new FindDataSourceTable(snappySession) ::
           DataSourceAnalysis(conf) ::
           ResolveRelationsExtended ::
+          AnalyzeDMLExternalTables(snappySession) ::
           ResolveQueryHints(snappySession) ::
           (if (conf.runSQLonFile) new ResolveDataSource(snappySession) :: Nil else Nil)
 
@@ -146,7 +147,21 @@ class SnappySessionState(snappySession: SnappySession)
     def apply(plan: LogicalPlan): LogicalPlan = plan resolveOperators {
       case i@PutIntoTable(u: UnresolvedRelation, _) =>
         i.copy(table = EliminateSubqueryAliases(getTable(u)))
+      case d@DMLExternalTable(_, u: UnresolvedRelation, _) =>
+        d.copy(query = EliminateSubqueryAliases(getTable(u)))
+    }
+  }
 
+  case class AnalyzeDMLExternalTables(sparkSession: SparkSession) extends Rule[LogicalPlan] {
+    def apply(plan: LogicalPlan): LogicalPlan = plan transform {
+      case c: DMLExternalTable if !c.query.resolved =>
+        c.copy(query = analyzeQuery(c.query))
+    }
+
+    private def analyzeQuery(query: LogicalPlan): LogicalPlan = {
+      val qe = sparkSession.sessionState.executePlan(query)
+      qe.assertAnalyzed()
+      qe.analyzed
     }
   }
 


### PR DESCRIPTION
## Changes proposed in this pull request

- Spark 2.0.2 merge
- Added new Analyzer rule AnalyzeDMLExternalTables.
- This rule converts UnresolvedRelation and eliminate SubqueryAliases to convert into LogicalRelation
- For DML statements, added new RunnableCommand
- Bumped up Spark's version to 2.0.2 from 2.0.0

## Patch testing


## ReleaseNotes.txt changes


## Other PRs 

Spark PR https://github.com/SnappyDataInc/spark/pull/23
