### PR TITLE
Updated LocalJoin to handle cover colocated join cases as well.

### DIFF
--- a/cluster/src/dunit/scala/org/apache/spark/sql/TPCHDUnitTest.scala
+++ b/cluster/src/dunit/scala/org/apache/spark/sql/TPCHDUnitTest.scala
@@ -45,27 +45,55 @@ class TPCHDUnitTest(s: String) extends ClusterManagerTestBase(s) {
   def testSnappy(): Unit = {
     val snc = SnappyContext(sc)
     TPCHUtils.createAndLoadTables(snc, isSnappy = true)
-    queryExecution(snc, isSnappy = true)
-    validateResult(snc, isSnappy = true)
+    TPCHUtils.queryExecution(snc, isSnappy = true)
+    TPCHUtils.validateResult(snc, isSnappy = true)
   }
 
   def _testSpark(): Unit = {
     val snc = SnappyContext(sc)
     TPCHUtils.createAndLoadTables(snc, isSnappy = false)
-    queryExecution(snc, isSnappy = false)
-    validateResult(snc, isSnappy = false)
+    TPCHUtils.queryExecution(snc, isSnappy = false)
+    TPCHUtils.validateResult(snc, isSnappy = false)
   }
 
+}
 
-  private def queryExecution(snc: SnappyContext, isSnappy: Boolean): Unit = {
-    snc.sql(s"set spark.sql.shuffle.partitions= 4")
-    snc.sql(s"set spark.sql.crossJoin.enabled = true")
+object TPCHUtils {
 
-    queries.foreach(query => TPCH_Snappy.execute(query, snc,
-      isResultCollection = true, isSnappy = isSnappy, avgPrintStream = System.out))
+  val queries = Array("q1", "q2", "q3", "q4", "q5", "q6", "q7", "q8", "q9",
+    "q10", "q11", "q12", "q13", "q14", "q15", "q16", "q17", "q18", "q19",
+    "q20", "q21", "q22")
+
+  def createAndLoadTables(snc: SnappyContext, isSnappy: Boolean): Unit = {
+    val tpchDataPath = getClass.getResource("/TPCH").getPath
+
+    val usingOptionString =
+      s"""
+           USING row
+           OPTIONS ()"""
+
+    TPCHReplicatedTable.createPopulateRegionTable(usingOptionString, snc,
+      tpchDataPath, isSnappy, null)
+    TPCHReplicatedTable.createPopulateNationTable(usingOptionString, snc,
+      tpchDataPath, isSnappy, null)
+    TPCHReplicatedTable.createPopulateSupplierTable(usingOptionString, snc,
+      tpchDataPath, isSnappy, null)
+
+    val buckets_Order_Lineitem = "5"
+    val buckets_Cust_Part_PartSupp = "5"
+    TPCHColumnPartitionedTable.createAndPopulateOrderTable(snc, tpchDataPath,
+      isSnappy, buckets_Order_Lineitem, null)
+    TPCHColumnPartitionedTable.createAndPopulateLineItemTable(snc, tpchDataPath,
+      isSnappy, buckets_Order_Lineitem, null)
+    TPCHColumnPartitionedTable.createPopulateCustomerTable(snc, tpchDataPath,
+      isSnappy, buckets_Cust_Part_PartSupp, null)
+    TPCHColumnPartitionedTable.createPopulatePartTable(snc, tpchDataPath,
+      isSnappy, buckets_Cust_Part_PartSupp, null)
+    TPCHColumnPartitionedTable.createPopulatePartSuppTable(snc, tpchDataPath,
+      isSnappy, buckets_Cust_Part_PartSupp, null)
   }
 
-  private def validateResult(snc: SnappyContext, isSnappy: Boolean): Unit = {
+  def validateResult(snc: SnappyContext, isSnappy: Boolean): Unit = {
     val sc: SparkContext = snc.sparkContext
 
     val fineName = if (isSnappy) "Result_Snappy.out" else "Result_Spark.out"
@@ -116,36 +144,11 @@ class TPCHDUnitTest(s: String) extends ClusterManagerTestBase(s) {
     }
   }
 
-}
+  def queryExecution(snc: SnappyContext, isSnappy: Boolean): Unit = {
+    snc.sql(s"set spark.sql.shuffle.partitions= 4")
+    snc.sql(s"set spark.sql.crossJoin.enabled = true")
 
-object TPCHUtils {
-
-  def createAndLoadTables(snc: SnappyContext, isSnappy: Boolean): Unit = {
-    val tpchDataPath = getClass.getResource("/TPCH").getPath
-
-    val usingOptionString =
-      s"""
-           USING row
-           OPTIONS ()"""
-
-    TPCHReplicatedTable.createPopulateRegionTable(usingOptionString, snc,
-      tpchDataPath, isSnappy, null)
-    TPCHReplicatedTable.createPopulateNationTable(usingOptionString, snc,
-      tpchDataPath, isSnappy, null)
-    TPCHReplicatedTable.createPopulateSupplierTable(usingOptionString, snc,
-      tpchDataPath, isSnappy, null)
-
-    val buckets_Order_Lineitem = "5"
-    val buckets_Cust_Part_PartSupp = "5"
-    TPCHColumnPartitionedTable.createAndPopulateOrderTable(snc, tpchDataPath,
-      isSnappy, buckets_Order_Lineitem, null)
-    TPCHColumnPartitionedTable.createAndPopulateLineItemTable(snc, tpchDataPath,
-      isSnappy, buckets_Order_Lineitem, null)
-    TPCHColumnPartitionedTable.createPopulateCustomerTable(snc, tpchDataPath,
-      isSnappy, buckets_Cust_Part_PartSupp, null)
-    TPCHColumnPartitionedTable.createPopulatePartTable(snc, tpchDataPath,
-      isSnappy, buckets_Cust_Part_PartSupp, null)
-    TPCHColumnPartitionedTable.createPopulatePartSuppTable(snc, tpchDataPath,
-      isSnappy, buckets_Cust_Part_PartSupp, null)
+    queries.foreach(query => TPCH_Snappy.execute(query, snc,
+      isResultCollection = true, isSnappy = isSnappy, avgPrintStream = System.out))
   }
 }

--- a/cluster/src/dunit/scala/org/apache/spark/sql/TPCHSuite.scala
+++ b/cluster/src/dunit/scala/org/apache/spark/sql/TPCHSuite.scala
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2016 SnappyData, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License. You
+ * may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License. See accompanying
+ * LICENSE file.
+ */
+
+package org.apache.spark.sql
+
+import io.snappydata.SnappyFunSuite
+import org.scalatest.BeforeAndAfterAll
+
+/**
+ * Suite to run TPCH in a single VM. Disabled, by default,
+ * as TPCH is run with the TPCHDunitTest. This is primarily
+ * for debugging.
+ */
+class TPCHSuite extends SnappyFunSuite with BeforeAndAfterAll  {
+
+  ignore("Test TPCH") {
+    val snc = SnappyContext(sc)
+    TPCHUtils.createAndLoadTables(snc, isSnappy = true)
+    TPCHUtils.queryExecution(snc, isSnappy = true)
+    TPCHUtils.validateResult(snc, isSnappy = true)
+  }
+}

--- a/core/src/main/scala/io/snappydata/Literals.scala
+++ b/core/src/main/scala/io/snappydata/Literals.scala
@@ -229,6 +229,10 @@ object Property extends Enumeration {
         "store. When inserting data into the column storage this is " +
         "the unit (in MB) that will be used to split the data into chunks " +
         "for efficient storage and retrieval.", Some(32))
+
+  val LocalHashJoinSize = SQLVal[Long](s"${Constant.PROPERTY_PREFIX}localhashjoinsize",
+    "The join would be converted into a hash join if the table is of size less" +
+        "than localhashjoinsize. Default value is 100 MB.", Some(100*1024*1024))
 }
 
 // extractors for properties

--- a/core/src/main/scala/org/apache/spark/sql/SnappyStrategies.scala
+++ b/core/src/main/scala/org/apache/spark/sql/SnappyStrategies.scala
@@ -17,7 +17,7 @@
 package org.apache.spark.sql
 
 import org.apache.spark.sql.catalyst.expressions.aggregate.{AggregateExpression, AggregateFunction, Final, ImperativeAggregate, Partial, PartialMerge}
-import org.apache.spark.sql.catalyst.expressions.{Alias, Expression, NamedExpression}
+import org.apache.spark.sql.catalyst.expressions.{Alias, Expression, NamedExpression, RowOrdering}
 import org.apache.spark.sql.catalyst.planning.{ExtractEquiJoinKeys, PhysicalAggregation, PhysicalOperation}
 import org.apache.spark.sql.catalyst.plans.logical.{Join, LogicalPlan, ReturnAnswer}
 import org.apache.spark.sql.catalyst.plans.{ExistenceJoin, Inner, JoinType, LeftAnti, LeftOuter, LeftSemi, RightOuter}
@@ -61,15 +61,33 @@ private[sql] trait SnappyStrategies {
   object LocalJoinStrategies extends Strategy {
     def apply(plan: LogicalPlan): Seq[SparkPlan] = plan match {
       case ExtractEquiJoinKeys(joinType, leftKeys, rightKeys, condition,
-      left, right) =>
-        if (canBuildRight(joinType) && canLocalJoin(right)) {
+      left, right) if canBuildRight(joinType) && canLocalJoin(right) =>
+        makeLocalHashJoin(leftKeys, rightKeys, left, right, condition,
+          joinType, joins.BuildRight, true)
+      case ExtractEquiJoinKeys(joinType, leftKeys, rightKeys, condition,
+      left, right) if canBuildLeft(joinType) && canLocalJoin(left) =>
           makeLocalHashJoin(leftKeys, rightKeys, left, right, condition,
-            joinType, joins.BuildRight)
-        } else if (canBuildLeft(joinType) && canLocalJoin(left)) {
-          makeLocalHashJoin(leftKeys, rightKeys, left, right, condition,
-            joinType, joins.BuildLeft)
-        } else Nil
+            joinType, joins.BuildLeft, true)
+      case ExtractEquiJoinKeys(joinType, leftKeys, rightKeys, condition, left, right)
+        if canBuildRight(joinType) && canBuildLocalHashMap(right) ||
+            !RowOrdering.isOrderable(leftKeys) =>
+        makeLocalHashJoin(leftKeys, rightKeys, left, right, condition,
+          joinType, joins.BuildRight, false)
+      case ExtractEquiJoinKeys(joinType, leftKeys, rightKeys, condition, left, right)
+        if canBuildLeft(joinType) && canBuildLocalHashMap(left) ||
+            !RowOrdering.isOrderable(leftKeys) =>
+        makeLocalHashJoin(leftKeys, rightKeys, left, right, condition,
+          joinType, joins.BuildLeft, false)
       case _ => Nil
+    }
+
+    /**
+     * Matches a plan whose size is small enough to build a hash table.
+     *
+     */
+    private def canBuildLocalHashMap(plan: LogicalPlan): Boolean = {
+      plan.statistics.sizeInBytes <
+          io.snappydata.Property.LocalHashJoinSize.configEntry.getConf[Long](conf)
     }
 
     private def canBuildRight(joinType: JoinType): Boolean = joinType match {
@@ -106,9 +124,10 @@ private[sql] trait SnappyStrategies {
         right: LogicalPlan,
         condition: Option[Expression],
         joinType: JoinType,
-        side: joins.BuildSide): Seq[SparkPlan] = {
+        side: joins.BuildSide,
+        replicatedTableJoin: Boolean): Seq[SparkPlan] = {
       joins.LocalJoin(leftKeys, rightKeys, side, condition,
-        joinType, planLater(left), planLater(right)) :: Nil
+        joinType, planLater(left), planLater(right), replicatedTableJoin) :: Nil
     }
   }
 

--- a/core/src/main/scala/org/apache/spark/sql/execution/RowTableScan.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/RowTableScan.scala
@@ -43,19 +43,15 @@ private[sql] final case class RowTableScan(
     extends PartitionedPhysicalScan(output, dataRDD, numBuckets,
       partitionColumns, baseRelation.asInstanceOf[BaseRelation]) {
 
-  private[sql] var input: String = _
-
   override def doProduce(ctx: CodegenContext): String = {
     // a parent plan may set a custom input (e.g. LocalJoin)
     // for that case no need to add the "shouldStop()" calls
     var builderInput = true
-    if (input == null) {
-      // PartitionedPhysicalRDD always has one input
-      input = ctx.freshName("input")
-      ctx.addMutableState("scala.collection.Iterator",
-        input, s"$input = inputs[0];")
-      builderInput = false
-    }
+    // PartitionedPhysicalRDD always has one input
+    val input = ctx.freshName("input")
+    ctx.addMutableState("scala.collection.Iterator",
+      input, s"$input = inputs[0];")
+    builderInput = false
     val numOutputRows = metricTerm(ctx, "numOutputRows")
     ctx.currentVars = null
 
@@ -67,7 +63,6 @@ private[sql] final case class RowTableScan(
         doProduceWithProjection(ctx, input, builderInput, numOutputRows,
           output, baseRelation)
     }
-    input = null
     code
   }
 

--- a/core/src/main/scala/org/apache/spark/sql/execution/joins/DelegateRDD.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/joins/DelegateRDD.scala
@@ -1,0 +1,305 @@
+/*
+ * Copyright (c) 2016 SnappyData, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License. You
+ * may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License. See accompanying
+ * LICENSE file.
+ */
+package org.apache.spark.sql.execution.joins
+
+import scala.collection.{Map}
+import scala.io.Codec
+import scala.reflect.{ClassTag, _}
+
+import org.apache.hadoop.io.compress.CompressionCodec
+import org.apache.spark.partial.{BoundedDouble, PartialResult}
+import org.apache.spark.rdd._
+import org.apache.spark.storage.{StorageLevel}
+import org.apache.spark._
+import org.apache.spark.api.java.JavaRDD
+import org.apache.spark.util.{Utils}
+
+/**
+ * RDD that delegates all the calls to the base RDD. However the dependencies of
+ * this RDD can be altered.
+ */
+class DelegateRDD[T: ClassTag](
+    sc: SparkContext,
+    baseRdd: RDD[T],
+    implicit val alldependencies: Seq[Dependency[_]] = null)
+    extends RDD[T](sc,
+      if (alldependencies == null) { baseRdd.dependencies }
+      else { alldependencies} )
+        with Serializable {
+
+  override protected def getPartitions: Array[Partition] = baseRdd.partitions
+
+  override def compute(split: Partition, context: TaskContext): Iterator[T] =
+    baseRdd.compute(split, context)
+
+  @transient override val partitioner: Option[Partitioner] = baseRdd.partitioner
+
+  override def persist(newLevel: StorageLevel): this.type = {
+    baseRdd.persist(newLevel);
+    this
+  }
+
+  override def persist(): this.type = {
+    baseRdd.persist()
+    this
+  }
+
+  override def cache(): this.type = {
+    baseRdd.cache()
+    this
+  }
+
+  override def unpersist(blocking: Boolean = true): this.type = {
+    baseRdd.unpersist(blocking)
+    this
+  }
+
+  override def getStorageLevel: StorageLevel = baseRdd.getStorageLevel
+
+
+  override def map[U: ClassTag](f: T => U): RDD[U] = baseRdd.map(f)
+  override def flatMap[U: ClassTag](f: T => TraversableOnce[U]): RDD[U] = baseRdd.flatMap(f)
+  override  def filter(f: T => Boolean): RDD[T] = baseRdd.filter(f)
+  override def distinct(numPartitions: Int)(implicit ord: Ordering[T] = null): RDD[T] =
+    baseRdd.distinct(numPartitions)(ord)
+
+  override def distinct(): RDD[T] = baseRdd.distinct
+
+  override def repartition(numPartitions: Int)(implicit ord: Ordering[T] = null): RDD[T] =
+    baseRdd.repartition(numPartitions)(ord)
+
+  override def coalesce(numPartitions: Int, shuffle: Boolean = false,
+      partitionCoalescer: Option[PartitionCoalescer] = Option.empty)
+      (implicit ord: Ordering[T] = null)
+  : RDD[T] = baseRdd.coalesce(numPartitions, shuffle, partitionCoalescer)(ord)
+
+  override def sample(
+      withReplacement: Boolean,
+      fraction: Double,
+      seed: Long = Utils.random.nextLong): RDD[T] = baseRdd.sample(withReplacement, fraction, seed)
+
+  override def randomSplit(
+      weights: Array[Double],
+      seed: Long = Utils.random.nextLong): Array[RDD[T]] = baseRdd.randomSplit(weights, seed)
+
+  override def takeSample(
+      withReplacement: Boolean,
+      num: Int,
+      seed: Long = Utils.random.nextLong): Array[T] = baseRdd.takeSample(withReplacement, num, seed)
+
+  override def union(other: RDD[T]): RDD[T] = baseRdd.union(other)
+
+  override def ++(other: RDD[T]): RDD[T] = baseRdd.++(other)
+  override def sortBy[K](
+      f: (T) => K,
+      ascending: Boolean = true,
+      numPartitions: Int = this.partitions.length)
+      (implicit ord: Ordering[K], ctag: ClassTag[K]): RDD[T] =
+    baseRdd.sortBy(f, ascending, numPartitions)(ord, ctag)
+
+  override def intersection(other: RDD[T]): RDD[T] = baseRdd.intersection(other)
+
+  override def intersection(
+      other: RDD[T],
+      partitioner: Partitioner)(implicit ord: Ordering[T] = null): RDD[T] =
+    baseRdd.intersection(other, partitioner)(ord)
+
+  override def intersection(other: RDD[T], numPartitions: Int): RDD[T] =
+    baseRdd.intersection(other, numPartitions)
+
+  override def glom(): RDD[Array[T]] = baseRdd.glom
+
+  override def cartesian[U: ClassTag](other: RDD[U]): RDD[(T, U)] = baseRdd.cartesian(other)
+
+  override def groupBy[K](f: T => K)(implicit kt: ClassTag[K]): RDD[(K, Iterable[T])] =
+    baseRdd.groupBy(f)(kt)
+
+  override def groupBy[K](
+      f: T => K,
+      numPartitions: Int)(implicit kt: ClassTag[K]): RDD[(K, Iterable[T])] =
+    baseRdd.groupBy(f, numPartitions)
+
+  override def groupBy[K](f: T => K, p: Partitioner)
+      (implicit kt: ClassTag[K], ord: Ordering[K] = null)
+  : RDD[(K, Iterable[T])] = baseRdd.groupBy(f, p)(kt, ord)
+
+  override def pipe(command: String): RDD[String] = baseRdd.pipe(command)
+
+  override def pipe(command: String, env: Map[String, String]): RDD[String] =
+    baseRdd.pipe(command, env)
+
+  override def pipe(
+      command: Seq[String],
+      env: Map[String, String] = Map(),
+      printPipeContext: (String => Unit) => Unit = null,
+      printRDDElement: (T, String => Unit) => Unit = null,
+      separateWorkingDir: Boolean = false,
+      bufferSize: Int = 8192,
+      encoding: String = Codec.defaultCharsetCodec.name): RDD[String] =
+    baseRdd.pipe(command, env, printPipeContext,
+      printRDDElement, separateWorkingDir, bufferSize, encoding)
+
+  override def mapPartitions[U: ClassTag](
+      f: Iterator[T] => Iterator[U],
+      preservesPartitioning: Boolean = false): RDD[U] =
+    baseRdd.mapPartitions(f, preservesPartitioning)
+
+  override def mapPartitionsWithIndex[U: ClassTag](
+      f: (Int, Iterator[T]) => Iterator[U],
+      preservesPartitioning: Boolean = false): RDD[U] =
+    baseRdd.mapPartitionsWithIndex(f, preservesPartitioning)
+
+  override def zip[U: ClassTag](other: RDD[U]): RDD[(T, U)] = baseRdd.zip(other)
+
+  override def zipPartitions[B: ClassTag, V: ClassTag]
+  (rdd2: RDD[B], preservesPartitioning: Boolean)
+      (f: (Iterator[T], Iterator[B]) => Iterator[V]): RDD[V] =
+    baseRdd.zipPartitions(rdd2, preservesPartitioning)(f)
+
+  override def zipPartitions[B: ClassTag, V: ClassTag]
+  (rdd2: RDD[B])
+      (f: (Iterator[T], Iterator[B]) => Iterator[V]): RDD[V] = baseRdd.zipPartitions(rdd2)(f)
+
+  override def zipPartitions[B: ClassTag, C: ClassTag, V: ClassTag]
+  (rdd2: RDD[B], rdd3: RDD[C], preservesPartitioning: Boolean)
+      (f: (Iterator[T], Iterator[B], Iterator[C]) => Iterator[V]): RDD[V] =
+    baseRdd.zipPartitions(rdd2, rdd3, preservesPartitioning) (f)
+
+  override def zipPartitions[B: ClassTag, C: ClassTag, V: ClassTag]
+  (rdd2: RDD[B], rdd3: RDD[C])
+      (f: (Iterator[T], Iterator[B], Iterator[C]) => Iterator[V]): RDD[V] =
+    baseRdd.zipPartitions(rdd2, rdd3)(f)
+
+  override def zipPartitions[B: ClassTag, C: ClassTag, D: ClassTag, V: ClassTag]
+  (rdd2: RDD[B], rdd3: RDD[C], rdd4: RDD[D], preservesPartitioning: Boolean)
+      (f: (Iterator[T], Iterator[B], Iterator[C], Iterator[D]) => Iterator[V]): RDD[V] =
+    baseRdd.zipPartitions(rdd2, rdd3, rdd4, preservesPartitioning)(f)
+
+  override def zipPartitions[B: ClassTag, C: ClassTag, D: ClassTag, V: ClassTag]
+  (rdd2: RDD[B], rdd3: RDD[C], rdd4: RDD[D])
+      (f: (Iterator[T], Iterator[B], Iterator[C], Iterator[D]) => Iterator[V]): RDD[V] =
+    baseRdd.zipPartitions(rdd2, rdd3, rdd4)(f)
+
+
+  override def foreach(f: T => Unit): Unit =
+    baseRdd.foreach(f)
+
+  override def foreachPartition(f: Iterator[T] => Unit): Unit =
+    baseRdd.foreachPartition(f)
+
+  override def collect(): Array[T] =
+    baseRdd.collect()
+
+  override def toLocalIterator: Iterator[T] =
+    baseRdd.toLocalIterator
+
+  override def collect[U: ClassTag](f: PartialFunction[T, U]): RDD[U] =
+    baseRdd.collect(f)
+
+  override def subtract(other: RDD[T]): RDD[T] =
+    baseRdd.subtract(other)
+
+  override def subtract(other: RDD[T], numPartitions: Int): RDD[T] =
+    baseRdd.subtract(other, numPartitions)
+
+  override def subtract(
+      other: RDD[T],
+      p: Partitioner)(implicit ord: Ordering[T] = null): RDD[T] =
+    baseRdd.subtract(other, p)(ord)
+
+  override def reduce(f: (T, T) => T): T = baseRdd.reduce(f)
+
+  override def treeReduce(f: (T, T) => T, depth: Int = 2): T = baseRdd.treeReduce(f, depth)
+
+  override def fold(zeroValue: T)(op: (T, T) => T): T = baseRdd.fold(zeroValue)(op)
+
+  override def aggregate[U: ClassTag](zeroValue: U)(seqOp: (U, T) => U, combOp: (U, U) => U): U =
+    baseRdd.aggregate(zeroValue)(seqOp, combOp)
+
+
+  override def treeAggregate[U: ClassTag](zeroValue: U)(
+      seqOp: (U, T) => U,
+      combOp: (U, U) => U,
+      depth: Int = 2): U = baseRdd.treeAggregate(zeroValue)(seqOp, combOp, depth)
+
+  override def count(): Long = baseRdd.count
+
+  override def countApprox(
+      timeout: Long,
+      confidence: Double = 0.95): PartialResult[BoundedDouble] =
+    baseRdd.countApprox(timeout, confidence)
+
+  override def countByValue()(implicit ord: Ordering[T] = null): Map[T, Long] =
+    baseRdd.countByValue()(ord)
+
+  override def countByValueApprox(timeout: Long, confidence: Double = 0.95)
+      (implicit ord: Ordering[T] = null)
+  : PartialResult[Map[T, BoundedDouble]] =
+    baseRdd.countByValueApprox(timeout, confidence)(ord)
+
+  override def countApproxDistinct(p: Int, sp: Int): Long = baseRdd.countApproxDistinct(p, sp)
+
+  override def countApproxDistinct(relativeSD: Double = 0.05): Long =
+    baseRdd.countApproxDistinct(relativeSD)
+
+  override def zipWithIndex(): RDD[(T, Long)] = baseRdd.zipWithIndex()
+
+  override def zipWithUniqueId(): RDD[(T, Long)] = baseRdd.zipWithUniqueId()
+
+  override def take(num: Int): Array[T] = baseRdd.take(num)
+
+  override def first(): T = baseRdd.first
+
+  override def top(num: Int)(implicit ord: Ordering[T]): Array[T] = baseRdd.top(num)
+
+  override def takeOrdered(num: Int)(implicit ord: Ordering[T]): Array[T] =
+    baseRdd.takeOrdered(num)(ord)
+
+  override def max()(implicit ord: Ordering[T]): T = baseRdd.max()(ord)
+
+  override def min()(implicit ord: Ordering[T]): T = baseRdd.min()(ord)
+
+  override def isEmpty(): Boolean = baseRdd.isEmpty
+
+  override def saveAsTextFile(path: String): Unit = baseRdd.saveAsTextFile(path)
+
+  override def saveAsTextFile(path: String, codec: Class[_ <: CompressionCodec]): Unit =
+    baseRdd.saveAsTextFile(path, codec)
+
+  override def saveAsObjectFile(path: String): Unit = baseRdd.saveAsObjectFile(path)
+
+  override def keyBy[K](f: T => K): RDD[(K, T)] = baseRdd.keyBy(f)
+
+  override def checkpoint(): Unit = baseRdd.checkpoint()
+
+  override def localCheckpoint(): this.type = {
+    baseRdd.localCheckpoint()
+    this
+  }
+
+  override def isCheckpointed: Boolean = baseRdd.isCheckpointed
+
+  override def getCheckpointFile: Option[String] = baseRdd.getCheckpointFile
+
+  /** A description of this RDD and its recursive dependencies for debugging. */
+  override def toDebugString: String = baseRdd.toDebugString
+
+  override def toString: String = baseRdd.toString()
+
+  override def toJavaRDD() : JavaRDD[T] = baseRdd.toJavaRDD
+}
+

--- a/core/src/main/scala/org/apache/spark/sql/execution/joins/LocalJoin.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/joins/LocalJoin.scala
@@ -36,13 +36,14 @@ import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.codegen.{CodegenContext, ExprCode, GenerateUnsafeProjection}
 import org.apache.spark.sql.catalyst.expressions.{AttributeSet, BindReferences, BoundReference, Expression, UnsafeRow}
 import org.apache.spark.sql.catalyst.plans._
-import org.apache.spark.sql.catalyst.plans.physical.{Distribution, Partitioning, UnspecifiedDistribution}
+import org.apache.spark.sql.catalyst.plans.physical.{ClusteredDistribution, Distribution, Partitioning, UnspecifiedDistribution}
 import org.apache.spark.sql.collection.Utils
-import org.apache.spark.sql.execution._
+import org.apache.spark.sql.execution.{r, _}
 import org.apache.spark.sql.execution.metric.SQLMetrics
 import org.apache.spark.sql.snappy._
 import org.apache.spark.sql.types.{LongType, StructType, TypeUtilities}
-import org.apache.spark.{Partition, SparkEnv, TaskContext}
+import org.apache.spark.sql.{SnappyAggregation, SnappySession}
+import org.apache.spark.{Dependency, Partition, ShuffleDependency, SparkEnv, TaskContext}
 
 /**
  * :: DeveloperApi ::
@@ -59,7 +60,8 @@ case class LocalJoin(leftKeys: Seq[Expression],
     condition: Option[Expression],
     joinType: JoinType,
     left: SparkPlan,
-    right: SparkPlan)
+    right: SparkPlan,
+    val replicatedTableJoin: Boolean)
     extends BinaryExecNode with HashJoin with BatchConsumer {
 
   override def nodeName: String = "LocalJoin"
@@ -83,7 +85,12 @@ case class LocalJoin(leftKeys: Seq[Expression],
   override def outputPartitioning: Partitioning = streamedPlan.outputPartitioning
 
   override def requiredChildDistribution: Seq[Distribution] =
-    UnspecifiedDistribution :: UnspecifiedDistribution :: Nil
+    if (replicatedTableJoin) {
+      UnspecifiedDistribution :: UnspecifiedDistribution :: Nil
+    }
+    else {
+      ClusteredDistribution(leftKeys) :: ClusteredDistribution(rightKeys) :: Nil
+    }
 
   protected lazy val (buildSideKeys, streamSideKeys) = {
     require(leftKeys.map(_.dataType) == rightKeys.map(_.dataType),
@@ -95,11 +102,8 @@ case class LocalJoin(leftKeys: Seq[Expression],
   }
 
   private lazy val streamRDD = streamedPlan.execute()
-  private lazy val (buildRDD, buildPartition) = {
-    val rdd = buildPlan.execute()
-    assert(rdd.getNumPartitions == 1)
-    (rdd, rdd.partitions(0))
-  }
+  private lazy val buildRDD = buildPlan.execute()
+
 
   /**
    * Overridden by concrete implementations of SparkPlan.
@@ -112,20 +116,39 @@ case class LocalJoin(leftKeys: Seq[Expression],
 
     // materialize dependencies in the entire buildRDD graph for
     // buildRDD.iterator to work in the compute of mapPartitionsPreserve below
-    materializeDependencies(buildRDD, new mutable.HashSet[RDD[_]]())
-
-    val schema = buildPlan.schema
-    streamRDD.mapPartitionsPreserveWithPartition { (context, _, itr) =>
-      val start = System.nanoTime()
-      val hashed = HashedRelationCache.get(schema, buildKeys, buildRDD,
-        buildPartition, context)
-      buildTime += (System.nanoTime() - start) / 1000000L
-      val estimatedSize = hashed.estimatedSize
-      buildDataSize += estimatedSize
-      context.taskMetrics().incPeakExecutionMemory(estimatedSize)
-      context.addTaskCompletionListener(_ => hashed.close())
-      join(itr, hashed, numOutputRows)
+    if (buildRDD.partitions.size == 1) {
+      materializeDependencies(buildRDD, new mutable.HashSet[RDD[_]]())
+      val schema = buildPlan.schema
+      streamRDD.mapPartitionsPreserveWithPartition { (context, split, itr) =>
+        val start = System.nanoTime()
+        val hashed = HashedRelationCache.get(schema, buildKeys, buildRDD,
+          buildRDD.partitions(0), context)
+        buildTime += (System.nanoTime() - start) / 1000000L
+        val estimatedSize = hashed.estimatedSize
+        buildDataSize += estimatedSize
+        context.taskMetrics().incPeakExecutionMemory(estimatedSize)
+        context.addTaskCompletionListener(_ => hashed.close())
+        join(itr, hashed, numOutputRows)
+      }
+    } else {
+      streamRDD.zipPartitions(buildRDD) { (streamIter, buildIter) =>
+        val hashed = buildHashedRelation(buildIter)
+        join(streamIter, hashed, numOutputRows)
+      }
     }
+  }
+
+  private def buildHashedRelation(iter: Iterator[InternalRow]): HashedRelation = {
+    val buildDataSize = longMetric("buildDataSize")
+    val buildTime = longMetric("buildTime")
+    val start = System.nanoTime()
+    val context = TaskContext.get()
+    val relation = HashedRelation(iter, buildKeys, taskMemoryManager = context.taskMemoryManager())
+    buildTime += (System.nanoTime() - start) / 1000000
+    buildDataSize += relation.estimatedSize
+    // This relation is usually used until the end of task.
+    context.addTaskCompletionListener(_ => relation.close())
+    relation
   }
 
   private[spark] def materializeDependencies[T](rdd: RDD[T],
@@ -137,8 +160,22 @@ case class LocalJoin(leftKeys: Seq[Expression],
   // return empty here as code of required variables is explicitly instantiated
   override def usedInputs: AttributeSet = AttributeSet.empty
 
-  override def inputRDDs(): Seq[RDD[InternalRow]] =
-    streamedPlan.asInstanceOf[CodegenSupport].inputRDDs()
+  lazy val buildCodegenRDDs = buildPlan.asInstanceOf[CodegenSupport].inputRDDs()
+
+  override def inputRDDs(): Seq[RDD[InternalRow]] = {
+    // If the build side has shuffle dependencies.
+    if (buildCodegenRDDs.length == 1 && buildCodegenRDDs(0).dependencies.size >= 1 &&
+        buildCodegenRDDs(0).dependencies.exists(x =>
+        {x.isInstanceOf[ShuffleDependency[_, _, _]]})){
+      streamedPlan.asInstanceOf[CodegenSupport].inputRDDs().map(rdd => {
+        new DelegateRDD[InternalRow](rdd.sparkContext, rdd,
+          (rdd.dependencies ++ buildCodegenRDDs(0).dependencies.filter(
+            _.isInstanceOf[ShuffleDependency[_, _, _]])))
+      })
+    } else {
+      streamedPlan.asInstanceOf[CodegenSupport].inputRDDs()
+    }
+  }
 
   override def doProduce(ctx: CodegenContext): String = {
     if (true) {
@@ -161,31 +198,19 @@ case class LocalJoin(leftKeys: Seq[Expression],
     val hashSetClassName = classOf[ObjectHashSet[_]].getName
     ctx.addMutableState(hashSetClassName, hashMapTerm, "")
 
-    // add reference to the row table RDD directly since it is not possible
-    // to pass to inputRDDs in the general case (when streamPlan already
-    //   has 2 RDDs)
-    val rowIterator = ctx.freshName("rowIterator")
-    // find the underlying RowTableScan and set it up to use its RDD's direct
-    // iterator for best performance
-    val rowTableScan = buildPlan.collectFirst {
-      case scan: RowTableScan if scan.numBuckets == 1 =>
-        scan.input = rowIterator; scan
-    }.getOrElse(throw new IllegalStateException(
-      s"Failed to find replicated table for LocalJoin in $buildPlan"))
-    val rdd = rowTableScan.dataRDD
-    assert(rdd.getNumPartitions == 1)
-    val rowTableRDD = ctx.addReferenceObj("rowTableRDD", rdd)
-    val rowTablePart = ctx.addReferenceObj("singlePartition", rdd.partitions(0))
     // using the expression IDs is enough to ensure uniqueness
+    val buildCodeGen = buildPlan.asInstanceOf[CodegenSupport]
+    val rdds = buildCodegenRDDs
     val exprIds = buildPlan.output.map(_.exprId.id).toArray
     val cacheKeyTerm = ctx.addReferenceObj("cacheKey",
-      new CacheKey(exprIds, rdd.id))
+      new CacheKey(exprIds, rdds.head.id))
 
     // generate local variables for HashMap data array and mask
     mapDataTerm = ctx.freshName("mapData")
     maskTerm = ctx.freshName("hashMapMask")
     keyIsUniqueTerm = ctx.freshName("keyIsUnique")
     numRowsTerm = ctx.freshName("numRows")
+
     // generate the map accessor to generate key/value class
     // and get map access methods
     val session = sqlContext.sparkSession.asInstanceOf[SnappySession]
@@ -193,25 +218,61 @@ case class LocalJoin(leftKeys: Seq[Expression],
       buildPlan.output, "LocalMap", hashMapTerm, mapDataTerm, maskTerm,
       multiMap = true, this, this.parent, buildPlan)
 
-    val entryClass = mapAccessor.getClassName
-    val numKeyColumns = buildSideKeys.length
+    val buildRDDs = ctx.addReferenceObj("buildRDDs", rdds.toArray,
+      s"${classOf[RDD[_]].getName}[]")
+    val buildParts = rdds.map(_.partitions)
+    val partitionClass = classOf[Partition].getName
+    val buildPartsVar = ctx.addReferenceObj("buildParts", buildParts.toArray,
+      s"$partitionClass[][]")
+    val allIterators = ctx.freshName("allIterators")
+    val indexVar = ctx.freshName("index")
     val contextName = ctx.freshName("context")
     val taskContextClass = classOf[TaskContext].getName
     ctx.addMutableState(taskContextClass, contextName,
       s"this.$contextName = $taskContextClass.get();")
-    ctx.addMutableState("scala.collection.Iterator", rowIterator,
-      s"this.$rowIterator = $rowTableRDD.iterator($rowTablePart, $contextName);")
-    ctx.addNewFunction(getOrCreateMap,
-      s"""
-        public final void $createMap() throws java.io.IOException {
-          $hashSetClassName $hashMapTerm = new $hashSetClassName(128, 0.6,
-            $numKeyColumns, scala.reflect.ClassTag$$.MODULE$$.apply(
-              $entryClass.class));
-          this.$hashMapTerm = $hashMapTerm;
-          int $maskTerm = $hashMapTerm.mask();
-          $entryClass[] $mapDataTerm = ($entryClass[])$hashMapTerm.data();
 
-          ${buildPlan.asInstanceOf[CodegenSupport].produce(ctx, mapAccessor)}
+
+    // switch inputs to use the buildPlan RDD iterators
+    ctx.addMutableState("scala.collection.Iterator[]", allIterators,
+      s"""
+         |$allIterators = inputs;
+         |inputs = new scala.collection.Iterator[$buildRDDs.length];
+         |$taskContextClass $contextName = $taskContextClass.get();
+         |for (int $indexVar = 0; $indexVar < $buildRDDs.length; $indexVar++) {
+         |  $partitionClass[] parts = $buildPartsVar[$indexVar];
+         |  // check for replicate table
+         |  if (parts.length == 1) {
+         |    inputs[$indexVar] = $buildRDDs[$indexVar].iterator(
+         |      parts[0], $contextName);
+         |  } else {
+         |    inputs[$indexVar] = $buildRDDs[$indexVar].iterator(
+         |      parts[partitionIndex], $contextName);
+         |  }
+         |}
+      """.stripMargin)
+
+    val buildProduce = buildCodeGen.produce(ctx, mapAccessor)
+    // switch inputs back to streamPlan iterators
+    val numIterators = ctx.freshName("numIterators")
+    ctx.addMutableState("int", numIterators, s"inputs = $allIterators;")
+
+    val entryClass = mapAccessor.getClassName
+    val numKeyColumns = buildSideKeys.length
+
+    val buildSideCreateMap =
+      s"""$hashSetClassName $hashMapTerm = new $hashSetClassName(128, 0.6,
+      $numKeyColumns, scala.reflect.ClassTag$$.MODULE$$.apply(
+        $entryClass.class));
+      this.$hashMapTerm = $hashMapTerm;
+      int $maskTerm = $hashMapTerm.mask();
+      $entryClass[] $mapDataTerm = ($entryClass[])$hashMapTerm.data();
+      $buildProduce"""
+
+    if (replicatedTableJoin) {
+      ctx.addNewFunction(getOrCreateMap,
+        s"""
+        public final void $createMap() throws java.io.IOException {
+           $buildSideCreateMap
         }
 
         public final void $getOrCreateMap() throws java.io.IOException {
@@ -228,12 +289,17 @@ case class LocalJoin(leftKeys: Seq[Expression],
           }
         }
       """)
+    } else {
+      ctx.addNewFunction(getOrCreateMap,
+        s"""
+          public final void $getOrCreateMap() throws java.io.IOException {
+            $buildSideCreateMap
+          }
+      """)
+    }
 
     // clear the parent by reflection if plan is sent by operators like Sort
     TypeUtilities.parentSetter.invoke(buildPlan, null)
-
-    // clear the input of RowTableScan
-    rowTableScan.input = null
 
     // The child could change `copyResult` to true, but we had already
     // consumed all the rows, so `copyResult` should be reset to `false`.
@@ -250,35 +316,41 @@ case class LocalJoin(leftKeys: Seq[Expression],
     val buildTime = metricTerm(ctx, "buildTime")
     val numOutputRows = metricTerm(ctx, "numOutputRows")
     // initialization of min/max for integral keys
-    val initMinMaxVars = mapAccessor.integralKeys.map { index =>
-      val minVar = mapAccessor.integralKeysMinVars(index)
-      val maxVar = mapAccessor.integralKeysMaxVars(index)
-      s"""
-        final long $minVar = $hashMapTerm.getMinValue($index);
-        final long $maxVar = $hashMapTerm.getMaxValue($index);
-      """
+    val initMinMaxVars = mapAccessor.integralKeys.zipWithIndex.map {
+      case (indexKey, index) =>
+        val minVar = mapAccessor.integralKeysMinVars(index)
+        val maxVar = mapAccessor.integralKeysMaxVars(index)
+        s"""
+          final long $minVar = $hashMapTerm.getMinValue($indexKey);
+          final long $maxVar = $hashMapTerm.getMaxValue($indexKey);
+        """
     }.mkString("\n")
-    // increment numOutputRows in finally block
-    val depth = session.addFinallyCode(ctx,
-      s"$numOutputRows.${metricAdd(numRowsTerm)};")
+
     val produced = streamedPlan.asInstanceOf[CodegenSupport].produce(ctx, this)
+
+    val beforeMap = ctx.freshName("beforeMap")
 
     s"""
       boolean $keyIsUniqueTerm = true;
       if (!$initMap) {
-        final long beforeMap = System.nanoTime();
+        final long $beforeMap = System.nanoTime();
         $getOrCreateMap();
-        $keyIsUniqueTerm = $hashMapTerm.keyIsUnique();
-        $buildTime.${metricAdd("(System.nanoTime() - beforeMap) / 1000000")};
+        $buildTime.${metricAdd(s"(System.nanoTime() - $beforeMap) / 1000000")};
         $initMap = true;
       }
+      $keyIsUniqueTerm = $hashMapTerm.keyIsUnique();
       $initMinMaxVars
       final int $maskTerm = $hashMapTerm.mask();
       final $entryClass[] $mapDataTerm = ($entryClass[])$hashMapTerm.data();
       $dictInit
       long $numRowsTerm = 0L;
-      ${session.evaluateFinallyCode(ctx, produced, depth)}
+      try {
+        ${session.evaluateFinallyCode(ctx, produced)}
+      } finally {
+        $numOutputRows.${metricAdd(numRowsTerm)};
+      }
     """
+
   }
 
   override def doConsume(ctx: CodegenContext, input: Seq[ExprCode],
@@ -290,9 +362,11 @@ case class LocalJoin(leftKeys: Seq[Expression],
     val relationTerm = ctx.freshName("relation")
     val relationIsUnique = ctx.freshName("keyIsUnique")
     val buildRDDRef = ctx.addReferenceObj("buildRDD", buildRDD)
-    val buildPartRef = ctx.addReferenceObj("buildPartition", buildPartition)
-    ctx.addMutableState(classOf[HashedRelation].getName, relationTerm,
-      prepareHashedRelation(ctx, relationTerm, buildRDDRef, buildPartRef))
+    if (buildRDD.partitions.size == 1) {
+      val buildPartRef = ctx.addReferenceObj("buildPartition", buildRDD.partitions(0))
+      ctx.addMutableState(classOf[HashedRelation].getName, relationTerm,
+        prepareHashedRelation(ctx, relationTerm, buildRDDRef, buildPartRef))
+    }
     ctx.addMutableState(classOf[Boolean].getName, relationIsUnique,
       s"$relationIsUnique = $relationTerm.keyIsUnique();")
 
@@ -312,6 +386,7 @@ case class LocalJoin(leftKeys: Seq[Expression],
 
   private def doConsumeOptimized(ctx: CodegenContext,
       input: Seq[ExprCode]): String = {
+    val evaluatedInputVars = evaluateVariables(input)
     // variable that holds if relation is unique to optimize iteration
     val entryVar = ctx.freshName("entry")
     val localValueVar = ctx.freshName("value")
@@ -335,10 +410,15 @@ case class LocalJoin(leftKeys: Seq[Expression],
           streamSideKeys.map(BindReferences.bindReference(_, left.output)))
     }
     val streamKeyVars = ctx.generateExpressions(streamKeys)
-    mapAccessor.generateMapLookup(entryVar, localValueVar, keyIsUniqueTerm,
+
+    val mapAccesCode = mapAccessor.generateMapLookup(entryVar, localValueVar, keyIsUniqueTerm,
       numRowsTerm, nullMaskVars, initCode, checkCondition,
       streamSideKeys, streamKeyVars, buildKeyVars, buildVars, input,
       resultVars, dictionaryArrayTerm, joinType)
+    s"""
+       $evaluatedInputVars
+       $mapAccesCode
+     """
   }
 
   override def canConsume(plan: SparkPlan): Boolean = {


### PR DESCRIPTION
## Changes proposed in this pull request


1. Updated LocalJoin to handle cover colocated join cases as well.
2. SnappyStrategies now convert a non-replicated table equi join into a local join if the plan.statistics.sizeInBytes < 100 MB. This default size can be altered using snappydata.localhashjoinsize SQLConf property.
3. Build side and stream side produce the code inside the doProduce of the LocalJoin. To supply the iterator of the rdd of build-side to the produce of build side, slightly hackish way has been used.
4. For colocated join, there is no need to cache the map.
5. Specified the clustering of local join so that the exchange nodes are introduced when needed.
6. Since the inputRdds of LocalJoin returns stream side rdd, the shuffle dependencies of the build rdd are never materialized during the query execution. This always results in 0 rows. Fixed this by creating a DelegateRDD for the stream RDD that has the dependencies of the stream rdd and the build rdd.
7. Fixed few issues in generated code exposed by the Local join tables.

## Patch testing

Ran precheckin

