### PR TITLE
Snap 1201

### DIFF
--- a/dtests/src/test/java/io/snappydata/hydra/longRun/local.embeded.longRun.conf
+++ b/dtests/src/test/java/io/snappydata/hydra/longRun/local.embeded.longRun.conf
@@ -1,0 +1,5 @@
+hydra.HostPrms-hostNames =
+  fcn "hydra.TestConfigFcns.pool(\"<host1> <host2> <host3> <host4>\", ${snappyStoreHosts})" ncf
+  fcn "hydra.TestConfigFcns.pool(\"<host1> <host2>\", ${leadHosts})" ncf
+  fcn "hydra.TestConfigFcns.pool(\"<host3> <host4>\", ${locatorHosts})" ncf
+;

--- a/dtests/src/test/java/io/snappydata/hydra/longRun/local.split.longRun.conf
+++ b/dtests/src/test/java/io/snappydata/hydra/longRun/local.split.longRun.conf
@@ -1,0 +1,6 @@
+hydra.HostPrms-hostNames =
+  fcn "hydra.TestConfigFcns.pool(\"<host1> <host2> <host3> <host4>\", ${snappyStoreHosts})" ncf
+  fcn "hydra.TestConfigFcns.pool(\"<host1> <host2>\", ${leadHosts})" ncf
+  fcn "hydra.TestConfigFcns.pool(\"<host3> <host4>\", ${locatorHosts})" ncf
+  fcn "hydra.TestConfigFcns.pool(\"<host1> <host2> <host3>\", ${workerHosts})" ncf
+;

--- a/dtests/src/test/java/io/snappydata/hydra/longRun/longRunTest.bt
+++ b/dtests/src/test/java/io/snappydata/hydra/longRun/longRunTest.bt
@@ -3,8 +3,8 @@
 //currently we are running with northwind schema.
 
 // Embeded mode 
-//io/snappydata/hydra/cluster/longRunTestEmbededMode.conf
-//  A=snappyStore snappyStoreHosts=4 snappyStoreVMsPerHost=1 snappyStoreThreadsPerVM=4
+//io/snappydata/hydra/longRun/longRunTestEmbededMode.conf
+//  A=snappyStore snappyStoreHosts=4 snappyStoreVMsPerHost=2 snappyStoreThreadsPerVM=4
 //  B=lead leadHosts=2 leadVMsPerHost=1 leadThreadsPerVM=2
 //  C=locator locatorHosts=3 locatorVMsPerHost=1 locatorThreadsPerVM=1
 //  redundantCopies=1
@@ -13,7 +13,7 @@
 //  fullResultSetValidation = true
 
 // Embeded mode HA
-//io/snappydata/hydra/cluster/longRunTestEmbededModeWithHA.conf
+//io/snappydata/hydra/longRun/longRunTestEmbededModeWithHA.conf
 //  A=snappyStore snappyStoreHosts=4 snappyStoreVMsPerHost=2 snappyStoreThreadsPerVM=4
 //  B=lead leadHosts=2 leadVMsPerHost=1 leadThreadsPerVM=2
 //  C=locator locatorHosts=3 locatorVMsPerHost=1 locatorThreadsPerVM=1
@@ -23,7 +23,7 @@
 //  fullResultSetValidation = true
 
 // Split mode 
-//io/snappydata/hydra/cluster/longRunTestSplitMode.conf
+//io/snappydata/hydra/longRun/longRunTestSplitMode.conf
 //  A=snappyStore snappyStoreHosts=4 snappyStoreVMsPerHost=2 snappyStoreThreadsPerVM=4
 //  B=lead leadHosts=2 leadVMsPerHost=1 leadThreadsPerVM=2
 //  C=locator locatorHosts=3 locatorVMsPerHost=1 locatorThreadsPerVM=1
@@ -34,7 +34,7 @@
 //  fullResultSetValidation = true
 
 // Split mode HA
-io/snappydata/hydra/cluster/longRunTestSplitModeWithHA.conf
+io/snappydata/hydra/longRun/longRunTestSplitModeWithHA.conf
   A=snappyStore snappyStoreHosts=4 snappyStoreVMsPerHost=2 snappyStoreThreadsPerVM=4
   B=lead leadHosts=2 leadVMsPerHost=1 leadThreadsPerVM=2
   C=locator locatorHosts=2 locatorVMsPerHost=1 locatorThreadsPerVM=1

