### PR TITLE
[SNAP-1205]Avoid exchange when the table is partitioned with the join key

### DIFF
--- a/cluster/src/main/scala/io/snappydata/ToolsCallbackImpl.scala
+++ b/cluster/src/main/scala/io/snappydata/ToolsCallbackImpl.scala
@@ -21,6 +21,7 @@ import io.snappydata.impl.LeadImpl
 import org.apache.spark.SparkContext
 import org.apache.spark.sql.catalyst.expressions.Expression
 import org.apache.spark.sql.catalyst.plans.physical.{OrderlessHashPartitioning, Partitioning}
+import org.apache.spark.sql.store.StoreUtils
 
 object ToolsCallbackImpl extends ToolsCallback {
 
@@ -29,6 +30,13 @@ object ToolsCallbackImpl extends ToolsCallback {
   }
 
   def getOrderlessHashPartitioning(partitionColumns: Seq[Expression],
-      numPartitions: Int, numBuckets: Int): Partitioning = OrderlessHashPartitioning(
-    partitionColumns, numPartitions, numBuckets)
+      numPartitions: Int, numBuckets: Int): Partitioning = {
+    if (StoreUtils.ENABLE_BUCKET_RDD_DELINKING) {
+      OrderlessHashPartitioning(
+        partitionColumns, numPartitions, numBuckets)
+    } else {
+      OrderlessHashPartitioning(
+        partitionColumns, numPartitions, 0)
+    }
+  }
 }


### PR DESCRIPTION
## Changes proposed in this pull request

When a join result is joined with another table that is already partitioned on the join key, the exchange isn't avoided.  


The issue is with bucket linking we need to ensure that the  numBuckets of the two join children is same. But, when one join child is a join result of two tables, numBuckets is always 0 and hence the partitioning mismatch. 

Avoided the exchange by disabling setting of buckets for non delinking cases. 

## Patch testing

Running pre-checkin. 