### PR TITLE
Snap 1219

### DIFF
--- a/core/src/main/scala/org/apache/spark/sql/execution/columnar/impl/ColumnFormatRelation.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/columnar/impl/ColumnFormatRelation.scala
@@ -299,22 +299,30 @@ class BaseColumnFormatRelation(
     try {
       tableExists = JdbcExtendedUtils.tableExists(table, conn,
         dialect, sqlContext)
-      if (mode == SaveMode.Ignore && tableExists) {
-        dialect match {
-          case GemFireXDDialect =>
-            GemFireXDDialect.initializeTable(table,
-              sqlContext.conf.caseSensitiveAnalysis, conn)
-            GemFireXDDialect.initializeTable(ColumnFormatRelation.
-                cachedBatchTableName(table),
-              sqlContext.conf.caseSensitiveAnalysis, conn)
-          case _ => // Do nothing
-        }
-        return
-      }
 
-      if (mode == SaveMode.ErrorIfExists && tableExists) {
-        // sys.error(s"Table $table already exists.")
-        return
+      if (tableExists) {
+        mode match {
+          case SaveMode.Ignore =>
+            // TODO: Suranjan for split mode when driver acts as client
+            // we will need to change this code and add a flag to
+            // CREATE_ALL_BUCKETS to create only when no buckets created
+            if (region.getRegionAdvisor().getCreatedBucketsCount == 0) {
+              dialect match {
+                case GemFireXDDialect =>
+                  GemFireXDDialect.initializeTable(table,
+                    sqlContext.conf.caseSensitiveAnalysis, conn)
+                  GemFireXDDialect.initializeTable(ColumnFormatRelation.
+                      cachedBatchTableName(table),
+                    sqlContext.conf.caseSensitiveAnalysis, conn)
+                case _ => // Do nothing
+              }
+            }
+            return
+          case SaveMode.ErrorIfExists =>
+            // sys.error(s"Table $table already exists.") TODO: Why so?
+            return
+          case _ => // Ignore
+        }
       }
     } finally {
       conn.close()


### PR DESCRIPTION
## Changes proposed in this pull request

ColumnFormatRelation creates table and buckets while its creation.
  For new session too, if table is already present, table
  creation is a no-op. However, creation of buckets may not be a no-op
  in certain scenarios. e.g Persistent tables with a node down case.
  Now before creating buckets checking if buckets were already created.
## Patch testing

Manually

## ReleaseNotes.txt changes

N/A

## Other PRs 

N/A