### PR TITLE
Fix for SNAP-1207

### DIFF
--- a/cluster/src/main/scala/org/apache/spark/executor/SnappyExecutor.scala
+++ b/cluster/src/main/scala/org/apache/spark/executor/SnappyExecutor.scala
@@ -77,8 +77,11 @@ class SnappyMutableURLClassLoader(urls: Array[URL], parent: ClassLoader)
   protected val jobJars = scala.collection.mutable.Map[String, URLClassLoader]()
 
   protected def getJobName: String = {
-    val jobFile = Executor.taskDeserializationProps.
-        get().getProperty(io.snappydata.Constant.JOB_SERVER_JAR_NAME, "")
+    var jobFile = ""
+    if (null != Executor.taskDeserializationProps.get()) {
+      jobFile = Executor.taskDeserializationProps.get().getProperty(io.snappydata.Constant
+          .JOB_SERVER_JAR_NAME, "")
+    }
     new File(jobFile).getName
   }
 

--- a/cluster/src/main/scala/org/apache/spark/executor/SnappyExecutor.scala
+++ b/cluster/src/main/scala/org/apache/spark/executor/SnappyExecutor.scala
@@ -78,8 +78,9 @@ class SnappyMutableURLClassLoader(urls: Array[URL], parent: ClassLoader)
 
   protected def getJobName: String = {
     var jobFile = ""
-    if (null != Executor.taskDeserializationProps.get()) {
-      jobFile = Executor.taskDeserializationProps.get().getProperty(io.snappydata.Constant
+    val taskDeserializationProps = Executor.taskDeserializationProps.get()
+    if (null != taskDeserializationProps) {
+      jobFile = taskDeserializationProps.getProperty(io.snappydata.Constant
           .JOB_SERVER_JAR_NAME, "")
     }
     new File(jobFile).getName


### PR DESCRIPTION
## Changes proposed in this pull request
*  Fix for SNAP-1207
* This issue was intermitent which was caused when PutAllPRMessage was received by a member which has PartitionRegionPool but ThreadLocal was not set hence null check is safe here.

## Patch testing
Tested by executing unit tests which was failing previously multiple times using a script

## ReleaseNotes.txt changes

(Does this change require an entry in ReleaseNotes.txt? If yes, has it been added to it?) NA

## Other PRs 

(Does this change require changes in other projects- store, spark, spark-jobserver, aqp? Add the links of PR of the other subprojects that are related to this change) No

