### PR TITLE
Check the size of left side before deciding the build side 

### DIFF
--- a/core/src/main/scala/org/apache/spark/sql/SnappyStrategies.scala
+++ b/core/src/main/scala/org/apache/spark/sql/SnappyStrategies.scala
@@ -71,8 +71,14 @@ private[sql] trait SnappyStrategies {
       case ExtractEquiJoinKeys(joinType, leftKeys, rightKeys, condition, left, right)
         if canBuildRight(joinType) && canBuildLocalHashMap(right) ||
             !RowOrdering.isOrderable(leftKeys) =>
-        makeLocalHashJoin(leftKeys, rightKeys, left, right, condition,
-          joinType, joins.BuildRight, false)
+        if (canBuildLeft(joinType) && canBuildLocalHashMap(left) &&
+            left.statistics.sizeInBytes < right.statistics.sizeInBytes) {
+          makeLocalHashJoin(leftKeys, rightKeys, left, right, condition,
+            joinType, joins.BuildLeft, false)
+        } else {
+          makeLocalHashJoin(leftKeys, rightKeys, left, right, condition,
+            joinType, joins.BuildRight, false)
+        }
       case ExtractEquiJoinKeys(joinType, leftKeys, rightKeys, condition, left, right)
         if canBuildLeft(joinType) && canBuildLocalHashMap(left) ||
             !RowOrdering.isOrderable(leftKeys) =>


### PR DESCRIPTION
## Changes proposed in this pull request
Currently if a hashmap can be build for the right side, it is marked as the build side without checking the size of the left side.

Checking the size of the left side before marking right as the build side.