### PR TITLE
Handling Exchange via EnsureRequirements

### DIFF
--- a/cluster/src/dunit/scala/io/snappydata/cluster/DistributedIndexDUnitTest.scala
+++ b/cluster/src/dunit/scala/io/snappydata/cluster/DistributedIndexDUnitTest.scala
@@ -95,8 +95,6 @@ class DistributedIndexDUnitTest(s: String) extends ClusterManagerTestBase(s) {
 //      CreateIndexTest.validateIndex(Seq.empty, tableName)(_)
 //    }
 
-    System.setProperty("LOG-NOW", "xxx")
-    getLogWriter.info("SB: About to execute queries")
     executeQ(s"select * from $tableName where col2 = 'bbb' and col3 = 'halo' ") {
       CreateIndexTest.validateIndex(Seq(indexTwo))(_)
     }
@@ -104,8 +102,6 @@ class DistributedIndexDUnitTest(s: String) extends ClusterManagerTestBase(s) {
     executeQ(s"select * from $tableName where col1 = 111 and col3 = 'halo' ") {
       CreateIndexTest.validateIndex(Seq(indexThree))(_)
     }
-    getLogWriter.info("SB: Done executing the queries")
-    System.clearProperty("LOG-NOW")
   }
 
 }

--- a/cluster/src/dunit/scala/io/snappydata/cluster/DistributedIndexDUnitTest.scala
+++ b/cluster/src/dunit/scala/io/snappydata/cluster/DistributedIndexDUnitTest.scala
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 2016 SnappyData, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License. You
+ * may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License. See accompanying
+ * LICENSE file.
+ */
+package io.snappydata.cluster
+
+import scala.collection.mutable.ListBuffer
+
+import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.store.CreateIndexTest
+import org.apache.spark.sql.{SaveMode, SnappyContext}
+
+/**
+ * Tests various distributed index related tests.
+ */
+class DistributedIndexDUnitTest(s: String) extends ClusterManagerTestBase(s) {
+
+  val tablesToDrop = new ListBuffer[String]
+  val indexesToDrop = new ListBuffer[String]
+  override def tearDown2(): Unit = {
+    try {
+      val snContext = SnappyContext(sc)
+      if (snContext != null) {
+        snContext.setConf(io.snappydata.Property.EnableExperimentalFeatures.name,
+          io.snappydata.Property.EnableExperimentalFeatures.configEntry.defaultValueString)
+        snContext.setConf(SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key,
+          SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.defaultValue.get.toString)
+        indexesToDrop.reverse.foreach(i => snContext.sql(s"DROP INDEX $i "))
+        tablesToDrop.reverse.foreach(t => snContext.sql(s"DROP TABLE $t "))
+        indexesToDrop.clear()
+        tablesToDrop.clear()
+      }
+    } finally {
+      super.tearDown2()
+    }
+  }
+
+  def createBaseTable(snContext: SnappyContext, tableName: String): Unit = {
+    val props = Map(
+      "PARTITION_BY" -> "col1")
+    snContext.sql("drop table if exists " + tableName)
+
+    val data = Seq(Seq(111, "aaa", "hello"),
+      Seq(222, "bbb", "halo"),
+      Seq(333, "aaa", "hello"),
+      Seq(444, "bbb", "halo"),
+      Seq(555, "ccc", "halo"),
+      Seq(666, "ccc", "halo")
+    )
+
+    val rdd = sc.parallelize(data, data.length).map(s =>
+      new Data2(s(0).asInstanceOf[Int], s(1).asInstanceOf[String], s(2).asInstanceOf[String]))
+    val dataDF = snContext.createDataFrame(rdd)
+
+    dataDF.write.format("column").mode(SaveMode.Append).options(props).saveAsTable(tableName)
+    tablesToDrop += tableName
+  }
+
+  def testPartitionedSingleColumnTable(): Unit = {
+    val tableName = "tabOne"
+
+    val snContext = SnappyContext(sc)
+    snContext.setConf(io.snappydata.Property.EnableExperimentalFeatures.configEntry.key, "true")
+    snContext.setConf(SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key, "-1")
+    createBaseTable(snContext, tableName)
+    ClusterManagerTestBase.logger.info("Creating indexes")
+    val indexOne = s"${tableName}_IdxOne"
+    val indexTwo = s"${tableName}_IdxTwo"
+    val indexThree = s"${tableName}_IdxThree"
+//    snContext.sql(s"create index $indexOne on $tableName (COL1)")
+//    indexesToDrop += indexOne
+    snContext.sql(s"create index $indexTwo on $tableName (COL2, COL3)")
+    indexesToDrop += indexTwo
+    snContext.sql(s"create index $indexThree on $tableName (COL1, COL3)")
+    indexesToDrop += indexThree
+
+    val executeQ = CreateIndexTest.QueryExecutor(snContext)
+//    executeQ(s"select * from $tableName where col1 = 111") {
+//      CreateIndexTest.validateIndex(Seq(indexOne))(_)
+//    }
+
+//    executeQ(s"select * from $tableName where col2 = 'aaa' ") {
+//      CreateIndexTest.validateIndex(Seq.empty, tableName)(_)
+//    }
+
+    System.setProperty("LOG-NOW", "xxx")
+    getLogWriter.info("SB: About to execute queries")
+    executeQ(s"select * from $tableName where col2 = 'bbb' and col3 = 'halo' ") {
+      CreateIndexTest.validateIndex(Seq(indexTwo))(_)
+    }
+
+    executeQ(s"select * from $tableName where col1 = 111 and col3 = 'halo' ") {
+      CreateIndexTest.validateIndex(Seq(indexThree))(_)
+    }
+    getLogWriter.info("SB: Done executing the queries")
+    System.clearProperty("LOG-NOW")
+  }
+
+}

