### PR TITLE
Fix Backward compatibility with 2.0.0 Spark

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -95,7 +95,7 @@ allprojects {
     productName = 'SnappyData'
     scalaBinaryVersion = '2.11'
     scalaVersion = scalaBinaryVersion + '.8'
-    sparkVersion = '2.0.2'
+    sparkVersion = '2.0.0'
     snappySparkVersion = '2.0.3-2'
     sparkDistName = "spark-${sparkVersion}-bin-hadoop2.7"
     log4jVersion = '1.2.17'

--- a/core/src/dunit/scala/io/snappydata/cluster/SplitClusterDUnitTest.scala
+++ b/core/src/dunit/scala/io/snappydata/cluster/SplitClusterDUnitTest.scala
@@ -610,8 +610,8 @@ object SplitClusterDUnitTest extends SplitClusterDUnitTestObject {
 
   private def checkValidJsonString(s: String): Unit = {
     try {
-      val parser = new ObjectMapper().getJsonFactory
-          .createJsonParser(s)
+      val parser = new ObjectMapper().getFactory()
+          .createParser(s)
       while (parser.nextToken() != null) {
       }
       return

--- a/core/src/main/scala/org/apache/spark/sql/CachedDataFrame.scala
+++ b/core/src/main/scala/org/apache/spark/sql/CachedDataFrame.scala
@@ -26,7 +26,7 @@ import com.esotericsoftware.kryo.{Kryo, KryoSerializable}
 
 import org.apache.spark.io.CompressionCodec
 import org.apache.spark.rdd.RDD
-import org.apache.spark.sql.backwardcomp.SnappyExecutedCommandExec
+import org.apache.spark.sql.backwardcomp.ExecutedCommand
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.codegen.CodeAndComment
 import org.apache.spark.sql.catalyst.expressions.{UnsafeProjection, UnsafeRow}
@@ -159,7 +159,7 @@ class CachedDataFrame(df: Dataset[Row],
               plan.executeCollect().iterator.map(converter))._1))
           }
 
-        case plan@(_: ExecutedCommandExec | _: LocalTableScanExec | _: SnappyExecutedCommandExec) =>
+        case plan@(_: ExecutedCommandExec | _: LocalTableScanExec | _: ExecutedCommand) =>
           if (skipUnpartitionedDataProcessing) {
             // no processing required
             plan.executeCollect().iterator.asInstanceOf[Iterator[R]]

--- a/core/src/main/scala/org/apache/spark/sql/CachedDataFrame.scala
+++ b/core/src/main/scala/org/apache/spark/sql/CachedDataFrame.scala
@@ -26,6 +26,7 @@ import com.esotericsoftware.kryo.{Kryo, KryoSerializable}
 
 import org.apache.spark.io.CompressionCodec
 import org.apache.spark.rdd.RDD
+import org.apache.spark.sql.backwardcomp.SnappyExecutedCommandExec
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.codegen.CodeAndComment
 import org.apache.spark.sql.catalyst.expressions.{UnsafeProjection, UnsafeRow}
@@ -158,7 +159,7 @@ class CachedDataFrame(df: Dataset[Row],
               plan.executeCollect().iterator.map(converter))._1))
           }
 
