### PR TITLE
Fix for SNAP-1262.Excluded slf4j dependency as it is getting added fr…

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -603,6 +603,7 @@ task product(type: Zip) {
         exclude '**antlr4-4*.jar'
         // exclude scalatest included by spark-tags
         exclude '**scalatest*.jar'
+        exclude 'slf4j*.jar'
         if (rootProject.hasProperty('hadoop-provided')) {
           exclude 'hadoop-*.jar'
         }


### PR DESCRIPTION
…om the snappydata-client jar

## Changes proposed in this pull request
Fix for SNAP-1262.Excluded slf4j dependency as it is getting added from the snappydata-client jar

## Patch testing
Tested Manually and also with quickstart

## ReleaseNotes.txt changes

(Does this change require an entry in ReleaseNotes.txt? If yes, has it been added to it?) No

## Other PRs 

(Does this change require changes in other projects- store, spark, spark-jobserver, aqp? Add the links of PR of the other subprojects that are related to this change) NA