--- a/dtests/src/test/java/io/snappydata/hydra/longRun/longRunTest.bt
+++ b/dtests/src/test/java/io/snappydata/hydra/longRun/longRunTest.bt
@@ -1,37 +1,39 @@
-// can run any one test for ~40 hrs without stopping the cluster, individual lead and server node will go down in HA version of test.
+//can run any one test for ~40 hrs without stopping the cluster, individual lead and server node will go down in HA version of test.
 //We can also run the tests one after other, but the cluster will stop after each test.
 //currently we are running with northwind schema.
 
+/*
 // Embeded mode 
-//io/snappydata/hydra/longRun/longRunTestEmbededMode.conf
-//  A=snappyStore snappyStoreHosts=4 snappyStoreVMsPerHost=2 snappyStoreThreadsPerVM=4
-//  B=lead leadHosts=2 leadVMsPerHost=1 leadThreadsPerVM=2
-//  C=locator locatorHosts=3 locatorVMsPerHost=1 locatorThreadsPerVM=1
-//  redundantCopies=1
-//  dataFilesLocation="$GEMFIRE/../../../tests/common/src/main/resources/northwind/"
-//  tableType="Colocated"
-//  fullResultSetValidation = true
+io/snappydata/hydra/longRun/longRunTestEmbededMode.conf
+  A=snappyStore snappyStoreHosts=4 snappyStoreVMsPerHost=2 snappyStoreThreadsPerVM=4
+  B=lead leadHosts=2 leadVMsPerHost=1 leadThreadsPerVM=2
+  C=locator locatorHosts=3 locatorVMsPerHost=1 locatorThreadsPerVM=1
+  redundantCopies=1
+  dataFilesLocation="$GEMFIRE/../../../tests/common/src/main/resources/northwind/"
+  tableType="Colocated"
+  fullResultSetValidation = true
 
 // Embeded mode HA
-//io/snappydata/hydra/longRun/longRunTestEmbededModeWithHA.conf
-//  A=snappyStore snappyStoreHosts=4 snappyStoreVMsPerHost=2 snappyStoreThreadsPerVM=4
-//  B=lead leadHosts=2 leadVMsPerHost=1 leadThreadsPerVM=2
-//  C=locator locatorHosts=3 locatorVMsPerHost=1 locatorThreadsPerVM=1
-//  redundantCopies=1
-//  dataFilesLocation="$GEMFIRE/../../../tests/common/src/main/resources/northwind/"
-//  tableType="Colocated"
-//  fullResultSetValidation = true
+io/snappydata/hydra/longRun/longRunTestEmbededModeWithHA.conf
+  A=snappyStore snappyStoreHosts=4 snappyStoreVMsPerHost=2 snappyStoreThreadsPerVM=4
+  B=lead leadHosts=2 leadVMsPerHost=1 leadThreadsPerVM=2
+  C=locator locatorHosts=3 locatorVMsPerHost=1 locatorThreadsPerVM=1
+  redundantCopies=1
+  dataFilesLocation="$GEMFIRE/../../../tests/common/src/main/resources/northwind/"
+  tableType="Colocated"
+  fullResultSetValidation = true
 
 // Split mode 
-//io/snappydata/hydra/longRun/longRunTestSplitMode.conf
-//  A=snappyStore snappyStoreHosts=4 snappyStoreVMsPerHost=2 snappyStoreThreadsPerVM=4
-//  B=lead leadHosts=2 leadVMsPerHost=1 leadThreadsPerVM=2
-//  C=locator locatorHosts=3 locatorVMsPerHost=1 locatorThreadsPerVM=1
-//  D=worker workerHosts=3 workerVMsPerHost=1 workerThreadsPerVM=1
-//  redundantCopies=1
-//  dataFilesLocation="$GEMFIRE/../../../tests/common/src/main/resources/northwind/"
-//  tableType="Colocated"
-//  fullResultSetValidation = true
+io/snappydata/hydra/longRun/longRunTestSplitMode.conf
+  A=snappyStore snappyStoreHosts=4 snappyStoreVMsPerHost=2 snappyStoreThreadsPerVM=4
+  B=lead leadHosts=2 leadVMsPerHost=1 leadThreadsPerVM=2
+  C=locator locatorHosts=3 locatorVMsPerHost=1 locatorThreadsPerVM=1
+  D=worker workerHosts=3 workerVMsPerHost=1 workerThreadsPerVM=1
+  redundantCopies=1
+  dataFilesLocation="$GEMFIRE/../../../tests/common/src/main/resources/northwind/"
+  tableType="Colocated"
+  fullResultSetValidation = true
+*/
 
 // Split mode HA
 io/snappydata/hydra/longRun/longRunTestSplitModeWithHA.conf