-        case plan@(_: ExecutedCommandExec | _: LocalTableScanExec) =>
+        case plan@(_: ExecutedCommandExec | _: LocalTableScanExec | _: SnappyExecutedCommandExec) =>
           if (skipUnpartitionedDataProcessing) {
             // no processing required
             plan.executeCollect().iterator.asInstanceOf[Iterator[R]]

--- a/core/src/main/scala/org/apache/spark/sql/SnappyDDLParser.scala
+++ b/core/src/main/scala/org/apache/spark/sql/SnappyDDLParser.scala
@@ -46,6 +46,9 @@ import org.apache.spark.sql.{SnappyParserConsts => Consts}
 import org.apache.spark.streaming.{Duration, Milliseconds, Minutes, Seconds, SnappyStreamingContext}
 
 /**
+ * **Copy of RunnableCommand to ensure a compatibility between
+ * Spark 2.0.0 and Snappy Spark 2.0.2**
+ *
  * A logical command that is executed for its side-effects.  `SnappyRunnableCommand`s are
  * wrapped in `SnappyExecutedCommandExec` during execution.
  */
@@ -56,6 +59,9 @@ trait SnappyRunnableCommand extends LeafNode with logical.Command  {
 
 private[sql] case class SnappyExecutedCommandExec(cmd: SnappyRunnableCommand) extends SparkPlan {
   /**
+   * **Copy of ExecutedCommandExec to ensure a compatibility between
+   * Spark 2.0.0 and Snappy Spark 2.0.2**
+   *
    * A concrete command should override this lazy field to wrap up any side effects caused by the
    * command or any other computation that should be evaluated exactly once. The value of this field
    * can be used as the contents of the corresponding RDD generated from the physical plan of this
@@ -393,7 +399,7 @@ abstract class SnappyDDLParser(session: SnappySession)
   protected def describeTable: Rule1[LogicalPlan] = rule {
     DESCRIBE ~ (EXTENDED ~> trueFn).? ~ tableIdentifier ~>
         ((extended: Any, tableIdent: TableIdentifier) =>
-          org.apache.spark.sql.DescribeTableCommand(tableIdent, Map.empty[String, String], extended
+          org.apache.spark.sql.SnappyDescribeTableCommand(tableIdent, Map.empty[String, String], extended
               .asInstanceOf[Option[Boolean]].isDefined, isFormatted = false))
   }
 
@@ -718,12 +724,15 @@ private[sql] case class SnappyStreamingActionsCommand(action: Int,
 }
 
 /**
+ * **Copy of DescribeTableCommand to ensure a compatibility between
+ * Spark 2.0.0 and Snappy Spark 2.0.2
+ *
  * Command that looks like
  * {{{
  *   DESCRIBE [EXTENDED|FORMATTED] table_name partitionSpec?;
  * }}}
  */
-case class DescribeTableCommand(
+case class SnappyDescribeTableCommand(
     table: TableIdentifier,
     partitionSpec: Map[String, String],
     isExtended: Boolean,
@@ -900,6 +909,9 @@ case class DescribeTableCommand(
     append(buffer, "Database:", table.database, "")
     append(buffer, "Table:", tableIdentifier.table, "")
     append(buffer, "Location:", partition.storage.locationUri.getOrElse(""), "")
+    // **Removed the partition parameters info from the output to ensure a compatibility
+    // between Spark 2.0.0 and Snappy Spark 2.0.2**
+
     //    append(buffer, "Partition Parameters:", "", "")
     //    partition.parameters.foreach { case (key, value) =>
     //      append(buffer, s"  $key", value, "")

--- a/core/src/main/scala/org/apache/spark/sql/SnappyDDLParser.scala
+++ b/core/src/main/scala/org/apache/spark/sql/SnappyDDLParser.scala
@@ -17,28 +17,72 @@
 
 package org.apache.spark.sql
 
+import java.util.Date
+
+import scala.collection.mutable.ArrayBuffer
 import scala.util.Try
 
 import io.snappydata.Constant
 import org.parboiled2._
 import shapeless.{::, HNil}
 
+import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.SnappyParserConsts.{falseFn, trueFn}
+import org.apache.spark.sql.catalyst.catalog.{CatalogColumn, CatalogTable, CatalogTablePartition, CatalogTableType, SessionCatalog}
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.parser.ParserUtils
 import org.apache.spark.sql.catalyst.plans.logical._
-import org.apache.spark.sql.catalyst.plans.QueryPlan
-import org.apache.spark.sql.catalyst.{FunctionIdentifier, TableIdentifier}
+import org.apache.spark.sql.catalyst.plans.{QueryPlan, logical}
+import org.apache.spark.sql.catalyst.{CatalystTypeConverters, FunctionIdentifier, InternalRow, TableIdentifier}
 import org.apache.spark.sql.collection.Utils
+import org.apache.spark.sql.execution.SparkPlan
 import org.apache.spark.sql.execution.columnar.ExternalStoreUtils
 import org.apache.spark.sql.execution.command._
-import org.apache.spark.sql.execution.datasources.{CreateTableUsing, DataSource, RefreshTable}
+import org.apache.spark.sql.execution.datasources.{BucketSpec, CreateTableUsing, DataSource, RefreshTable}
 import org.apache.spark.sql.sources.ExternalSchemaRelationProvider
 import org.apache.spark.sql.streaming.StreamPlanProvider
 import org.apache.spark.sql.types._
 import org.apache.spark.sql.{SnappyParserConsts => Consts}
 import org.apache.spark.streaming.{Duration, Milliseconds, Minutes, Seconds, SnappyStreamingContext}
 
+/**
+ * A logical command that is executed for its side-effects.  `SnappyRunnableCommand`s are
+ * wrapped in `SnappyExecutedCommandExec` during execution.
+ */
+trait SnappyRunnableCommand extends LeafNode with logical.Command  {
+  override def output: Seq[Attribute] = Seq.empty
+  def run(sparkSession: SparkSession): Seq[Row]
+}
+
+private[sql] case class SnappyExecutedCommandExec(cmd: SnappyRunnableCommand) extends SparkPlan {
+  /**
+   * A concrete command should override this lazy field to wrap up any side effects caused by the
+   * command or any other computation that should be evaluated exactly once. The value of this field
+   * can be used as the contents of the corresponding RDD generated from the physical plan of this
+   * command.
+   *
+   * The `execute()` method of all the physical command classes should reference `sideEffectResult`
+   * so that the command can be executed eagerly right after the command query is created.
+   */
+  protected[sql] lazy val sideEffectResult: Seq[InternalRow] = {
+    val converter = CatalystTypeConverters.createToCatalystConverter(schema)
+    cmd.run(sqlContext.sparkSession).map(converter(_).asInstanceOf[InternalRow])
+  }
+
+  override protected def innerChildren: Seq[QueryPlan[_]] = cmd :: Nil
+
+  override def output: Seq[Attribute] = cmd.output
+
+  override def children: Seq[SparkPlan] = Nil
+
+  override def executeCollect(): Array[InternalRow] = sideEffectResult.toArray
+
+  override def executeTake(limit: Int): Array[InternalRow] = sideEffectResult.take(limit).toArray
+
+  protected override def doExecute(): RDD[InternalRow] = {
+    sqlContext.sparkContext.parallelize(sideEffectResult, 1)
+  }
+}
 abstract class SnappyDDLParser(session: SnappySession)
     extends SnappyBaseParser(session) {
   final def ALL: Rule0 = rule { keyword(Consts.ALL) }
@@ -349,7 +393,7 @@ abstract class SnappyDDLParser(session: SnappySession)
   protected def describeTable: Rule1[LogicalPlan] = rule {
     DESCRIBE ~ (EXTENDED ~> trueFn).? ~ tableIdentifier ~>
         ((extended: Any, tableIdent: TableIdentifier) =>
-          DescribeTableCommand(tableIdent, Map.empty[String, String], extended
+          org.apache.spark.sql.DescribeTableCommand(tableIdent, Map.empty[String, String], extended
               .asInstanceOf[Option[Boolean]].isDefined, isFormatted = false))
   }
 
@@ -520,7 +564,7 @@ private[sql] case class CreateMetastoreTableUsing(
     provider: String,
     allowExisting: Boolean,
     options: Map[String, String],
-    isBuiltIn: Boolean) extends RunnableCommand {
+    isBuiltIn: Boolean) extends SnappyRunnableCommand {
 
   override def run(session: SparkSession): Seq[Row] = {
     val snc = session.asInstanceOf[SnappySession]
@@ -543,7 +587,7 @@ private[sql] case class CreateMetastoreTableUsingSelect(
     mode: SaveMode,
     options: Map[String, String],
     query: LogicalPlan,
-    isBuiltIn: Boolean) extends RunnableCommand {
+    isBuiltIn: Boolean) extends SnappyRunnableCommand {
 
   override def run(session: SparkSession): Seq[Row] = {
     val snc = session.asInstanceOf[SnappySession]
@@ -566,7 +610,7 @@ private[sql] case class CreateMetastoreTableUsingSelect(
 
 private[sql] case class DropTable(
     tableIdent: TableIdentifier,
-    ifExists: Boolean) extends RunnableCommand {
+    ifExists: Boolean) extends SnappyRunnableCommand {
 
   override def run(session: SparkSession): Seq[Row] = {
     val snc = session.asInstanceOf[SnappySession]
@@ -577,7 +621,7 @@ private[sql] case class DropTable(
 }
 
 private[sql] case class TruncateTable(
-    tableIdent: TableIdentifier) extends RunnableCommand {
+    tableIdent: TableIdentifier) extends SnappyRunnableCommand {
 
   override def run(session: SparkSession): Seq[Row] = {
     val snc = session.asInstanceOf[SnappySession]
@@ -590,7 +634,7 @@ private[sql] case class TruncateTable(
 private[sql] case class CreateIndex(indexName: TableIdentifier,
     baseTable: TableIdentifier,
     indexColumns: Map[String, Option[SortDirection]],
-    options: Map[String, String]) extends RunnableCommand {
+    options: Map[String, String]) extends SnappyRunnableCommand {
 
   override def run(session: SparkSession): Seq[Row] = {
     val snc = session.asInstanceOf[SnappySession]
@@ -604,7 +648,7 @@ private[sql] case class CreateIndex(indexName: TableIdentifier,
 
 private[sql] case class DropIndex(
     indexName: TableIdentifier,
-    ifExists: Boolean) extends RunnableCommand {
+    ifExists: Boolean) extends SnappyRunnableCommand {
 
   override def run(session: SparkSession): Seq[Row] = {
     val snc = session.asInstanceOf[SnappySession]
@@ -619,14 +663,16 @@ case class DMLExternalTable(
     tableName: TableIdentifier,
     query: LogicalPlan,
     command: String)
-    extends Command {
+    extends LeafNode with Command {
 
   override def innerChildren: Seq[QueryPlan[_]] = Seq(query)
   override lazy val resolved: Boolean = query.resolved
+  override def output: Seq[Attribute] = Seq.empty
+  override def children: Seq[LogicalPlan] = query :: Nil
 
 }
 
-private[sql] case class SetSchema(schemaName: String) extends RunnableCommand {
+private[sql] case class SetSchema(schemaName: String) extends SnappyRunnableCommand {
   override def run(sparkSession: SparkSession): Seq[Row] = {
     sparkSession.asInstanceOf[SnappySession].setSchema(schemaName)
     Seq.empty[Row]
@@ -634,7 +680,7 @@ private[sql] case class SetSchema(schemaName: String) extends RunnableCommand {
 }
 
 private[sql] case class SnappyStreamingActionsCommand(action: Int,
-    batchInterval: Option[Duration]) extends RunnableCommand {
+    batchInterval: Option[Duration]) extends SnappyRunnableCommand {
 
   override def run(session: SparkSession): Seq[Row] = {
 
@@ -668,5 +714,214 @@ private[sql] case class SnappyStreamingActionsCommand(action: Int,
         }
     }
     Seq.empty[Row]
+  }
+}
+
+/**
+ * Command that looks like
+ * {{{
+ *   DESCRIBE [EXTENDED|FORMATTED] table_name partitionSpec?;
+ * }}}
+ */
+case class DescribeTableCommand(
+    table: TableIdentifier,
+    partitionSpec: Map[String, String],
+    isExtended: Boolean,
+    isFormatted: Boolean)
+    extends SnappyRunnableCommand {
+
+  override val output: Seq[Attribute] = Seq(
+    // Column names are based on Hive.
+    AttributeReference("col_name", StringType, nullable = false,
+      new MetadataBuilder().putString("comment", "name of the column").build())(),
+    AttributeReference("data_type", StringType, nullable = false,
+      new MetadataBuilder().putString("comment", "data type of the column").build())(),
+    AttributeReference("comment", StringType, nullable = true,
+      new MetadataBuilder().putString("comment", "comment of the column").build())()
+  )
+
+  def run(sparkSession: SparkSession): Seq[Row] = {
+    val result = new ArrayBuffer[Row]
+    val catalog = sparkSession.sessionState.catalog
+
+    if (catalog.isTemporaryTable(table)) {
+      if (partitionSpec.nonEmpty) {
+        throw new AnalysisException(
+          s"DESC PARTITION is not allowed on a temporary view: ${table.identifier}")
+      }
+      describeSchema(catalog.lookupRelation(table).schema, result)
+    } else {
+      val metadata = catalog.getTableMetadata(table)
+
+      if (DDLUtils.isDatasourceTable(metadata)) {
+        DDLUtils.getSchemaFromTableProperties(metadata) match {
+          case Some(userSpecifiedSchema) => describeSchema(userSpecifiedSchema, result)
+          case None => describeSchema(catalog.lookupRelation(table).schema, result)
+        }
+      } else {
+        describeSchema(metadata.schema, result)
+      }
+
+      describePartitionInfo(metadata, result)
+
+      if (partitionSpec.isEmpty) {
+        if (isExtended) {
+          describeExtendedTableInfo(metadata, result)
+        } else if (isFormatted) {
+          describeFormattedTableInfo(metadata, result)
+        }
+      } else {
+        describeDetailedPartitionInfo(catalog, metadata, result)
+      }
+    }
+
+    result
+  }
+
+  private def describePartitionInfo(table: CatalogTable, buffer: ArrayBuffer[Row]): Unit = {
+    if (DDLUtils.isDatasourceTable(table)) {
+      val userSpecifiedSchema = DDLUtils.getSchemaFromTableProperties(table)
+      val partColNames = DDLUtils.getPartitionColumnsFromTableProperties(table)
+      for (schema <- userSpecifiedSchema if partColNames.nonEmpty) {
+        append(buffer, "# Partition Information", "", "")
+        append(buffer, s"# ${output.head.name}", output(1).name, output(2).name)
+        describeSchema(StructType(partColNames.map(schema(_))), buffer)
+      }
+    } else {
+      if (table.partitionColumns.nonEmpty) {
+        append(buffer, "# Partition Information", "", "")
+        append(buffer, s"# ${output.head.name}", output(1).name, output(2).name)
+        describeSchema(table.partitionColumns, buffer)
+      }
+    }
+  }
+
+  private def describeExtendedTableInfo(table: CatalogTable, buffer: ArrayBuffer[Row]): Unit = {
+    append(buffer, "", "", "")
+    append(buffer, "# Detailed Table Information", table.toString, "")
+  }
+
+  private def describeFormattedTableInfo(table: CatalogTable, buffer: ArrayBuffer[Row]): Unit = {
+    append(buffer, "", "", "")
+    append(buffer, "# Detailed Table Information", "", "")
+    append(buffer, "Database:", table.database, "")
+    append(buffer, "Owner:", table.owner, "")
+    append(buffer, "Create Time:", new Date(table.createTime).toString, "")
+    append(buffer, "Last Access Time:", new Date(table.lastAccessTime).toString, "")
+    append(buffer, "Location:", table.storage.locationUri.getOrElse(""), "")
+    append(buffer, "Table Type:", table.tableType.name, "")
+
+    append(buffer, "Table Parameters:", "", "")
+    table.properties.filterNot {
+      // Hides schema properties that hold user-defined schema, partition columns, and bucketing
+      // information since they are already extracted and shown in other parts.
+      case (key, _) => key.startsWith(CreateDataSourceTableUtils.DATASOURCE_SCHEMA)
+    }.foreach { case (key, value) =>
+      append(buffer, s"  $key", value, "")
+    }
+
+    describeStorageInfo(table, buffer)
+  }
+
+  private def describeStorageInfo(metadata: CatalogTable, buffer: ArrayBuffer[Row]): Unit = {
+    append(buffer, "", "", "")
+    append(buffer, "# Storage Information", "", "")
+    metadata.storage.serde.foreach(serdeLib => append(buffer, "SerDe Library:", serdeLib, ""))
+    metadata.storage.inputFormat.foreach(format => append(buffer, "InputFormat:", format, ""))
+    metadata.storage.outputFormat.foreach(format => append(buffer, "OutputFormat:", format, ""))
+    append(buffer, "Compressed:", if (metadata.storage.compressed) "Yes" else "No", "")
+    describeBucketingInfo(metadata, buffer)
+
+    append(buffer, "Storage Desc Parameters:", "", "")
+    metadata.storage.serdeProperties.foreach { case (key, value) =>
+      append(buffer, s"  $key", value, "")
+    }
+  }
+
+  private def describeBucketingInfo(metadata: CatalogTable, buffer: ArrayBuffer[Row]): Unit = {
+    def appendBucketInfo(numBuckets: Int, bucketColumns: Seq[String], sortColumns: Seq[String]) = {
+      append(buffer, "Num Buckets:", numBuckets.toString, "")
+      append(buffer, "Bucket Columns:", bucketColumns.mkString("[", ", ", "]"), "")
+      append(buffer, "Sort Columns:", sortColumns.mkString("[", ", ", "]"), "")
+    }
+
+    DDLUtils.getBucketSpecFromTableProperties(metadata) match {
+      case Some(bucketSpec) =>
+        appendBucketInfo(
+          bucketSpec.numBuckets,
+          bucketSpec.bucketColumnNames,
+          bucketSpec.sortColumnNames)
+      case None =>
+        appendBucketInfo(
+          metadata.numBuckets,
+          metadata.bucketColumnNames,
+          metadata.sortColumnNames)
+    }
+  }
+
+  private def describeDetailedPartitionInfo(
+      catalog: SessionCatalog,
+      metadata: CatalogTable,
+      result: ArrayBuffer[Row]): Unit = {
+    if (metadata.tableType == CatalogTableType.VIEW) {
+      throw new AnalysisException(
+        s"DESC PARTITION is not allowed on a view: ${table.identifier}")
+    }
+    if (DDLUtils.isDatasourceTable(metadata)) {
+      throw new AnalysisException(
+        s"DESC PARTITION is not allowed on a datasource table: ${table.identifier}")
+    }
+    val partition = catalog.getPartition(table, partitionSpec)
+    if (isExtended) {
+      describeExtendedDetailedPartitionInfo(table, metadata, partition, result)
+    } else if (isFormatted) {
+      describeFormattedDetailedPartitionInfo(table, metadata, partition, result)
+      describeStorageInfo(metadata, result)
+    }
+  }
+
+  private def describeExtendedDetailedPartitionInfo(
+      tableIdentifier: TableIdentifier,
+      table: CatalogTable,
+      partition: CatalogTablePartition,
+      buffer: ArrayBuffer[Row]): Unit = {
+    append(buffer, "", "", "")
+    append(buffer, "Detailed Partition Information " + partition.toString, "", "")
+  }
+
+  private def describeFormattedDetailedPartitionInfo(
+      tableIdentifier: TableIdentifier,
+      table: CatalogTable,
+      partition: CatalogTablePartition,
+      buffer: ArrayBuffer[Row]): Unit = {
+    append(buffer, "", "", "")
+    append(buffer, "# Detailed Partition Information", "", "")
+    append(buffer, "Partition Value:", s"[${partition.spec.values.mkString(", ")}]", "")
+    append(buffer, "Database:", table.database, "")
+    append(buffer, "Table:", tableIdentifier.table, "")
+    append(buffer, "Location:", partition.storage.locationUri.getOrElse(""), "")
+    //    append(buffer, "Partition Parameters:", "", "")
+    //    partition.parameters.foreach { case (key, value) =>
+    //      append(buffer, s"  $key", value, "")
+    //    }
+  }
+
+  private def describeSchema(schema: Seq[CatalogColumn], buffer: ArrayBuffer[Row]): Unit = {
+    schema.foreach { column =>
+      append(buffer, column.name, column.dataType.toLowerCase, column.comment.orNull)
+    }
+  }
+
+  private def describeSchema(schema: StructType, buffer: ArrayBuffer[Row]): Unit = {
+    schema.foreach { column =>
+      val comment =
+        if (column.metadata.contains("comment")) column.metadata.getString("comment") else null
+      append(buffer, column.name, column.dataType.simpleString, comment)
+    }
+  }
+
+  private def append(
+      buffer: ArrayBuffer[Row], column: String, dataType: String, comment: String): Unit = {
+    buffer += Row(column, dataType, comment)
   }
 }

--- a/core/src/main/scala/org/apache/spark/sql/SnappyDDLParser.scala
+++ b/core/src/main/scala/org/apache/spark/sql/SnappyDDLParser.scala
@@ -28,7 +28,7 @@ import shapeless.{::, HNil}
 
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.SnappyParserConsts.{falseFn, trueFn}
-import org.apache.spark.sql.backwardcomp.{SnappyDescribeTableCommand, SnappyRunnableCommand}
+import org.apache.spark.sql.backwardcomp.{DescribeTable, ExecuteCommand}
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.parser.ParserUtils
 import org.apache.spark.sql.catalyst.plans.logical._
@@ -355,7 +355,7 @@ abstract class SnappyDDLParser(session: SnappySession)
   protected def describeTable: Rule1[LogicalPlan] = rule {
     DESCRIBE ~ (EXTENDED ~> trueFn).? ~ tableIdentifier ~>
         ((extended: Any, tableIdent: TableIdentifier) =>
-          SnappyDescribeTableCommand(tableIdent, Map.empty[String, String], extended
+          DescribeTable(tableIdent, Map.empty[String, String], extended
               .asInstanceOf[Option[Boolean]].isDefined, isFormatted = false))
   }
 
@@ -526,7 +526,7 @@ private[sql] case class CreateMetastoreTableUsing(
     provider: String,
     allowExisting: Boolean,
     options: Map[String, String],
-    isBuiltIn: Boolean) extends SnappyRunnableCommand {
+    isBuiltIn: Boolean) extends ExecuteCommand {
 
   override def run(session: SparkSession): Seq[Row] = {
     val snc = session.asInstanceOf[SnappySession]
@@ -549,7 +549,7 @@ private[sql] case class CreateMetastoreTableUsingSelect(
     mode: SaveMode,
     options: Map[String, String],
     query: LogicalPlan,
-    isBuiltIn: Boolean) extends SnappyRunnableCommand {
+    isBuiltIn: Boolean) extends ExecuteCommand {
 
   override def run(session: SparkSession): Seq[Row] = {
     val snc = session.asInstanceOf[SnappySession]
@@ -572,7 +572,7 @@ private[sql] case class CreateMetastoreTableUsingSelect(
 
 private[sql] case class DropTable(
     tableIdent: TableIdentifier,
-    ifExists: Boolean) extends SnappyRunnableCommand {
+    ifExists: Boolean) extends ExecuteCommand {
 
   override def run(session: SparkSession): Seq[Row] = {
     val snc = session.asInstanceOf[SnappySession]
@@ -583,7 +583,7 @@ private[sql] case class DropTable(
 }
 
 private[sql] case class TruncateTable(
-    tableIdent: TableIdentifier) extends SnappyRunnableCommand {
+    tableIdent: TableIdentifier) extends ExecuteCommand {
 
   override def run(session: SparkSession): Seq[Row] = {
     val snc = session.asInstanceOf[SnappySession]
@@ -596,7 +596,7 @@ private[sql] case class TruncateTable(
 private[sql] case class CreateIndex(indexName: TableIdentifier,
     baseTable: TableIdentifier,
     indexColumns: Map[String, Option[SortDirection]],
-    options: Map[String, String]) extends SnappyRunnableCommand {
+    options: Map[String, String]) extends ExecuteCommand {
 
   override def run(session: SparkSession): Seq[Row] = {
     val snc = session.asInstanceOf[SnappySession]
@@ -610,7 +610,7 @@ private[sql] case class CreateIndex(indexName: TableIdentifier,
 
 private[sql] case class DropIndex(
     indexName: TableIdentifier,
-    ifExists: Boolean) extends SnappyRunnableCommand {
+    ifExists: Boolean) extends ExecuteCommand {
 
   override def run(session: SparkSession): Seq[Row] = {
     val snc = session.asInstanceOf[SnappySession]
@@ -632,7 +632,7 @@ case class DMLExternalTable(
   override def output: Seq[Attribute] = Seq.empty
 }
 
-private[sql] case class SetSchema(schemaName: String) extends SnappyRunnableCommand {
+private[sql] case class SetSchema(schemaName: String) extends ExecuteCommand {
   override def run(sparkSession: SparkSession): Seq[Row] = {
     sparkSession.asInstanceOf[SnappySession].setSchema(schemaName)
     Seq.empty[Row]
@@ -640,7 +640,7 @@ private[sql] case class SetSchema(schemaName: String) extends SnappyRunnableComm
 }
 
 private[sql] case class SnappyStreamingActionsCommand(action: Int,
-    batchInterval: Option[Duration]) extends SnappyRunnableCommand {
+    batchInterval: Option[Duration]) extends ExecuteCommand {
 
   override def run(session: SparkSession): Seq[Row] = {
 

--- a/core/src/main/scala/org/apache/spark/sql/SnappyDDLParser.scala
+++ b/core/src/main/scala/org/apache/spark/sql/SnappyDDLParser.scala
@@ -630,8 +630,6 @@ case class DMLExternalTable(
   override def innerChildren: Seq[QueryPlan[_]] = Seq(query)
   override lazy val resolved: Boolean = query.resolved
   override def output: Seq[Attribute] = Seq.empty
-  override def children: Seq[LogicalPlan] = query :: Nil
-
 }
 
 private[sql] case class SetSchema(schemaName: String) extends SnappyRunnableCommand {

--- a/core/src/main/scala/org/apache/spark/sql/SnappySession.scala
+++ b/core/src/main/scala/org/apache/spark/sql/SnappySession.scala
@@ -37,7 +37,7 @@ import io.snappydata.Constant
 import org.apache.spark.annotation.{DeveloperApi, Experimental}
 import org.apache.spark.rdd.RDD
 import org.apache.spark.scheduler.{SparkListener, SparkListenerApplicationEnd}
-import org.apache.spark.sql.backwardcomp.SnappyExecutedCommandExec
+import org.apache.spark.sql.backwardcomp.ExecutedCommand
 import org.apache.spark.sql.catalyst.analysis.EliminateSubqueryAliases
 import org.apache.spark.sql.catalyst.encoders.RowEncoder
 import org.apache.spark.sql.catalyst.expressions.codegen.CodegenContext
@@ -1528,9 +1528,7 @@ object SnappySession extends Logging {
       case plan => plan
     }
     val (cachedRDD, shuffleDeps, rddId, localCollect) = executedPlan match {
-      case _: ExecutedCommandExec =>
-        throw new EntryExistsException("uncached plan", df) // don't cache
-      case _: SnappyExecutedCommandExec =>
+      case _: ExecutedCommandExec | _: ExecutedCommand =>
         throw new EntryExistsException("uncached plan", df) // don't cache
       case plan: CollectAggregateExec =>
         (null, findShuffleDependencies(plan.childRDD).toArray,

--- a/core/src/main/scala/org/apache/spark/sql/SnappySession.scala
+++ b/core/src/main/scala/org/apache/spark/sql/SnappySession.scala
@@ -37,6 +37,7 @@ import io.snappydata.Constant
 import org.apache.spark.annotation.{DeveloperApi, Experimental}
 import org.apache.spark.rdd.RDD
 import org.apache.spark.scheduler.{SparkListener, SparkListenerApplicationEnd}
+import org.apache.spark.sql.backwardcomp.SnappyExecutedCommandExec
 import org.apache.spark.sql.catalyst.analysis.EliminateSubqueryAliases
 import org.apache.spark.sql.catalyst.encoders.RowEncoder
 import org.apache.spark.sql.catalyst.expressions.codegen.CodegenContext
@@ -1528,6 +1529,8 @@ object SnappySession extends Logging {
     }
     val (cachedRDD, shuffleDeps, rddId, localCollect) = executedPlan match {
       case _: ExecutedCommandExec =>
+        throw new EntryExistsException("uncached plan", df) // don't cache
+      case _: SnappyExecutedCommandExec =>
         throw new EntryExistsException("uncached plan", df) // don't cache
       case plan: CollectAggregateExec =>
         (null, findShuffleDependencies(plan.childRDD).toArray,

--- a/core/src/main/scala/org/apache/spark/sql/backwardcomp/logicalPlans.scala
+++ b/core/src/main/scala/org/apache/spark/sql/backwardcomp/logicalPlans.scala
@@ -1,0 +1,257 @@
+/*
+ * Copyright (c) 2016 SnappyData, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License. You
+ * may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License. See accompanying
+ * LICENSE file.
+ */
+package org.apache.spark.sql.backwardcomp
+
+import java.util.Date
+
+import scala.collection.mutable.ArrayBuffer
+
+import org.apache.spark.sql.catalyst.catalog.{CatalogColumn, CatalogTable, CatalogTablePartition, CatalogTableType, SessionCatalog}
+import org.apache.spark.sql.{AnalysisException, Row, SparkSession}
+import org.apache.spark.sql.catalyst.TableIdentifier
+import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeReference}
+import org.apache.spark.sql.catalyst.plans.logical
+import org.apache.spark.sql.catalyst.plans.logical.LeafNode
+import org.apache.spark.sql.execution.command.{CreateDataSourceTableUtils, DDLUtils}
+import org.apache.spark.sql.types.{MetadataBuilder, StringType, StructType}
+
+/**
+ * **Copy of RunnableCommand to ensure a compatibility between
+ * Spark 2.0.0 and Snappy Spark 2.0.2**
+ *
+ * A logical command that is executed for its side-effects.  `SnappyRunnableCommand`s are
+ * wrapped in `SnappyExecutedCommandExec` during execution.
+ */
+trait SnappyRunnableCommand extends LeafNode with logical.Command  {
+  override def output: Seq[Attribute] = Seq.empty
+  def run(sparkSession: SparkSession): Seq[Row]
+}
+
+/**
+ * **Copy of DescribeTableCommand to ensure a compatibility between
+ * Spark 2.0.0 and Snappy Spark 2.0.2
+ *
+ * Command that looks like
+ * {{{
+ *   DESCRIBE [EXTENDED|FORMATTED] table_name partitionSpec?;
+ * }}}
+ */
+case class SnappyDescribeTableCommand(
+    table: TableIdentifier,
+    partitionSpec: Map[String, String],
+    isExtended: Boolean,
+    isFormatted: Boolean)
+    extends SnappyRunnableCommand {
+
+  override val output: Seq[Attribute] = Seq(
+    // Column names are based on Hive.
+    AttributeReference("col_name", StringType, nullable = false,
+      new MetadataBuilder().putString("comment", "name of the column").build())(),
+    AttributeReference("data_type", StringType, nullable = false,
+      new MetadataBuilder().putString("comment", "data type of the column").build())(),
+    AttributeReference("comment", StringType, nullable = true,
+      new MetadataBuilder().putString("comment", "comment of the column").build())()
+  )
+
+  def run(sparkSession: SparkSession): Seq[Row] = {
+    val result = new ArrayBuffer[Row]
+    val catalog = sparkSession.sessionState.catalog
+
+    if (catalog.isTemporaryTable(table)) {
+      if (partitionSpec.nonEmpty) {
+        throw new AnalysisException(
+          s"DESC PARTITION is not allowed on a temporary view: ${table.identifier}")
+      }
+      describeSchema(catalog.lookupRelation(table).schema, result)
+    } else {
+      val metadata = catalog.getTableMetadata(table)
+
+      if (DDLUtils.isDatasourceTable(metadata)) {
+        DDLUtils.getSchemaFromTableProperties(metadata) match {
+          case Some(userSpecifiedSchema) => describeSchema(userSpecifiedSchema, result)
+          case None => describeSchema(catalog.lookupRelation(table).schema, result)
+        }
+      } else {
+        describeSchema(metadata.schema, result)
+      }
+
+      describePartitionInfo(metadata, result)
+
+      if (partitionSpec.isEmpty) {
+        if (isExtended) {
+          describeExtendedTableInfo(metadata, result)
+        } else if (isFormatted) {
+          describeFormattedTableInfo(metadata, result)
+        }
+      } else {
+        describeDetailedPartitionInfo(catalog, metadata, result)
+      }
+    }
+
+    result
+  }
+
+  private def describePartitionInfo(table: CatalogTable, buffer: ArrayBuffer[Row]): Unit = {
+    if (DDLUtils.isDatasourceTable(table)) {
+      val userSpecifiedSchema = DDLUtils.getSchemaFromTableProperties(table)
+      val partColNames = DDLUtils.getPartitionColumnsFromTableProperties(table)
+      for (schema <- userSpecifiedSchema if partColNames.nonEmpty) {
+        append(buffer, "# Partition Information", "", "")
+        append(buffer, s"# ${output.head.name}", output(1).name, output(2).name)
+        describeSchema(StructType(partColNames.map(schema(_))), buffer)
+      }
+    } else {
+      if (table.partitionColumns.nonEmpty) {
+        append(buffer, "# Partition Information", "", "")
+        append(buffer, s"# ${output.head.name}", output(1).name, output(2).name)
+        describeSchema(table.partitionColumns, buffer)
+      }
+    }
+  }
+
+  private def describeExtendedTableInfo(table: CatalogTable, buffer: ArrayBuffer[Row]): Unit = {
+    append(buffer, "", "", "")
+    append(buffer, "# Detailed Table Information", table.toString, "")
+  }
+
+  private def describeFormattedTableInfo(table: CatalogTable, buffer: ArrayBuffer[Row]): Unit = {
+    append(buffer, "", "", "")
+    append(buffer, "# Detailed Table Information", "", "")
+    append(buffer, "Database:", table.database, "")
+    append(buffer, "Owner:", table.owner, "")
+    append(buffer, "Create Time:", new Date(table.createTime).toString, "")
+    append(buffer, "Last Access Time:", new Date(table.lastAccessTime).toString, "")
+    append(buffer, "Location:", table.storage.locationUri.getOrElse(""), "")
+    append(buffer, "Table Type:", table.tableType.name, "")
+
+    append(buffer, "Table Parameters:", "", "")
+    table.properties.filterNot {
+      // Hides schema properties that hold user-defined schema, partition columns, and bucketing
+      // information since they are already extracted and shown in other parts.
+      case (key, _) => key.startsWith(CreateDataSourceTableUtils.DATASOURCE_SCHEMA)
+    }.foreach { case (key, value) =>
+      append(buffer, s"  $key", value, "")
+    }
+
+    describeStorageInfo(table, buffer)
+  }
+
+  private def describeStorageInfo(metadata: CatalogTable, buffer: ArrayBuffer[Row]): Unit = {
+    append(buffer, "", "", "")
+    append(buffer, "# Storage Information", "", "")
+    metadata.storage.serde.foreach(serdeLib => append(buffer, "SerDe Library:", serdeLib, ""))
+    metadata.storage.inputFormat.foreach(format => append(buffer, "InputFormat:", format, ""))
+    metadata.storage.outputFormat.foreach(format => append(buffer, "OutputFormat:", format, ""))
+    append(buffer, "Compressed:", if (metadata.storage.compressed) "Yes" else "No", "")
+    describeBucketingInfo(metadata, buffer)
+
+    append(buffer, "Storage Desc Parameters:", "", "")
+    metadata.storage.serdeProperties.foreach { case (key, value) =>
+      append(buffer, s"  $key", value, "")
+    }
+  }
+
+  private def describeBucketingInfo(metadata: CatalogTable, buffer: ArrayBuffer[Row]): Unit = {
+    def appendBucketInfo(numBuckets: Int, bucketColumns: Seq[String], sortColumns: Seq[String]) = {
+      append(buffer, "Num Buckets:", numBuckets.toString, "")
+      append(buffer, "Bucket Columns:", bucketColumns.mkString("[", ", ", "]"), "")
+      append(buffer, "Sort Columns:", sortColumns.mkString("[", ", ", "]"), "")
+    }
+
+    DDLUtils.getBucketSpecFromTableProperties(metadata) match {
+      case Some(bucketSpec) =>
+        appendBucketInfo(
+          bucketSpec.numBuckets,
+          bucketSpec.bucketColumnNames,
+          bucketSpec.sortColumnNames)
+      case None =>
+        appendBucketInfo(
+          metadata.numBuckets,
+          metadata.bucketColumnNames,
+          metadata.sortColumnNames)
+    }
+  }
+
+  private def describeDetailedPartitionInfo(
+      catalog: SessionCatalog,
+      metadata: CatalogTable,
+      result: ArrayBuffer[Row]): Unit = {
+    if (metadata.tableType == CatalogTableType.VIEW) {
+      throw new AnalysisException(
+        s"DESC PARTITION is not allowed on a view: ${table.identifier}")
+    }
+    if (DDLUtils.isDatasourceTable(metadata)) {
+      throw new AnalysisException(
+        s"DESC PARTITION is not allowed on a datasource table: ${table.identifier}")
+    }
+    val partition = catalog.getPartition(table, partitionSpec)
+    if (isExtended) {
+      describeExtendedDetailedPartitionInfo(table, metadata, partition, result)
+    } else if (isFormatted) {
+      describeFormattedDetailedPartitionInfo(table, metadata, partition, result)
+      describeStorageInfo(metadata, result)
+    }
+  }
+
+  private def describeExtendedDetailedPartitionInfo(
+      tableIdentifier: TableIdentifier,
+      table: CatalogTable,
+      partition: CatalogTablePartition,
+      buffer: ArrayBuffer[Row]): Unit = {
+    append(buffer, "", "", "")
+    append(buffer, "Detailed Partition Information " + partition.toString, "", "")
+  }
+
+  private def describeFormattedDetailedPartitionInfo(
+      tableIdentifier: TableIdentifier,
+      table: CatalogTable,
+      partition: CatalogTablePartition,
+      buffer: ArrayBuffer[Row]): Unit = {
+    append(buffer, "", "", "")
+    append(buffer, "# Detailed Partition Information", "", "")
+    append(buffer, "Partition Value:", s"[${partition.spec.values.mkString(", ")}]", "")
+    append(buffer, "Database:", table.database, "")
+    append(buffer, "Table:", tableIdentifier.table, "")
+    append(buffer, "Location:", partition.storage.locationUri.getOrElse(""), "")
+    // **Removed the partition parameters info from the output to ensure a compatibility
+    // between Spark 2.0.0 and Snappy Spark 2.0.2**
+
+    //    append(buffer, "Partition Parameters:", "", "")
+    //    partition.parameters.foreach { case (key, value) =>
+    //      append(buffer, s"  $key", value, "")
+    //    }
+  }
+
+  private def describeSchema(schema: Seq[CatalogColumn], buffer: ArrayBuffer[Row]): Unit = {
+    schema.foreach { column =>
+      append(buffer, column.name, column.dataType.toLowerCase, column.comment.orNull)
+    }
+  }
+
+  private def describeSchema(schema: StructType, buffer: ArrayBuffer[Row]): Unit = {
+    schema.foreach { column =>
+      val comment =
+        if (column.metadata.contains("comment")) column.metadata.getString("comment") else null
+      append(buffer, column.name, column.dataType.simpleString, comment)
+    }
+  }
+
+  private def append(
+      buffer: ArrayBuffer[Row], column: String, dataType: String, comment: String): Unit = {
+    buffer += Row(column, dataType, comment)
+  }
+}

--- a/core/src/main/scala/org/apache/spark/sql/backwardcomp/logicalPlans.scala
+++ b/core/src/main/scala/org/apache/spark/sql/backwardcomp/logicalPlans.scala
@@ -36,7 +36,7 @@ import org.apache.spark.sql.types.{MetadataBuilder, StringType, StructType}
  * A logical command that is executed for its side-effects.  `SnappyRunnableCommand`s are
  * wrapped in `SnappyExecutedCommandExec` during execution.
  */
-trait SnappyRunnableCommand extends LeafNode with logical.Command  {
+trait ExecuteCommand extends LeafNode with logical.Command  {
   override def output: Seq[Attribute] = Seq.empty
   def run(sparkSession: SparkSession): Seq[Row]
 }
@@ -50,12 +50,12 @@ trait SnappyRunnableCommand extends LeafNode with logical.Command  {
  *   DESCRIBE [EXTENDED|FORMATTED] table_name partitionSpec?;
  * }}}
  */
-case class SnappyDescribeTableCommand(
+case class DescribeTable(
     table: TableIdentifier,
     partitionSpec: Map[String, String],
     isExtended: Boolean,
     isFormatted: Boolean)
-    extends SnappyRunnableCommand {
+    extends ExecuteCommand {
 
   override val output: Seq[Attribute] = Seq(
     // Column names are based on Hive.

--- a/core/src/main/scala/org/apache/spark/sql/backwardcomp/sparkPlans.scala
+++ b/core/src/main/scala/org/apache/spark/sql/backwardcomp/sparkPlans.scala
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2016 SnappyData, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License. You
+ * may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License. See accompanying
+ * LICENSE file.
+ */
+package org.apache.spark.sql.backwardcomp
+
+import org.apache.spark.rdd.RDD
+import org.apache.spark.sql.catalyst.{CatalystTypeConverters, InternalRow}
+import org.apache.spark.sql.catalyst.expressions.Attribute
+import org.apache.spark.sql.catalyst.plans.QueryPlan
+import org.apache.spark.sql.execution.SparkPlan
+
+private[sql] case class SnappyExecutedCommandExec(cmd: SnappyRunnableCommand) extends SparkPlan {
+  /**
+   * **Copy of ExecutedCommandExec to ensure a compatibility between
+   * Spark 2.0.0 and Snappy Spark 2.0.2**
+   *
+   * A concrete command should override this lazy field to wrap up any side effects caused by the
+   * command or any other computation that should be evaluated exactly once. The value of this field
+   * can be used as the contents of the corresponding RDD generated from the physical plan of this
+   * command.
+   *
+   * The `execute()` method of all the physical command classes should reference `sideEffectResult`
+   * so that the command can be executed eagerly right after the command query is created.
+   */
+  protected[sql] lazy val sideEffectResult: Seq[InternalRow] = {
+    val converter = CatalystTypeConverters.createToCatalystConverter(schema)
+    cmd.run(sqlContext.sparkSession).map(converter(_).asInstanceOf[InternalRow])
+  }
+
+  override protected def innerChildren: Seq[QueryPlan[_]] = cmd :: Nil
+
+  override def output: Seq[Attribute] = cmd.output
+
+  override def children: Seq[SparkPlan] = Nil
+
+  override def executeCollect(): Array[InternalRow] = sideEffectResult.toArray
+
+  override def executeTake(limit: Int): Array[InternalRow] = sideEffectResult.take(limit).toArray
+
+  protected override def doExecute(): RDD[InternalRow] = {
+    sqlContext.sparkContext.parallelize(sideEffectResult, 1)
+  }
+}

--- a/core/src/main/scala/org/apache/spark/sql/backwardcomp/sparkPlans.scala
+++ b/core/src/main/scala/org/apache/spark/sql/backwardcomp/sparkPlans.scala
@@ -22,7 +22,7 @@ import org.apache.spark.sql.catalyst.expressions.Attribute
 import org.apache.spark.sql.catalyst.plans.QueryPlan
 import org.apache.spark.sql.execution.SparkPlan
 
-private[sql] case class SnappyExecutedCommandExec(cmd: SnappyRunnableCommand) extends SparkPlan {
+private[sql] case class ExecutedCommand(cmd: ExecuteCommand) extends SparkPlan {
   /**
    * **Copy of ExecutedCommandExec to ensure a compatibility between
    * Spark 2.0.0 and Snappy Spark 2.0.2**

--- a/core/src/main/scala/org/apache/spark/sql/collection/Utils.scala
+++ b/core/src/main/scala/org/apache/spark/sql/collection/Utils.scala
@@ -722,7 +722,9 @@ object Utils {
 
   def generateJson(dataType: DataType, gen: JsonGenerator,
       row: InternalRow): Unit = {
-    JacksonGenerator(StructType(Seq(StructField("", dataType))), gen)(row)
+    // JacksonGenerator(StructType(Seq(StructField("", dataType))), gen)(row)
+    // compatibility with both Spark 2.0.0 and 2.0.2
+    TypeUtilities.jacksonApply(StructType(Seq(StructField("", dataType))), gen, row)
   }
 
   def getNumColumns(partitioning: Partitioning): Int = partitioning match {

--- a/core/src/main/scala/org/apache/spark/sql/internal/SnappySessionState.scala
+++ b/core/src/main/scala/org/apache/spark/sql/internal/SnappySessionState.scala
@@ -30,8 +30,8 @@ import org.apache.spark.sql._
 import org.apache.spark.sql.aqp.SnappyContextFunctions
 import org.apache.spark.sql.catalyst.CatalystConf
 import org.apache.spark.sql.catalyst.analysis.{Analyzer, EliminateSubqueryAliases, NoSuchTableException, UnresolvedRelation}
-import org.apache.spark.sql.catalyst.catalog.{CatalogRelation, SessionCatalog}
-import org.apache.spark.sql.catalyst.expressions.{Alias, Attribute, Cast, PredicateHelper, RowOrdering}
+import org.apache.spark.sql.catalyst.catalog.CatalogRelation
+import org.apache.spark.sql.catalyst.expressions.{Alias, Attribute, Cast, PredicateHelper}
 import org.apache.spark.sql.catalyst.optimizer.{Optimizer, ReorderJoin}
 import org.apache.spark.sql.catalyst.planning.PhysicalOperation
 import org.apache.spark.sql.catalyst.plans.logical.{InsertIntoTable, Join, LogicalPlan, Project}
@@ -39,7 +39,7 @@ import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.collection.Utils
 import org.apache.spark.sql.execution._
 import org.apache.spark.sql.execution.columnar.impl.IndexColumnFormatRelation
-import org.apache.spark.sql.execution.datasources.{DataSourceAnalysis, FindDataSourceTable, HadoopFsRelation, LogicalRelation, PartitioningUtils, ResolveDataSource, StoreDataSourceStrategy}
+import org.apache.spark.sql.execution.datasources.{DataSourceAnalysis, FindDataSourceTable, HadoopFsRelation, LogicalRelation, ResolveDataSource, StoreDataSourceStrategy}
 import org.apache.spark.sql.execution.exchange.{EnsureRequirements, ReuseExchange}
 import org.apache.spark.sql.hive.SnappyStoreHiveCatalog
 import org.apache.spark.sql.internal.SQLConf.SQLConfigBuilder

--- a/core/src/main/scala/org/apache/spark/sql/sources/StoreStrategy.scala
+++ b/core/src/main/scala/org/apache/spark/sql/sources/StoreStrategy.scala
@@ -17,10 +17,10 @@
 package org.apache.spark.sql.sources
 
 import org.apache.spark.sql._
+import org.apache.spark.sql.backwardcomp.{SnappyDescribeTableCommand, SnappyExecutedCommandExec, SnappyRunnableCommand}
 import org.apache.spark.sql.catalyst.expressions.Attribute
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.apache.spark.sql.execution.SparkPlan
-import org.apache.spark.sql.execution.command.{ExecutedCommandExec, RunnableCommand}
 import org.apache.spark.sql.execution.datasources.{CreateTableUsing, CreateTableUsingAsSelect, LogicalRelation}
 import org.apache.spark.sql.types.DataType
 
@@ -67,7 +67,7 @@ object StoreStrategy extends Strategy {
 
     case PutIntoTable(l@LogicalRelation(t: RowPutRelation, _, _), query) =>
       SnappyExecutedCommandExec(PutIntoDataSource(l, t, query)) :: Nil
-    case r: org.apache.spark.sql.SnappyDescribeTableCommand => SnappyExecutedCommandExec(r) :: Nil
+    case r: SnappyDescribeTableCommand => SnappyExecutedCommandExec(r) :: Nil
 
     case r: SnappyRunnableCommand => SnappyExecutedCommandExec(r) :: Nil
 

--- a/core/src/main/scala/org/apache/spark/sql/types/TypeUtilities.scala
+++ b/core/src/main/scala/org/apache/spark/sql/types/TypeUtilities.scala
@@ -20,9 +20,13 @@ import java.util.Properties
 
 import com.esotericsoftware.kryo.Kryo
 import com.esotericsoftware.kryo.io.{Input, Output}
+import com.fasterxml.jackson.core.JsonGenerator
 
 import org.apache.spark.rdd.RDD
+import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.execution.CodegenSupport
+import org.apache.spark.sql.execution.datasources.json.{JSONOptions, JacksonGenerator}
+
 
 object TypeUtilities {
 
@@ -103,4 +107,21 @@ object TypeUtilities {
     }
     props
   }
+
+  private[spark] val jacksonApply: (StructType, JsonGenerator,
+      InternalRow) => Unit = {
+    val applyMethod = JacksonGenerator.getClass.getMethods
+        .find(_.getName == "apply").get
+    applyMethod.getParameterCount match {
+      case 3 => // Spark 2.0.0
+        (rowSchema: StructType, gen: JsonGenerator, row: InternalRow) =>
+          applyMethod.invoke(JacksonGenerator, rowSchema,
+            gen, row).asInstanceOf[Unit]
+      case 4 => // Spark 2.0.2
+        (rowSchema: StructType, gen: JsonGenerator, row: InternalRow) =>
+          applyMethod.invoke(JacksonGenerator, rowSchema, gen,
+            new JSONOptions(Map.empty[String, String]), row).asInstanceOf[Unit]
+    }
+  }
+
 }

--- a/core/src/test/scala/org/apache/spark/sql/store/SnappyCatalogSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/store/SnappyCatalogSuite.scala
@@ -403,7 +403,7 @@ abstract class CatalogTestUtils {
   def newTable(name: String, db: String): CatalogTable = newTable(name, Some(db))
 
   def newTable(name: String, database: Option[String] = None): CatalogTable = {
-    CatalogTable(
+      CatalogTable(
       identifier = TableIdentifier(name, database),
       tableType = CatalogTableType.EXTERNAL,
       storage = storageFormat,
@@ -413,7 +413,10 @@ abstract class CatalogTestUtils {
         CatalogColumn("a", "int"),
         CatalogColumn("b", "string")),
       partitionColumnNames = Seq("a", "b"),
-      bucketColumnNames = Seq("col1"))
+      bucketColumnNames = Seq("col1"),
+      // Pass the properties so that the hack applied in SnappyExternalCatalog.createTable
+      // takes affect
+      properties = Map("spark.sql.sources.provider" -> "column"))
   }
 
   def newFunc(name: String, database: Option[String] = None): CatalogFunction = {


### PR DESCRIPTION
## Changes proposed in this pull request

Snappy 0.7 should work with Spark versions >= 2.0.0 and versions < = 2.0.2 in connector mode. This PR fixes the issues related to that. 
- Changed the spark version for snappy-core to 2.0.0. 
- Copied three classes from Spark to Snappy as there is no compatibility between 2.0.0 and 2.0.2 versions of those classes. RunCommand, DescribeTableCommand, ExecutedCommandExec. 
- Added reflection to create JacksonGenerator object as its apply method has changed between two versions. 
- Added reflection to find out the parameter 'child' for CreateTableUsingAsSelect. 

## Patch testing
 
Clean precheckin. 
