### PR TITLE
Add support to start the snappy cluster using snappy-start-all sc…

### DIFF
--- a/dtests/src/test/java/io/snappydata/hydra/cluster/SnappyBB.java
+++ b/dtests/src/test/java/io/snappydata/hydra/cluster/SnappyBB.java
@@ -58,6 +58,7 @@ public class SnappyBB extends Blackboard {
     public static int primaryLocatorStarted;
     public static int doneFullResultSetValidation;
     public static int locatorsStarted;
+    public static int snappyClusterStarted;
     public static int leadsStarted;
     public static int sparkClusterStarted;
     public static int doneExecution;

--- a/dtests/src/test/java/io/snappydata/hydra/cluster/SnappyTest.java
+++ b/dtests/src/test/java/io/snappydata/hydra/cluster/SnappyTest.java
@@ -1817,7 +1817,6 @@ public class SnappyTest implements Serializable {
         tmpArr = getPrimaryLeadVM(cycleLeadVMTarget);
         List<ClientVmInfo> vmList;
         vmList = (List<ClientVmInfo>) (tmpArr[0]);
-        Log.getLogWriter().info("SS tempArray: " + tmpArr[0].toString());
         Set<String> myDirList = new LinkedHashSet<String>();
         myDirList = getFileContents("logDir_", myDirList);
         for (int i = 0; i < vmList.size(); i++) {
@@ -1964,7 +1963,7 @@ public class SnappyTest implements Serializable {
             if (num == 1) {
                 pb = new ProcessBuilder(snappyTest.getScriptLocation("snappy-start-all.sh"), "start");
                 log = new File(".");
-                String dest = log.getCanonicalPath() + File.separator + "snappyClusterSystem.log";
+                String dest = log.getCanonicalPath() + File.separator + "snappySystem.log";
                 File logFile = new File(dest);
                 snappyTest.executeProcess(pb, logFile);
                 snappyTest.recordSnappyProcessIDinNukeRun("LocatorLauncher");

--- a/dtests/src/test/java/io/snappydata/hydra/cluster/SnappyTest.java
+++ b/dtests/src/test/java/io/snappydata/hydra/cluster/SnappyTest.java
@@ -1817,6 +1817,7 @@ public class SnappyTest implements Serializable {
         tmpArr = getPrimaryLeadVM(cycleLeadVMTarget);
         List<ClientVmInfo> vmList;
         vmList = (List<ClientVmInfo>) (tmpArr[0]);
+        Log.getLogWriter().info("SS tempArray: " + tmpArr[0].toString());
         Set<String> myDirList = new LinkedHashSet<String>();
         myDirList = getFileContents("logDir_", myDirList);
         for (int i = 0; i < vmList.size(); i++) {
@@ -1949,6 +1950,31 @@ public class SnappyTest implements Serializable {
     public int getMyTid() {
         int myTid = RemoteTestModule.getCurrentThread().getThreadId();
         return myTid;
+    }
+
+
+    /**
+     * Start snappy cluster using snappy-start-all.sh script.
+     */
+    public static synchronized void HydraTask_startSnappyCluster() {
+        File log = null;
+        ProcessBuilder pb = null;
+        try {
+            int num = (int) SnappyBB.getBB().getSharedCounters().incrementAndRead(SnappyBB.snappyClusterStarted);
+            if (num == 1) {
+                pb = new ProcessBuilder(snappyTest.getScriptLocation("snappy-start-all.sh"), "start");
+                log = new File(".");
+                String dest = log.getCanonicalPath() + File.separator + "snappyClusterSystem.log";
+                File logFile = new File(dest);
+                snappyTest.executeProcess(pb, logFile);
+                snappyTest.recordSnappyProcessIDinNukeRun("LocatorLauncher");
+                snappyTest.recordSnappyProcessIDinNukeRun("ServerLauncher");
+                snappyTest.recordSnappyProcessIDinNukeRun("LeaderLauncher");
+            }
+        } catch (IOException e) {
+            String s = "problem occurred while retriving destination logFile path " + log;
+            throw new TestException(s, e);
+        }
     }
 
     /**

--- a/dtests/src/test/java/io/snappydata/hydra/northwind/startDualModeCluster.conf
+++ b/dtests/src/test/java/io/snappydata/hydra/northwind/startDualModeCluster.conf
@@ -74,7 +74,11 @@ INITTASK    taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = H
             runMode = always
             threadGroups = snappyThreads;
 
-INITTASK    taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = HydraTask_createAndStartSnappyLocator
+INITTASK    taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = HydraTask_startSnappyCluster
+            runMode = always
+            threadGroups = snappyThreads;
+
+/*INITTASK    taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = HydraTask_createAndStartSnappyLocator
             runMode = always
             threadGroups = locatorThreads;
 
@@ -84,7 +88,7 @@ INITTASK    taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = H
 
 INITTASK    taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = HydraTask_createAndStartSnappyLeader
             runMode = always
-            threadGroups = leadThreads;
+            threadGroups = leadThreads;*/
 
 INITTASK    taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = HydraTask_startSparkCluster
             runMode = always

--- a/dtests/src/test/java/io/snappydata/hydra/northwind/stopDualModeCluster.conf
+++ b/dtests/src/test/java/io/snappydata/hydra/northwind/stopDualModeCluster.conf
@@ -7,14 +7,17 @@ CLOSETASK   taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = H
 CLOSETASK   taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = HydraTask_stopSparkCluster
             threadGroups = snappyThreads;
 
-CLOSETASK   taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = HydraTask_stopSnappyLeader
+CLOSETASK   taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = HydraTask_stopSnappyCluster
+            threadGroups = snappyThreads;
+
+/*CLOSETASK   taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = HydraTask_stopSnappyLeader
             threadGroups = snappyThreads;
 
 CLOSETASK   taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = HydraTask_stopSnappyServers
             threadGroups = snappyThreads;
 
 CLOSETASK   taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = HydraTask_stopSnappyLocator
-            threadGroups = snappyThreads;
+            threadGroups = snappyThreads;*/
 
 CLOSETASK   taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = HydraTask_deleteSnappyConfig
             threadGroups = snappyThreads;


### PR DESCRIPTION
## Changes proposed in this pull request

- Added support to start the snappy cluster using snappy-start-all script
- Modified north wind tests to start the cluster using snappy-start-all and stop by using snappy-stop-all script

## Patch testing

Verified the changes by running few tests from northWind.bt

## ReleaseNotes.txt changes

NA

## Other PRs 

NO