--- a/dtests/src/test/java/io/snappydata/hydra/longRun/longRunTest.bt
+++ b/dtests/src/test/java/io/snappydata/hydra/longRun/longRunTest.bt
@@ -1,0 +1,45 @@
+// can run any one test for ~40 hrs without stopping the cluster, individual lead and server node will go down in HA version of test.
+//We can also run the tests one after other, but the cluster will stop after each test.
+//currently we are running with northwind schema.
+
+// Embeded mode 
+//io/snappydata/hydra/cluster/longRunTestEmbededMode.conf
+//  A=snappyStore snappyStoreHosts=4 snappyStoreVMsPerHost=1 snappyStoreThreadsPerVM=4
+//  B=lead leadHosts=2 leadVMsPerHost=1 leadThreadsPerVM=2
+//  C=locator locatorHosts=3 locatorVMsPerHost=1 locatorThreadsPerVM=1
+//  redundantCopies=1
+//  dataFilesLocation="$GEMFIRE/../../../tests/common/src/main/resources/northwind/"
+//  tableType="Colocated"
+//  fullResultSetValidation = true
+
+// Embeded mode HA
+//io/snappydata/hydra/cluster/longRunTestEmbededModeWithHA.conf
+//  A=snappyStore snappyStoreHosts=4 snappyStoreVMsPerHost=2 snappyStoreThreadsPerVM=4
+//  B=lead leadHosts=2 leadVMsPerHost=1 leadThreadsPerVM=2
+//  C=locator locatorHosts=3 locatorVMsPerHost=1 locatorThreadsPerVM=1
+//  redundantCopies=1
+//  dataFilesLocation="$GEMFIRE/../../../tests/common/src/main/resources/northwind/"
+//  tableType="Colocated"
+//  fullResultSetValidation = true
+
+// Split mode 
+//io/snappydata/hydra/cluster/longRunTestSplitMode.conf
+//  A=snappyStore snappyStoreHosts=4 snappyStoreVMsPerHost=2 snappyStoreThreadsPerVM=4
+//  B=lead leadHosts=2 leadVMsPerHost=1 leadThreadsPerVM=2
+//  C=locator locatorHosts=3 locatorVMsPerHost=1 locatorThreadsPerVM=1
+//  D=worker workerHosts=3 workerVMsPerHost=1 workerThreadsPerVM=1
+//  redundantCopies=1
+//  dataFilesLocation="$GEMFIRE/../../../tests/common/src/main/resources/northwind/"
+//  tableType="Colocated"
+//  fullResultSetValidation = true
+
+// Split mode HA
+io/snappydata/hydra/cluster/longRunTestSplitModeWithHA.conf
+  A=snappyStore snappyStoreHosts=4 snappyStoreVMsPerHost=2 snappyStoreThreadsPerVM=4
+  B=lead leadHosts=2 leadVMsPerHost=1 leadThreadsPerVM=2
+  C=locator locatorHosts=2 locatorVMsPerHost=1 locatorThreadsPerVM=1
+  D=worker workerHosts=3 workerVMsPerHost=1 workerThreadsPerVM=1
+  redundantCopies=1
+  dataFilesLocation="$GEMFIRE/../../../tests/common/src/main/resources/northwind/"
+  tableType="Colocated"
+  fullResultSetValidation = true

