### PR TITLE
[SNAP-1225] Performance improvements for hash joins (and other fixes)

### DIFF
--- a/cluster/src/dunit/scala/org/apache/spark/sql/TPCHDUnitTest.scala
+++ b/cluster/src/dunit/scala/org/apache/spark/sql/TPCHDUnitTest.scala
@@ -144,11 +144,12 @@ object TPCHUtils {
     }
   }
 
-  def queryExecution(snc: SnappyContext, isSnappy: Boolean): Unit = {
-    snc.sql(s"set spark.sql.shuffle.partitions= 4")
+  def queryExecution(snc: SnappyContext, isSnappy: Boolean, warmup: Int = 0,
+      runsForAverage: Int = 1, isResultCollection: Boolean = true): Unit = {
     snc.sql(s"set spark.sql.crossJoin.enabled = true")
 
     queries.foreach(query => TPCH_Snappy.execute(query, snc,
-      isResultCollection = true, isSnappy = isSnappy, avgPrintStream = System.out))
+      isResultCollection, isSnappy, warmup = warmup,
+      runsForAverage = runsForAverage, avgPrintStream = System.out))
   }
 }

--- a/cluster/src/dunit/scala/org/apache/spark/sql/TPCHDUnitTest.scala
+++ b/cluster/src/dunit/scala/org/apache/spark/sql/TPCHDUnitTest.scala
@@ -32,16 +32,6 @@ class TPCHDUnitTest(s: String) extends ClusterManagerTestBase(s) {
     "q10", "q11", "q12", "q13", "q14", "q15", "q16", "q17", "q18", "q19",
     "q20", "q21", "q22")
 
