### PR TITLE
Additional test coverage for install jar feature

### DIFF
--- a/dtests/src/test/java/io/snappydata/hydra/cluster/SnappyPrms.java
+++ b/dtests/src/test/java/io/snappydata/hydra/cluster/SnappyPrms.java
@@ -205,6 +205,11 @@ public class SnappyPrms extends BasePrms {
     public static Long userAppJar;
 
     /**
+     * (String) AppName for the user app jar containing snappy job class.
+     */
+    public static Long userAppName;
+
+    /**
      * (String) A unique identifier for the JAR installation. The identifier you provide must specify a schema name delimiter. For example: APP.myjar.
      */
     public static Long jarIdentifier;
@@ -438,6 +443,11 @@ public class SnappyPrms extends BasePrms {
     public static String getUserAppJar() {
         Long key = userAppJar;
         return BasePrms.tasktab().stringAt(key, BasePrms.tab().stringAt(key, null));
+    }
+
+    public static String getUserAppName() {
+        Long key = userAppName;
+        return BasePrms.tasktab().stringAt(key, BasePrms.tab().stringAt(key, "myApp"));
     }
 
     public static String getJarIdentifier() {

--- a/dtests/src/test/java/io/snappydata/hydra/cluster/SnappyTest.java
+++ b/dtests/src/test/java/io/snappydata/hydra/cluster/SnappyTest.java
@@ -1420,7 +1420,7 @@ public class SnappyTest implements Serializable {
         int currentThread = snappyTest.getMyTid();
         String logFile = "snappyJobResult_thread_" + currentThread + "_" + System.currentTimeMillis() + ".log";
         SnappyBB.getBB().getSharedMap().put("logFilesForJobs_" + currentThread + "_" + System.currentTimeMillis(), logFile);
-        snappyTest.executeSnappyJob(SnappyPrms.getSnappyJobClassNames(), logFile, SnappyPrms.getUserAppJar(), jarPath);
+        snappyTest.executeSnappyJob(SnappyPrms.getSnappyJobClassNames(), logFile, SnappyPrms.getUserAppJar(), jarPath, SnappyPrms.getUserAppName());
     }
 
     /**
@@ -1554,10 +1554,12 @@ public class SnappyTest implements Serializable {
         }
     }
 
-    public void executeSnappyJob(Vector jobClassNames, String logFileName, String userAppJar, String jarPath) {
+    public void executeSnappyJob(Vector jobClassNames, String logFileName, String userAppJar, String jarPath, String appName) {
         String snappyJobScript = getScriptLocation("snappy-job.sh");
         File log = null, logFile = null;
 //        userAppJar = SnappyPrms.getUserAppJar();
+        if(appName == null) appName = SnappyPrms.getUserAppName();
+        Log.getLogWriter().info("appName is: " + appName);
         snappyTest.verifyDataForJobExecution(jobClassNames, userAppJar);
         leadHost = getLeadHost();
         try {
@@ -1569,8 +1571,8 @@ public class SnappyTest implements Serializable {
                 } else {
                     APP_PROPS = SnappyPrms.getCommaSepAPPProps() + ",logFileName=" + logFileName + ",shufflePartitions=" + SnappyPrms.getShufflePartitions();
                 }
-                String curlCommand1 = "curl --data-binary @" + snappyTest.getUserAppJarLocation(userAppJar, jarPath) + " " + leadHost + ":" + LEAD_PORT + "/jars/myapp";
-                String curlCommand2 = "curl -d " + APP_PROPS + " '" + leadHost + ":" + LEAD_PORT + "/jobs?appName=myapp&classPath=" + userJob + "'";
+                String curlCommand1 = "curl --data-binary @" + snappyTest.getUserAppJarLocation(userAppJar, jarPath) + " " + leadHost + ":" + LEAD_PORT + "/jars/" + appName;
+                String curlCommand2 = "curl -d " + APP_PROPS + " '" + leadHost + ":" + LEAD_PORT + "/jobs?appName=" + appName + "&classPath=" + userJob + "'";
                 ProcessBuilder pb = new ProcessBuilder("/bin/bash", "-c", curlCommand1);
                 log = new File(".");
                 String dest = log.getCanonicalPath() + File.separator + logFileName;

--- a/dtests/src/test/java/io/snappydata/hydra/cluster/SnappyTest.java
+++ b/dtests/src/test/java/io/snappydata/hydra/cluster/SnappyTest.java
@@ -1559,7 +1559,6 @@ public class SnappyTest implements Serializable {
         File log = null, logFile = null;
 //        userAppJar = SnappyPrms.getUserAppJar();
         if(appName == null) appName = SnappyPrms.getUserAppName();
-        Log.getLogWriter().info("appName is: " + appName);
         snappyTest.verifyDataForJobExecution(jobClassNames, userAppJar);
         leadHost = getLeadHost();
         try {

--- a/dtests/src/test/java/io/snappydata/hydra/cluster/startEmbeddedModeCluster.conf
+++ b/dtests/src/test/java/io/snappydata/hydra/cluster/startEmbeddedModeCluster.conf
@@ -1,0 +1,75 @@
+hydra.Prms-testRequirement = "Test to start the snappy cluster in embedded mode";
+hydra.Prms-testDescription = "This test starts the snappy embedded mode cluster.";
+
+INCLUDE $JTESTS/hydraconfig/hydraparams1.inc;
+INCLUDE $JTESTS/hydraconfig/topology_3.inc;
+
+hydra.gemfirexd.GfxdHelperPrms-persistDD = true;
+hydra.gemfirexd.GfxdHelperPrms-createDiskStore = true;
+hydra.GemFirePrms-names = gemfire1;
+hydra.ClientPrms-gemfireNames = gemfire1;
+hydra.GemFirePrms-distributedSystem = ds;
+
+THREADGROUP snappyStoreThreads
+            totalThreads = fcn "(${${A}Hosts} * ${${A}VMsPerHost} *  ${${A}ThreadsPerVM}) " ncf
+            totalVMs     = fcn "(${${A}Hosts} * ${${A}VMsPerHost})" ncf
+            clientNames  = fcn "hydra.TestConfigFcns.generateNames(\"${A}\",
+                                ${${A}Hosts}, true)" ncf;
+
+THREADGROUP leadThreads
+            totalThreads = fcn "(${${B}Hosts} * ${${B}VMsPerHost} *  ${${B}ThreadsPerVM}) -1 " ncf
+            totalVMs     = fcn "(${${B}Hosts} * ${${B}VMsPerHost})" ncf
+            clientNames  = fcn "hydra.TestConfigFcns.generateNames(\"${B}\",
+                                ${${B}Hosts}, true)" ncf;
+
+THREADGROUP locatorThreads
+            totalThreads = fcn "(${${C}Hosts} * ${${C}VMsPerHost} *  ${${C}ThreadsPerVM}) " ncf
+            totalVMs     = fcn "(${${C}Hosts} * ${${C}VMsPerHost})" ncf
+            clientNames  = fcn "hydra.TestConfigFcns.generateNames(\"${C}\",
+                                ${${C}Hosts}, true)" ncf;
+
+THREADGROUP snappyThreads
+            totalThreads = 1
+            totalVMs     = 1
+            clientNames  = fcn "hydra.TestConfigFcns.generateNames(\"${B}\",
+                                ${${B}Hosts}, true)" ncf;
+
+INITTASK    taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = HydraTask_initializeSnappyTest
+            runMode = always
+            threadGroups = snappyThreads, locatorThreads, snappyStoreThreads, leadThreads;
+
+INITTASK    taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = HydraTask_generateSnappyLocatorConfig
+            runMode = always
+            threadGroups = locatorThreads;
+
+INITTASK    taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = HydraTask_writeLocatorConfigData
+            runMode = always
+            threadGroups = snappyThreads;
+
+INITTASK    taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = HydraTask_generateSnappyServerConfig
+            runMode = always
+            threadGroups = snappyStoreThreads;
+
+INITTASK    taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = HydraTask_writeServerConfigData
+            runMode = always
+            threadGroups = snappyThreads;
+
+INITTASK    taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = HydraTask_generateSnappyLeadConfig
+            runMode = always
+            threadGroups = leadThreads, snappyThreads;
+
+INITTASK    taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = HydraTask_writeLeadConfigData
+            runMode = always
+            threadGroups = snappyThreads;
+
+INITTASK    taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = HydraTask_createAndStartSnappyLocator
+            runMode = always
+            threadGroups = locatorThreads;
+
+INITTASK    taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = HydraTask_createAndStartSnappyServers
+            runMode = always
+            threadGroups = snappyStoreThreads;
+
+INITTASK    taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = HydraTask_createAndStartSnappyLeader
+            runMode = always
+            threadGroups = leadThreads;

--- a/dtests/src/test/java/io/snappydata/hydra/cluster/stopEmbeddedModeCluster.conf
+++ b/dtests/src/test/java/io/snappydata/hydra/cluster/stopEmbeddedModeCluster.conf
@@ -1,0 +1,42 @@
+hydra.Prms-testRequirement = "Test to stop the snappy embedded mode cluster started using startEmbeddedModeCluster.conf";
+hydra.Prms-testDescription = "This test stops the snappy embedded mode cluster started using startEmbeddedModeCluster.conf.";
+
+CLOSETASK  taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = HydraTask_stopSnappy
+           threadGroups = snappyThreads;
+
+CLOSETASK  taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = HydraTask_stopSnappyLeader
+           threadGroups = snappyThreads;
+
+CLOSETASK  taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = HydraTask_stopSnappyServers
+           threadGroups = snappyThreads;
+
+CLOSETASK  taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = HydraTask_stopSnappyLocator
+           threadGroups = snappyThreads;
+
+CLOSETASK  taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = HydraTask_deleteSnappyConfig
+           threadGroups = snappyThreads;
+
+ENDTASK    taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = HydraTask_cleanUpSnappyProcessesOnFailure
+           clientNames = locator1;
+
+hydra.Prms-totalTaskTimeSec           = 100;
+hydra.Prms-maxResultWaitSec           = 900;
+
+hydra.Prms-maxCloseTaskResultWaitSec  = 900;
+
+hydra.CachePrms-names = defaultCache;
+sql.SQLPrms-useGfxdConfig = true;
+
+/* end task must stop snappy members because they are not stopped by Hydra */
+hydra.Prms-alwaysDoEndTasks = true;
+
+hydra.VmPrms-extraVMArgs   += fcn "hydra.TestConfigFcns.duplicate
+                                  (\"-Xms512m -Xmx1g \", ${${A}Hosts}, true)"
+                             ncf
+                             ,
+                             fcn "hydra.TestConfigFcns.duplicate
+                                  (\"-Xms512m -Xmx1g \", ${${B}Hosts}, true)"
+                             ncf;
+hydra.VmPrms-extraVMArgsSUN += "-XX:PermSize=64M -XX:MaxPermSize=256m";
+
+io.snappydata.hydra.cluster.SnappyPrms-userAppJar = snappydata-store-scala-tests*tests.jar;

--- a/dtests/src/test/java/io/snappydata/hydra/distJoin/distJoinWithServerHA.conf
+++ b/dtests/src/test/java/io/snappydata/hydra/distJoin/distJoinWithServerHA.conf
@@ -91,14 +91,14 @@ INITTASK    taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = b
 INITTASK   taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = HydraTask_executeSnappyJob
            io.snappydata.hydra.cluster.SnappyPrms-jobClassNames = io.snappydata.benchmark.snappy.TPCH_Snappy_Tables
            io.snappydata.hydra.cluster.SnappyPrms-appPropsForJobServer = "dataLocation=${dataLocation},Buckets_Order_Lineitem=${buckets_Order_Lineitem},Buckets_Cust_Part_PartSupp=${buckets_Cust_Part_PartSupp},useIndex=${useIndex}"
-           io.snappydata.hydra.cluster.SnappyPrms-userAppJar = snappy-cluster*tests.jar
+           io.snappydata.hydra.cluster.SnappyPrms-userAppJar = snappydata-cluster*tests.jar
            threadGroups = snappyThreads
            ;
 
 TASK       taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = HydraTask_executeSnappyJob
            io.snappydata.hydra.cluster.SnappyPrms-jobClassNames = io.snappydata.benchmark.snappy.TPCH_Snappy_Query
            io.snappydata.hydra.cluster.SnappyPrms-appPropsForJobServer = "queries=${queries},queryPlan=${queryPlan},spark.sql.shuffle.partitions=${shufflePartitions},spark.sql.inMemoryColumnarStorage.compressed=${inMemoryColumnarStorageCompressed},useIndex=${useIndex}"
-           io.snappydata.hydra.cluster.SnappyPrms-userAppJar = snappy-cluster*tests.jar
+           io.snappydata.hydra.cluster.SnappyPrms-userAppJar = snappydata-cluster*tests.jar
            threadGroups = snappyThreads
            weight = 60
            ;
@@ -106,7 +106,7 @@ TASK       taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = Hy
 TASK       taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = HydraTask_executeSnappyJob
            io.snappydata.hydra.cluster.SnappyPrms-jobClassNames = io.snappydata.benchmark.snappy.TPCH_Snappy_Query
            io.snappydata.hydra.cluster.SnappyPrms-appPropsForJobServer = "queries=11-12-13-14-15-16-17,queryPlan=${queryPlan},spark.sql.shuffle.partitions=${shufflePartitions},spark.sql.inMemoryColumnarStorage.compressed=${inMemoryColumnarStorageCompressed},useIndex=${useIndex}"
-           io.snappydata.hydra.cluster.SnappyPrms-userAppJar = snappy-cluster*tests.jar
+           io.snappydata.hydra.cluster.SnappyPrms-userAppJar = snappydata-cluster*tests.jar
            threadGroups = snappyStoreThreads
            maxThreads = 1
            weight = 60

--- a/dtests/src/test/java/io/snappydata/hydra/installJar/DynamicJarLoadingTest.java
+++ b/dtests/src/test/java/io/snappydata/hydra/installJar/DynamicJarLoadingTest.java
@@ -73,20 +73,26 @@ public class DynamicJarLoadingTest extends SnappyTest {
         return SnappyTestUtils.createJarFile((JavaConversions.asScalaBuffer(files)).toList(), dir);
     }
 
+    protected static String createJarFileWithIdenticalJobClass(String dir) {
+        List files = new ArrayList();
+        files.add(createJobClassWithDifferentLogStatements("DynamicJarLoadingJob", dir));
+        return SnappyTestUtils.createJarFile((JavaConversions.asScalaBuffer(files)).toList(), dir);
+    }
+
     public static void HydraTask_executeSnappyJobWithDynamicJarLoading_installJar() {
         String appJar = createJarFile(3, "1");
-        executeSnappyJobWithDynamicJarLoading(appJar, "snappyJobInstallJarResult_thread_");
+        executeSnappyJobWithDynamicJarLoading(appJar, "snappyJobInstallJarResult_thread_", null );
     }
 
     public static void HydraTask_executeSnappyJobWithDynamicJarLoading_modifyJar() {
         String appJar = createJarFile(2, "2");
-        executeSnappyJobWithDynamicJarLoading(appJar, "snappyJobModifyJarResult_thread_");
+        executeSnappyJobWithDynamicJarLoading(appJar, "snappyJobModifyJarResult_thread_", null);
     }
 
-    protected static void executeSnappyJobWithDynamicJarLoading(String appJar, String logFileName) {
+    protected static void executeSnappyJobWithDynamicJarLoading(String appJar, String logFileName, String appName) {
         int currentThread = snappyTest.getMyTid();
         String logFile = logFileName + currentThread + "_" + System.currentTimeMillis() + ".log";
-        snappyTest.executeSnappyJob(SnappyPrms.getSnappyJobClassNames(), logFile, appJar, getTempDir());
+        snappyTest.executeSnappyJob(SnappyPrms.getSnappyJobClassNames(), logFile, appJar, getTempDir(), appName);
     }
 
     public static File createSupportiveClasses(String className, String version, String destDir) {
@@ -123,6 +129,52 @@ public class DynamicJarLoadingTest extends SnappyTest {
                 "            String currentDirectory = new File(\".\").getCanonicalPath();\n" +
                 "            io.snappydata.hydra.installJar.TestUtils.verify(snc, jobConfig.getString(\"classVersion\"), pw, numServers,expectedException);\n" +
                 "            pw.println(\"****** DynamicJarLoadingJob finished ******\");" +
+                "            return String.format(\"See %s/\" + jobConfig.getString(\"logFileName\"), currentDirectory);\n" +
+                "        } catch (Exception e) {\n" +
+                "            pw.println(\"ERROR: failed with \" + e.getMessage());\n" +
+                "            e.printStackTrace(pw);\n" +
+                "        } finally {\n" +
+                "            pw.flush();\n" +
+                "            pw.close();\n" +
+                "        }\n" +
+                "        return null;\n" +
+                "    }" +
+                "\n" +
+                "    @Override\n" +
+                "    public SnappyJobValidation isValidJob(SnappyContext snc, Config config) {\n" +
+                "        return new SnappyJobValid();\n" +
+                "    }\n" +
+                "}";
+        return SnappyTestUtils.createCompiledClass(className,
+                new File(destDir),
+                SnappyTestUtils.getJavaSourceFromString(className, generalClassText),
+                new scala.collection.mutable.ArrayBuffer<URL>());
+    }
+
+    public static File createJobClassWithDifferentLogStatements(String className, String destDir) {
+        String generalClassText = "import com.typesafe.config.Config;\n" +
+                "import org.apache.spark.sql.SnappyContext;\n" +
+                "import org.apache.spark.sql.SnappyJobValid;\n" +
+                "import org.apache.spark.sql.SnappyJobValidation;\n" +
+                "import org.apache.spark.sql.JavaSnappySQLJob;\n" +
+                "\n" +
+                "import java.io.File;\n" +
+                "import java.io.FileOutputStream;\n" +
+                "import java.io.PrintWriter;\n" +
+                "import java.io.StringWriter;\n" +
+                "\n" +
+                "public class DynamicJarLoadingJob extends JavaSnappySQLJob {\n" +
+                "    @Override\n" +
+                "    public Object runSnappyJob(SnappyContext snc, Config jobConfig) {\n" +
+                "        PrintWriter pw = null;\n" +
+                "        try {\n" +
+                "            pw = new PrintWriter(new FileOutputStream(new File(jobConfig.getString(\"logFileName\")), true));\n" +
+                "            int numServers = Integer.parseInt(jobConfig.getString(\"numServers\"));\n" +
+                "            boolean expectedException = Boolean.parseBoolean(jobConfig.getString(\"expectedException\"));\n" +
+                "            pw.println(\"****** Started DynamicJarLoadingJob With having Identical name but different functionality ******\");\n" +
+                "            String currentDirectory = new File(\".\").getCanonicalPath();\n" +
+                "            io.snappydata.hydra.installJar.TestUtils.verify(snc, jobConfig.getString(\"classVersion\"), pw, numServers,expectedException);\n" +
+                "            pw.println(\"****** Finished DynamicJarLoadingJob With having Identical name but different functionality ******\");" +
                 "            return String.format(\"See %s/\" + jobConfig.getString(\"logFileName\"), currentDirectory);\n" +
                 "        } catch (Exception e) {\n" +
                 "            pw.println(\"ERROR: failed with \" + e.getMessage());\n" +
@@ -183,7 +235,18 @@ public class DynamicJarLoadingTest extends SnappyTest {
      */
     public static synchronized void HydraTask_executeSnappyJob_DynamicJarLoading() {
         String jarName = createJarFileWithOnlyJobClass(getTempDir());
-        executeSnappyJobWithDynamicJarLoading(jarName, "snappyJobResult_thread_");
+        String appName = "myApp_" + System.currentTimeMillis();
+        executeSnappyJobWithDynamicJarLoading(jarName, "snappyJobResult_thread_", appName);
+    }
+
+    /**
+     * Executes dynamically created snappy job which uses the classes loaded through gfxd install-jar/replace-jar command.
+     * The Job class name is identical with the job class generated using HydraTask_executeSnappyJob_DynamicJarLoading method, but the job functionality is different.
+     */
+    public static synchronized void HydraTask_executeSnappyJobWithIdenticalName() {
+        String jarName = createJarFileWithIdenticalJobClass(getTempDir());
+        String appName = "myApp_" + System.currentTimeMillis();
+        executeSnappyJobWithDynamicJarLoading(jarName, "snappyJobResult_WithIdenticalName_thread_", appName);
     }
 
     protected static synchronized void executeCommand(String jarName, String jarIdentifier, String command) {

--- a/dtests/src/test/java/io/snappydata/hydra/installJar/TestUtils.java
+++ b/dtests/src/test/java/io/snappydata/hydra/installJar/TestUtils.java
@@ -1,14 +1,26 @@
+/*
+ * Copyright (c) 2016 SnappyData, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License. You
+ * may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License. See accompanying
+ * LICENSE file.
+ */
 package io.snappydata.hydra.installJar;
 
 import org.apache.spark.SnappyTestUtils;
 import org.apache.spark.sql.SnappyContext;
-import util.TestException;
 
 import java.io.PrintWriter;
 
-/**
- * Created by swati on 26/8/16.
- */
 public class TestUtils {
 
     public static void verify(SnappyContext snc, String version, PrintWriter pw, int numServers, boolean expectedException) {
@@ -28,7 +40,8 @@ public class TestUtils {
             if (expectedException && e.getMessage().contains("java.lang.ClassNotFoundException")) {
                 pw.println("Got expected java.lang.ClassNotFoundException.....");
             } else if (!expectedException) {
-                throw new TestException("Exception occurred while executing the job " + "\nError Message:" + e.getMessage());
+                //throw new TestException("Exception occurred while executing the job " + "\nError Message:" + e.getMessage());
+                pw.println("Exception occurred while executing the job " + "\nError Message:" + e.getMessage());
             }
         }
     }

--- a/dtests/src/test/java/io/snappydata/hydra/installJar/TestUtils.java
+++ b/dtests/src/test/java/io/snappydata/hydra/installJar/TestUtils.java
@@ -47,4 +47,30 @@ public class TestUtils {
             }
         }
     }
+
+    public static void verifyClassFromPreviousJobExecution(SnappyContext snc, String version, PrintWriter pw, int numServers, boolean expectedException) {
+        try {
+            pw.println("Class version : " + version);
+            if (version.equalsIgnoreCase("1")) {
+                SnappyTestUtils.verifyClassOnExecutors(snc, "FakeClass0", "1", numServers, pw);
+                SnappyTestUtils.verifyClassOnExecutors(snc, "FakeClass1", "1", numServers, pw);
+                SnappyTestUtils.verifyClassOnExecutors(snc, "FakeClass2", "1", numServers, pw);
+                SnappyTestUtils.verifyClassOnExecutors(snc, "FakeClass3", "1", numServers, pw);
+            } else {
+                SnappyTestUtils.verifyClassOnExecutors(snc, "FakeClass0", "2", numServers, pw);
+                SnappyTestUtils.verifyClassOnExecutors(snc, "FakeClass1", "2", numServers, pw);
+                SnappyTestUtils.verifyClassOnExecutors(snc, "FakeClass2", "2", numServers, pw);
+                SnappyTestUtils.verifyClassOnExecutors(snc, "FakeClass3", "1", numServers, pw);
+            }
+        } catch (Exception e) {
+            if (expectedException && e.getMessage().contains("java.lang.ClassNotFoundException")) {
+                pw.println("Got expected java.lang.ClassNotFoundException.....");
+                pw.flush();
+            } else if (!expectedException) {
+                //throw new util.TestException("Exception occurred while executing the job " + "\nError Message:" + e.getMessage());
+                pw.println("Exception occurred while executing the job " + "\nError Message:" + e.getMessage());
+                pw.flush();
+            }
+        }
+    }
 }

--- a/dtests/src/test/java/io/snappydata/hydra/installJar/TestUtils.java
+++ b/dtests/src/test/java/io/snappydata/hydra/installJar/TestUtils.java
@@ -39,9 +39,11 @@ public class TestUtils {
         } catch (Exception e) {
             if (expectedException && e.getMessage().contains("java.lang.ClassNotFoundException")) {
                 pw.println("Got expected java.lang.ClassNotFoundException.....");
+                pw.flush();
             } else if (!expectedException) {
-                //throw new TestException("Exception occurred while executing the job " + "\nError Message:" + e.getMessage());
+                //throw new util.TestException("Exception occurred while executing the job " + "\nError Message:" + e.getMessage());
                 pw.println("Exception occurred while executing the job " + "\nError Message:" + e.getMessage());
+                pw.flush();
             }
         }
     }

--- a/dtests/src/test/java/io/snappydata/hydra/installJar/dynamicJarLoadingUsingSnappyJob.conf
+++ b/dtests/src/test/java/io/snappydata/hydra/installJar/dynamicJarLoadingUsingSnappyJob.conf
@@ -1,83 +1,12 @@
 hydra.Prms-testRequirement = "Test to verify dynamic jar loading feature using snappy job";
 hydra.Prms-testDescription = "
-This test starts the snappy cluster and spark cluster, then initializes snappyContext.
+This test starts the snappy cluster.
 Creates classes with version 1, snappyJob and jar at runtime and executes the snappyjob with the created jar.
 Test then modify the jar dynamically by creating classes with version 2 and snappyJob and then executes the snappyjob with the modified jar.
 It then again executes the snappy job to verify that we get expected ClassNotFoundException for older class version.
 Test verifies that the jars contains the required class versions each time";
 
-INCLUDE $JTESTS/hydraconfig/hydraparams1.inc;
-INCLUDE $JTESTS/hydraconfig/topology_3.inc;
-
-hydra.gemfirexd.GfxdHelperPrms-persistDD = true;
-hydra.gemfirexd.GfxdHelperPrms-createDiskStore = true;
-hydra.GemFirePrms-names = gemfire1;
-hydra.ClientPrms-gemfireNames = gemfire1;
-hydra.GemFirePrms-distributedSystem = ds;
-
-THREADGROUP snappyStoreThreads
-            totalThreads = fcn "(${${A}Hosts} * ${${A}VMsPerHost} *  ${${A}ThreadsPerVM}) " ncf
-            totalVMs     = fcn "(${${A}Hosts} * ${${A}VMsPerHost})" ncf
-            clientNames  = fcn "hydra.TestConfigFcns.generateNames(\"${A}\",
-                                ${${A}Hosts}, true)" ncf;
-
-THREADGROUP leadThreads
-            totalThreads = fcn "(${${B}Hosts} * ${${B}VMsPerHost} *  ${${B}ThreadsPerVM}) -1 " ncf
-            totalVMs     = fcn "(${${B}Hosts} * ${${B}VMsPerHost})" ncf
-            clientNames  = fcn "hydra.TestConfigFcns.generateNames(\"${B}\",
-                                ${${B}Hosts}, true)" ncf;
-
-THREADGROUP locatorThreads
-            totalThreads = fcn "(${${C}Hosts} * ${${C}VMsPerHost} *  ${${C}ThreadsPerVM}) " ncf
-            totalVMs     = fcn "(${${C}Hosts} * ${${C}VMsPerHost})" ncf
-            clientNames  = fcn "hydra.TestConfigFcns.generateNames(\"${C}\",
-                                ${${C}Hosts}, true)" ncf;
-
-THREADGROUP snappyThreads
-            totalThreads = 1
-            totalVMs     = 1
-            clientNames  = fcn "hydra.TestConfigFcns.generateNames(\"${B}\",
-                                ${${B}Hosts}, true)" ncf;
-
-INITTASK    taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = HydraTask_initializeSnappyTest
-            runMode = always
-            threadGroups = snappyThreads, locatorThreads, snappyStoreThreads, leadThreads;
-
-INITTASK    taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = HydraTask_generateSnappyLocatorConfig
-            runMode = always
-            threadGroups = locatorThreads;
-
-INITTASK    taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = HydraTask_writeLocatorConfigData
-            runMode = always
-            threadGroups = snappyThreads;
-
-INITTASK    taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = HydraTask_generateSnappyServerConfig
-            runMode = always
-            threadGroups = snappyStoreThreads;
-
-INITTASK    taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = HydraTask_writeServerConfigData
-            runMode = always
-            threadGroups = snappyThreads;
-
-INITTASK    taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = HydraTask_generateSnappyLeadConfig
-            runMode = always
-            threadGroups = leadThreads, snappyThreads;
-
-INITTASK    taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = HydraTask_writeLeadConfigData
-            runMode = always
-            threadGroups = snappyThreads;
-
-INITTASK    taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = HydraTask_createAndStartSnappyLocator
-            runMode = always
-            threadGroups = locatorThreads;
-
-INITTASK    taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = HydraTask_createAndStartSnappyServers
-            runMode = always
-            threadGroups = snappyStoreThreads;
-
-INITTASK    taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = HydraTask_createAndStartSnappyLeader
-            runMode = always
-            threadGroups = leadThreads;
+INCLUDE $JTESTS/io/snappydata/hydra/cluster/startEmbeddedModeCluster.conf;
 
 INITTASK    taskClass   = io.snappydata.hydra.installJar.DynamicJarLoadingTest taskMethod  = HydraTask_executeSnappyJobWithDynamicJarLoading_installJar
             io.snappydata.hydra.cluster.SnappyPrms-jobClassNames= DynamicJarLoadingJob
@@ -107,44 +36,5 @@ INITTASK   taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = Hy
            threadGroups = snappyThreads
            maxTimesToRun = 1;*/
 
-CLOSETASK  taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = HydraTask_stopSnappy
-           threadGroups = snappyThreads;
-
-CLOSETASK  taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = HydraTask_stopSnappyLeader
-           threadGroups = snappyThreads;
-
-CLOSETASK  taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = HydraTask_stopSnappyServers
-           threadGroups = snappyThreads;
-
-CLOSETASK  taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = HydraTask_stopSnappyLocator
-           threadGroups = snappyThreads;
-
-CLOSETASK  taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = HydraTask_deleteSnappyConfig
-           threadGroups = snappyThreads;
-
-ENDTASK    taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = HydraTask_cleanUpSnappyProcessesOnFailure
-           clientNames = locator1;
-
-hydra.Prms-totalTaskTimeSec           = 100;
-hydra.Prms-maxResultWaitSec           = 900;
-
-hydra.Prms-maxCloseTaskResultWaitSec  = 900;
-hydra.Prms-serialExecution            = true;
-
-hydra.CachePrms-names = defaultCache;
-sql.SQLPrms-useGfxdConfig = true;
-
-/* end task must stop snappy members because they are not stopped by Hydra */
-hydra.Prms-alwaysDoEndTasks = true;
-
-hydra.VmPrms-extraVMArgs   += fcn "hydra.TestConfigFcns.duplicate
-                                  (\"-Xms512m -Xmx1g \", ${${A}Hosts}, true)"
-                             ncf
-                             ,
-                             fcn "hydra.TestConfigFcns.duplicate
-                                  (\"-Xms512m -Xmx1g \", ${${B}Hosts}, true)"
-                             ncf;
-hydra.VmPrms-extraVMArgsSUN += "-XX:PermSize=64M -XX:MaxPermSize=256m";
-
-io.snappydata.hydra.cluster.SnappyPrms-userAppJar = snappydata-store-scala-tests*tests.jar;
+INCLUDE $JTESTS/io/snappydata/hydra/cluster/stopEmbeddedModeCluster.conf;
 

--- a/dtests/src/test/java/io/snappydata/hydra/installJar/dynamicJarLoadingUsingSnappyJobsWithIdenticalNames.conf
+++ b/dtests/src/test/java/io/snappydata/hydra/installJar/dynamicJarLoadingUsingSnappyJobsWithIdenticalNames.conf
@@ -1,0 +1,41 @@
+hydra.Prms-testRequirement = "Test to verify dynamic jar loading feature using snappy jobs with identical names but different functionality";
+hydra.Prms-testDescription = "
+This test starts the snappy cluster.
+Creates classes with version 1 and jar packaging these classes at runtime, then executes the gemxd install-jar command to install a local jar file to RowStore.
+It then creates two snappy jobs dynamically with identical names but different functionality and jars containing these job classes.
+Then executes the snappy jobs in parallel with the created jars.
+Test verifies that the classes loaded through install-jar command are accessible to the snappy jobs and both the jobs works fine in parallel in spite of having same class name.";
+
+INCLUDE $JTESTS/io/snappydata/hydra/cluster/startEmbeddedModeCluster.conf;
+
+INITTASK    taskClass   = io.snappydata.hydra.installJar.DynamicJarLoadingTest taskMethod  = HydraTask_executeInstallJarCommand_DynamicJarLoading
+            threadGroups = snappyThreads;
+
+INITTASK   taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = HydraTask_executeSnappyJob
+           io.snappydata.hydra.cluster.SnappyPrms-jobClassNames = io.snappydata.hydra.InstallJarTest
+           io.snappydata.hydra.cluster.SnappyPrms-appPropsForJobServer = "classVersion=1,numServers=${snappyStoreHosts},expectedException=false"
+           io.snappydata.hydra.cluster.SnappyPrms-userAppJar = snappydata-store-scala-tests*tests.jar
+           io.snappydata.hydra.cluster.SnappyPrms-numTimesToRetry = 2
+           threadGroups = snappyThreads
+           ;
+
+TASK        taskClass   = io.snappydata.hydra.installJar.DynamicJarLoadingTest taskMethod  = HydraTask_executeSnappyJob_DynamicJarLoading
+            io.snappydata.hydra.cluster.SnappyPrms-jobClassNames= DynamicJarLoadingJob
+            io.snappydata.hydra.cluster.SnappyPrms-appPropsForJobServer = "classVersion=1,numServers=${snappyStoreHosts},expectedException=false"
+            io.snappydata.hydra.cluster.SnappyPrms-numTimesToRetry = 2
+            threadGroups = snappyStoreThreads
+            maxThreads = 1
+            maxTimesToRun = 3
+            ;
+
+TASK        taskClass   = io.snappydata.hydra.installJar.DynamicJarLoadingTest taskMethod  = HydraTask_executeSnappyJobWithIdenticalName
+            io.snappydata.hydra.cluster.SnappyPrms-jobClassNames= DynamicJarLoadingJob
+            io.snappydata.hydra.cluster.SnappyPrms-appPropsForJobServer = "classVersion=1,numServers=${snappyStoreHosts},expectedException=false"
+            io.snappydata.hydra.cluster.SnappyPrms-numTimesToRetry = 2
+            threadGroups = leadThreads
+            maxThreads = 1
+            maxTimesToRun = 3
+            ;
+
+INCLUDE $JTESTS/io/snappydata/hydra/cluster/stopEmbeddedModeCluster.conf;
+

--- a/dtests/src/test/java/io/snappydata/hydra/installJar/dynamicJarLoadingUsingSnappyShell.conf
+++ b/dtests/src/test/java/io/snappydata/hydra/installJar/dynamicJarLoadingUsingSnappyShell.conf
@@ -1,6 +1,6 @@
 hydra.Prms-testRequirement = "Test to verify dynamic jar loading feature by using gemxd install-jar and replace-jar commands and then accessing the classes through snappy job.";
 hydra.Prms-testDescription = "
-This test starts the snappy cluster and spark cluster, then initializes snappyContext.
+This test starts the snappy cluster.
 Creates classes with version 1 and jar packaging these classes at runtime, then executes the gemxd install-jar command to install a local jar file to RowStore.
 It then creates the snappy job dynamically and a jar containing this job, then executes the snappy job with the created jar.
 Test then modify the jar dynamically by creating classes with version 2 in one jar and then executes the gemxd replace-jar command
@@ -9,83 +9,7 @@ Again the job is created dynamically and then executes the snappyjob with the mo
 Test then removes the jar using remove-jar command and again executes the snappy job to verify that we get expected ClassNotFoundException.
 Test verifies that the classes loaded through install-jar and replace-jar command are accessible to the snappy job.";
 
-INCLUDE $JTESTS/hydraconfig/hydraparams1.inc;
-INCLUDE $JTESTS/hydraconfig/topology_3.inc;
-
-hydra.gemfirexd.GfxdHelperPrms-persistDD = true;
-hydra.gemfirexd.GfxdHelperPrms-createDiskStore = true;
-hydra.GemFirePrms-names = gemfire1;
-hydra.ClientPrms-gemfireNames = gemfire1;
-hydra.GemFirePrms-distributedSystem = ds;
-
-THREADGROUP snappyStoreThreads
-            totalThreads = fcn "(${${A}Hosts} * ${${A}VMsPerHost} *  ${${A}ThreadsPerVM}) " ncf
-            totalVMs     = fcn "(${${A}Hosts} * ${${A}VMsPerHost})" ncf
-            clientNames  = fcn "hydra.TestConfigFcns.generateNames(\"${A}\",
-                                ${${A}Hosts}, true)" ncf;
-
-THREADGROUP leadThreads
-            totalThreads = fcn "(${${B}Hosts} * ${${B}VMsPerHost} *  ${${B}ThreadsPerVM}) -1 " ncf
-            totalVMs     = fcn "(${${B}Hosts} * ${${B}VMsPerHost})" ncf
-            clientNames  = fcn "hydra.TestConfigFcns.generateNames(\"${B}\",
-                                ${${B}Hosts}, true)" ncf;
-
-THREADGROUP locatorThreads
-            totalThreads = fcn "(${${C}Hosts} * ${${C}VMsPerHost} *  ${${C}ThreadsPerVM}) " ncf
-            totalVMs     = fcn "(${${C}Hosts} * ${${C}VMsPerHost})" ncf
-            clientNames  = fcn "hydra.TestConfigFcns.generateNames(\"${C}\",
-                                ${${C}Hosts}, true)" ncf;
-
-THREADGROUP snappyThreads
-            totalThreads = 1
-            totalVMs     = 1
-            clientNames  = fcn "hydra.TestConfigFcns.generateNames(\"${B}\",
-                                ${${B}Hosts}, true)" ncf;
-
-INITTASK    taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = HydraTask_initializeSnappyTest
-            runMode = always
-            threadGroups = snappyThreads, locatorThreads, snappyStoreThreads, leadThreads;
-
-INITTASK    taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = HydraTask_generateSnappyLocatorConfig
-            runMode = always
-            threadGroups = locatorThreads;
-
-INITTASK    taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = HydraTask_writeLocatorConfigData
-            runMode = always
-            threadGroups = snappyThreads;
-
-INITTASK    taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = HydraTask_generateSnappyServerConfig
-            runMode = always
-            threadGroups = snappyStoreThreads;
-
-INITTASK    taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = HydraTask_writeServerConfigData
-            runMode = always
-            threadGroups = snappyThreads;
-
-INITTASK    taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = HydraTask_generateSnappyLeadConfig
-            runMode = always
-            threadGroups = leadThreads, snappyThreads;
-
-INITTASK    taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = HydraTask_writeLeadConfigData
-            runMode = always
-            threadGroups = snappyThreads;
-
-INITTASK    taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = HydraTask_createAndStartSnappyLocator
-            runMode = always
-            threadGroups = locatorThreads;
-
-INITTASK    taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = HydraTask_createAndStartSnappyServers
-            runMode = always
-            threadGroups = snappyStoreThreads;
-
-INITTASK    taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = HydraTask_createAndStartSnappyLeader
-            runMode = always
-            threadGroups = leadThreads;
-
-/*INITTASK    taskClass   = io.snappydata.hydra.installJar.DynamicJarLoadingTest taskMethod  = HydraTask_executeInstallJarCommand
-            io.snappydata.hydra.cluster.SnappyPrms-userAppJar = snappydata-store-scala-tests*tests.jar
-            //io.snappydata.hydra.cluster.SnappyPrms-jarIdentifier = myJar
-            threadGroups = snappyThreads;*/
+INCLUDE $JTESTS/io/snappydata/hydra/cluster/startEmbeddedModeCluster.conf;
 
 INITTASK    taskClass   = io.snappydata.hydra.installJar.DynamicJarLoadingTest taskMethod  = HydraTask_executeInstallJarCommand_DynamicJarLoading
             threadGroups = snappyThreads;
@@ -114,41 +38,4 @@ INITTASK    taskClass   = io.snappydata.hydra.installJar.DynamicJarLoadingTest t
             io.snappydata.hydra.cluster.SnappyPrms-numTimesToRetry = 2
             threadGroups = snappyThreads;
 
-CLOSETASK   taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = HydraTask_stopSnappy
-            threadGroups = snappyThreads;
-
-CLOSETASK   taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = HydraTask_stopSnappyLeader
-            threadGroups = snappyThreads;
-
-CLOSETASK   taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = HydraTask_stopSnappyServers
-            threadGroups = snappyThreads;
-
-CLOSETASK   taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = HydraTask_stopSnappyLocator
-            threadGroups = snappyThreads;
-
-CLOSETASK   taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = HydraTask_deleteSnappyConfig
-            threadGroups = snappyThreads;
-
-ENDTASK     taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = HydraTask_cleanUpSnappyProcessesOnFailure
-            clientNames = locator1;
-
-hydra.Prms-totalTaskTimeSec           = 100;
-hydra.Prms-maxResultWaitSec           = 900;
-
-hydra.Prms-maxCloseTaskResultWaitSec  = 900;
-hydra.Prms-serialExecution            = true;
-
-hydra.CachePrms-names = defaultCache;
-sql.SQLPrms-useGfxdConfig = true;
-
-/* end task must stop snappy members because they are not stopped by Hydra */
-hydra.Prms-alwaysDoEndTasks = true;
-
-hydra.VmPrms-extraVMArgs   += fcn "hydra.TestConfigFcns.duplicate
-                                  (\"-Xms512m -Xmx1g \", ${${A}Hosts}, true)"
-                             ncf
-                             ,
-                             fcn "hydra.TestConfigFcns.duplicate
-                                  (\"-Xms512m -Xmx1g \", ${${B}Hosts}, true)"
-                             ncf;
-hydra.VmPrms-extraVMArgsSUN += "-XX:PermSize=64M -XX:MaxPermSize=256m";
+INCLUDE $JTESTS/io/snappydata/hydra/cluster/stopEmbeddedModeCluster.conf;

--- a/dtests/src/test/java/io/snappydata/hydra/installJar/dynamicJarLoadingUsingSparkApp.conf
+++ b/dtests/src/test/java/io/snappydata/hydra/installJar/dynamicJarLoadingUsingSparkApp.conf
@@ -1,0 +1,70 @@
+hydra.Prms-testRequirement = "Test to verify dynamic jar loading feature by using gemxd install-jar command and then accessing the classes through spark App.";
+hydra.Prms-testDescription = "
+This test starts the snappy cluster and spark cluster, then initializes snappyContext.
+Creates classes with version 1 and jar packaging these classes at runtime, then executes the gemxd install-jar command to install a local jar file to RowStore.
+It then creates the snappy job dynamically and a jar containing this job, then executes the snappy job with the created jar.
+Test then executes the spark App to verify that we get expected ClassNotFoundException.
+Test verifies that the classes loaded through install-jar command are not accessible to the spark App.";
+
+INCLUDE $JTESTS/io/snappydata/hydra/northwind/startDualModeCluster.conf;
+
+INITTASK    taskClass   = io.snappydata.hydra.installJar.DynamicJarLoadingTest taskMethod  = HydraTask_executeInstallJarCommand_DynamicJarLoading
+            threadGroups = snappyThreads;
+
+INITTASK    taskClass   = io.snappydata.hydra.installJar.DynamicJarLoadingTest taskMethod  = HydraTask_executeSnappyJob_DynamicJarLoading
+            io.snappydata.hydra.cluster.SnappyPrms-jobClassNames= DynamicJarLoadingJob
+            io.snappydata.hydra.cluster.SnappyPrms-appPropsForJobServer = "classVersion=1,numServers=${snappyStoreHosts},expectedException=false"
+            io.snappydata.hydra.cluster.SnappyPrms-numTimesToRetry = 2
+            threadGroups = snappyThreads;
+
+INITTASK    taskClass   = io.snappydata.hydra.installJar.DynamicJarLoadingTest taskMethod  = HydraTask_executeSnappyJob_DynamicJarLoading
+            io.snappydata.hydra.cluster.SnappyPrms-jobClassNames= DynamicJarLoadingJob
+            io.snappydata.hydra.cluster.SnappyPrms-appPropsForJobServer = "classVersion=1,numServers=${snappyStoreHosts},expectedException=false"
+            io.snappydata.hydra.cluster.SnappyPrms-numTimesToRetry = 2
+            threadGroups = snappyThreads;
+
+INITTASK    taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = HydraTask_executeSparkJob
+            io.snappydata.hydra.cluster.SnappyPrms-sparkJobClassNames = io.snappydata.hydra.InstallJarTestSparkApp
+            io.snappydata.hydra.cluster.SnappyPrms-userAppArgs = "1 ${snappyStoreHosts} true"
+            io.snappydata.hydra.cluster.SnappyPrms-userAppJar = snappydata-store-scala-tests*tests.jar
+            threadGroups = snappyThreads
+            ;
+
+CLOSETASK   taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = HydraTask_stopSnappy
+            threadGroups = snappyThreads;
+
+CLOSETASK   taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = HydraTask_stopSnappyLeader
+            threadGroups = snappyThreads;
+
+CLOSETASK   taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = HydraTask_stopSnappyServers
+            threadGroups = snappyThreads;
+
+CLOSETASK   taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = HydraTask_stopSnappyLocator
+            threadGroups = snappyThreads;
+
+CLOSETASK   taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = HydraTask_deleteSnappyConfig
+            threadGroups = snappyThreads;
+
+ENDTASK     taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = HydraTask_cleanUpSnappyProcessesOnFailure
+            clientNames = locator1;
+
+hydra.Prms-totalTaskTimeSec           = 100;
+hydra.Prms-maxResultWaitSec           = 900;
+
+hydra.Prms-maxCloseTaskResultWaitSec  = 900;
+hydra.Prms-serialExecution            = true;
+
+hydra.CachePrms-names = defaultCache;
+sql.SQLPrms-useGfxdConfig = true;
+
+/* end task must stop snappy members because they are not stopped by Hydra */
+hydra.Prms-alwaysDoEndTasks = true;
+
+hydra.VmPrms-extraVMArgs   += fcn "hydra.TestConfigFcns.duplicate
+                                  (\"-Xms512m -Xmx1g \", ${${A}Hosts}, true)"
+                             ncf
+                             ,
+                             fcn "hydra.TestConfigFcns.duplicate
+                                  (\"-Xms512m -Xmx1g \", ${${B}Hosts}, true)"
+                             ncf;
+hydra.VmPrms-extraVMArgsSUN += "-XX:PermSize=64M -XX:MaxPermSize=256m";

--- a/dtests/src/test/java/io/snappydata/hydra/installJar/dynamicJarLoadingUsingSparkApp.conf
+++ b/dtests/src/test/java/io/snappydata/hydra/installJar/dynamicJarLoadingUsingSparkApp.conf
@@ -1,6 +1,6 @@
 hydra.Prms-testRequirement = "Test to verify dynamic jar loading feature by using gemxd install-jar command and then accessing the classes through spark App.";
 hydra.Prms-testDescription = "
-This test starts the snappy cluster and spark cluster, then initializes snappyContext.
+This test starts the snappy cluster and spark cluster.
 Creates classes with version 1 and jar packaging these classes at runtime, then executes the gemxd install-jar command to install a local jar file to RowStore.
 It then creates the snappy job dynamically and a jar containing this job, then executes the snappy job with the created jar.
 Test then executes the spark App to verify that we get expected ClassNotFoundException.
@@ -30,41 +30,4 @@ INITTASK    taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = H
             threadGroups = snappyThreads
             ;
 
-CLOSETASK   taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = HydraTask_stopSnappy
-            threadGroups = snappyThreads;
-
-CLOSETASK   taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = HydraTask_stopSnappyLeader
-            threadGroups = snappyThreads;
-
-CLOSETASK   taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = HydraTask_stopSnappyServers
-            threadGroups = snappyThreads;
-
-CLOSETASK   taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = HydraTask_stopSnappyLocator
-            threadGroups = snappyThreads;
-
-CLOSETASK   taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = HydraTask_deleteSnappyConfig
-            threadGroups = snappyThreads;
-
-ENDTASK     taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = HydraTask_cleanUpSnappyProcessesOnFailure
-            clientNames = locator1;
-
-hydra.Prms-totalTaskTimeSec           = 100;
-hydra.Prms-maxResultWaitSec           = 900;
-
-hydra.Prms-maxCloseTaskResultWaitSec  = 900;
-hydra.Prms-serialExecution            = true;
-
-hydra.CachePrms-names = defaultCache;
-sql.SQLPrms-useGfxdConfig = true;
-
-/* end task must stop snappy members because they are not stopped by Hydra */
-hydra.Prms-alwaysDoEndTasks = true;
-
-hydra.VmPrms-extraVMArgs   += fcn "hydra.TestConfigFcns.duplicate
-                                  (\"-Xms512m -Xmx1g \", ${${A}Hosts}, true)"
-                             ncf
-                             ,
-                             fcn "hydra.TestConfigFcns.duplicate
-                                  (\"-Xms512m -Xmx1g \", ${${B}Hosts}, true)"
-                             ncf;
-hydra.VmPrms-extraVMArgsSUN += "-XX:PermSize=64M -XX:MaxPermSize=256m";
+INCLUDE $JTESTS/io/snappydata/hydra/northwind/stopDualModeCluster.conf;

--- a/dtests/src/test/java/io/snappydata/hydra/installJar/installJar.bt
+++ b/dtests/src/test/java/io/snappydata/hydra/installJar/installJar.bt
@@ -8,11 +8,6 @@ io/snappydata/hydra/installJar/dynamicJarLoadingUsingSnappyShell.conf
   B=lead leadHosts=1 leadVMsPerHost=1 leadThreadsPerVM=2
   C=locator locatorHosts=3 locatorVMsPerHost=1 locatorThreadsPerVM=1
 
-io/snappydata/hydra/installJar/dynamicJarLoadingUsingInstallJarBytes.conf
-  A=snappyStore snappyStoreHosts=3 snappyStoreVMsPerHost=1 snappyStoreThreadsPerVM=1
-  B=lead leadHosts=1 leadVMsPerHost=1 leadThreadsPerVM=2
-  C=locator locatorHosts=3 locatorVMsPerHost=1 locatorThreadsPerVM=1
-
 io/snappydata/hydra/installJar/dynamicJarLoadingUsingSparkApp.conf
   A=snappyStore snappyStoreHosts=3 snappyStoreVMsPerHost=1 snappyStoreThreadsPerVM=1
   B=lead leadHosts=1 leadVMsPerHost=1 leadThreadsPerVM=2

--- a/dtests/src/test/java/io/snappydata/hydra/installJar/installJar.bt
+++ b/dtests/src/test/java/io/snappydata/hydra/installJar/installJar.bt
@@ -18,3 +18,8 @@ io/snappydata/hydra/installJar/dynamicJarLoadingUsingSnappyJobsWithIdenticalName
   A=snappyStore snappyStoreHosts=3 snappyStoreVMsPerHost=1 snappyStoreThreadsPerVM=1
   B=lead leadHosts=1 leadVMsPerHost=1 leadThreadsPerVM=2
   C=locator locatorHosts=3 locatorVMsPerHost=1 locatorThreadsPerVM=1
+
+io/snappydata/hydra/installJar/verifyCleanupAfterSnappyJobsExecution.conf
+  A=snappyStore snappyStoreHosts=3 snappyStoreVMsPerHost=1 snappyStoreThreadsPerVM=1
+  B=lead leadHosts=1 leadVMsPerHost=1 leadThreadsPerVM=2
+  C=locator locatorHosts=3 locatorVMsPerHost=1 locatorThreadsPerVM=1

--- a/dtests/src/test/java/io/snappydata/hydra/installJar/installJar.bt
+++ b/dtests/src/test/java/io/snappydata/hydra/installJar/installJar.bt
@@ -19,7 +19,7 @@ io/snappydata/hydra/installJar/dynamicJarLoadingUsingSnappyJobsWithIdenticalName
   B=lead leadHosts=1 leadVMsPerHost=1 leadThreadsPerVM=2
   C=locator locatorHosts=3 locatorVMsPerHost=1 locatorThreadsPerVM=1
 
-io/snappydata/hydra/installJar/verifyCleanupAfterSnappyJobsExecution.conf
+io/snappydata/hydra/installJar/verifyCleanupAfterSnappyJobExecution.conf
   A=snappyStore snappyStoreHosts=3 snappyStoreVMsPerHost=1 snappyStoreThreadsPerVM=1
   B=lead leadHosts=1 leadVMsPerHost=1 leadThreadsPerVM=2
   C=locator locatorHosts=3 locatorVMsPerHost=1 locatorThreadsPerVM=1

--- a/dtests/src/test/java/io/snappydata/hydra/installJar/installJar.bt
+++ b/dtests/src/test/java/io/snappydata/hydra/installJar/installJar.bt
@@ -7,3 +7,14 @@ io/snappydata/hydra/installJar/dynamicJarLoadingUsingSnappyShell.conf
   A=snappyStore snappyStoreHosts=3 snappyStoreVMsPerHost=1 snappyStoreThreadsPerVM=1
   B=lead leadHosts=1 leadVMsPerHost=1 leadThreadsPerVM=2
   C=locator locatorHosts=3 locatorVMsPerHost=1 locatorThreadsPerVM=1
+
+io/snappydata/hydra/installJar/dynamicJarLoadingUsingInstallJarBytes.conf
+  A=snappyStore snappyStoreHosts=3 snappyStoreVMsPerHost=1 snappyStoreThreadsPerVM=1
+  B=lead leadHosts=1 leadVMsPerHost=1 leadThreadsPerVM=2
+  C=locator locatorHosts=3 locatorVMsPerHost=1 locatorThreadsPerVM=1
+
+io/snappydata/hydra/installJar/dynamicJarLoadingUsingSparkApp.conf
+  A=snappyStore snappyStoreHosts=3 snappyStoreVMsPerHost=1 snappyStoreThreadsPerVM=1
+  B=lead leadHosts=1 leadVMsPerHost=1 leadThreadsPerVM=2
+  C=locator locatorHosts=3 locatorVMsPerHost=1 locatorThreadsPerVM=1
+  D=worker workerHosts=3 workerVMsPerHost=1 workerThreadsPerVM=1

--- a/dtests/src/test/java/io/snappydata/hydra/installJar/installJar.bt
+++ b/dtests/src/test/java/io/snappydata/hydra/installJar/installJar.bt
@@ -13,3 +13,8 @@ io/snappydata/hydra/installJar/dynamicJarLoadingUsingSparkApp.conf
   B=lead leadHosts=1 leadVMsPerHost=1 leadThreadsPerVM=2
   C=locator locatorHosts=3 locatorVMsPerHost=1 locatorThreadsPerVM=1
   D=worker workerHosts=3 workerVMsPerHost=1 workerThreadsPerVM=1
+
+io/snappydata/hydra/installJar/dynamicJarLoadingUsingSnappyJobsWithIdenticalNames.conf
+  A=snappyStore snappyStoreHosts=3 snappyStoreVMsPerHost=1 snappyStoreThreadsPerVM=1
+  B=lead leadHosts=1 leadVMsPerHost=1 leadThreadsPerVM=2
+  C=locator locatorHosts=3 locatorVMsPerHost=1 locatorThreadsPerVM=1

--- a/dtests/src/test/java/io/snappydata/hydra/installJar/verifyCleanupAfterSnappyJobExecution.conf
+++ b/dtests/src/test/java/io/snappydata/hydra/installJar/verifyCleanupAfterSnappyJobExecution.conf
@@ -1,0 +1,31 @@
+hydra.Prms-testRequirement = "Test to verify cleanup happens properly after snappy job execution";
+hydra.Prms-testDescription = "
+This test starts the snappy cluster.
+Creates classes with version 1, snappyJob and jar at runtime and executes the snappyjob with the created jar.
+Test then creates classes with version 2 and snappyJob accessing a class loaded through previous job execution with version 1 and a jar containing the new classes and job class.
+It then again executes the snappy job accessing a class loaded through previous job execution with version 1.
+Test verifies that we get expected ClassNotFoundException for classes loaded through previous job execution.";
+
+INCLUDE $JTESTS/io/snappydata/hydra/cluster/startEmbeddedModeCluster.conf;
+
+INITTASK    taskClass = io.snappydata.hydra.installJar.DynamicJarLoadingTest taskMethod  = HydraTask_executeSnappyJob_DynamicJarLoading_WithClasses
+            io.snappydata.hydra.cluster.SnappyPrms-jobClassNames= DynamicJarLoadingJob
+            io.snappydata.hydra.cluster.SnappyPrms-appPropsForJobServer = "classVersion=1,numServers=${snappyStoreHosts},expectedException=false"
+            io.snappydata.hydra.cluster.SnappyPrms-numTimesToRetry = 2
+            threadGroups = snappyThreads;
+
+INITTASK    taskClass = io.snappydata.hydra.installJar.DynamicJarLoadingTest taskMethod  = HydraTask_executeSnappyJob_DynamicJarLoading_verifyCleanUp
+            io.snappydata.hydra.cluster.SnappyPrms-jobClassNames= DynamicJarLoadingJob
+            io.snappydata.hydra.cluster.SnappyPrms-appPropsForJobServer = "classVersion=2,numServers=${snappyStoreHosts},expectedException=true"
+            io.snappydata.hydra.cluster.SnappyPrms-numTimesToRetry = 2
+            threadGroups = snappyThreads;
+
+INITTASK   taskClass = io.snappydata.hydra.cluster.SnappyTest taskMethod  = HydraTask_executeSnappyJob
+           io.snappydata.hydra.cluster.SnappyPrms-jobClassNames = io.snappydata.hydra.InstallJarTest
+           io.snappydata.hydra.cluster.SnappyPrms-appPropsForJobServer = "classVersion=1,numServers=${snappyStoreHosts},expectedException=true"
+           io.snappydata.hydra.cluster.SnappyPrms-userAppJar = snappydata-store-scala-tests*tests.jar
+           io.snappydata.hydra.cluster.SnappyPrms-numTimesToRetry = 2
+           threadGroups = snappyThreads
+           ;
+
+INCLUDE $JTESTS/io/snappydata/hydra/cluster/stopEmbeddedModeCluster.conf;

--- a/dtests/src/test/java/io/snappydata/hydra/northwind/nwReplicatedRowTablesTest.conf
+++ b/dtests/src/test/java/io/snappydata/hydra/northwind/nwReplicatedRowTablesTest.conf
@@ -19,7 +19,8 @@ TASK        taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = H
             io.snappydata.hydra.cluster.SnappyPrms-sparkJobClassNames = io.snappydata.hydra.northwind.ValidateNWQueriesApp
             io.snappydata.hydra.cluster.SnappyPrms-userAppArgs = "${tableType}"
             io.snappydata.hydra.cluster.SnappyPrms-userAppJar = snappydata-store-scala-tests*tests.jar
-            threadGroups = leadThreads;
+            threadGroups = leadThreads
+            maxThreads = 1;
 
 TASK        taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = HydraTask_executeSQLScripts
             io.snappydata.hydra.cluster.SnappyPrms-sqlScriptNames = nw_queries.sql

--- a/dtests/src/test/scala/io/snappydata/hydra/InstallJarTest.scala
+++ b/dtests/src/test/scala/io/snappydata/hydra/InstallJarTest.scala
@@ -29,12 +29,12 @@ class InstallJarTest extends SnappySQLJob {
     def getCurrentDirectory = new java.io.File(".").getCanonicalPath
     val pw: PrintWriter = new PrintWriter(new FileOutputStream(new File(jobConfig.getString("logFileName"))), true)
     Try {
-      pw.println("****** DynamicJarLoadingJob started ******")
+      pw.println("****** InstallJarTest started ******")
       val currentDirectory: String = new File(".").getCanonicalPath
       val numServers: Int = jobConfig.getString("numServers").toInt
       val expectedException: Boolean = jobConfig.getString("expectedException").toBoolean
       TestUtils.verify(snc, jobConfig.getString("classVersion"), pw, numServers, expectedException)
-      pw.println("****** DynamicJarLoadingJob finished ******")
+      pw.println("****** InstallJarTest finished ******")
       return String.format("See %s/" + jobConfig.getString("logFileName"), currentDirectory)
     } match {
       case Success(v) => pw.close()

--- a/dtests/src/test/scala/io/snappydata/hydra/InstallJarTest.scala
+++ b/dtests/src/test/scala/io/snappydata/hydra/InstallJarTest.scala
@@ -36,12 +36,11 @@ class InstallJarTest extends SnappySQLJob {
       TestUtils.verify(snc, jobConfig.getString("classVersion"), pw, numServers, expectedException)
       pw.println("****** DynamicJarLoadingJob finished ******")
       return String.format("See %s/" + jobConfig.getString("logFileName"), currentDirectory)
-
     } match {
       case Success(v) => pw.close()
         s"See ${getCurrentDirectory}/${jobConfig.getString("logFileName")}"
       case Failure(e) =>
-        pw.println(e.getMessage)
+        pw.println("Exception occurred while executing the job " + "\nError Message:" + e.getMessage)
         pw.close();
         throw e;
     }

--- a/dtests/src/test/scala/io/snappydata/hydra/InstallJarTestSparkApp.scala
+++ b/dtests/src/test/scala/io/snappydata/hydra/InstallJarTestSparkApp.scala
@@ -37,12 +37,10 @@ object InstallJarTestSparkApp {
     Try {
       pw.println("****** DynamicJarLoadingJob started ******")
       pw.flush()
-      val currentDirectory: String = new File(".").getCanonicalPath
       val numServers: Int = args(1).toInt
       val expectedException: Boolean = args(2).toBoolean
       TestUtils.verify(snc, args(0), pw, numServers, expectedException)
       pw.println("****** DynamicJarLoadingJob finished ******")
-      return String.format("See %s/" + outputFile, currentDirectory)
     } match {
       case Success(v) => pw.close()
       case Failure(e) =>

--- a/dtests/src/test/scala/io/snappydata/hydra/InstallJarTestSparkApp.scala
+++ b/dtests/src/test/scala/io/snappydata/hydra/InstallJarTestSparkApp.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016 SnappyData, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License. You
+ * may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License. See accompanying
+ * LICENSE file.
+ */
 package io.snappydata.hydra
 
 import java.io.{File, FileOutputStream, PrintWriter}
@@ -8,9 +24,6 @@ import org.apache.spark.{SparkContext, SparkConf}
 
 import scala.util.{Failure, Success, Try}
 
-/**
- * Created by swati on 22/11/16.
- */
 object InstallJarTestSparkApp {
   val conf = new SparkConf().
     setAppName("InstallJarTest Application")
@@ -23,20 +36,18 @@ object InstallJarTestSparkApp {
     val pw = new PrintWriter(new FileOutputStream(new File(outputFile), true));
     Try {
       pw.println("****** DynamicJarLoadingJob started ******")
+      pw.flush()
       val currentDirectory: String = new File(".").getCanonicalPath
       val numServers: Int = args(1).toInt
       val expectedException: Boolean = args(2).toBoolean
       TestUtils.verify(snc, args(0), pw, numServers, expectedException)
       pw.println("****** DynamicJarLoadingJob finished ******")
       return String.format("See %s/" + outputFile, currentDirectory)
-
     } match {
       case Success(v) => pw.close()
       case Failure(e) =>
-        pw.println(e.getMessage)
-        pw.close();
-        throw e;
+        pw.println("Exception occurred while executing the job " + "\nError Message:" + e.getMessage)
+        pw.close()
     }
   }
-
 }

--- a/dtests/src/test/scala/io/snappydata/hydra/InstallJarTestSparkApp.scala
+++ b/dtests/src/test/scala/io/snappydata/hydra/InstallJarTestSparkApp.scala
@@ -1,0 +1,42 @@
+package io.snappydata.hydra
+
+import java.io.{File, FileOutputStream, PrintWriter}
+
+import io.snappydata.hydra.installJar.TestUtils
+import org.apache.spark.sql.SnappyContext
+import org.apache.spark.{SparkContext, SparkConf}
+
+import scala.util.{Failure, Success, Try}
+
+/**
+ * Created by swati on 22/11/16.
+ */
+object InstallJarTestSparkApp {
+  val conf = new SparkConf().
+    setAppName("InstallJarTest Application")
+  val sc = new SparkContext(conf)
+  val snc = SnappyContext(sc)
+
+  def main(args: Array[String]): Unit = {
+    val threadID = Thread.currentThread().getId
+    val outputFile = "ValidateInstallJarTestApp_thread_" + threadID + "_" + System.currentTimeMillis + ".out"
+    val pw = new PrintWriter(new FileOutputStream(new File(outputFile), true));
+    Try {
+      pw.println("****** DynamicJarLoadingJob started ******")
+      val currentDirectory: String = new File(".").getCanonicalPath
+      val numServers: Int = args(1).toInt
+      val expectedException: Boolean = args(2).toBoolean
+      TestUtils.verify(snc, args(0), pw, numServers, expectedException)
+      pw.println("****** DynamicJarLoadingJob finished ******")
+      return String.format("See %s/" + outputFile, currentDirectory)
+
+    } match {
+      case Success(v) => pw.close()
+      case Failure(e) =>
+        pw.println(e.getMessage)
+        pw.close();
+        throw e;
+    }
+  }
+
+}


### PR DESCRIPTION
## Changes proposed in this pull request

- Added test to verify that the classes loaded through install-jar command are not accessible to the spark App
- Added test to verify classes loaded through install-jar command are accessible to the snappy jobs and both the jobs works fine in parallel in spite of having same class name
- Added support in framework to specify the appName while running the snappy job.
- Added separate conf files for starting and stopping snappy embedded mode cluster

## Patch testing

Verified the changes by running installJar.bt

## ReleaseNotes.txt changes

NA

## Other PRs 

No
