### PR TITLE
Fix

### DIFF
--- a/cluster/src/main/resources/jobserver-defaults.conf
+++ b/cluster/src/main/resources/jobserver-defaults.conf
@@ -30,13 +30,13 @@ spark {
     # }
 
     filedao {
-      rootdir = /tmp/spark-jobserver/filedao/data
+      rootdir = <basedir>/spark-jobserver/filedao/data
     }
 
     datadao {
       # storage directory for files that are uploaded to the server
       # via POST/data commands
-      rootdir = /tmp/spark-jobserver/upload
+      rootdir = <basedir>/spark-jobserver/upload
     }
 
 

--- a/cluster/src/main/resources/jobserver-overrides.conf
+++ b/cluster/src/main/resources/jobserver-overrides.conf
@@ -28,7 +28,7 @@ spark {
       jdbc-driver = org.h2.Driver
 
       # Directory where default H2 driver stores its data. Only needed for H2.
-      rootdir = /tmp/spark-jobserver/sqldao/data
+      rootdir = <basedir>/spark-jobserver/sqldao/data
 
       # Full JDBC URL / init string, along with username and password.  Sorry, needs to match above.
       # Substitutions may be used to launch job-server, but leave it out here in the default or tests won't pass

--- a/cluster/src/main/scala/io/snappydata/impl/LeadImpl.scala
+++ b/cluster/src/main/scala/io/snappydata/impl/LeadImpl.scala
@@ -387,10 +387,11 @@ class LeadImpl extends ServerImpl with Lead with Logging {
 
   def getDynamicOverrides: Properties = {
     val dynamicOverrides = new Properties()
+    val replaceString = "<basedir>"
 
     def replace(key: String, value: String, newValue: String) = {
-      assert (value.indexOf("/tmp") >= 0)
-      dynamicOverrides.setProperty(key, value.replace("/tmp", newValue))
+      assert (value.indexOf(replaceString) >= 0)
+      dynamicOverrides.setProperty(key, value.replace(replaceString, newValue))
     }
 
     val workingDir = System.getProperty(

--- a/cluster/src/test/scala/io/snappydata/tools/LeaderLauncherSpec.scala
+++ b/cluster/src/test/scala/io/snappydata/tools/LeaderLauncherSpec.scala
@@ -29,8 +29,8 @@ import org.apache.spark.sql.SnappyContext
 import org.apache.spark.{SparkConf, SparkContext}
 
 /**
-  * BDD style tests
-  */
+ * BDD style tests
+ */
 class LeaderLauncherSpec extends WordSpec with Matchers {
 
   private def doExtract(param: String, prop: String) = param.toLowerCase.startsWith("-" + prop)
@@ -69,30 +69,30 @@ class LeaderLauncherSpec extends WordSpec with Matchers {
 
       "have host-data true for loner" in {
 
-//        {
-//
-//          val l = new LeadImpl
-//          val conf = new SparkConf().
-//              setMaster(s"${Constant.JDBC_URL_PREFIX}${Property.mcastPort}=0").
-//              setAppName("check hostdata true")
-//          val sc = new SparkContext(conf)
-//          try {
-//            val opts = l.initStartupArgs(conf, sc)
-//
-//            val hdProp = opts.get(Constant.STORE_PROPERTY_PREFIX +
-//                com.pivotal.gemfirexd.Attribute.GFXD_HOST_DATA)
-//
-//            assert(hdProp != null)
-//            assert(hdProp.toBoolean == true)
-//          } finally {
-//            sc.stop()
-//          }
-//        }
+        //        {
+        //
+        //          val l = new LeadImpl
+        //          val conf = new SparkConf().
+        //              setMaster(s"${Constant.JDBC_URL_PREFIX}${Property.mcastPort}=0").
+        //              setAppName("check hostdata true")
+        //          val sc = new SparkContext(conf)
+        //          try {
+        //            val opts = l.initStartupArgs(conf, sc)
+        //
+        //            val hdProp = opts.get(Constant.STORE_PROPERTY_PREFIX +
+        //                com.pivotal.gemfirexd.Attribute.GFXD_HOST_DATA)
+        //
+        //            assert(hdProp != null)
+        //            assert(hdProp.toBoolean == true)
+        //          } finally {
+        //            sc.stop()
+        //          }
+        //        }
 
         {
           // Stop if already any present
           val sparkContext = SnappyContext.globalSparkContext
-          if(sparkContext != null) sparkContext.stop()
+          if (sparkContext != null) sparkContext.stop()
 
           val l = new LeadImpl
           val conf = (new SparkConf).
@@ -174,6 +174,36 @@ class LeaderLauncherSpec extends WordSpec with Matchers {
         }.getMessage.equals(LocalizedMessages.res.getTextMessage("SD_ZERO_ARGS"))
       }
 
+      " have jobserver tmp directory redirected " in {
+        val l = new LeadImpl
+        val conf = l.getConfig(Array.empty)
+        val f = conf.getString("spark.jobserver.filedao.rootdir")
+        assert(f.indexOf("/tmp") == -1)
+        assert(f equals "./spark-jobserver/filedao/data")
+        val d = conf.getString("spark.jobserver.datadao.rootdir")
+        assert(d.indexOf("/tmp") == -1)
+        assert(d equals "./spark-jobserver/upload")
+        val s = conf.getString("spark.jobserver.sqldao.rootdir")
+        assert(s.indexOf("/tmp") == -1)
+        assert(s equals "./spark-jobserver/sqldao/data")
+      }
+
+      " have jobserver tmp directory from syshome" in {
+        val directory = "/dummy"
+        System.setProperty(
+          com.pivotal.gemfirexd.internal.iapi.reference.Property.SYSTEM_HOME_PROPERTY, directory)
+        val l = new LeadImpl
+        val conf = l.getConfig(Array.empty)
+        val f = conf.getString("spark.jobserver.filedao.rootdir")
+        assert(f.indexOf("/tmp") == -1)
+        assert(f startsWith directory)
+        val d = conf.getString("spark.jobserver.datadao.rootdir")
+        assert(d.indexOf("/tmp") == -1)
+        assert(d startsWith directory)
+        val s = conf.getString("spark.jobserver.sqldao.rootdir")
+        assert(s.indexOf("/tmp") == -1)
+        assert(s startsWith directory)
+      }
     } // end started
   }
 

--- a/cluster/src/test/scala/io/snappydata/tools/LeaderLauncherSpec.scala
+++ b/cluster/src/test/scala/io/snappydata/tools/LeaderLauncherSpec.scala
@@ -174,17 +174,18 @@ class LeaderLauncherSpec extends WordSpec with Matchers {
         }.getMessage.equals(LocalizedMessages.res.getTextMessage("SD_ZERO_ARGS"))
       }
 
+      val replaceString = "<dir>"
       " have jobserver tmp directory redirected " in {
         val l = new LeadImpl
         val conf = l.getConfig(Array.empty)
         val f = conf.getString("spark.jobserver.filedao.rootdir")
-        assert(f.indexOf("/tmp") == -1)
+        assert(f.indexOf(replaceString) == -1)
         assert(f equals "./spark-jobserver/filedao/data")
         val d = conf.getString("spark.jobserver.datadao.rootdir")
-        assert(d.indexOf("/tmp") == -1)
+        assert(d.indexOf(replaceString) == -1)
         assert(d equals "./spark-jobserver/upload")
         val s = conf.getString("spark.jobserver.sqldao.rootdir")
-        assert(s.indexOf("/tmp") == -1)
+        assert(s.indexOf(replaceString) == -1)
         assert(s equals "./spark-jobserver/sqldao/data")
       }
 
@@ -195,13 +196,13 @@ class LeaderLauncherSpec extends WordSpec with Matchers {
         val l = new LeadImpl
         val conf = l.getConfig(Array.empty)
         val f = conf.getString("spark.jobserver.filedao.rootdir")
-        assert(f.indexOf("/tmp") == -1)
+        assert(f.indexOf(replaceString) == -1)
         assert(f startsWith directory)
         val d = conf.getString("spark.jobserver.datadao.rootdir")
-        assert(d.indexOf("/tmp") == -1)
+        assert(d.indexOf(replaceString) == -1)
         assert(d startsWith directory)
         val s = conf.getString("spark.jobserver.sqldao.rootdir")
-        assert(s.indexOf("/tmp") == -1)
+        assert(s.indexOf(replaceString) == -1)
         assert(s startsWith directory)
       }
     } // end started


### PR DESCRIPTION
## Changes proposed in this pull request

In jobserver-defaults.conf, rootdir for spark/jobserver/filedao and spark/jobserver/datadao point to /tmp/spark-jobserver.
For multi users, we cannot overwrite the existing directory created by other user. So, we change the rootdir for above and use workingDir mentioned by "-dir" during startup. This addresses concerns like loosing job configuration across restarts etc.

## Patch testing

Added unit test verifying the same.

## ReleaseNotes.txt changes
If upgraded, jobserver configuration requires to be redone. As we are yet to release GA, this is not important to mention in relelase notes.

## Other PRs 

(Does this change require changes in other projects- store, spark, spark-jobserver, aqp? Add the links of PR of the other subprojects that are related to this change)

- redirecting rootdir from /tmp to "-dir" startup parameter via
gemfirexd.system.home variable set in the launcher

- non-overridable js props like sqldao.rootdir is now dynamically
computed using the above.

- added tests to verify /tmp is no more there in the js startup
settings.