### PR TITLE
[SNAP-1199] Fix for SNAP-1199.Treat external table as external instea…

### DIFF
--- a/core/src/main/scala/org/apache/spark/sql/hive/SnappyStoreHiveCatalog.scala
+++ b/core/src/main/scala/org/apache/spark/sql/hive/SnappyStoreHiveCatalog.scala
@@ -717,7 +717,7 @@ class SnappyStoreHiveCatalog(externalCatalog: SnappyExternalCatalog,
       case x: IndexColumnFormatRelation => ExternalTableType.Index
       case x: JDBCAppendableRelation => ExternalTableType.Column
       case x: StreamPlan => ExternalTableType.Stream
-      case _ => ExternalTableType.Row
+      case _ => ExternalTableType.External
     }
   }
 
@@ -889,4 +889,5 @@ object ExternalTableType {
   val Stream = ExternalTableType("STREAM")
   val Sample = ExternalTableType("SAMPLE")
   val TopK = ExternalTableType("TOPK")
+  val External = ExternalTableType("EXTERNAL")
 }


### PR DESCRIPTION
## Changes proposed in this pull request
* Treat external table as external instead of Row table to avoid catalog inconsistency while catalog cleanup

## Patch testing
Tested manually 

## ReleaseNotes.txt changes

(Does this change require an entry in ReleaseNotes.txt? If yes, has it been added to it?) No

## Other PRs 
[Store PR-130](https://github.com/SnappyDataInc/snappy-store/pull/130)

…d of Row table