### PR TITLE
[SNAP-1185] Changing all internal.Logging references to public one

### DIFF
--- a/cluster/src/main/scala/io/snappydata/cluster/ExecutorInitiator.scala
+++ b/cluster/src/main/scala/io/snappydata/cluster/ExecutorInitiator.scala
@@ -156,20 +156,13 @@ object ExecutorInitiator extends Logging {
 
                     val driverConf = new SparkConf
                     Utils.setDefaultSerializerAndCodec(driverConf)
-                    // Specify a default directory for executor, if the local directory for executor
-                    // is set via the executor conf,
-                    // it will override this property later in the code
-                    val localDirForExecutor = new File("./" + "executor").getAbsolutePath
 
-                    driverConf.set("spark.local.dir", localDirForExecutor)
                     for ((key, value) <- props) {
                       // this is required for SSL in standalone mode
-                      if (!key.equals("spark.local.dir")) {
-                        if (SparkCallbacks.isExecutorStartupConf(key)) {
-                          driverConf.setIfMissing(key, value)
-                        } else {
-                          driverConf.set(key, value)
-                        }
+                      if (SparkCallbacks.isExecutorStartupConf(key)) {
+                        driverConf.setIfMissing(key, value)
+                      } else {
+                        driverConf.set(key, value)
                       }
                     }
                     // TODO: Hemant: add executor specific properties from local

--- a/cluster/src/test/scala/org/apache/spark/sql/execution/benchmark/ColumnCacheBenchmark.scala
+++ b/cluster/src/test/scala/org/apache/spark/sql/execution/benchmark/ColumnCacheBenchmark.scala
@@ -118,6 +118,7 @@ class ColumnCacheBenchmark extends SnappyFunSuite {
   private def benchmarkRandomizedKeys(size: Int, readPathOnly: Boolean): Unit = {
     val numIters = 10
     val benchmark = new Benchmark("Cache random keys", size)
+    snappySession.sql(s"set ${SQLConf.COLUMN_BATCH_SIZE.key} = 10000")
     snappySession.sql("drop table if exists test")
     var testDF = snappySession.range(size)
         .selectExpr("id", "floor(rand() * 10000) as k")

--- a/cluster/src/test/scala/org/apache/spark/sql/execution/benchmark/TPCETrade.scala
+++ b/cluster/src/test/scala/org/apache/spark/sql/execution/benchmark/TPCETrade.scala
@@ -38,7 +38,6 @@ class TPCETrade extends SnappyFunSuite {
         .setIfMissing("spark.master", s"local[$numProcessors]")
         .setAppName("microbenchmark")
     conf.set("spark.sql.shuffle.partitions", numProcessors.toString)
-    // conf.set(SQLConf.COLUMN_BATCH_SIZE.key, "100000")
     conf.set("snappydata.store.eviction-heap-percentage", "90")
     conf.set("snappydata.store.critical-heap-percentage", "95")
     if (addOn != null) {
@@ -54,6 +53,7 @@ class TPCETrade extends SnappyFunSuite {
     val tradeSize = 500000L
     val numDays = 1
     val numIters = 10
+    snappySession.sql(s"set ${SQLConf.COLUMN_BATCH_SIZE.key} = 10000")
     TPCETradeTest.benchmarkRandomizedKeys(snappySession, quoteSize, tradeSize,
       quoteSize, numDays, queryNumber = 1, numIters, doInit = true)
     TPCETradeTest.benchmarkRandomizedKeys(snappySession, quoteSize, tradeSize,

--- a/core/src/main/scala/org/apache/spark/Logging.scala
+++ b/core/src/main/scala/org/apache/spark/Logging.scala
@@ -34,6 +34,8 @@ trait Logging {
   // be serialized and used on another machine
   @transient private var log_ : Logger = _
 
+  @transient private[this] var levelFlags: Int = _
+
   // Method to get the logger name for this object
   protected def logName = {
     // Ignore trailing $'s in the class names for Scala objects
@@ -49,21 +51,54 @@ trait Logging {
     log_
   }
 
-  protected lazy val infoEnabled = log.isInfoEnabled
-  protected lazy val debugEnabled = log.isDebugEnabled
-  protected lazy val traceEnabled = log.isTraceEnabled
+  private def setLevel(value: Boolean, enabled: Int, disabled: Int): Unit = {
+    if (value) levelFlags |= enabled else levelFlags |= disabled
+  }
+
+  protected final def isInfoEnabled: Boolean = {
+    val levelFlags = this.levelFlags
+    if ((levelFlags & Logging.INFO_ENABLED) != 0) true
+    else if ((levelFlags & Logging.INFO_DISABLED) != 0) false
+    else {
+      val value = log.isInfoEnabled
+      setLevel(value, Logging.INFO_ENABLED, Logging.INFO_DISABLED)
+      value
+    }
+  }
+
+  protected final def isDebugEnabled: Boolean = {
+    val levelFlags = this.levelFlags
+    if ((levelFlags & Logging.DEBUG_DISABLED) != 0) false
+    else if ((levelFlags & Logging.DEBUG_ENABLED) != 0) true
+    else {
+      val value = log.isDebugEnabled
+      setLevel(value, Logging.DEBUG_ENABLED, Logging.DEBUG_DISABLED)
+      value
+    }
+  }
+
+  protected final def isTraceEnabled: Boolean = {
+    val levelFlags = this.levelFlags
+    if ((levelFlags & Logging.TRACE_DISABLED) != 0) false
+    else if ((levelFlags & Logging.TRACE_ENABLED) != 0) true
+    else {
+      val value = log.isTraceEnabled
+      setLevel(value, Logging.TRACE_ENABLED, Logging.TRACE_DISABLED)
+      value
+    }
+  }
 
   // Log methods that take only a String
   protected def logInfo(msg: => String) {
-    if (infoEnabled) log.info(msg)
+    if (isInfoEnabled) log.info(msg)
   }
 
   protected def logDebug(msg: => String) {
-    if (debugEnabled) log.debug(msg)
+    if (isDebugEnabled) log.debug(msg)
   }
 
   protected def logTrace(msg: => String) {
-    if (traceEnabled) log.trace(msg)
+    if (isTraceEnabled) log.trace(msg)
   }
 
   protected def logWarning(msg: => String) {
@@ -76,15 +111,15 @@ trait Logging {
 
   // Log methods that take Throwables (Exceptions/Errors) too
   protected def logInfo(msg: => String, throwable: Throwable) {
-    if (infoEnabled) log.info(msg, throwable)
+    if (isInfoEnabled) log.info(msg, throwable)
   }
 
   protected def logDebug(msg: => String, throwable: Throwable) {
-    if (debugEnabled) log.debug(msg, throwable)
+    if (isDebugEnabled) log.debug(msg, throwable)
   }
 
   protected def logTrace(msg: => String, throwable: Throwable) {
-    if (traceEnabled) log.trace(msg, throwable)
+    if (isTraceEnabled) log.trace(msg, throwable)
   }
 
   protected def logWarning(msg: => String, throwable: Throwable) {
@@ -94,8 +129,6 @@ trait Logging {
   protected def logError(msg: => String, throwable: Throwable) {
     if (log.isErrorEnabled) log.error(msg, throwable)
   }
-
-  protected def isTraceEnabled: Boolean = traceEnabled
 
   protected def initializeLogIfNecessary(isInterpreter: Boolean): Unit = {
     if (!Logging.initialized) {
@@ -152,6 +185,14 @@ trait Logging {
 }
 
 private object Logging {
+
+  private val INFO_ENABLED = 0x1
+  private val INFO_DISABLED = 0x2
+  private val DEBUG_ENABLED = 0x4
+  private val DEBUG_DISABLED = 0x8
+  private val TRACE_ENABLED = 0x10
+  private val TRACE_DISABLED = 0x20
+
   @volatile private var initialized = false
   val initLock = new Object()
   try {

--- a/core/src/main/scala/org/apache/spark/Logging.scala
+++ b/core/src/main/scala/org/apache/spark/Logging.scala
@@ -17,9 +17,153 @@
 
 package org.apache.spark
 
+import org.apache.log4j.{Level, LogManager, PropertyConfigurator}
+import org.slf4j.impl.StaticLoggerBinder
+import org.slf4j.{Logger, LoggerFactory}
+
+import org.apache.spark.util.Utils
+
 /**
  * Utility trait for classes that want to log data. Creates an SLF4J logger
  * for the class and allows logging messages at different levels using methods
  * that only evaluate parameters lazily if the log level is enabled.
  */
-trait Logging extends org.apache.spark.internal.Logging
+trait Logging {
+
+  // Make the log field transient so that objects with Logging can
+  // be serialized and used on another machine
+  @transient private var log_ : Logger = _
+
+  // Method to get the logger name for this object
+  protected def logName = {
+    // Ignore trailing $'s in the class names for Scala objects
+    this.getClass.getName.stripSuffix("$")
+  }
+
+  // Method to get or create the logger for this object
+  protected def log: Logger = {
+    if (log_ == null) {
+      initializeLogIfNecessary(false)
+      log_ = LoggerFactory.getLogger(logName)
+    }
+    log_
+  }
+
+  protected lazy val infoEnabled = log.isInfoEnabled
+  protected lazy val debugEnabled = log.isDebugEnabled
+  protected lazy val traceEnabled = log.isTraceEnabled
+
+  // Log methods that take only a String
+  protected def logInfo(msg: => String) {
+    if (infoEnabled) log.info(msg)
+  }
+
+  protected def logDebug(msg: => String) {
+    if (debugEnabled) log.debug(msg)
+  }
+
+  protected def logTrace(msg: => String) {
+    if (traceEnabled) log.trace(msg)
+  }
+
+  protected def logWarning(msg: => String) {
+    if (log.isWarnEnabled) log.warn(msg)
+  }
+
+  protected def logError(msg: => String) {
+    if (log.isErrorEnabled) log.error(msg)
+  }
+
+  // Log methods that take Throwables (Exceptions/Errors) too
+  protected def logInfo(msg: => String, throwable: Throwable) {
+    if (infoEnabled) log.info(msg, throwable)
+  }
+
+  protected def logDebug(msg: => String, throwable: Throwable) {
+    if (debugEnabled) log.debug(msg, throwable)
+  }
+
+  protected def logTrace(msg: => String, throwable: Throwable) {
+    if (traceEnabled) log.trace(msg, throwable)
+  }
+
+  protected def logWarning(msg: => String, throwable: Throwable) {
+    if (log.isWarnEnabled) log.warn(msg, throwable)
+  }
+
+  protected def logError(msg: => String, throwable: Throwable) {
+    if (log.isErrorEnabled) log.error(msg, throwable)
+  }
+
+  protected def isTraceEnabled: Boolean = traceEnabled
+
+  protected def initializeLogIfNecessary(isInterpreter: Boolean): Unit = {
+    if (!Logging.initialized) {
+      Logging.initLock.synchronized {
+        if (!Logging.initialized) {
+          initializeLogging(isInterpreter)
+        }
+      }
+    }
+  }
+
+  private def initializeLogging(isInterpreter: Boolean): Unit = {
+    // Don't use a logger in here, as this is itself occurring during initialization of a logger
+    // If Log4j 1.2 is being used, but is not initialized, load a default properties file
+    val binderClass = StaticLoggerBinder.getSingleton.getLoggerFactoryClassStr
+    // This distinguishes the log4j 1.2 binding, currently
+    // org.slf4j.impl.Log4jLoggerFactory, from the log4j 2.0 binding, currently
+    // org.apache.logging.slf4j.Log4jLoggerFactory
+    val usingLog4j12 = "org.slf4j.impl.Log4jLoggerFactory".equals(binderClass)
+    if (usingLog4j12) {
+      val log4j12Initialized = LogManager.getRootLogger.getAllAppenders.hasMoreElements
+      // scalastyle:off println
+      if (!log4j12Initialized) {
+        val defaultLogProps = "org/apache/spark/log4j-defaults.properties"
+        Option(Utils.getSparkClassLoader.getResource(defaultLogProps)) match {
+          case Some(url) =>
+            PropertyConfigurator.configure(url)
+            System.err.println(s"Using Spark's default log4j profile: $defaultLogProps")
+          case None =>
+            System.err.println(s"Spark was unable to load $defaultLogProps")
+        }
+      }
+
+      if (isInterpreter) {
+        // Use the repl's main class to define the default log level when running the shell,
+        // overriding the root logger's config if they're different.
+        val rootLogger = LogManager.getRootLogger
+        val replLogger = LogManager.getLogger(logName)
+        val replLevel = Option(replLogger.getLevel).getOrElse(Level.WARN)
+        if (replLevel != rootLogger.getEffectiveLevel) {
+          System.err.printf("Setting default log level to \"%s\".\n", replLevel)
+          System.err.println("To adjust logging level use sc.setLogLevel(newLevel).")
+          rootLogger.setLevel(replLevel)
+        }
+      }
+      // scalastyle:on println
+    }
+    Logging.initialized = true
+
+    // Force a call into slf4j to initialize it. Avoids this happening from multiple threads
+    // and triggering this: http://mailman.qos.ch/pipermail/slf4j-dev/2010-April/002956.html
+    log
+  }
+}
+
+private object Logging {
+  @volatile private var initialized = false
+  val initLock = new Object()
+  try {
+    // We use reflection here to handle the case where users remove the
+    // slf4j-to-jul bridge order to route their logs to JUL.
+    val bridgeClass = Utils.classForName("org.slf4j.bridge.SLF4JBridgeHandler")
+    bridgeClass.getMethod("removeHandlersForRootLogger").invoke(null)
+    val installed = bridgeClass.getMethod("isInstalled").invoke(null).asInstanceOf[Boolean]
+    if (!installed) {
+      bridgeClass.getMethod("install").invoke(null)
+    }
+  } catch {
+    case e: ClassNotFoundException => // can't log anything yet so just fail silently
+  }
+}

--- a/core/src/main/scala/org/apache/spark/sql/SnappyContext.scala
+++ b/core/src/main/scala/org/apache/spark/sql/SnappyContext.scala
@@ -30,7 +30,6 @@ import io.snappydata.{SnappyTableStatsProviderService, Constant, Property}
 
 import org.apache.spark.annotation.{DeveloperApi, Experimental}
 import org.apache.spark.api.java.JavaSparkContext
-import org.apache.spark.internal.Logging
 import org.apache.spark.rdd.RDD
 import org.apache.spark.scheduler.{SparkListener, SparkListenerApplicationEnd}
 import org.apache.spark.sql.catalyst.expressions.SortDirection
@@ -49,7 +48,7 @@ import org.apache.spark.sql.streaming._
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.storage.{BlockManagerId, StorageLevel}
 import org.apache.spark.streaming.dstream.DStream
-import org.apache.spark.{SparkConf, SparkContext, SparkEnv, SparkException}
+import org.apache.spark.{Logging, SparkConf, SparkContext, SparkEnv, SparkException}
 
 /**
  * Main entry point for SnappyData extensions to Spark. A SnappyContext
@@ -79,7 +78,7 @@ import org.apache.spark.{SparkConf, SparkContext, SparkEnv, SparkException}
  */
 class SnappyContext protected[spark](val snappySession: SnappySession)
     extends SQLContext(snappySession)
-    with Serializable with Logging {
+    with Serializable {
 
   self =>
 

--- a/core/src/main/scala/org/apache/spark/sql/SnappySession.scala
+++ b/core/src/main/scala/org/apache/spark/sql/SnappySession.scala
@@ -28,7 +28,6 @@ import io.snappydata.Constant
 
 import org.apache.spark.SparkContext
 import org.apache.spark.annotation.{DeveloperApi, Experimental}
-import org.apache.spark.internal.Logging
 import org.apache.spark.rdd.RDD
 import org.apache.spark.scheduler.{SparkListener, SparkListenerApplicationEnd}
 import org.apache.spark.sql.catalyst.analysis.EliminateSubqueryAliases
@@ -55,7 +54,7 @@ import org.apache.spark.streaming.dstream.DStream
 
 class SnappySession(@transient private val sc: SparkContext,
     @transient private val existingSharedState: Option[SnappySharedState])
-    extends SparkSession(sc) with Logging {
+    extends SparkSession(sc) {
 
   self =>
 

--- a/core/src/main/scala/org/apache/spark/sql/collection/Utils.scala
+++ b/core/src/main/scala/org/apache/spark/sql/collection/Utils.scala
@@ -32,7 +32,6 @@ import com.esotericsoftware.kryo.{Kryo, KryoSerializable}
 import io.snappydata.{Constant, ToolsCallback}
 import org.apache.commons.math3.distribution.NormalDistribution
 
-import org.apache.spark.internal.Logging
 import org.apache.spark.io.CompressionCodec
 import org.apache.spark.rdd.RDD
 import org.apache.spark.scheduler.TaskLocation
@@ -50,7 +49,7 @@ import org.apache.spark.sql.sources.CastLongTime
 import org.apache.spark.sql.types._
 import org.apache.spark.storage.BlockManagerId
 import org.apache.spark.util.io.ChunkedByteBuffer
-import org.apache.spark.{Partition, Partitioner, SparkConf, SparkContext, SparkEnv, TaskContext}
+import org.apache.spark.{Logging, Partition, Partitioner, SparkConf, SparkContext, SparkEnv, TaskContext}
 
 object Utils {
 

--- a/core/src/main/scala/org/apache/spark/sql/execution/columnar/JDBCAppendableRelation.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/columnar/JDBCAppendableRelation.scala
@@ -22,7 +22,7 @@ import scala.collection.mutable
 
 import _root_.io.snappydata.{Constant, SnappyTableStatsProviderService}
 
-import org.apache.spark.internal.Logging
+import org.apache.spark.Logging
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql._
 import org.apache.spark.sql.catalyst.InternalRow

--- a/core/src/main/scala/org/apache/spark/sql/execution/columnar/impl/StoreCallbacksImpl.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/columnar/impl/StoreCallbacksImpl.scala
@@ -32,18 +32,13 @@ import com.pivotal.gemfirexd.internal.iapi.store.access.TransactionController
 import com.pivotal.gemfirexd.internal.impl.jdbc.EmbedConnection
 import io.snappydata.Constant
 
-import org.apache.spark.SparkException
-import org.apache.spark.internal.Logging
-import org.apache.spark.sql._
-import org.apache.spark.sql.execution.ConnectionPool
-import org.apache.spark.sql.execution.columnar.{ExternalStoreUtils, CachedBatchCreator, ExternalStore}
-import org.apache.spark.sql.{SparkSession, SplitClusterMode, SnappySession, SnappyContext, SQLContext}
-import org.apache.spark.sql.execution.ConnectionPool
+import org.apache.spark.{Logging, SparkException}
+import org.apache.spark.sql.execution.columnar.{CachedBatchCreator, ExternalStore, ExternalStoreUtils}
 import org.apache.spark.sql.execution.joins.HashedRelationCache
 import org.apache.spark.sql.hive.SnappyStoreHiveCatalog
 import org.apache.spark.sql.store.{StoreHashFunction, StoreUtils}
 import org.apache.spark.sql.types._
-import org.apache.spark.sql.{SnappyContext, SnappySession, SplitClusterMode}
+import org.apache.spark.sql.{SnappyContext, SnappySession, SplitClusterMode, _}
 
 object StoreCallbacksImpl extends StoreCallbacks with Logging with Serializable {
 
@@ -119,7 +114,7 @@ object StoreCallbacksImpl extends StoreCallbacks with Logging with Serializable 
             null, null, 0, null, null, 0, null)
 
           val dependents = if (catalogEntry.dependents.nonEmpty) {
-            catalogEntry.dependents.map(executorCatalog.get(_).get)
+            catalogEntry.dependents.map(executorCatalog(_))
           } else {
             Seq.empty
           }

--- a/core/src/main/scala/org/apache/spark/sql/execution/ui/SnappyStatsPage.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/ui/SnappyStatsPage.scala
@@ -22,9 +22,11 @@ package org.apache.spark.sql.execution.ui
 import javax.servlet.http.HttpServletRequest
 
 import scala.xml.Node
+
 import com.pivotal.gemfirexd.internal.engine.ui.SnappyRegionStats
 import io.snappydata.SnappyTableStatsProviderService
-import org.apache.spark.internal.Logging
+
+import org.apache.spark.Logging
 import org.apache.spark.sql.SnappyContext
 import org.apache.spark.ui.{UIUtils, WebUIPage}
 import org.apache.spark.util.Utils
@@ -38,7 +40,7 @@ private[ui] class SnappyStatsPage(parent: SnappyStatsTab)
     val uiDisplayInfo = SnappyTableStatsProviderService
         .getAggregatedTableStatsOnDemand(SnappyContext.globalSparkContext)
 
-    val nodes = if (!uiDisplayInfo.isEmpty) {
+    val nodes = if (uiDisplayInfo.nonEmpty) {
       <span>
         <h4>Snappy Tables</h4>{UIUtils.listingTable(header, rowTable, uiDisplayInfo.values)}
       </span>

--- a/core/src/main/scala/org/apache/spark/sql/execution/ui/SnappyStatsTab.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/ui/SnappyStatsTab.scala
@@ -19,7 +19,7 @@
 
 package org.apache.spark.sql.execution.ui
 
-import org.apache.spark.internal.Logging
+import org.apache.spark.Logging
 import org.apache.spark.ui.{SparkUI, SparkUITab}
 
 /** Web UI showing storage status of all Snappy Tables */

--- a/core/src/main/scala/org/apache/spark/sql/hive/SnappyExternalCatalog.scala
+++ b/core/src/main/scala/org/apache/spark/sql/hive/SnappyExternalCatalog.scala
@@ -26,7 +26,7 @@ import org.apache.hadoop.fs.{FileSystem, Path}
 import org.apache.hadoop.hive.ql.metadata.{Hive, HiveException}
 import org.apache.thrift.TException
 
-import org.apache.spark.internal.Logging
+import org.apache.spark.Logging
 import org.apache.spark.sql._
 import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.catalog._

--- a/core/src/main/scala/org/apache/spark/sql/hive/SnappyStoreHiveCatalog.scala
+++ b/core/src/main/scala/org/apache/spark/sql/hive/SnappyStoreHiveCatalog.scala
@@ -32,7 +32,6 @@ import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.hive.metastore.api.Table
 import org.apache.hadoop.hive.ql.metadata.{Hive, HiveException}
 
-import org.apache.spark.internal.Logging
 import org.apache.spark.sql._
 import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.analysis.{FunctionRegistry, NoSuchDatabaseException}
@@ -67,7 +66,7 @@ class SnappyStoreHiveCatalog(externalCatalog: SnappyExternalCatalog,
       functionResourceLoader,
       functionRegistry,
       sqlConf,
-      hadoopConf) with Logging {
+      hadoopConf) {
 
   val sparkConf = snappySession.sparkContext.getConf
 

--- a/core/src/main/scala/org/apache/spark/sql/internal/SnappySessionState.scala
+++ b/core/src/main/scala/org/apache/spark/sql/internal/SnappySessionState.scala
@@ -22,7 +22,6 @@ import scala.collection.concurrent.TrieMap
 import com.gemstone.gemfire.internal.cache.{CacheDistributionAdvisee, ColocationHelper, PartitionedRegion}
 
 import org.apache.spark.Partition
-import org.apache.spark.internal.Logging
 import org.apache.spark.internal.config.ConfigEntry
 import org.apache.spark.sql.aqp.SnappyContextFunctions
 import org.apache.spark.sql.catalyst.CatalystConf
@@ -198,7 +197,7 @@ class SnappySessionState(snappySession: SnappySession)
 }
 
 private[sql] class SnappyConf(@transient val session: SnappySession)
-    extends SQLConf with Serializable with CatalystConf with Logging {
+    extends SQLConf with Serializable with CatalystConf {
 
   /**
    * Records the number of shuffle partitions to be used determined on runtime

--- a/core/src/main/scala/org/apache/spark/sql/internal/SnappySharedState.scala
+++ b/core/src/main/scala/org/apache/spark/sql/internal/SnappySharedState.scala
@@ -17,7 +17,6 @@
 package org.apache.spark.sql.internal
 
 import org.apache.spark.SparkContext
-import org.apache.spark.internal.Logging
 import org.apache.spark.sql.hive.{HiveClientUtil, SnappyExternalCatalog}
 
 /**
@@ -26,16 +25,13 @@ import org.apache.spark.sql.hive.{HiveClientUtil, SnappyExternalCatalog}
  *
  */
 private[sql] class SnappySharedState(override val sparkContext: SparkContext)
-      extends SharedState(sparkContext) with Logging {
-
+    extends SharedState(sparkContext) {
 
   /**
    * A Hive client used to interact with the metastore.
    */
   lazy val metadataHive = new HiveClientUtil(sparkContext).client
 
-
   override lazy val externalCatalog =
     new SnappyExternalCatalog(metadataHive, sparkContext.hadoopConfiguration)
-
 }

--- a/core/src/main/scala/org/apache/spark/sql/row/JDBCMutableRelation.scala
+++ b/core/src/main/scala/org/apache/spark/sql/row/JDBCMutableRelation.scala
@@ -20,8 +20,6 @@ import java.sql.Connection
 
 import io.snappydata.SnappyTableStatsProviderService
 
-import org.apache.spark.Partition
-import org.apache.spark.internal.Logging
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql._
 import org.apache.spark.sql.catalyst.InternalRow
@@ -34,6 +32,7 @@ import org.apache.spark.sql.hive.QualifiedTableName
 import org.apache.spark.sql.sources._
 import org.apache.spark.sql.store.CodeGeneration
 import org.apache.spark.sql.types._
+import org.apache.spark.{Logging, Partition}
 
 /**
  * A LogicalPlan implementation for an external row table whose contents

--- a/core/src/main/scala/org/apache/spark/sql/sources/jdbcExtensions.scala
+++ b/core/src/main/scala/org/apache/spark/sql/sources/jdbcExtensions.scala
@@ -21,7 +21,7 @@ import java.util.Properties
 
 import scala.util.control.NonFatal
 
-import org.apache.spark.internal.Logging
+import org.apache.spark.Logging
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.apache.spark.sql.execution.columnar.ExternalStoreUtils

--- a/core/src/main/scala/org/apache/spark/sql/store/CodeGeneration.scala
+++ b/core/src/main/scala/org/apache/spark/sql/store/CodeGeneration.scala
@@ -27,7 +27,7 @@ import com.google.common.cache.{CacheBuilder, CacheLoader}
 import com.pivotal.gemfirexd.internal.engine.distributed.GfxdHeapDataOutputStream
 import org.codehaus.janino.CompilerFactory
 
-import org.apache.spark.internal.Logging
+import org.apache.spark.Logging
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.encoders.RowEncoder

--- a/core/src/main/scala/org/apache/spark/sql/store/StoreUtils.scala
+++ b/core/src/main/scala/org/apache/spark/sql/store/StoreUtils.scala
@@ -25,16 +25,14 @@ import com.gemstone.gemfire.distributed.internal.membership.InternalDistributedM
 import com.gemstone.gemfire.internal.cache.{CacheDistributionAdvisee, PartitionedRegion}
 import com.pivotal.gemfirexd.internal.engine.Misc
 
-import org.apache.spark.Partition
-import org.apache.spark.internal.Logging
 import org.apache.spark.sql.collection.{MultiBucketExecutorPartition, ToolsCallbackInit, Utils}
 import org.apache.spark.sql.execution.columnar.ExternalStoreUtils
 import org.apache.spark.sql.execution.columnar.impl.StoreCallbacksImpl
 import org.apache.spark.sql.hive.SnappyStoreHiveCatalog
 import org.apache.spark.sql.sources.ConnectionProperties
 import org.apache.spark.sql.types._
-import org.apache.spark.sql.{AnalysisException, BlockAndExecutorId, SQLContext, SnappyContext,
-SnappySession}
+import org.apache.spark.sql.{AnalysisException, BlockAndExecutorId, SQLContext, SnappyContext, SnappySession}
+import org.apache.spark.{Logging, Partition}
 
 
 object StoreUtils extends Logging {

--- a/core/src/main/scala/org/apache/spark/sql/streaming/DirectKafkaStreamSource.scala
+++ b/core/src/main/scala/org/apache/spark/sql/streaming/DirectKafkaStreamSource.scala
@@ -20,7 +20,7 @@ import scala.reflect.ClassTag
 
 import kafka.serializer.Decoder
 
-import org.apache.spark.internal.Logging
+import org.apache.spark.Logging
 import org.apache.spark.sql._
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.encoders.RowEncoder

--- a/core/src/main/scala/org/apache/spark/sql/streaming/RabbitMQUtils.scala
+++ b/core/src/main/scala/org/apache/spark/sql/streaming/RabbitMQUtils.scala
@@ -22,7 +22,7 @@ import scala.util.{Failure, Success, Try}
 import com.rabbitmq.client.QueueingConsumer.Delivery
 import com.rabbitmq.client.{Address, Channel, Connection, ConnectionFactory, QueueingConsumer}
 
-import org.apache.spark.internal.Logging
+import org.apache.spark.Logging
 import org.apache.spark.storage.StorageLevel
 import org.apache.spark.streaming.SnappyStreamingContext
 import org.apache.spark.streaming.dstream.ReceiverInputDStream

--- a/core/src/main/scala/org/apache/spark/sql/streaming/StreamBaseRelation.scala
+++ b/core/src/main/scala/org/apache/spark/sql/streaming/StreamBaseRelation.scala
@@ -18,7 +18,6 @@ package org.apache.spark.sql.streaming
 
 import scala.collection.mutable
 
-import org.apache.spark.internal.Logging
 import org.apache.spark.rdd.{EmptyRDD, RDD}
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.catalyst.InternalRow
@@ -28,7 +27,7 @@ import org.apache.spark.sql.sources._
 import org.apache.spark.storage.StorageLevel
 import org.apache.spark.streaming.dstream.{DStream, InputDStream, ReceiverInputDStream}
 import org.apache.spark.streaming.{SnappyStreamingContext, StreamUtils, StreamingContextState, Time}
-import org.apache.spark.util
+import org.apache.spark.{Logging, util}
 
 abstract class StreamBaseRelation(options: Map[String, String])
     extends ParentRelation with StreamPlan with TableScan

--- a/core/src/main/scala/org/apache/spark/sql/streaming/twitter/TwitterInputDStream.scala
+++ b/core/src/main/scala/org/apache/spark/sql/streaming/twitter/TwitterInputDStream.scala
@@ -21,7 +21,7 @@ import twitter4j._
 import twitter4j.auth.{Authorization, OAuthAuthorization}
 import twitter4j.conf.ConfigurationBuilder
 
-import org.apache.spark.internal.Logging
+import org.apache.spark.Logging
 import org.apache.spark.storage.StorageLevel
 import org.apache.spark.streaming._
 import org.apache.spark.streaming.dstream._

--- a/core/src/main/scala/org/apache/spark/streaming/SnappyStreamingContext.scala
+++ b/core/src/main/scala/org/apache/spark/streaming/SnappyStreamingContext.scala
@@ -25,12 +25,11 @@ import org.apache.hadoop.conf.Configuration
 
 import org.apache.spark.annotation.Experimental
 import org.apache.spark.deploy.SparkHadoopUtil
-import org.apache.spark.internal.Logging
 import org.apache.spark.sql.streaming.{SchemaDStream, StreamSqlHelper}
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.sql.{DataFrame, Row, SnappySession}
 import org.apache.spark.streaming.dstream.DStream
-import org.apache.spark.{SparkConf, SparkContext}
+import org.apache.spark.{Logging, SparkConf, SparkContext}
 
 /**
  * Main entry point for SnappyData extensions to Spark Streaming.

--- a/core/src/test/scala/org/apache/spark/sql/store/ColumnTableBatchInsertTest.scala
+++ b/core/src/test/scala/org/apache/spark/sql/store/ColumnTableBatchInsertTest.scala
@@ -21,12 +21,12 @@ import io.snappydata.SnappyFunSuite
 import io.snappydata.core.{Data, TestData}
 import org.scalatest.BeforeAndAfter
 
-import org.apache.spark.internal.Logging
+import org.apache.spark.Logging
 import org.apache.spark.sql.SaveMode
 
 class ColumnTableBatchInsertTest extends SnappyFunSuite
-with Logging
-with BeforeAndAfter {
+    with Logging
+    with BeforeAndAfter {
 
   val tableName: String = "ColumnTable"
   val props = Map.empty[String, String]

--- a/core/src/test/scala/org/apache/spark/sql/store/ColumnTableInternalValidationTest.scala
+++ b/core/src/test/scala/org/apache/spark/sql/store/ColumnTableInternalValidationTest.scala
@@ -23,7 +23,7 @@ import com.pivotal.gemfirexd.internal.engine.Misc
 import io.snappydata.SnappyFunSuite
 import org.scalatest.BeforeAndAfter
 
-import org.apache.spark.internal.Logging
+import org.apache.spark.Logging
 import org.apache.spark.sql.AnalysisException
 import org.apache.spark.sql.execution.columnar.impl.ColumnFormatRelation
 

--- a/core/src/test/scala/org/apache/spark/sql/store/ColumnTableTest.scala
+++ b/core/src/test/scala/org/apache/spark/sql/store/ColumnTableTest.scala
@@ -30,7 +30,7 @@ import io.snappydata.core.{Data, TestData, TestData2}
 import org.apache.hadoop.hive.ql.parse.ParseDriver
 import org.scalatest.{BeforeAndAfter, BeforeAndAfterAll}
 
-import org.apache.spark.internal.Logging
+import org.apache.spark.Logging
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.apache.spark.sql.execution.columnar.JDBCAppendableRelation
 import org.apache.spark.sql.{AnalysisException, DataFrame, SaveMode, SparkSession, TableNotFoundException}

--- a/core/src/test/scala/org/apache/spark/sql/store/SnappyCatalogSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/store/SnappyCatalogSuite.scala
@@ -51,28 +51,29 @@ import org.apache.spark.util.Utils
  */
 
 class SnappyCatalogSuite extends SnappyFunSuite
-with BeforeAndAfter
-with BeforeAndAfterAll {
+    with BeforeAndAfter
+    with BeforeAndAfterAll {
 
-  var snappySession : SnappySession = null
+  var snappySession: SnappySession = _
 
-  private var sessionCatalog: SessionCatalog = null
+  private var sessionCatalog: SessionCatalog = _
 
   before {
     try {
-      if(sessionCatalog != null) {
-        sessionCatalog.reset
+      if (sessionCatalog != null) {
+        sessionCatalog.reset()
       }
       snappySession = new SnappySession(snc.sparkContext)
       sessionCatalog = snappySession.sessionState.catalog
     } finally {
-      //super.afterEach()
+      // super.afterEach()
     }
   }
 
   private val utils = new CatalogTestUtils {
     override val tableInputFormat: String = "org.apache.hadoop.mapred.SequenceFileInputFormat"
     override val tableOutputFormat: String = "org.apache.hadoop.mapred.SequenceFileOutputFormat"
+
     override def newEmptyCatalog(): ExternalCatalog = snc.sharedState.externalCatalog
   }
 
@@ -118,9 +119,11 @@ with BeforeAndAfterAll {
     val tableMetadata = sessionCatalog.getTableMetadata(TableIdentifier(tableName, dbName))
     val columns = dbName
         .map { db => snappySession.catalog.listColumns(db, tableName) }
-        .getOrElse { snappySession.catalog.listColumns(tableName) }
+        .getOrElse {
+          snappySession.catalog.listColumns(tableName)
+        }
     assume(tableMetadata.schema.nonEmpty, "bad test")
-   // assume(tableMetadata.partitionColumnNames.nonEmpty, "bad test")
+    // assume(tableMetadata.partitionColumnNames.nonEmpty, "bad test")
     assume(tableMetadata.bucketColumnNames.nonEmpty, "bad test")
     assert(columns.collect().map(_.name).toSet == tableMetadata.schema.map(_.name).toSet)
     columns.collect().foreach { col =>
@@ -144,7 +147,8 @@ with BeforeAndAfterAll {
   }
 
   test("list databases") {
-    assert(snappySession.catalog.listDatabases().collect().map(_.name.toUpperCase).toSet == Set("APP", "DEFAULT"))
+    assert(snappySession.catalog.listDatabases().collect()
+        .map(_.name.toUpperCase).toSet == Set("APP", "DEFAULT"))
     createDatabase("my_db1")
     createDatabase("my_db2")
     assert(snappySession.catalog.listDatabases().collect().map(_.name.toUpperCase).toSet ==
@@ -165,7 +169,8 @@ with BeforeAndAfterAll {
     assert(snappySession.catalog.listTables().collect().map(_.name.toLowerCase).toSet ==
         Set("my_table2", "my_temp_table"))
     dropTable("my_temp_table")
-    assert(snappySession.catalog.listTables().collect().map(_.name.toLowerCase).toSet == Set("my_table2"))
+    assert(snappySession.catalog.listTables().collect()
+        .map(_.name.toLowerCase).toSet == Set("my_table2"))
   }
 
   test("list tables with database") {
@@ -234,9 +239,11 @@ with BeforeAndAfterAll {
 
     // Make sure database is set properly.
     assert(
-      snappySession.catalog.listFunctions("my_db1").collect().map(_.database).toSet == Set("MY_DB1", null))
+      snappySession.catalog.listFunctions("my_db1").collect()
+          .map(_.database).toSet == Set("MY_DB1", null))
     assert(
-      snappySession.catalog.listFunctions("my_db2").collect().map(_.database).toSet == Set("MY_DB2", null))
+      snappySession.catalog.listFunctions("my_db2").collect()
+          .map(_.database).toSet == Set("MY_DB2", null))
 
     // Remove the function and make sure they no longer appear.
     dropFunction("my_func1", Some("my_db1"))
@@ -338,6 +345,7 @@ abstract class CatalogTestUtils {
   // Unimplemented methods
   val tableInputFormat: String
   val tableOutputFormat: String
+
   def newEmptyCatalog(): ExternalCatalog
 
   // These fields must be lazy because they rely on fields that are not implemented yet
@@ -423,5 +431,4 @@ abstract class CatalogTestUtils {
       parts: Seq[CatalogTablePartition]): Boolean = {
     catalog.listPartitions(db, table).map(_.spec).toSet == parts.map(_.spec).toSet
   }
-
 }

--- a/core/src/test/scala/org/apache/spark/sql/store/UnifiedPartitionerTest.scala
+++ b/core/src/test/scala/org/apache/spark/sql/store/UnifiedPartitionerTest.scala
@@ -30,7 +30,7 @@ import io.snappydata.SnappyFunSuite
 import io.snappydata.core.{Data1, Data4, TestData2}
 import org.scalatest.{BeforeAndAfter, BeforeAndAfterAll}
 
-import org.apache.spark.internal.Logging
+import org.apache.spark.Logging
 import org.apache.spark.sql.ColumnName
 import org.apache.spark.sql.catalyst.expressions.{Expression, Literal, Murmur3Hash}
 import org.apache.spark.sql.types.{DataType, _}

--- a/core/src/test/scala/org/apache/spark/sql/streaming/SnappyStreamingSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/streaming/SnappyStreamingSuite.scala
@@ -19,8 +19,8 @@ package org.apache.spark.sql.streaming
 import java.io.File
 import java.net.InetSocketAddress
 import java.util
+import java.util.Properties
 import java.util.concurrent.TimeoutException
-import java.util.{Map => JMap, Properties}
 
 import scala.annotation.tailrec
 import scala.collection.mutable
@@ -43,8 +43,6 @@ import org.scalatest.concurrent.Eventually
 import org.scalatest.{BeforeAndAfter, BeforeAndAfterAll}
 import twitter4j.{Status, TwitterObjectFactory}
 
-import org.apache.spark.SparkConf
-import org.apache.spark.internal.Logging
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.types.DataTypes._
 import org.apache.spark.sql.types.{DataTypes, StructType}
@@ -54,13 +52,14 @@ import org.apache.spark.streaming.dstream.DStream
 import org.apache.spark.streaming.kafka.{KafkaCluster, KafkaUtils}
 import org.apache.spark.streaming.{Duration, Seconds, SnappyStreamingContext, Time}
 import org.apache.spark.util.Utils
+import org.apache.spark.{Logging, SparkConf}
 
 
 class SnappyStreamingSuite
     extends SnappyFunSuite with Eventually
     with BeforeAndAfter with BeforeAndAfterAll{
 
-  private var kc: KafkaCluster = null
+  private var kc: KafkaCluster = _
 
   protected var kafkaUtils: EmbeddedKafkaUtils = _
 
@@ -396,7 +395,7 @@ class SnappyStreamingSuite
       df.count()
     })
 
-    //Create Table to collect the data for schemaStream1
+    // Create Table to collect the data for schemaStream1
     ssnc.snappyContext.dropTable("dataTable", ifExists = true)
     ssnc.snappyContext.createTable("dataTable", "column", schemaStream1.schema,
       Map.empty[String, String])
@@ -425,7 +424,8 @@ class SnappyStreamingSuite
 
 
     val resultStream: SchemaDStream = ssnc.registerCQ("SELECT t1.id, t1.text FROM " +
-        "tweetStream1 window (duration 2 seconds, slide 1 seconds) t1 JOIN tweetStream2 t2 ON t1.id = t2.id ")
+        "tweetStream1 window (duration 2 seconds, slide 1 seconds) t1 " +
+        "JOIN tweetStream2 t2 ON t1.id = t2.id ")
 
 
     ssnc.snappyContext.dropTable("joinDataColumnTable", ifExists = true)
@@ -461,9 +461,9 @@ class SnappyStreamingSuite
       row => row.getInt(0)
     }
 
-    val colValues = (1 to 30).toSeq
+    val colValues = 1 to 30
     assert(listOfRows.length == 30)
-    //Assert values
+    // Assert values
     colValues.foreach(v => assert(listOfRows.contains(v)))
     ssnc.sql("drop table dataTable")
 
@@ -474,7 +474,7 @@ class SnappyStreamingSuite
 
 
     val result = ssnc.sql("select id from joinDataColumnTable")
-    val expectedValues = Seq(9,10,19,20,29,30)
+    val expectedValues = Seq(9, 10, 19, 20, 29, 30)
 
     val r = result.collect()  map {
       row => row.getInt(0)
@@ -721,7 +721,7 @@ protected class EmbeddedKafkaUtils extends Logging {
 
         ZkUtils.getLeaderForPartition(zkClient, topic, partition).isDefined &&
             Request.isValidBrokerId(leaderAndInSyncReplicas.leader) &&
-            leaderAndInSyncReplicas.isr.size >= 1
+            leaderAndInSyncReplicas.isr.nonEmpty
 
       case _ =>
         false


### PR DESCRIPTION
## Changes proposed in this pull request

Since the public interface of the internal Logging has been changed (new flags "infoEnabled" etc),
so need to make a copy in the public Logging class and change all uses to public Logging class.

Update the spark link.

## Patch testing

precheckin

## ReleaseNotes.txt changes

NA

## Other PRs 

https://github.com/SnappyDataInc/spark/pull/28