### PR TITLE
[SNAP-1245] Result mismatch due to variables not being re-evaluated in loop

### DIFF
--- a/core/src/main/scala/org/apache/spark/sql/execution/joins/LocalJoin.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/joins/LocalJoin.scala
@@ -387,7 +387,7 @@ case class LocalJoin(leftKeys: Seq[Expression],
     mapAccessor.generateMapLookup(entryVar, localValueVar, keyIsUniqueTerm,
       numRowsTerm, nullMaskVars, initCode, checkCondition,
       streamSideKeys, streamKeyVars, buildKeyVars, buildVars, input,
-      resultVars, dictionaryArrayTerm, joinType)
+      resultVars, dictionaryArrayTerm, joinType, buildSide)
   }
 
   override def canConsume(plan: SparkPlan): Boolean = {


### PR DESCRIPTION
## Changes proposed in this pull request

The reason for the issue was that the pre-evaluation of only required variables actually evaluated too much in some cases. The build side variables (i.e. results coming from the hash map of join) should never be pre-evaluated rather only the child streaming plan side variables should be. The difference in the generated code looks like below (for Q35 of NorthWindTest):

before (incorrect)
```java
/* 308 */           if (localjoin_entry == null) continue;
/* 309 */
/* 310 */           int localjoin_entryIndex = 0;
/* 311 */           int localjoin_numEntries = -1;
/* 312 */           Val_localjoin_LocalMap[] localjoin_values = null;
/* 313 */           // for first iteration, entry object itself has value fields
/* 314 */           Val_localjoin_LocalMap localjoin_value = localjoin_entry;
/* 315 */
/* 316 */           final UTF8String localjoin_localField = localjoin_entry.field0;
/* 317 */           boolean localjoin_isNull = (localjoin_localField == null);
/* 318 */           final int scan_col2 = scan_row1.getAsInt(1, scan_nullHolder1);
/* 319 */           final boolean scan_isNull4 = scan_nullHolder1.wasNullAndClear();
/* 320 */           final UTF8String localjoin_localField1 = localjoin_value.field1;
/* 321 */           boolean localjoin_isNull1 = (localjoin_localField1 == null);
/* 322 */
/* 323 */           while (true) {
/* 324 */             do { // single iteration loop meant for breaking out with "continue"
/* 325 */               localjoin_numRows++;
/* 326 */
/* 327 */               boolean expand_isNull2 = true;
/* 328 */               int expand_value2 = -1;
/* 329 */               boolean expand_isNull3 = true;
/* 330 */               UTF8String expand_value3 = null;
/* 331 */               boolean expand_isNull4 = true;
```

with fix (correct)
```java
/* 293 */           if (localjoin_entry == null) continue;
/* 294 */
/* 295 */           int localjoin_entryIndex = 0;
/* 296 */           int localjoin_numEntries = -1;
/* 297 */           Val_localjoin_LocalMap[] localjoin_values = null;
/* 298 */           // for first iteration, entry object itself has value fields
/* 299 */           Val_localjoin_LocalMap localjoin_value = localjoin_entry;
/* 300 */
/* 301 */           final UTF8String localjoin_localField = localjoin_entry.field0;
/* 302 */           boolean localjoin_isNull = (localjoin_localField == null);
/* 303 */           final int scan_col2 = scan_row1.getAsInt(1, scan_nullHolder1);
/* 304 */           final boolean scan_isNull4 = scan_nullHolder1.wasNullAndClear();
/* 305 */
/* 306 */           while (true) {
/* 307 */             do { // single iteration loop meant for breaking out with "continue"
/* 308 */               localjoin_numRows++;
/* 309 */
/* 310 */               final UTF8String localjoin_localField1 = localjoin_value.field1;
/* 311 */               boolean localjoin_isNull1 = (localjoin_localField1 == null);
/* 312 */
/* 313 */               boolean expand_isNull2 = true;
/* 314 */               UTF8String expand_value2 = null;
/* 315 */               boolean expand_isNull3 = true;
/* 316 */               int expand_value3 = -1;
```

The localjoin_localField1 and localjoin_isNull1 variables should be evaluated in loop vs only once outside before.

- previous change in 5eeef15 evaluated only the required variables but in some cases
  evaluated too much; now only consider input variables (i.e. from child streamed plan)
  for pre-evaluation while let the rest of result variables (i.e. from the hash map
      of join) be evaluated as required
- when avoiding the copy of UTF8String, be more conservative and only do it for LocalJoin
  and not for other kinds of joins (does not have a direct bearing on this bug)

## Patch testing

precheckin; NorthWind hydra test with validation

## ReleaseNotes.txt changes

NA

## Other PRs 

NA

