### PR TITLE
Fix for SNAP-1183

### DIFF
--- a/cluster/src/test/scala/org/apache/spark/sql/NWQueries.scala
+++ b/cluster/src/test/scala/org/apache/spark/sql/NWQueries.scala
@@ -195,7 +195,7 @@ object NWQueries extends SnappyFunSuite {
       " ) b on a.OrderID = b.OrderID" +
       " where a.ShippedDate is not null" +
       " and a.ShippedDate > '1996-12-24' and a.ShippedDate < '1997-09-30'" +
-      " order by a.ShippedDate"
+      " order by ShippedDate"
 
   val Q37: String = "select distinct a.CategoryID," +
       " a.CategoryName," +
@@ -388,7 +388,7 @@ object NWQueries extends SnappyFunSuite {
     "Q33" -> Q33,
     "Q34" -> Q34,
     "Q35" -> Q35,
-    //"Q36" -> Q36, commented due to SNAP-1183
+    "Q36" -> Q36,
     "Q37" -> Q37,
     "Q38" -> Q38,
     "Q39" -> Q39,

--- a/dtests/src/resources/scripts/northWind/nw_queries.sql
+++ b/dtests/src/resources/scripts/northWind/nw_queries.sql
@@ -104,7 +104,7 @@ select distinct (a.ShippedDate) as ShippedDate, a.OrderID, b.Subtotal, year(a.Sh
      inner join ( select distinct OrderID, sum(UnitPrice * Quantity * (1 - Discount)) as Subtotal
      from order_details group by OrderID ) b on a.OrderID = b.OrderID
      where a.ShippedDate is not null and a.ShippedDate > Cast('1996-12-24' as TIMESTAMP) and a.ShippedDate < Cast('1997-09-30' as TIMESTAMP)
-     order by a.ShippedDate;
+     order by ShippedDate;
 
 select distinct a.CategoryID, a.CategoryName, b.ProductName, sum(c.ExtendedPrice) as ProductSales
      from Categories a

--- a/dtests/src/test/scala/io/snappydata/hydra/northwind/NWQueries.scala
+++ b/dtests/src/test/scala/io/snappydata/hydra/northwind/NWQueries.scala
@@ -193,7 +193,7 @@ object NWQueries {
     " where a.ShippedDate is not null" +
     " and a.ShippedDate > Cast('1996-12-24' as TIMESTAMP) and " +
     " a.ShippedDate < Cast('1997-09-30' as TIMESTAMP)" +
-    " order by a.ShippedDate"
+    " order by ShippedDate"
 
   val Q37: String = "select distinct a.CategoryID," +
     " a.CategoryName," +


### PR DESCRIPTION
## Changes proposed in this pull request

- Removed the "a." qualification in the ORDER BY clause from Q36
- Enabled Q36 in northWind dunit and scala test

## Patch testing

Verified the changes by running northWind.bt, northwind dunit and scala test

## ReleaseNotes.txt changes
 
NA

## Other PRs 

No