--- a/core/src/main/scala/org/apache/spark/sql/execution/ExistingPlans.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/ExistingPlans.scala
@@ -184,7 +184,17 @@ trait PartitionedDataSourceScan extends PrunedUnsafeFilteredScan {
   def connectionType: ConnectionType.Value
 }
 
-private[sql] final case class ZipPartitionScan(basePlan: SparkPlan with CodegenSupport,
+/** Combines two SparkPlan or one SparkPlan and another RDD and acts as a LeafExecNode for the
+ *  higher operators.  Typical usage is like combining additional plan or rdd with
+ *  ColumnTableScan without breaking WholeStageCodegen.
+ * @param basePlan left plan that must be code generated.
+ * @param basePartKeys left partitioner expression
+ * @param otherPlan optional. otherRDD can be used instead of this.
+ * @param otherPartKeys right partitioner expression
+ * @param otherRDD another rdd instead of right plan.
+ * @param relation the underlying relation object of the rdd.
+ */
+private[sql] final case class ZipPartitionScan(basePlan: CodegenSupport,
     basePartKeys: Seq[Expression],
     otherPlan: SparkPlan,
     otherPartKeys: Seq[Expression],

--- a/core/src/main/scala/org/apache/spark/sql/execution/ExistingPlans.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/ExistingPlans.scala
@@ -20,19 +20,25 @@ import scala.collection.mutable.ArrayBuffer
 
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.SnappySession
+import org.apache.spark.sql.SnappySession
+import org.apache.spark.sql.SnappySession
+import org.apache.spark.sql.AnalysisException
 import org.apache.spark.sql.catalyst.errors._
 import org.apache.spark.sql.catalyst.expressions.codegen.{CodegenContext, ExprCode}
 import org.apache.spark.sql.catalyst.expressions.{Attribute, Expression, _}
-import org.apache.spark.sql.catalyst.plans.physical.{HashPartitioning, Partitioning, SinglePartition}
+import org.apache.spark.sql.catalyst.plans.physical.{ClusteredDistribution, Distribution,
+HashPartitioning, Partitioning, SinglePartition}
 import org.apache.spark.sql.catalyst.util.{ArrayData, MapData}
 import org.apache.spark.sql.catalyst.{InternalRow, TableIdentifier}
 import org.apache.spark.sql.collection.{ToolsCallbackInit, Utils}
-import org.apache.spark.sql.execution.columnar.impl.{BaseColumnFormatRelation, IndexColumnFormatRelation}
+import org.apache.spark.sql.execution.columnar.impl.{BaseColumnFormatRelation,
+IndexColumnFormatRelation}
 import org.apache.spark.sql.execution.columnar.{ColumnTableScan, ConnectionType}
 import org.apache.spark.sql.execution.exchange.ShuffleExchange
 import org.apache.spark.sql.execution.metric.{SQLMetric, SQLMetrics}
 import org.apache.spark.sql.execution.row.RowFormatRelation
-import org.apache.spark.sql.sources.{BaseRelation, Filter, PrunedUnsafeFilteredScan, SamplingRelation}
+import org.apache.spark.sql.sources.{BaseRelation, Filter, PrunedUnsafeFilteredScan,
+SamplingRelation}
 import org.apache.spark.sql.types._
 import org.apache.spark.unsafe.types.{CalendarInterval, UTF8String}
 
@@ -129,11 +135,20 @@ private[sql] object PartitionedPhysicalScan {
         val (a, f) = scanBuilderArgs
         val baseTableRDD = table.buildRowBufferRDD(Array.empty,
           a.map(_.name).toArray, f.toArray, useResultSet = false)
+        val resolver = columnScan.sqlContext.sessionState.analyzer.resolver
         val rowBufferScan = RowTableScan(output, baseTableRDD, numBuckets,
           Seq.empty, table)
-        val bufferExchange = ShuffleExchange(columnScan.outputPartitioning,
-          rowBufferScan)
-        ZipPartitionScan(columnScan, bufferExchange)
+        val otherPartKeys = partitionColumns.map(e =>
+          e.transform {
+            case a: AttributeReference => rowBufferScan.output.find(
+              rba => resolver(rba.name, a.name)).
+                getOrElse(throw new AnalysisException(s"RowBuffer output column $a not found in " +
+                    s"${rowBufferScan.output.mkString(",")}"))
+          })
+        assert(columnScan.outputPartitioning.satisfies(
+          ClusteredDistribution(columnScan.partitionColumns)))
+        ZipPartitionScan(columnScan, columnScan.partitionColumns,
+          rowBufferScan, otherPartKeys)
       case _: BaseColumnFormatRelation =>
         ColumnTableScan(output, rdd, otherRDDs, numBuckets,
           partitionColumns, relation, allFilters, schemaAttributes)
@@ -168,15 +183,23 @@ trait PartitionedDataSourceScan extends PrunedUnsafeFilteredScan {
 }
 
 private[sql] final case class ZipPartitionScan(basePlan: SparkPlan with CodegenSupport,
-    otherPlan: SparkPlan, otherRDD: RDD[InternalRow] = null,
-    relation: PartitionedDataSourceScan = null) extends LeafExecNode with CodegenSupport {
+    basePartKeys: Seq[Expression],
+    otherPlan: SparkPlan,
+    otherPartKeys: Seq[Expression],
+    otherRDD: Option[RDD[InternalRow]] = None,
+    relation: Option[PartitionedDataSourceScan] = None) extends LeafExecNode with CodegenSupport {
 
   private var consumedCode: String = _
   private val consumedVars: ArrayBuffer[ExprCode] = ArrayBuffer.empty
   private val inputCode = basePlan.asInstanceOf[CodegenSupport]
 
+  override def children: Seq[SparkPlan] = basePlan :: otherPlan :: Nil
+
+  override def requiredChildDistribution: Seq[Distribution] =
+    ClusteredDistribution(basePartKeys) :: ClusteredDistribution(otherPartKeys) :: Nil
+
   override def inputRDDs(): Seq[RDD[InternalRow]] =
-    inputCode.inputRDDs ++ Seq(Option(otherPlan).fold(otherRDD)(_.execute()))
+    inputCode.inputRDDs ++ Seq(Option(otherPlan).fold(otherRDD.get)(_.execute()))
 
   override protected def doProduce(ctx: CodegenContext): String = {
     val child1Produce = inputCode.produce(ctx, this)
@@ -186,7 +209,7 @@ private[sql] final case class ZipPartitionScan(basePlan: SparkPlan with CodegenS
     val row = ctx.freshName("row")
     val columnsInputEval = Option(otherPlan).getOrElse(basePlan).output.zipWithIndex.map { case
       (ref, ordinal) =>
-      val baseIndex = Option(otherPlan).fold(relation.schema.fieldIndex(ref.name))(_ => ordinal)
+      val baseIndex = Option(otherPlan).fold(relation.get.schema.fieldIndex(ref.name))(_ => ordinal)
       val ev = consumedVars(ordinal)
       val dataType = ref.dataType
       val javaType = ctx.javaType(dataType)


### PR DESCRIPTION
## Changes proposed in this pull request

+ Now instead of creating ShuffleExchange explicitly, using
requiredChildDistribution to indicate shuffle is required at this
operator.

+ Adding IndexColumnFormatRelation too in avoiding 1 to many partition
to bucket mapping in other words avoiding delinking of partition ->
buckets.

tests: Added new dunit which will be enhanced to cover more conditions
as covered in unit test

## Patch testing

(Fill in the details about how this patch was tested)

## ReleaseNotes.txt changes

(Does this change require an entry in ReleaseNotes.txt? If yes, has it been added to it?)

## Other PRs 

(Does this change require changes in other projects- store, spark, spark-jobserver, aqp? Add the links of PR of the other subprojects that are related to this change)