-  /*
-  test("snappy test") {
-    val snc = SnappyContext(sc)
-    snc.sql("set spark.sql.inMemoryColumnarStorage.batchSize = 10000")
-    TPCHUtils.createAndLoadTables(snc, isSnappy = true)
-    queryExecution(snc, isSnappy = true)
-    validateResult(snc, isSnappy = true)
-  }
-  */
-
   def testSnappy(): Unit = {
     val snc = SnappyContext(sc)
     TPCHUtils.createAndLoadTables(snc, isSnappy = true)

--- a/cluster/src/dunit/scala/org/apache/spark/sql/TPCHSuite.scala
+++ b/cluster/src/dunit/scala/org/apache/spark/sql/TPCHSuite.scala
@@ -17,8 +17,10 @@
 
 package org.apache.spark.sql
 
-import io.snappydata.SnappyFunSuite
+import io.snappydata.{Property, SnappyFunSuite}
 import org.scalatest.BeforeAndAfterAll
+
+import org.apache.spark.sql.internal.SQLConf
 
 /**
  * Suite to run TPCH in a single VM. Disabled, by default,
@@ -29,8 +31,13 @@ class TPCHSuite extends SnappyFunSuite with BeforeAndAfterAll  {
 
   ignore("Test TPCH") {
     val snc = SnappyContext(sc)
+    snc.conf.setConfString(SQLConf.COLUMN_BATCH_SIZE.key, "10000")
+    snc.conf.setConfString(SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key, "104857600")
+    Property.HashJoinSize.set(snc.conf, 1L * 1024 * 1024 * 1024)
     TPCHUtils.createAndLoadTables(snc, isSnappy = true)
     TPCHUtils.queryExecution(snc, isSnappy = true)
+    // TPCHUtils.queryExecution(snc, isSnappy = true, warmup = 6, runsForAverage = 10,
+    //  isResultCollection = false)
     TPCHUtils.validateResult(snc, isSnappy = true)
   }
 }

--- a/cluster/src/test/scala/io/snappydata/benchmark/snappy/TPCH_Snappy.scala
+++ b/cluster/src/test/scala/io/snappydata/benchmark/snappy/TPCH_Snappy.scala
@@ -732,7 +732,7 @@ object TPCH_Snappy {
         "     and o_orderdate < add_months('1993-07-01',3)" +
         "     and exists (" +
         "         select" +
-        "             1" +
+        "             l_orderkey" +
         "         from" +
         "             LINEITEM" +
         "         where" +
@@ -853,7 +853,7 @@ object TPCH_Snappy {
     //    1. NATION = BRAZIL;
     //    2. REGION = AMERICA;
     //    3. TYPE = ECONOMY ANODIZED STEEL.
-      if(!useIndex) {
+    if (!useIndex) {
         "select" +
             "         o_year," +
             "         sum(case" +
@@ -868,13 +868,13 @@ object TPCH_Snappy {
             "                         n2.n_name as nation" +
             "                 from" +
             "                         LINEITEM," +
+            "                         PART," +
             "                         ORDERS," +
             "                         CUSTOMER," +
             "                         SUPPLIER," +
             "                         NATION n1," +
             "                         REGION," +
-            "                         NATION n2," +
-            "                         PART" +
+            "                         NATION n2" +
             "                 where" +
             "                         p_partkey = l_partkey" +
             "                         and s_suppkey = l_suppkey" +
@@ -891,7 +891,7 @@ object TPCH_Snappy {
             "         o_year" +
             " order by" +
             "         o_year"
-      }else{
+    } else {
         "select" +
             "         o_year," +
             "         sum(case" +
@@ -951,10 +951,10 @@ object TPCH_Snappy {
           "amount" +
           "         from" +
           "                 LINEITEM," +
+          "                 PART," +
           "                 ORDERS," +
           "                 SUPPLIER," +
           "                 NATION," +
-          "                 PART," +
           "                 PARTSUPP" +
           "         where" +
           "                 s_suppkey = l_suppkey" +
@@ -1699,7 +1699,7 @@ object TPCH_Snappy {
         "         and l1.l_receiptdate > l1.l_commitdate" +
         "         and exists (" +
         "                 select" +
-        "                         1" +
+        "                         l2.l_orderkey" +
         "                 from" +
         "                         LINEITEM l2" +
         "                 where" +
@@ -1708,7 +1708,7 @@ object TPCH_Snappy {
         "         )" +
         "         and not exists (" +
         "                 select" +
-        "                         1" +
+        "                         l3.l_orderkey" +
         "                 from" +
         "                         LINEITEM l3" +
         "                 where" +
@@ -1822,7 +1822,7 @@ object TPCH_Snappy {
       "                 )" +
       "                 and not exists (" +
       "                         select" +
-      "                                 1" +
+      "                                 o_custtkey" +
       "                         from" +
       "                                 ORDERS" +
       "                         where" +

--- a/cluster/src/test/scala/io/snappydata/benchmark/snappy/TPCH_Snappy.scala
+++ b/cluster/src/test/scala/io/snappydata/benchmark/snappy/TPCH_Snappy.scala
@@ -35,7 +35,8 @@ object TPCH_Snappy {
   }
 
   def execute(queryNumber: String, sqlContext: SQLContext, isResultCollection: Boolean,
-      isSnappy: Boolean, itr : Int = 0, useIndex: Boolean = false, warmup : Integer = 0, runsForAverage :Integer=1, avgPrintStream:PrintStream=null): Unit = {
+      isSnappy: Boolean, itr: Int = 0, useIndex: Boolean = false, warmup: Int = 0,
+      runsForAverage: Int = 1, avgPrintStream: PrintStream = null): Unit = {
 
     val planFileName = if (isSnappy) "Plan_Snappy.out" else "Plan_Spark.out"
     val queryFileName = if (isSnappy) s"Snappy_${queryNumber}.out" else s"Spark_${queryNumber}.out"
@@ -731,7 +732,7 @@ object TPCH_Snappy {
         "     and o_orderdate < add_months('1993-07-01',3)" +
         "     and exists (" +
         "         select" +
-        "             *" +
+        "             1" +
         "         from" +
         "             LINEITEM" +
         "         where" +
@@ -1698,7 +1699,7 @@ object TPCH_Snappy {
         "         and l1.l_receiptdate > l1.l_commitdate" +
         "         and exists (" +
         "                 select" +
-        "                         *" +
+        "                         1" +
         "                 from" +
         "                         LINEITEM l2" +
         "                 where" +
@@ -1707,7 +1708,7 @@ object TPCH_Snappy {
         "         )" +
         "         and not exists (" +
         "                 select" +
-        "                         *" +
+        "                         1" +
         "                 from" +
         "                         LINEITEM l3" +
         "                 where" +
@@ -1821,7 +1822,7 @@ object TPCH_Snappy {
       "                 )" +
       "                 and not exists (" +
       "                         select" +
-      "                                 *" +
+      "                                 1" +
       "                         from" +
       "                                 ORDERS" +
       "                         where" +

--- a/cluster/src/test/scala/org/apache/spark/sql/execution/benchmark/ColumnCacheBenchmark.scala
+++ b/cluster/src/test/scala/org/apache/spark/sql/execution/benchmark/ColumnCacheBenchmark.scala
@@ -55,7 +55,6 @@ class ColumnCacheBenchmark extends SnappyFunSuite {
         .setIfMissing("spark.master", "local[1]")
         .setAppName("microbenchmark")
     conf.set("spark.sql.shuffle.partitions", "1")
-    conf.set("spark.sql.autoBroadcastJoinThreshold", "1")
     if (addOn != null) {
       addOn(conf)
     }
@@ -143,7 +142,7 @@ class ColumnCacheBenchmark extends SnappyFunSuite {
         params.foreach { case (k, v) => sparkSession.conf.set(k, v) }
         params.foreach { case (k, v) => snappySession.conf.set(k, v) }
         if (!nullable) {
-          testDF = sparkSession.internalCreateDataFrame(testDF.queryExecution.toRdd,
+          testDF = ColumnCacheBenchmark.applySchema(testDF,
             StructType(testDF.schema.fields.map(_.copy(nullable = false))))
           testDF.createOrReplaceTempView("test")
         }
@@ -221,5 +220,12 @@ class ColumnCacheBenchmark extends SnappyFunSuite {
     ), snappy = true, nullable = false)
 
     benchmark.run()
+  }
+}
+
+object ColumnCacheBenchmark {
+
+  def applySchema(df: DataFrame, newSchema: StructType): DataFrame = {
+    df.sqlContext.internalCreateDataFrame(df.queryExecution.toRdd, newSchema)
   }
 }

--- a/core/src/main/java/org/apache/spark/sql/execution/HashingUtil.java
+++ b/core/src/main/java/org/apache/spark/sql/execution/HashingUtil.java
@@ -21,18 +21,24 @@ package org.apache.spark.sql.execution;
  */
 public abstract class HashingUtil {
 
+  /** 2<sup>32</sup> &middot; &phi;, &phi; = (&#x221A;5 &minus; 1)/2. */
+  private static final int INT_PHI = 0x9E3779B9;
+
   private static final int C1 = 0xcc9e2d51;
   private static final int C2 = 0x1b873593;
 
-  /**
-   * Simpler mixing for integer values that are reasonably hashed.
-   * Constant taken from h2 tests (CalculateHashConstant.java).
+  /** Quickly mixes the bits of an integer.
+   *
+   * <p>This method mixes the bits of the argument by multiplying by the
+   * golden ratio and XORshifting the result. It is borrowed from
+   * <a href="https://github.com/OpenHFT/Koloboke">Koloboke</a>, and
+   * it has slightly worse behaviour than MurmurHash3 (in open-addressed
+   * hash tables the average number of probes is slightly larger),
+   * but it's much faster.
    */
-  public static int hashInt(int v) {
-    v = ((v >>> 16) ^ v) * 0x45d9f3b;
-    v = ((v >>> 16) ^ v) * 0x45d9f3b;
-    v = (v >>> 16) ^ v;
-    return v;
+  public static int hashInt(final int v) {
+    final int h = v * INT_PHI;
+    return h ^ (h >>> 16);
   }
 
   // Public Murmur3 methods for invocation by generated code.

--- a/core/src/main/scala/org/apache/spark/sql/SnappyStrategies.scala
+++ b/core/src/main/scala/org/apache/spark/sql/SnappyStrategies.scala
@@ -24,6 +24,7 @@ import org.apache.spark.sql.catalyst.plans.{ExistenceJoin, Inner, JoinType, Left
 import org.apache.spark.sql.execution._
 import org.apache.spark.sql.execution.aggregate.{AggUtils, CollectAggregateExec, SnappyHashAggregateExec}
 import org.apache.spark.sql.execution.datasources.LogicalRelation
+import org.apache.spark.sql.execution.joins.{BuildLeft, BuildRight}
 import org.apache.spark.sql.internal.DefaultPlanner
 import org.apache.spark.sql.streaming._
 
@@ -68,6 +69,17 @@ private[sql] trait SnappyStrategies {
       left, right) if canBuildLeft(joinType) && canLocalJoin(left) =>
           makeLocalHashJoin(leftKeys, rightKeys, left, right, condition,
             joinType, joins.BuildLeft, true)
+
+      case ExtractEquiJoinKeys(joinType, leftKeys, rightKeys, condition, left, right)
+        if canBuildRight(joinType) && canBroadcast(right) =>
+        Seq(joins.BroadcastHashJoinExec(
+          leftKeys, rightKeys, joinType, BuildRight, condition, planLater(left), planLater(right)))
+
+      case ExtractEquiJoinKeys(joinType, leftKeys, rightKeys, condition, left, right)
+        if canBuildLeft(joinType) && canBroadcast(left) =>
+        Seq(joins.BroadcastHashJoinExec(
+          leftKeys, rightKeys, joinType, BuildLeft, condition, planLater(left), planLater(right)))
+
       case ExtractEquiJoinKeys(joinType, leftKeys, rightKeys, condition, left, right)
         if canBuildRight(joinType) && canBuildLocalHashMap(right) ||
             !RowOrdering.isOrderable(leftKeys) =>
@@ -92,6 +104,14 @@ private[sql] trait SnappyStrategies {
         (canBuildRight(joinType) && canLocalJoin(right)) ||
             (canBuildLeft(joinType) && canLocalJoin(left))
       case _ => false
+    }
+
+    /**
+     * Matches a plan whose output should be small enough to be used in broadcast join.
+     */
+    private def canBroadcast(plan: LogicalPlan): Boolean = {
+      plan.statistics.isBroadcastable ||
+          plan.statistics.sizeInBytes <= conf.autoBroadcastJoinThreshold
     }
 
     /**

--- a/core/src/main/scala/org/apache/spark/sql/execution/ObjectHashMapAccessor.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/ObjectHashMapAccessor.scala
@@ -306,13 +306,13 @@ case class ObjectHashMapAccessor(@transient session: SnappySession,
       s"$hashMapTerm.updateLimits(${keyVars(index).value}, $index);"
     }.mkString("\n")
     // for SnappyData column or row tables there is no need to make
-    // a copy of non-primitive values into the map
+    // a copy of non-primitive values into the map since they are immutable
     var hasExchange = false
     val doCopy = child.find {
-      case _: PartitionedPhysicalScan if !hasExchange => true
+      case _: PartitionedPhysicalScan => true
       case _: Exchange => hasExchange = true; false
       case _ => false
-    }.isEmpty
+    }.isEmpty || hasExchange
     val multiValuesUpdateCode = if (valueClassName.isEmpty) {
       s"""
         // no value field, only count

--- a/core/src/main/scala/org/apache/spark/sql/execution/ObjectHashSet.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/ObjectHashSet.scala
@@ -77,8 +77,9 @@ final class ObjectHashSet[T <: AnyRef : ClassTag](initialCapacity: Int,
 
   def keyIsUnique: Boolean = _keyIsUnique
 
-  def setKeyIsUnique(unique: Boolean): Unit =
-    _keyIsUnique = unique
+  def setKeyIsUnique(unique: Boolean): Unit = {
+    if (_keyIsUnique != unique) _keyIsUnique = unique
+  }
 
   private def initArray(values: Array[Long], init: Long): Unit = {
     var index = 0

--- a/core/src/main/scala/org/apache/spark/sql/execution/columnar/ColumnTableScan.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/columnar/ColumnTableScan.scala
@@ -469,7 +469,9 @@ private[sql] final case class ColumnTableScan(
       """
     } else if (isOffHeap) {
       val filterCode = if (filterFunction.isEmpty) {
-        s"final $execRowClass $batch = ($execRowClass)$colInput.next();"
+        val columnBatchesSeen = metricTerm(ctx, "columnBatchesSeen")
+        s"""final $execRowClass $batch = ($execRowClass)$colInput.next();
+          $columnBatchesSeen.${metricAdd("1")};"""
       } else {
         s"""$execRowClass $batch;
           while (true) {
@@ -489,8 +491,10 @@ private[sql] final case class ColumnTableScan(
       """
     } else {
       val filterCode = if (filterFunction.isEmpty) {
+        val columnBatchesSeen = metricTerm(ctx, "columnBatchesSeen")
         s"""final $rowFormatterClass $rowFormatter = $colInput.rowFormatter();
-          $buffers = (byte[][])$colInput.next();"""
+          $buffers = (byte[][])$colInput.next();
+          $columnBatchesSeen.${metricAdd("1")};"""
       } else {
         s"""$rowFormatterClass $rowFormatter;
            while (true) {

--- a/core/src/main/scala/org/apache/spark/sql/execution/joins/LocalJoin.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/joins/LocalJoin.scala
@@ -115,7 +115,7 @@ case class LocalJoin(leftKeys: Seq[Expression],
 
     // materialize dependencies in the entire buildRDD graph for
     // buildRDD.iterator to work in the compute of mapPartitionsPreserve below
-    if (buildRDD.partitions.size == 1) {
+    if (buildRDD.partitions.length == 1) {
       materializeDependencies(buildRDD, new mutable.HashSet[RDD[_]]())
       val schema = buildPlan.schema
       streamRDD.mapPartitionsPreserveWithPartition { (context, split, itr) =>
@@ -361,7 +361,7 @@ case class LocalJoin(leftKeys: Seq[Expression],
     val relationTerm = ctx.freshName("relation")
     val relationIsUnique = ctx.freshName("keyIsUnique")
     val buildRDDRef = ctx.addReferenceObj("buildRDD", buildRDD)
-    if (buildRDD.partitions.size == 1) {
+    if (buildRDD.partitions.length == 1) {
       val buildPartRef = ctx.addReferenceObj("buildPartition", buildRDD.partitions(0))
       ctx.addMutableState(classOf[HashedRelation].getName, relationTerm,
         prepareHashedRelation(ctx, relationTerm, buildRDDRef, buildPartRef))


### PR DESCRIPTION
## Changes proposed in this pull request

As seen in TPCH Q4 and others, building hash join map was taking a lot of time. The major contributors are:

1) Copying of UTF8String -- while this is okay for small maps, it causes a large overhead for larger ones
2) EXISTS(SELECT *) is not optimized by Spark so all columns of the table appear in projection and get populated in the map. Currently TPCH queries have been modified to use "SELECT 1" -- needs fix in Spark optimizer or addition to snappydata optimizer.
3) Multi-values array increments in steps of 1. Now using a 25% increment (with minimum as 4)

Apart from above, micro-benchmarked insert/get performance of a bunch of hash maps: Spark's OpenHashSet, Scala's HashSet, JDK's HashSet, FastUtil's ObjectOpenHashSet and compared to Snappy's implementation. The conclusion was that ours is nearly the best in both inserts and gets. Updated the hashing function from FastUtil to improve performance a bit.

With above changes, the time taken by Q4 at 1X scale on laptop went from ~1s to 250-280ms. Detailed set of changes below:

- avoid creating a copy of incoming string for join map creation when the incoming
  data is from a column or row table (and there is no intervening Exchange); use UTF8String
  as field type in the generated class instead of a byte[] (latter was used to reduce
      overhead but for this case there is no overhead)
- increment the multi-values for a key in the join map in increments of 25% rather than 1
- increment columnBatchesSeen in scan_nextBatch() even when there was no filter defined
- updated the TPCH queries to use "SELECT 1" in EXISTS clause rather than "SELECT *"
- enhanced TPCH column tables to create/load from parquet files automatically; creation
  is done (from CSV files) when the flag TPCHColumnPartitionedTable.CREATE_PARQUET is set;
  added arguments to TPCHDUnitTest.execute to allow specifying warmup/runs (e.g. when running
      TPCHSuite manually for performance)
- added a more efficient hashInt method to HashingUtil taken from fastutil (which in turn
    takes it from Koloboke) -- this gives ~10% improvement in gets in micro-benchmarks
- moving pre-evaluation of input variables to before consuming the result of join
  (see comments in https://github.com/SnappyDataInc/snappydata/pull/450)

## Patch testing

precheckin

## ReleaseNotes.txt changes

NA

## Other PRs 

NA