--- a/dtests/src/test/java/io/snappydata/hydra/longRun/longRunTestEmbededMode.conf
+++ b/dtests/src/test/java/io/snappydata/hydra/longRun/longRunTestEmbededMode.conf
@@ -1,0 +1,134 @@
+hydra.Prms-testRequirement = "Test to verify functionality in embeded mode while running the cluster on long duration with different schemas";
+hydra.Prms-testDescription = "This test starts the snappy cluster, initializes snappyContext, create tables using snappy job. 
+                        After initialization, test is executing snappy job and sql scripts which test queries with row tables and column tables using the schema.
+                        These tasks will run for ~40 hrs, which can be configured. ";
+
+INCLUDE $JTESTS/hydraconfig/hydraparams1.inc;
+INCLUDE $JTESTS/hydraconfig/topology_3.inc;
+
+hydra.GemFirePrms-names = gemfire1;
+hydra.ClientPrms-gemfireNames = gemfire1;
+hydra.GemFirePrms-distributedSystem = ds;
+
+THREADGROUP snappyStoreThreads
+            totalThreads = fcn "(${${A}Hosts} * ${${A}VMsPerHost} *  ${${A}ThreadsPerVM}) " ncf
+            totalVMs     = fcn "(${${A}Hosts} * ${${A}VMsPerHost})" ncf
+            clientNames  = fcn "hydra.TestConfigFcns.generateNames(\"${A}\",
+                                ${${A}Hosts}, true)" ncf;
+
+THREADGROUP leadThreads
+            totalThreads = fcn "(${${B}Hosts} * ${${B}VMsPerHost} *  ${${B}ThreadsPerVM}) -1 " ncf
+            totalVMs     = fcn "(${${B}Hosts} * ${${B}VMsPerHost})" ncf
+            clientNames  = fcn "hydra.TestConfigFcns.generateNames(\"${B}\",
+                                ${${B}Hosts}, true)" ncf;
+
+THREADGROUP locatorThreads
+            totalThreads = fcn "(${${C}Hosts} * ${${C}VMsPerHost} *  ${${C}ThreadsPerVM}) " ncf
+            totalVMs     = fcn "(${${C}Hosts} * ${${C}VMsPerHost})" ncf
+            clientNames  = fcn "hydra.TestConfigFcns.generateNames(\"${C}\",
+                                ${${C}Hosts}, true)" ncf;
+
+THREADGROUP snappyThreads
+            totalThreads = 1
+            totalVMs     = 1
+            clientNames  = fcn "hydra.TestConfigFcns.generateNames(\"${B}\",
+                                ${${B}Hosts}, true)" ncf;
+
+INITTASK     taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = HydraTask_initializeSnappyTest
+  runMode = always
+  threadGroups = snappyThreads, locatorThreads, snappyStoreThreads, leadThreads;
+
+INITTASK     taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = HydraTask_generateSnappyLocatorConfig
+    runMode = always
+    threadGroups = locatorThreads;
+
+INITTASK     taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = HydraTask_writeLocatorConfigData
+    runMode = always
+    threadGroups = snappyThreads;
+
+INITTASK     taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = HydraTask_generateSnappyServerConfig
+    runMode = always
+    threadGroups = snappyStoreThreads;
+
+INITTASK     taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = HydraTask_writeServerConfigData
+    runMode = always
+    threadGroups = snappyThreads;
+
+INITTASK     taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = HydraTask_generateSnappyLeadConfig
+    runMode = always
+    threadGroups = leadThreads, snappyThreads;
+
+INITTASK     taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = HydraTask_writeLeadConfigData
+    runMode = always
+    threadGroups = snappyThreads;
+
+INITTASK     taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = HydraTask_createAndStartSnappyLocator
+    runMode = always
+    threadGroups = locatorThreads;
+
+INITTASK     taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = HydraTask_createAndStartSnappyServers
+    runMode = always
+    threadGroups = snappyStoreThreads;
+
+INITTASK     taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = HydraTask_createAndStartSnappyLeader
+    runMode = always
+    threadGroups = leadThreads;
+
+INITTASK    taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = HydraTask_executeSQLScripts
+            io.snappydata.hydra.cluster.SnappyPrms-sqlScriptNames = create_and_load_colocatedTables_persistent.sql
+            io.snappydata.hydra.cluster.SnappyPrms-dataLocation = ${dataFilesLocation}
+            threadGroups = snappyThreads
+            ;
+
+TASK        taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = HydraTask_executeSnappyJob
+            io.snappydata.hydra.cluster.SnappyPrms-jobClassNames = io.snappydata.hydra.northwind.ValidateNWQueriesJob
+            io.snappydata.hydra.cluster.SnappyPrms-appPropsForJobServer = "dataFilesLocation=${dataFilesLocation},tableType=${tableType},fullResultSetValidation=${fullResultSetValidation}"
+            io.snappydata.hydra.cluster.SnappyPrms-userAppJar = snappydata-store-scala-tests*tests.jar
+            threadGroups = snappyStoreThreads
+            maxThreads = 1;
+
+TASK        taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = HydraTask_executeSQLScripts
+            io.snappydata.hydra.cluster.SnappyPrms-sqlScriptNames = nw_queries.sql
+            threadGroups = snappyThreads
+            maxThreads = 1
+            ;
+
+CLOSETASK     taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = HydraTask_stopSnappy
+  threadGroups = snappyThreads;
+
+CLOSETASK     taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = HydraTask_stopSnappyLeader
+  threadGroups = snappyThreads;
+
+CLOSETASK     taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = HydraTask_stopSnappyServers
+  threadGroups = snappyThreads;
+
+CLOSETASK     taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = HydraTask_stopSnappyLocator
+  threadGroups = snappyThreads;
+
+CLOSETASK     taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = HydraTask_deleteSnappyConfig
+    threadGroups = snappyThreads;
+
+ENDTASK     taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = HydraTask_cleanUpSnappyProcessesOnFailure
+    clientNames = locator1;
+
+/* end task must stop snappy members because they are not stopped by Hydra */
+hydra.Prms-alwaysDoEndTasks = true;
+
+hydra.Prms-totalTaskTimeSec           = 144000;
+hydra.Prms-maxResultWaitSec           = 3600;
+hydra.Prms-maxCloseTaskResultWaitSec  = 3600;
+//hydra.Prms-serialExecution            = false;
+
+hydra.VmPrms-extraVMArgs   += fcn "hydra.TestConfigFcns.duplicate
+                                  (\"-Xms512m -Xmx1g \", ${${A}Hosts}, true)"
+                             ncf
+                             ,
+                             fcn "hydra.TestConfigFcns.duplicate
+                                  (\"-Xms512m -Xmx1g \", ${${B}Hosts}, true)"
+                             ncf;
+
+hydra.VmPrms-extraVMArgsSUN += "-XX:PermSize=64M -XX:MaxPermSize=256m";
+
+io.snappydata.hydra.cluster.SnappyPrms-userAppJar = snappydata-store-scala-tests*tests.jar;
+
+

--- a/dtests/src/test/java/io/snappydata/hydra/longRun/longRunTestEmbededMode.conf
+++ b/dtests/src/test/java/io/snappydata/hydra/longRun/longRunTestEmbededMode.conf
@@ -1,5 +1,5 @@
-hydra.Prms-testRequirement = "Test to verify functionality in embeded mode while running the cluster on long duration with different schemas";
-hydra.Prms-testDescription = "This test starts the snappy cluster, initializes snappyContext, create tables using snappy job. 
+hydra.Prms-testRequirement = "Test to verify product behavior when the cluster is up and running for longer duration with operations being performed continuously in embeded mode ";
+hydra.Prms-testDescription = "This test starts the snappy cluster, initializes snappyContext, create tables using sql scripts. 
                         After initialization, test is executing snappy job and sql scripts which test queries with row tables and column tables using the schema.
                         These tasks will run for ~40 hrs, which can be configured. ";
 

--- a/dtests/src/test/java/io/snappydata/hydra/longRun/longRunTestEmbededMode.conf
+++ b/dtests/src/test/java/io/snappydata/hydra/longRun/longRunTestEmbededMode.conf
@@ -84,12 +84,12 @@ TASK        taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = H
             io.snappydata.hydra.cluster.SnappyPrms-jobClassNames = io.snappydata.hydra.northwind.ValidateNWQueriesJob
             io.snappydata.hydra.cluster.SnappyPrms-appPropsForJobServer = "dataFilesLocation=${dataFilesLocation},tableType=${tableType},fullResultSetValidation=${fullResultSetValidation}"
             io.snappydata.hydra.cluster.SnappyPrms-userAppJar = snappydata-store-scala-tests*tests.jar
-            threadGroups = snappyStoreThreads
+            threadGroups = snappyThreads
             maxThreads = 1;
 
 TASK        taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = HydraTask_executeSQLScripts
             io.snappydata.hydra.cluster.SnappyPrms-sqlScriptNames = nw_queries.sql
-            threadGroups = snappyThreads
+            threadGroups = snappyStoreThreads
             maxThreads = 1
             ;
 

--- a/dtests/src/test/java/io/snappydata/hydra/longRun/longRunTestEmbededMode.conf
+++ b/dtests/src/test/java/io/snappydata/hydra/longRun/longRunTestEmbededMode.conf
@@ -1,6 +1,6 @@
 hydra.Prms-testRequirement = "Test to verify product behavior when the cluster is up and running for longer duration with operations being performed continuously in embeded mode ";
 hydra.Prms-testDescription = "This test starts the snappy cluster, initializes snappyContext, create tables using sql scripts. 
-                        After initialization, test is executing snappy job and sql scripts which test queries with row tables and column tables using the schema.
+                        After initialization, test executes tasks with snappy job and sql scripts which validate queries for row and column tables. 
                         These tasks will run for ~40 hrs, which can be configured. ";
 
 INCLUDE $JTESTS/hydraconfig/hydraparams1.inc;

--- a/dtests/src/test/java/io/snappydata/hydra/longRun/longRunTestEmbededModeWithHA.conf
+++ b/dtests/src/test/java/io/snappydata/hydra/longRun/longRunTestEmbededModeWithHA.conf
@@ -1,0 +1,36 @@
+hydra.Prms-testRequirement += " with lead and server nodes performing HA";
+hydra.Prms-testDescription += "While the tasks are being performed, the server and lead nodes will go down and come up.";
+
+INITTASK    taskClass   = util.StopStartVMs  taskMethod = StopStart_initTask
+            threadGroups = snappyThread, locatorThreads, snappyStoreThreads, leadThreads;
+
+INCLUDE $JTESTS/io/snappydata/hydra/longRun/longRunTestEmbededMode.conf;
+
+INITTASK    taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = backUpLeadConfigData
+            threadGroups = snappyThread;
+
+INITTASK    taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = backUpServerConfigData
+            threadGroups = snappyThread;
+
+TASK        taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = HydraTask_cycleLeadVM
+            maxThreads = 1
+            startInterval = 3600
+            threadGroups = snappyStoreThreads;
+
+TASK        taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = HydraTask_cycleStoreVms
+            startInterval = 3000
+            threadGroups = snappyThread;
+
+CLOSETASK   taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = restoreServerConfigData
+            threadGroups = snappyThread;
+
+CLOSETASK   taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = restoreLeadConfigData
+            threadGroups = snappyThread;
+
+io.snappydata.hydra.cluster.SnappyPrms-waitTimeBeforeNextCycleVM = 4200; //wait time before next restart.
+io.snappydata.hydra.cluster.SnappyPrms-cycleVms = true;
+
+//util.StopStartPrms-stopModes = ONEOF NICE_EXIT MEAN_KILL MEAN_EXIT NICE_KILL FOENO;
+util.StopStartPrms-stopModes = NICE_KILL;
+util.StopStartPrms-numVMsToStop = RANGE 1 ${redundantCopies} EGNAR;
+

--- a/dtests/src/test/java/io/snappydata/hydra/longRun/longRunTestEmbededModeWithHA.conf
+++ b/dtests/src/test/java/io/snappydata/hydra/longRun/longRunTestEmbededModeWithHA.conf
@@ -2,15 +2,15 @@ hydra.Prms-testRequirement += " with lead and server nodes performing HA";
 hydra.Prms-testDescription += "While the tasks are being performed, the server and lead nodes will go down and come up.";
 
 INITTASK    taskClass   = util.StopStartVMs  taskMethod = StopStart_initTask
-            threadGroups = snappyThread, locatorThreads, snappyStoreThreads, leadThreads;
+            threadGroups = snappyThreads, locatorThreads, snappyStoreThreads, leadThreads;
 
 INCLUDE $JTESTS/io/snappydata/hydra/longRun/longRunTestEmbededMode.conf;
 
 INITTASK    taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = backUpLeadConfigData
-            threadGroups = snappyThread;
+            threadGroups = snappyThreads;
 
 INITTASK    taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = backUpServerConfigData
-            threadGroups = snappyThread;
+            threadGroups = snappyThreads;
 
 TASK        taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = HydraTask_cycleLeadVM
             maxThreads = 1
@@ -19,13 +19,13 @@ TASK        taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = H
 
 TASK        taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = HydraTask_cycleStoreVms
             startInterval = 3000
-            threadGroups = snappyThread;
+            threadGroups = snappyThreads;
 
 CLOSETASK   taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = restoreServerConfigData
-            threadGroups = snappyThread;
+            threadGroups = snappyThreads;
 
 CLOSETASK   taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = restoreLeadConfigData
-            threadGroups = snappyThread;
+            threadGroups = snappyThreads;
 
 io.snappydata.hydra.cluster.SnappyPrms-waitTimeBeforeNextCycleVM = 4200; //wait time before next restart.
 io.snappydata.hydra.cluster.SnappyPrms-cycleVms = true;

--- a/dtests/src/test/java/io/snappydata/hydra/longRun/longRunTestSplitMode.conf
+++ b/dtests/src/test/java/io/snappydata/hydra/longRun/longRunTestSplitMode.conf
@@ -1,0 +1,49 @@
+hydra.Prms-testRequirement = "Test to verify functionality in split mode while running the cluster on long duration with different schemas";
+hydra.Prms-testDescription = "This test starts the snappy cluster and spoark, initializes snappyContext, create tables using snappy job.
+                        After initialization, test is executing snappy job, spark app and sql scripts which test queries with row tables and column tables using the schema.
+                        These tasks will run for ~40 hrs, which can be configured. ";
+
+INCLUDE $JTESTS/io/snappydata/hydra/northwind/startDualModeCluster.conf;
+
+INITTASK    taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = HydraTask_executeSQLScripts
+            io.snappydata.hydra.cluster.SnappyPrms-sqlScriptNames = create_and_load_colocatedTables_persistent.sql
+            io.snappydata.hydra.cluster.SnappyPrms-dataLocation = ${dataFilesLocation}
+            threadGroups = snappyThreads
+            ;
+
+TASK        taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = HydraTask_executeSnappyJob
+            io.snappydata.hydra.cluster.SnappyPrms-jobClassNames = io.snappydata.hydra.northwind.ValidateNWQueriesJob
+            io.snappydata.hydra.cluster.SnappyPrms-appPropsForJobServer = "dataFilesLocation=${dataFilesLocation},tableType=${tableType},fullResultSetValidation=${fullResultSetValidation}"
+            io.snappydata.hydra.cluster.SnappyPrms-userAppJar = snappydata-store-scala-tests*tests.jar
+            threadGroups = snappyStoreThreads
+            maxThreads = 1;
+
+TASK        taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = HydraTask_executeSparkJob
+            io.snappydata.hydra.cluster.SnappyPrms-sparkJobClassNames = io.snappydata.hydra.northwind.ValidateNWQueriesApp
+            io.snappydata.hydra.cluster.SnappyPrms-userAppArgs = "${dataFilesLocation} ${tableType} ${fullResultSetValidation}"
+            io.snappydata.hydra.cluster.SnappyPrms-userAppJar = snappydata-store-scala-tests*tests.jar
+            threadGroups = leadThreads
+            ;
+
+TASK        taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = HydraTask_executeSQLScripts
+            io.snappydata.hydra.cluster.SnappyPrms-sqlScriptNames = nw_queries.sql
+            threadGroups = snappyStoreThreads
+            maxThreads = 1
+            ;
+
+INCLUDE $JTESTS/io/snappydata/hydra/northwind/stopDualModeCluster.conf;\
+
+hydra.Prms-totalTaskTimeSec           = 144000;
+hydra.Prms-maxResultWaitSec           = 3600;
+hydra.Prms-maxCloseTaskResultWaitSec  = 3600;
+
+hydra.VmPrms-extraVMArgs   += fcn "hydra.TestConfigFcns.duplicate
+                                  (\"-Xms512m -Xmx1g \", ${${A}Hosts}, true)"
+                             ncf
+                             ,
+                             fcn "hydra.TestConfigFcns.duplicate
+                                  (\"-Xms512m -Xmx1g \", ${${B}Hosts}, true)"
+                             ncf;
+
+hydra.VmPrms-extraVMArgsSUN += "-XX:PermSize=64M -XX:MaxPermSize=256m";
+

--- a/dtests/src/test/java/io/snappydata/hydra/longRun/longRunTestSplitMode.conf
+++ b/dtests/src/test/java/io/snappydata/hydra/longRun/longRunTestSplitMode.conf
@@ -31,7 +31,7 @@ TASK        taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = H
             maxThreads = 1
             ;
 
-INCLUDE $JTESTS/io/snappydata/hydra/northwind/stopDualModeCluster.conf;\
+INCLUDE $JTESTS/io/snappydata/hydra/northwind/stopDualModeCluster.conf;
 
 hydra.Prms-totalTaskTimeSec           = 144000;
 hydra.Prms-maxResultWaitSec           = 3600;

--- a/dtests/src/test/java/io/snappydata/hydra/longRun/longRunTestSplitMode.conf
+++ b/dtests/src/test/java/io/snappydata/hydra/longRun/longRunTestSplitMode.conf
@@ -1,6 +1,6 @@
-hydra.Prms-testRequirement = "Test to verify functionality in split mode while running the cluster on long duration with different schemas";
-hydra.Prms-testDescription = "This test starts the snappy cluster and spoark, initializes snappyContext, create tables using snappy job.
-                        After initialization, test is executing snappy job, spark app and sql scripts which test queries with row tables and column tables using the schema.
+hydra.Prms-testRequirement = "Test to verify product behavior when the cluster is up and running for longer duration with operations being performed continuously in split mode ";
+hydra.Prms-testDescription = "This test starts the snappy cluster and spark cluster, initializes snappyContext, create tables using sql scripts.
+                        After initialization, test executes tasks for snappy job, spark app and sql scripts which validate queries for row and column tables. 
                         These tasks will run for ~40 hrs, which can be configured. ";
 
 INCLUDE $JTESTS/io/snappydata/hydra/northwind/startDualModeCluster.conf;

--- a/dtests/src/test/java/io/snappydata/hydra/longRun/longRunTestSplitModeWithHA.conf
+++ b/dtests/src/test/java/io/snappydata/hydra/longRun/longRunTestSplitModeWithHA.conf
@@ -1,0 +1,35 @@
+hydra.Prms-testRequirement += " with lead and server nodes performing HA";
+hydra.Prms-testDescription += "While the tasks are being performed, the server and lead nodes will go down and come up.";
+
+INITTASK    taskClass   = util.StopStartVMs  taskMethod = StopStart_initTask
+            threadGroups = snappyThreads, locatorThreads, snappyStoreThreads, leadThreads;
+
+INCLUDE $JTESTS/io/snappydata/hydra/longRun/longRunTestSplitMode.conf;
+
+INITTASK    taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = backUpLeadConfigData
+            threadGroups = snappyThreads;
+
+INITTASK    taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = backUpServerConfigData
+            threadGroups = snappyThreads;
+
+TASK        taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = HydraTask_cycleLeadVM
+            maxThreads = 1
+            startInterval = 3600
+            threadGroups = snappyStoreThreads;
+
+TASK        taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = HydraTask_cycleStoreVms
+            startInterval = 3000
+            threadGroups = snappyThreads;
+
+CLOSETASK   taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = restoreServerConfigData
+            threadGroups = snappyThreads;
+
+CLOSETASK   taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = restoreLeadConfigData
+            threadGroups = snappyThreads;
+
+io.snappydata.hydra.cluster.SnappyPrms-waitTimeBeforeNextCycleVM = 4200; //how long to wait before nodes will be cycled.
+io.snappydata.hydra.cluster.SnappyPrms-cycleVms = true;
+
+util.StopStartPrms-stopModes = NICE_KILL;
+util.StopStartPrms-numVMsToStop = RANGE 1 ${redundantCopies} EGNAR;
+


### PR DESCRIPTION
## Changes proposed in this pull request
Long Running tests for functional testing :
1. Tests are configured run for ~40 hrs in which there will be tasks performed for validation of queries. Currently added northWind Schema to the tests. But the tests can be with any schema.
2. HA tests will have leadHA and serverHA, which are triggered at different times and happen after every 60 mins. 
3. Added 4 tests : 
a. embeded mode, embeded mode with HA -  tables will be created using snappyJob and validation will be done using sqlScripts and snappyJob.
b.split mode and split mode HA - tables will be created using snappyJob and validation will be done using sqlScripts , snappyJob and sparkApp.

Currently enabled splitMode HA test in the Bt file.

## Patch testing

Ran the new tests on colo machines
