### PR TITLE
[SNAP-1252][SNAP-1251] Avoid exchange when join columns are superset of partitioning

### DIFF
--- a/cluster/src/main/scala/io/snappydata/ToolsCallbackImpl.scala
+++ b/cluster/src/main/scala/io/snappydata/ToolsCallbackImpl.scala
@@ -19,9 +19,8 @@ package io.snappydata
 import io.snappydata.impl.LeadImpl
 
 import org.apache.spark.SparkContext
-import org.apache.spark.sql.catalyst.expressions.Expression
+import org.apache.spark.sql.catalyst.expressions.{Attribute, Expression}
 import org.apache.spark.sql.catalyst.plans.physical.{OrderlessHashPartitioning, Partitioning}
-
 import org.apache.spark.ui.SparkUI
 import org.apache.spark.ui.SnappyDashboardTab
 
@@ -32,8 +31,10 @@ object ToolsCallbackImpl extends ToolsCallback {
   }
 
   def getOrderlessHashPartitioning(partitionColumns: Seq[Expression],
+      partitionColumnAliases: Seq[Option[Attribute]],
       numPartitions: Int, numBuckets: Int): Partitioning = {
-    OrderlessHashPartitioning(partitionColumns, numPartitions, numBuckets)
+    OrderlessHashPartitioning(partitionColumns, partitionColumnAliases,
+      numPartitions, numBuckets)
   }
 
   override def updateUI(scUI: Option[Any]): Unit = {

--- a/core/src/main/scala/io/snappydata/ToolsCallback.scala
+++ b/core/src/main/scala/io/snappydata/ToolsCallback.scala
@@ -17,7 +17,7 @@
 package io.snappydata
 
 import org.apache.spark.SparkContext
-import org.apache.spark.sql.catalyst.expressions.Expression
+import org.apache.spark.sql.catalyst.expressions.{Attribute, Expression}
 import org.apache.spark.sql.catalyst.plans.physical.Partitioning
 
 trait ToolsCallback {
@@ -25,6 +25,7 @@ trait ToolsCallback {
   def invokeLeadStartAddonService(sc: SparkContext): Unit
 
   def getOrderlessHashPartitioning(partitionColumns: Seq[Expression],
+      partitionColumnAliases: Seq[Option[Attribute]],
       numPartitions: Int, numBuckets: Int): Partitioning
 
   def updateUI(scUI: Option[Any]): Unit // Option[SparkUI] is expected

--- a/core/src/main/scala/org/apache/spark/sql/SnappyStrategies.scala
+++ b/core/src/main/scala/org/apache/spark/sql/SnappyStrategies.scala
@@ -16,10 +16,11 @@
  */
 package org.apache.spark.sql
 
-import org.apache.spark.sql.catalyst.expressions.aggregate.{AggregateExpression, AggregateFunction, Final, ImperativeAggregate, Partial, PartialMerge}
+import org.apache.spark.sql.catalyst.expressions.aggregate.{AggregateExpression, AggregateFunction, Complete, Final, ImperativeAggregate, Partial, PartialMerge}
 import org.apache.spark.sql.catalyst.expressions.{Alias, Expression, NamedExpression, RowOrdering}
 import org.apache.spark.sql.catalyst.planning.{ExtractEquiJoinKeys, PhysicalAggregation, PhysicalOperation}
 import org.apache.spark.sql.catalyst.plans.logical.{Join, LogicalPlan, ReturnAnswer}
+import org.apache.spark.sql.catalyst.plans.physical.ClusteredDistribution
 import org.apache.spark.sql.catalyst.plans.{ExistenceJoin, Inner, JoinType, LeftAnti, LeftOuter, LeftSemi, RightOuter}
 import org.apache.spark.sql.execution._
 import org.apache.spark.sql.execution.aggregate.{AggUtils, CollectAggregateExec, SnappyHashAggregateExec}
@@ -281,10 +282,11 @@ private[sql] trait SnappyStrategies {
         side: joins.BuildSide,
         replicatedTableJoin: Boolean): Seq[SparkPlan] = {
       joins.LocalJoin(leftKeys, rightKeys, side, condition,
-        joinType, planLater(left), planLater(right), replicatedTableJoin) :: Nil
+        joinType, planLater(left), planLater(right),
+        left.statistics.sizeInBytes, right.statistics.sizeInBytes,
+        replicatedTableJoin) :: Nil
     }
   }
-
 }
 
 /**

--- a/core/src/main/scala/org/apache/spark/sql/execution/RowTableScan.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/RowTableScan.scala
@@ -39,9 +39,11 @@ private[sql] final case class RowTableScan(
     dataRDD: RDD[Any],
     numBuckets: Int,
     partitionColumns: Seq[Expression],
+    partitionColumnAliases: Seq[Option[Attribute]],
     @transient baseRelation: PartitionedDataSourceScan)
     extends PartitionedPhysicalScan(output, dataRDD, numBuckets,
-      partitionColumns, baseRelation.asInstanceOf[BaseRelation]) {
+      partitionColumns, partitionColumnAliases,
+      baseRelation.asInstanceOf[BaseRelation]) {
 
   override def doProduce(ctx: CodegenContext): String = {
     // a parent plan may set a custom input (e.g. LocalJoin)

--- a/core/src/main/scala/org/apache/spark/sql/execution/columnar/ColumnTableScan.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/columnar/ColumnTableScan.scala
@@ -72,13 +72,14 @@ private[sql] final case class ColumnTableScan(
     otherRDDs: Seq[RDD[InternalRow]],
     numBuckets: Int,
     partitionColumns: Seq[Expression],
+    partitionColumnAliases: Seq[Option[Attribute]],
     @transient baseRelation: PartitionedDataSourceScan,
     allFilters: Seq[Expression],
     schemaAttributes: Seq[AttributeReference],
     isForSampleReservoirAsRegion: Boolean = false)
     extends PartitionedPhysicalScan(output, dataRDD, numBuckets,
-      partitionColumns, baseRelation.asInstanceOf[BaseRelation])
-    with CodegenSupport {
+      partitionColumns, partitionColumnAliases,
+      baseRelation.asInstanceOf[BaseRelation]) with CodegenSupport {
 
   override def getMetrics: Map[String, SQLMetric] = super.getMetrics ++ Map(
     "numRowsBuffer" -> SQLMetrics.createMetric(sparkContext,

--- a/core/src/main/scala/org/apache/spark/sql/execution/datasources/StoreDataSourceStrategy.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/datasources/StoreDataSourceStrategy.scala
@@ -19,7 +19,7 @@ package org.apache.spark.sql.execution.datasources
 import scala.collection.mutable
 
 import org.apache.spark.rdd.RDD
-import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeReference, AttributeSet, Expression, NamedExpression}
+import org.apache.spark.sql.catalyst.expressions.{Alias, Attribute, AttributeReference, AttributeSet, Expression, NamedExpression}
 import org.apache.spark.sql.catalyst.planning.PhysicalOperation
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.apache.spark.sql.catalyst.{InternalRow, expressions}
@@ -123,6 +123,12 @@ private[sql] object StoreDataSourceStrategy extends Strategy {
       relation.resolveQuoted(colName, sqlContext.sessionState.analyzer.resolver)
           .getOrElse(throw new AnalysisException(
             s"""Cannot resolve column "$colName" among (${relation.output})""")))
+    // check for joinedCols in projections
+    val joinedAliases = if (projects.nonEmpty) {
+      joinedCols.map(j => projects.collectFirst {
+        case a@Alias(child, _) if child.semanticEquals(j) => a.toAttribute
+      })
+    } else Seq.empty
     val metadata: Map[String, String] = if (numBuckets > 0) {
       Map.empty[String, String]
     } else {
@@ -154,6 +160,7 @@ private[sql] object StoreDataSourceStrategy extends Strategy {
           mappedProjects,
           numBuckets,
           joinedCols,
+          joinedAliases,
           rdd,
           otherRDDs,
           relation.relation.asInstanceOf[PartitionedDataSourceScan],
@@ -181,6 +188,7 @@ private[sql] object StoreDataSourceStrategy extends Strategy {
           requestedColumns,
           numBuckets,
           joinedCols,
+          joinedAliases,
           rdd,
           otherRDDs,
           relation.relation.asInstanceOf[PartitionedDataSourceScan],

--- a/core/src/main/scala/org/apache/spark/sql/execution/joins/LocalJoin.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/joins/LocalJoin.scala
@@ -136,9 +136,9 @@ case class LocalJoin(leftKeys: Seq[Expression],
     }
 
   /**
-   * Return if the partitioning is a subset of given join keys, and if so
-   * then return the subset as well as the indices of subset keys in the
-   * join keys (in order)
+   * Optionally return result if partitioning is a subset of given join keys,
+   * and if so then return the subset as well as the indices of subset keys
+   * in the join keys (in order).
    */
   private def getSubsetAndIndices(part: Partitioning,
       keys: Seq[Expression]): Option[(Seq[Expression], Seq[Int])] = part match {

--- a/core/src/main/scala/org/apache/spark/sql/execution/joins/LocalJoin.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/joins/LocalJoin.scala
@@ -36,11 +36,10 @@ import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.codegen.{CodegenContext, ExprCode, GenerateUnsafeProjection}
 import org.apache.spark.sql.catalyst.expressions.{AttributeSet, BindReferences, BoundReference, Expression, UnsafeRow}
 import org.apache.spark.sql.catalyst.plans._
-import org.apache.spark.sql.catalyst.plans.physical.{ClusteredDistribution, Distribution, Partitioning, UnspecifiedDistribution}
+import org.apache.spark.sql.catalyst.plans.physical.{BroadcastDistribution, ClusteredDistribution, Distribution, Partitioning, UnknownPartitioning, UnspecifiedDistribution}
 import org.apache.spark.sql.collection.Utils
 import org.apache.spark.sql.execution._
 import org.apache.spark.sql.execution.metric.SQLMetrics
-import org.apache.spark.sql.snappy._
 import org.apache.spark.sql.types.{LongType, StructType, TypeUtilities}
 import org.apache.spark.{Partition, ShuffleDependency, SparkEnv, TaskContext}
 
@@ -60,6 +59,8 @@ case class LocalJoin(leftKeys: Seq[Expression],
     joinType: JoinType,
     left: SparkPlan,
     right: SparkPlan,
+    leftSizeInBytes: BigInt,
+    rightSizeInBytes: BigInt,
     replicatedTableJoin: Boolean)
     extends BinaryExecNode with HashJoin with BatchConsumer {
 
@@ -86,10 +87,69 @@ case class LocalJoin(leftKeys: Seq[Expression],
   override def requiredChildDistribution: Seq[Distribution] =
     if (replicatedTableJoin) {
       UnspecifiedDistribution :: UnspecifiedDistribution :: Nil
+    } else {
+      // if left or right side is already distributed on a subset of keys
+      // then use the same partitioning (for the larger side to reduce exchange)
+      val leftClustered = ClusteredDistribution(leftKeys)
+      val rightClustered = ClusteredDistribution(rightKeys)
+      val leftPartitioning = left.outputPartitioning
+      val rightPartitioning = right.outputPartitioning
+      if (leftPartitioning.satisfies(leftClustered) ||
+          rightPartitioning.satisfies(rightClustered) ||
+          // if either side is broadcast then return defaults
+          leftPartitioning.isInstanceOf[BroadcastDistribution] ||
+          rightPartitioning.isInstanceOf[BroadcastDistribution] ||
+          // if both sides are unknown then return defaults too
+          (leftPartitioning.isInstanceOf[UnknownPartitioning] &&
+              rightPartitioning.isInstanceOf[UnknownPartitioning])) {
+        leftClustered :: rightClustered :: Nil
+      } else {
+        // try subsets of the keys on each side
+        val leftSubset = getSubsetAndIndices(leftPartitioning, leftKeys)
+        val rightSubset = getSubsetAndIndices(rightPartitioning, rightKeys)
+        leftSubset match {
+          case Some((l, li)) => rightSubset match {
+            case Some((r, ri)) =>
+            // check if key indices of both sides match
+            if (li == ri) {
+              ClusteredDistribution(l) :: ClusteredDistribution(r) :: Nil
+            } else {
+              // choose the bigger plan
+              if (leftSizeInBytes > rightSizeInBytes) {
+                ClusteredDistribution(l) ::
+                    ClusteredDistribution(li.map(rightKeys.apply)) :: Nil
+              } else {
+                ClusteredDistribution(ri.map(leftKeys.apply)) ::
+                    ClusteredDistribution(r) :: Nil
+              }
+            }
+            case None => ClusteredDistribution(l) ::
+                ClusteredDistribution(li.map(rightKeys.apply)) :: Nil
+          }
+          case None => rightSubset match {
+            case Some((r, ri)) => ClusteredDistribution(ri.map(leftKeys.apply)) ::
+                ClusteredDistribution(r) :: Nil
+            case None => leftClustered :: rightClustered :: Nil
+          }
+        }
+      }
     }
-    else {
-      ClusteredDistribution(leftKeys) :: ClusteredDistribution(rightKeys) :: Nil
-    }
+
+  /**
+   * Return if the partitioning is a subset of given join keys, and if so
+   * then return the subset as well as the indices of subset keys in the
+   * join keys (in order)
+   */
+  private def getSubsetAndIndices(part: Partitioning,
+      keys: Seq[Expression]): Option[(Seq[Expression], Seq[Int])] = part match {
+    case e: Expression =>
+      val numColumns = e.children.length
+      if (keys.length > numColumns) {
+        keys.indices.combinations(numColumns).map(s => s.map(keys.apply) -> s)
+            .find(p => part.satisfies(ClusteredDistribution(p._1)))
+      } else None
+    case _ => None
+  }
 
   protected lazy val (buildSideKeys, streamSideKeys) = {
     require(leftKeys.map(_.dataType) == rightKeys.map(_.dataType),


### PR DESCRIPTION
## Changes proposed in this pull request

- LocalJoin now adjusts its requiredChildDistributions to match that of a child in case
  partial set of join keys match the partitioning of one or both children
- check for subset match order to see if the same can be applied to both children,
  else if both had different matches then choose the child with bigger size as per plan statististics
- also add join column aliases from projections, if any, to OrderlessHashPartitioning

TODO: add similar to SortMergeJoinExec (or its optimized version in SnappyData when it is added)

## Patch testing

precheckin; TPCH Q2, Q5, Q9 plans, NorthWind test

## ReleaseNotes.txt changes

NA

## Other PRs 

https://github.com/SnappyDataInc/spark/pull/37