### PR TITLE
Fix for SNAP-1269 to use user specified schema if present in case of …

### DIFF
--- a/core/src/main/scala/org/apache/spark/sql/SnappySession.scala
+++ b/core/src/main/scala/org/apache/spark/sql/SnappySession.scala
@@ -1019,7 +1019,11 @@ class SnappySession(@transient private val sc: SparkContext,
               userSpecifiedSchema = userSpecifiedSchema,
               partitionColumns = partitionColumns,
               options = params).write(mode, data)
-            (r, Some(r.schema))
+            if (None != userSpecifiedSchema) {
+              (r, Some(userSpecifiedSchema.get))
+            } else {
+              (r, Some(r.schema))
+            }
         }
     }
 

--- a/core/src/test/scala/org/apache/spark/sql/store/ColumnTableTest.scala
+++ b/core/src/test/scala/org/apache/spark/sql/store/ColumnTableTest.scala
@@ -17,15 +17,16 @@
 package org.apache.spark.sql.store
 
 import java.sql.DriverManager
+import java.util
 
 import scala.util.{Failure, Success, Try}
 
 import com.gemstone.gemfire.cache.{EvictionAction, EvictionAlgorithm}
-import com.gemstone.gemfire.internal.cache.PartitionedRegion
+import com.gemstone.gemfire.internal.cache.{GemFireCacheImpl, PartitionedRegion}
 import com.pivotal.gemfirexd.internal.engine.Misc
 import com.pivotal.gemfirexd.internal.impl.jdbc.EmbedConnection
 import com.pivotal.gemfirexd.internal.impl.sql.compile.ParserImpl
-import io.snappydata.SnappyFunSuite
+import io.snappydata.{SnappyTableStatsProviderService, SnappyFunSuite}
 import io.snappydata.core.{Data, TestData, TestData2}
 import org.apache.hadoop.hive.ql.parse.ParseDriver
 import org.scalatest.{BeforeAndAfter, BeforeAndAfterAll}
@@ -926,6 +927,7 @@ class ColumnTableTest
 
     val region = Misc.getRegionForTable(
       JDBCAppendableRelation.cachedBatchTableName(tableName).toUpperCase, true)
+    SnappyTableStatsProviderService.publishColumnTableRowCountStats()
     val entries = region.asInstanceOf[PartitionedRegion].getPrStats
         .getPRNumRowsInCachedBatches
 


### PR DESCRIPTION
## Changes proposed in this pull request
* Fix for SNAP-1269 to use user specified schema if present in case of create table as select otherwise schema of base table will be used

## Patch testing
* Written scala test and verified it 

## ReleaseNotes.txt changes

(Does this change require an entry in ReleaseNotes.txt? If yes, has it been added to it?) No

## Other PRs 
NA