### PR TITLE
[SNAP-1256] Allow setting of default spark memory manager

### DIFF
--- a/cluster/src/main/scala/io/snappydata/cluster/ExecutorInitiator.scala
+++ b/cluster/src/main/scala/io/snappydata/cluster/ExecutorInitiator.scala
@@ -30,6 +30,7 @@ import com.gemstone.gemfire.internal.cache.GemFireCacheImpl
 import com.pivotal.gemfirexd.internal.engine.Misc
 import com.pivotal.gemfirexd.internal.engine.distributed.utils.GemFireXDUtils
 import com.pivotal.gemfirexd.internal.engine.store.ServerGroupUtils
+import io.snappydata.Property
 import io.snappydata.gemxd.ClusterCallbacksImpl
 
 import org.apache.spark.deploy.SparkHadoopUtil
@@ -167,10 +168,14 @@ object ExecutorInitiator extends Logging {
                     }
                     // TODO: Hemant: add executor specific properties from local
                     // TODO: conf to this conf that was received from driver.
-
-                    // If memory manager is not set, use Snappy unified memory manager
-                    driverConf.setIfMissing("spark.memory.manager",
-                      SNAPPY_MEMORY_MANAGER)
+                    if (Property.UseSparkMemoryManager.getOption(driverConf).exists(_.toBoolean)) {
+                      // If memory manager is set as spark,
+                      driverConf.remove("spark.memory.manager")
+                    } else {
+                      // If memory manager is not set, use Snappy unified memory manager
+                      driverConf.setIfMissing("spark.memory.manager",
+                        SNAPPY_MEMORY_MANAGER)
+                    }
 
                     val cores = driverConf.getInt("spark.executor.cores",
                       Runtime.getRuntime.availableProcessors() * 2)

--- a/core/src/main/scala/io/snappydata/Literals.scala
+++ b/core/src/main/scala/io/snappydata/Literals.scala
@@ -182,6 +182,10 @@ object Property extends Enumeration {
     s"Explicit JDBC driver class for ${MetaStoreDBURL.name} setting.",
     None, Constant.SPARK_PREFIX)
 
+  val UseSparkMemoryManager = Val(s"${Constant.SPARK_SNAPPY_PREFIX}useSparkUMM",
+    "If true then sets Spark UMM as the memory manager",
+    Some(false), prefix = null, isPublic = false)
+
   val ColumnBatchSize = SQLVal[Int](s"${Constant.PROPERTY_PREFIX}columnBatchSize",
     "The default size of blocks to use for storage in SnappyData column " +
         "store. When inserting data into the column storage this is " +


### PR DESCRIPTION
Added UseSparkMemoryManager property to specify if spark's default memory manager is to be used. We cannot use spark.memory.manager property to specify this as driver would try to load the specified class. So we cannot pass a flag or the fully qualified name of UnifiedMemoryManager (since it is a private class).