### PR TITLE
Avoid bcnl

### DIFF
--- a/cluster/src/dunit/scala/org/apache/spark/sql/TPCHDUnitTest.scala
+++ b/cluster/src/dunit/scala/org/apache/spark/sql/TPCHDUnitTest.scala
@@ -55,7 +55,7 @@ object TPCHUtils {
     "q20", "q21", "q22")
 
   def createAndLoadTables(snc: SnappyContext, isSnappy: Boolean): Unit = {
-    val tpchDataPath = getClass.getResource("/TPCH").getPath
+    val tpchDataPath = getClass.getResource("/TPCH").getPath //"/data/wrk/w/TPCH/1GB" //
 
     val usingOptionString =
       s"""

--- a/cluster/src/test/scala/io/snappydata/benchmark/snappy/TPCH.scala
+++ b/cluster/src/test/scala/io/snappydata/benchmark/snappy/TPCH.scala
@@ -1,0 +1,1002 @@
+/*
+ * Copyright (c) 2016 SnappyData, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License. You
+ * may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License. See accompanying
+ * LICENSE file.
+ */
+package io.snappydata.benchmark.snappy
+
+trait TPCHBase {
+  type QUERY_TYPE = Seq[String] // we can add parameter type check later.
+}
+
+/**
+ * Original TPCH queries as per specification.
+ */
+trait TPCH extends TPCHBase {
+
+  def q1: String =
+    s"""
+       |select
+       |      l_returnflag,
+       |      l_linestatus,
+       |      sum(l_quantity) as sum_qty,
+       |      sum(l_extendedprice) as sum_base_price,
+       |      sum(l_extendedprice*(1-l_discount)) as sum_disc_price,
+       |      sum(l_extendedprice*(1-l_discount)*(1+l_tax)) as sum_charge,
+       |      avg(l_quantity) as avg_qty,
+       |      avg(l_extendedprice) as avg_price,
+       |      avg(l_discount) as avg_disc,
+       |      count(*) as count_order
+       |from
+       |      lineitem
+       |where
+       |      l_shipdate <= date '1998-12-01' - interval '[DELTA]' day (3)
+       |group by
+       |      l_returnflag,
+       |      l_linestatus
+       |order by
+       |      l_returnflag,
+       |      l_linestatus
+     """.stripMargin
+
+  def q1Tokens: QUERY_TYPE = Seq("date '1998-12-01' - interval '[DELTA]' day (3)")
+
+  def q2: String =
+    s"""
+       |select
+       |      s_acctbal,
+       |      s_name,
+       |      n_name,
+       |      p_partkey,
+       |      p_mfgr,
+       |      s_address,
+       |      s_phone,
+       |      s_comment
+       |from
+       |      part,
+       |      supplier,
+       |      partsupp,
+       |      nation,
+       |      region
+       |where
+       |      p_partkey = ps_partkey
+       |      and s_suppkey = ps_suppkey
+       |      and p_size = [SIZE]
+       |      and p_type like '%[TYPE]'
+       |      and s_nationkey = n_nationkey
+       |      and n_regionkey = r_regionkey
+       |      and r_name = '[REGION]'
+       |      and ps_supplycost = (
+       |      select
+       |          min(ps_supplycost)
+       |      from
+       |          partsupp, supplier,
+       |          nation, region
+       |      where
+       |          p_partkey = ps_partkey
+       |          and s_suppkey = ps_suppkey
+       |          and s_nationkey = n_nationkey
+       |          and n_regionkey = r_regionkey
+       |          and r_name = '[REGION]'
+       |      )
+       |order by
+       |      s_acctbal desc,
+       |      n_name,
+       |      s_name,
+       |      p_partkey
+     """.stripMargin
+
+  def q2Tokens: QUERY_TYPE = Seq("[SIZE]", "[TYPE]", "[REGION]")
+
+  def q3: String =
+    s"""
+       |select
+       |      l_orderkey,
+       |      sum(l_extendedprice*(1-l_discount)) as revenue,
+       |      o_orderdate,
+       |      o_shippriority
+       |from
+       |      customer,
+       |      orders,
+       |      lineitem
+       |where
+       |      c_mktsegment = '[SEGMENT]'
+       |      and c_custkey = o_custkey
+       |      and l_orderkey = o_orderkey
+       |      and o_orderdate < date '[DATE]'
+       |      and l_shipdate > date '[DATE]'
+       |group by
+       |      l_orderkey,
+       |      o_orderdate,
+       |      o_shippriority
+       |order by
+       |      revenue desc,
+       |      o_orderdate
+     """.stripMargin
+
+  def q3Tokens: QUERY_TYPE = Seq("[SEGMENT]", "date '[DATE]'")
+
+  def q4: String =
+    s"""
+       |select
+       |      o_orderpriority,
+       |      count(*) as order_count
+       |from
+       |      orders
+       |where
+       |      o_orderdate >= date '[DATE]'
+       |      and o_orderdate < date '[DATE] ' + interval '3' month
+       |      and exists (
+       |      select
+       |            *
+       |      from
+       |            lineitem
+       |      where
+       |            l_orderkey = o_orderkey
+       |            and l_commitdate < l_receiptdate
+       |      )
+       |group by
+       |      o_orderpriority
+       |order by
+       |      o_orderpriority
+     """.stripMargin
+
+  // note the additional space for interval token. date '[DATE] ' gets distinguished from
+  // date '[DATE]' and hence replaceAll doesn't changes it. Didn't wanted to get into
+  // regex here.
+  def q4Tokens: QUERY_TYPE = Seq("date '[DATE]'", "date '[DATE] ' + interval '3' month")
+
+  def q5: String =
+    s"""
+       |select
+       |      n_name,
+       |      sum(l_extendedprice * (1 - l_discount)) as revenue
+       |from
+       |      customer,
+       |      orders,
+       |      lineitem,
+       |      supplier,
+       |      nation,
+       |      region
+       |where
+       |      c_custkey = o_custkey
+       |      and l_orderkey = o_orderkey
+       |      and l_suppkey = s_suppkey
+       |      and c_nationkey = s_nationkey
+       |      and s_nationkey = n_nationkey
+       |      and n_regionkey = r_regionkey
+       |      and r_name = '[REGION]'
+       |      and o_orderdate >= date '[DATE]'
+       |      and o_orderdate < date '[DATE] ' + interval '1' year
+       |group by
+       |      n_name
+       |order by
+       |      revenue desc
+     """.stripMargin
+
+  def q5Tokens: QUERY_TYPE = Seq("[REGION]", "date '[DATE]'", "date '[DATE] ' + interval '1' year")
+
+  def q6: String =
+    s"""
+       |select
+       |      sum(l_extendedprice*l_discount) as revenue
+       |from
+       |      lineitem
+       |where
+       |      l_shipdate >= date '[DATE]'
+       |      and l_shipdate < date '[DATE] ' + interval '1' year
+       |      and l_discount between [DISCOUNT] - 0.01 and [DISCOUNT] + 0.01
+       |      and l_quantity < [QUANTITY]
+     """.stripMargin
+
+  def q6Tokens: QUERY_TYPE = Seq("[DISCOUNT]", "date '[DATE]'",
+    "date '[DATE] ' + interval '1' year", "[QUANTITY]")
+
+  def q7: String =
+    s"""
+       |select
+       |      supp_nation,
+       |      cust_nation,
+       |      l_year,
+       |      sum(volume) as revenue
+       |from (
+       |      select
+       |            n1.n_name as supp_nation,
+       |            n2.n_name as cust_nation,
+       |            extract(year from l_shipdate) as l_year,
+       |            l_extendedprice * (1 - l_discount) as volume
+       |      from
+       |            supplier,
+       |            lineitem,
+       |            orders,
+       |            customer,
+       |            nation n1,
+       |            nation n2
+       |      where
+       |            s_suppkey = l_suppkey
+       |            and o_orderkey = l_orderkey
+       |            and c_custkey = o_custkey
+       |            and s_nationkey = n1.n_nationkey
+       |            and c_nationkey = n2.n_nationkey
+       |            and (
+       |                  (n1.n_name = '[NATION1]' and n2.n_name = '[NATION2]')
+       |                or (n1.n_name = '[NATION2]' and n2.n_name = '[NATION1]')
+       |            )
+       |            and l_shipdate between date '1995-01-01' and date '1996-12-31'
+       |      ) as shipping
+       |group by
+       |      supp_nation,
+       |      cust_nation,
+       |      l_year
+       |order by
+       |      supp_nation,
+       |      cust_nation,
+       |      l_year
+     """.stripMargin
+
+  def q7Tokens: QUERY_TYPE = Seq("between date '1995-01-01' and date '1996-12-31'",
+    "extract(year from ",
+    "[NATION1]", "[NATION2]")
+
+  def q8: String =
+    s"""
+       |select
+       |      o_year,
+       |      sum(case
+       |            when nation = '[NATION]' then volume
+       |            else 0
+       |          end) / sum(volume) as mkt_share
+       |from (
+       |      select
+       |          extract(year from o_orderdate) as o_year,
+       |          l_extendedprice * (1-l_discount) as volume,
+       |          n2.n_name as nation
+       |      from
+       |          part,
+       |          supplier,
+       |          lineitem,
+       |          orders,
+       |          customer,
+       |          nation n1,
+       |          nation n2,
+       |          region
+       |      where
+       |          p_partkey = l_partkey
+       |          and s_suppkey = l_suppkey
+       |          and l_orderkey = o_orderkey
+       |          and o_custkey = c_custkey
+       |          and c_nationkey = n1.n_nationkey
+       |          and n1.n_regionkey = r_regionkey
+       |          and r_name = '[REGION]'
+       |          and s_nationkey = n2.n_nationkey
+       |          and o_orderdate between date '1995-01-01' and date '1996-12-31'
+       |          and p_type = '[TYPE]'
+       |      ) as all_nations
+       |group by
+       |      o_year
+       |order by
+       |      o_year
+     """.stripMargin
+
+  def q8Tokens: QUERY_TYPE = Seq("between date '1995-01-01' and date '1996-12-31'",
+    "extract(year from ",
+    "[NATION]", "[REGION]", "[TYPE]")
+
+  def q9: String =
+    s"""
+       |select
+       |      nation,
+       |      o_year,
+       |      sum(amount) as sum_profit
+       |from (
+       |      select
+       |          n_name as nation,
+       |          extract(year from o_orderdate) as o_year,
+       |          l_extendedprice * (1 - l_discount) - ps_supplycost * l_quantity as amount
+       |      from
+       |          part,
+       |          supplier,
+       |          lineitem,
+       |          partsupp,
+       |          orders,
+       |          nation
+       |      where
+       |          s_suppkey = l_suppkey
+       |          and ps_suppkey = l_suppkey
+       |          and ps_partkey = l_partkey
+       |          and p_partkey = l_partkey
+       |          and o_orderkey = l_orderkey
+       |          and s_nationkey = n_nationkey
+       |          and p_name like '%[COLOR]%'
+       |      ) as profit
+       |group by
+       |      nation,
+       |      o_year
+       |order by
+       |      nation,
+       |      o_year desc
+     """.stripMargin
+
+  def q9Tokens: QUERY_TYPE = Seq("extract(year from ","[COLOR]")
+
+  def q10: String =
+    s"""
+       |select
+       |      c_custkey,
+       |      c_name,
+       |      sum(l_extendedprice * (1 - l_discount)) as revenue,
+       |      c_acctbal,
+       |      n_name,
+       |      c_address,
+       |      c_phone,
+       |      c_comment
+       |from
+       |      customer,
+       |      orders,
+       |      lineitem,
+       |      nation
+       |where
+       |      c_custkey = o_custkey
+       |      and l_orderkey = o_orderkey
+       |      and o_orderdate >= date '[DATE]'
+       |      and o_orderdate < date '[DATE] ' + interval '3' month
+       |      and l_returnflag = 'R'
+       |      and c_nationkey = n_nationkey
+       |group by
+       |      c_custkey,
+       |      c_name,
+       |      c_acctbal,
+       |      c_phone,
+       |      n_name,
+       |      c_address,
+       |      c_comment
+       |order by
+       |      revenue desc
+     """.stripMargin
+
+  def q10Tokens: QUERY_TYPE = Seq("date '[DATE]'", "date '[DATE] ' + interval '3' month")
+
+  def q11: String =
+    s"""
+       |select
+       |      ps_partkey,
+       |      sum(ps_supplycost * ps_availqty) as value
+       |from
+       |      partsupp,
+       |      supplier,
+       |      nation
+       |where
+       |      ps_suppkey = s_suppkey
+       |      and s_nationkey = n_nationkey
+       |      and n_name = '[NATION]'
+       |group by
+       |      ps_partkey having
+       |      sum(ps_supplycost * ps_availqty) > (
+       |      select
+       |            sum(ps_supplycost * ps_availqty) * [FRACTION]
+       |      from
+       |            partsupp,
+       |            supplier,
+       |            nation
+       |      where
+       |            ps_suppkey = s_suppkey
+       |            and s_nationkey = n_nationkey
+       |            and n_name = '[NATION]'
+       |      )
+       |order by
+       |      value desc
+     """.stripMargin
+
+  def q11Tokens: QUERY_TYPE = Seq("[NATION]", "[FRACTION]")
+
+  def q12: String =
+    s"""
+       |select
+       |      l_shipmode,
+       |      sum(case
+       |            when o_orderpriority ='1-URGENT' or o_orderpriority ='2-HIGH'
+       |              then 1
+       |            else 0
+       |          end
+       |      ) as high_line_count,
+       |      sum(case
+       |            when o_orderpriority <> '1-URGENT' and o_orderpriority <> '2-HIGH'
+       |              then 1
+       |            else 0
+       |          end
+       |      ) as low_line_count
+       |from
+       |      orders,
+       |      lineitem
+       |where
+       |      o_orderkey = l_orderkey
+       |      and l_shipmode in ('[SHIPMODE1]', '[SHIPMODE2]')
+       |      and l_commitdate < l_receiptdate
+       |      and l_shipdate < l_commitdate
+       |      and l_receiptdate >= date '[DATE]'
+       |      and l_receiptdate < date '[DATE] ' + interval '1' year
+       |group by
+       |      l_shipmode
+       |order by
+       |      l_shipmode
+     """.stripMargin
+
+  def q12Tokens: QUERY_TYPE = Seq("[SHIPMODE1]", "[SHIPMODE2]", "date '[DATE]'",
+    "date '[DATE] ' + interval '1' year")
+
+  def q13: String =
+    s"""
+       |select
+       |      c_count,
+       |      count(*) as custdist
+       |from (
+       |      select
+       |            c_custkey,
+       |            count(o_orderkey) as c_count
+       |      from
+       |            customer left outer join orders on
+       |            c_custkey = o_custkey
+       |            and o_comment not like '%[WORD1]%[WORD2]%'
+       |      group by
+       |            c_custkey
+       |      ) as c_orders
+       |group by
+       |      c_count
+       |order by
+       |      custdist desc,
+       |      c_count desc
+     """.stripMargin
+
+  def q13Tokens: QUERY_TYPE = Seq("[WORD1]", "[WORD2]")
+
+  def q14: String =
+    s"""
+       |select
+       |      100.00 * sum(case
+       |                      when p_type like 'PROMO%'
+       |                        then l_extendedprice*(1-l_discount)
+       |                      else 0
+       |                   end
+       |      ) / sum(l_extendedprice * (1 - l_discount)) as promo_revenue
+       |from
+       |      lineitem,
+       |      part
+       |where
+       |      l_partkey = p_partkey
+       |      and l_shipdate >= date '[DATE]'
+       |      and l_shipdate < date '[DATE] ' + interval '1' month
+     """.stripMargin
+
+  def q14Tokens: QUERY_TYPE = Seq("date '[DATE]'", "date '[DATE] ' + interval '1' month")
+
+  def q15v: String =
+    s"""
+       |create view revenue[STREAM_ID] (supplier_no, total_revenue) as
+       |      select
+       |            l_suppkey as supplier_no,
+       |            sum(l_extendedprice * (1 - l_discount)) as total_revenue
+       |      from
+       |            lineitem
+       |      where
+       |            l_shipdate >= date '[DATE]'
+       |            and l_shipdate < date '[DATE] ' + interval '3' month
+       |      group by
+       |            l_suppkey
+     """.stripMargin
+
+  def q15vTokens: QUERY_TYPE = Seq("[STREAM_ID]", "date '[DATE]'",
+    "date '[DATE] ' + interval '3' month")
+
+  def q15: String =
+    s"""
+       |select
+       |      s_suppkey,
+       |      s_name,
+       |      s_address,
+       |      s_phone,
+       |      total_revenue
+       |from
+       |      supplier,
+       |      revenue[STREAM_ID]
+       |where
+       |      s_suppkey = supplier_no
+       |      and total_revenue = (
+       |      select
+       |            max(total_revenue)
+       |      from
+       |            revenue[STREAM_ID]
+       |      )
+       |order by
+       |      s_suppkey
+     """.stripMargin
+
+  def q15Tokens: QUERY_TYPE = Seq("[STREAM_ID]")
+
+  def q16: String =
+    s"""
+       |select
+       |      p_brand,
+       |      p_type,
+       |      p_size,
+       |      count(distinct ps_suppkey) as supplier_cnt
+       |from
+       |      partsupp,
+       |      part
+       |where
+       |      p_partkey = ps_partkey
+       |      and p_brand <> '[BRAND]'
+       |      and p_type not like '[TYPE]%'
+       |      and p_size in ([SIZE1], [SIZE2], [SIZE3], [SIZE4], [SIZE5], [SIZE6], [SIZE7], [SIZE8])
+       |      and ps_suppkey not in (
+       |      select
+       |            s_suppkey
+       |      from
+       |            supplier
+       |      where
+       |            s_comment like '%Customer%Complaints%'
+       |      )
+       |group by
+       |      p_brand,
+       |      p_type,
+       |      p_size
+       |order by
+       |      supplier_cnt desc,
+       |      p_brand,
+       |      p_type,
+       |      p_size
+     """.stripMargin
+
+  def q16Tokens: QUERY_TYPE = Seq("[BRAND]", "[TYPE]", "[SIZE1]", "[SIZE2]", "[SIZE3]", "[SIZE4]",
+    "[SIZE5]", "[SIZE6]", "[SIZE7]", "[SIZE8]")
+
+  def q17: String =
+    s"""
+       |select
+       |      sum(l_extendedprice) / 7.0 as avg_yearly
+       |      from
+       |      lineitem,
+       |      part
+       |where
+       |      p_partkey = l_partkey
+       |      and p_brand = '[BRAND]'
+       |      and p_container = '[CONTAINER]'
+       |      and l_quantity < (
+       |      select
+       |            0.2 * avg(l_quantity)
+       |      from
+       |            lineitem
+       |      where
+       |            l_partkey = p_partkey
+       |      )
+     """.stripMargin
+
+  def q17Tokens: QUERY_TYPE = Seq("[BRAND]", "[CONTAINER]")
+
+  def q18: String =
+    s"""
+       |select
+       |      c_name,
+       |      c_custkey,
+       |      o_orderkey,
+       |      o_orderdate,
+       |      o_totalprice,
+       |      sum(l_quantity)
+       |from
+       |      customer,
+       |      orders,
+       |      lineitem
+       |where
+       |      o_orderkey in (
+       |      select
+       |            l_orderkey
+       |      from
+       |            lineitem
+       |      group by
+       |            l_orderkey
+       |      having
+       |            sum(l_quantity) > [QUANTITY]
+       |      )
+       |      and c_custkey = o_custkey
+       |      and o_orderkey = l_orderkey
+       |group by
+       |      c_name,
+       |      c_custkey,
+       |      o_orderkey,
+       |      o_orderdate,
+       |      o_totalprice
+       |order by
+       |      o_totalprice desc,
+       |      o_orderdate
+     """.stripMargin
+
+  def q18Tokens: QUERY_TYPE = Seq("[QUANTITY]")
+
+  def q19: String =
+    s"""
+       |select
+       |      sum(l_extendedprice * (1 - l_discount) ) as revenue
+       |from
+       |      lineitem,
+       |      part
+       |where
+       |      (
+       |        p_partkey = l_partkey
+       |        and p_brand = '[BRAND1]'
+       |        and p_container in ( 'SM CASE', 'SM BOX', 'SM PACK', 'SM PKG')
+       |        and l_quantity >= [QUANTITY1] and l_quantity <= [QUANTITY1] + 10
+       |        and p_size between 1 and 5
+       |        and l_shipmode in ('AIR', 'AIR REG')
+       |        and l_shipinstruct = 'DELIVER IN PERSON'
+       |      )
+       |      or
+       |      (
+       |        p_partkey = l_partkey
+       |        and p_brand = '[BRAND2]'
+       |        and p_container in ('MED BAG', 'MED BOX', 'MED PKG', 'MED PACK')
+       |        and l_quantity >= [QUANTITY2] and l_quantity <= [QUANTITY2] + 10
+       |        and p_size between 1 and 10
+       |        and l_shipmode in ('AIR', 'AIR REG')
+       |        and l_shipinstruct = 'DELIVER IN PERSON'
+       |      )
+       |      or
+       |      (
+       |        p_partkey = l_partkey
+       |        and p_brand = '[BRAND3]'
+       |        and p_container in ( 'LG CASE', 'LG BOX', 'LG PACK', 'LG PKG')
+       |        and l_quantity >= [QUANTITY3] and l_quantity <= [QUANTITY3] + 10
+       |        and p_size between 1 and 15
+       |        and l_shipmode in ('AIR', 'AIR REG')
+       |        and l_shipinstruct = 'DELIVER IN PERSON'
+       |      )
+     """.stripMargin
+
+  def q19Tokens: QUERY_TYPE = Seq("[BRAND1]", "[QUANTITY1]",
+    "[BRAND2]", "[QUANTITY2]",
+    "[BRAND3]", "[QUANTITY3]")
+
+  def q20: String =
+    s"""
+       |select
+       |      s_name,
+       |      s_address
+       |from
+       |      supplier, nation
+       |where
+       |      s_suppkey in (
+       |      select
+       |            ps_suppkey
+       |      from
+       |            partsupp
+       |      where
+       |            ps_partkey in (
+       |              select
+       |                  p_partkey
+       |              from
+       |                  part
+       |              where
+       |                  p_name like '[COLOR]%'
+       |            )
+       |      and ps_availqty > (
+       |              select
+       |                  0.5 * sum(l_quantity)
+       |              from
+       |                  lineitem
+       |              where
+       |                  l_partkey = ps_partkey
+       |                  and l_suppkey = ps_suppkey
+       |                  and l_shipdate >= date '[DATE]'
+       |                  and l_shipdate < date '[DATE] ' + interval '1' year
+       |            )
+       |      )
+       |      and s_nationkey = n_nationkey
+       |      and n_name = '[NATION]'
+       |order by
+       |      s_name
+     """.stripMargin
+
+  def q20Tokens: QUERY_TYPE = Seq("[COLOR]", "date '[DATE]'",
+    "date '[DATE] ' + interval '1' year", "[NATION]")
+
+  def q21: String =
+    s"""
+       |select
+       |      s_name,
+       |      count(*) as numwait
+       |from
+       |      supplier,
+       |      lineitem l1,
+       |      orders,
+       |      nation
+       |where
+       |      s_suppkey = l1.l_suppkey
+       |      and o_orderkey = l1.l_orderkey
+       |      and o_orderstatus = 'F'
+       |      and l1.l_receiptdate > l1.l_commitdate
+       |      and exists (
+       |            select
+       |                *
+       |            from
+       |                lineitem l2
+       |            where
+       |                l2.l_orderkey = l1.l_orderkey
+       |                and l2.l_suppkey <> l1.l_suppkey
+       |      )
+       |      and not exists (
+       |            select
+       |                *
+       |            from
+       |                lineitem l3
+       |            where
+       |                l3.l_orderkey = l1.l_orderkey
+       |                and l3.l_suppkey <> l1.l_suppkey
+       |                and l3.l_receiptdate > l3.l_commitdate
+       |      )
+       |      and s_nationkey = n_nationkey
+       |      and n_name = '[NATION]'
+       |group by
+       |      s_name
+       |order by
+       |      numwait desc,
+       |      s_name
+   """.stripMargin
+
+  def q21Tokens: QUERY_TYPE = Seq("[NATION]")
+
+  def q22: String =
+    s"""
+       |select
+       |      cntrycode,
+       |      count(*) as numcust,
+       |      sum(c_acctbal) as totacctbal
+       |from (
+       |      select
+       |          substring(c_phone from 1 for 2) as cntrycode,
+       |          c_acctbal
+       |      from
+       |          customer
+       |      where
+       |          substring(c_phone from 1 for 2) in
+       |            ('[I1]','[I2]','[I3]','[I4]','[I5]','[I6]','[I7]')
+       |          and c_acctbal > (
+       |                  select
+       |                      avg(c_acctbal)
+       |                  from
+       |                      customer
+       |                  where
+       |                      c_acctbal > 0.00
+       |                      and substring(c_phone from 1 for 2) in
+       |                        ('[I1]','[I2]','[I3]','[I4]','[I5]','[I6]','[I7]')
+       |          )
+       |          and not exists (
+       |                  select
+       |                      *
+       |                  from
+       |                      orders
+       |                  where
+       |                      o_custkey = c_custkey
+       |          )
+       |      ) as custsale
+       |group by
+       |      cntrycode
+       |order by
+       |      cntrycode
+     """.stripMargin
+
+  def q22Tokens: QUERY_TYPE = Seq("substring(c_phone from 1 for 2)", "[I1]", "[I2]", "[I3]",
+    "[I4]", "[I5]", "[I6]", "[I7]")
+
+
+}
+
+trait Adapter extends TPCHBase {
+  protected val qNumPattern = "(\\d+)(.*)".r
+  val viewName = "(?s)\\W+(create\\s+view\\s+)(\\w+)(.*?as)(.*)".r
+
+  protected val defaults = Map(
+    " 1 0 " -> "90",
+    " 2 0 " -> "24",
+    " 2 1 " -> "STEEL",
+    " 2 2 " -> "ASIA",
+    " 3 0 " -> "BUILDING",
+    " 3 1 " -> "1995-03-15",
+    " 4 0 " -> "1993-07-01",
+    " 4 1 " -> "1993-07-01",
+    " 5 0 " -> "ASIA",
+    " 5 1 " -> "1994-01-01",
+    " 5 2 " -> "1994-01-01",
+    " 6 0 " -> "0.06",
+    " 6 1 " -> "1994-01-01",
+    " 6 2 " -> "1994-01-01",
+    " 6 3 " -> "24",
+    " 7 0 " -> "<<<string replace>>>",
+    " 7 1 " -> "<<<string replace>>>",
+    " 7 2 " -> "FRANCE",
+    " 7 3 " -> "GERMANY",
+    " 8 0 " -> "<<<string replace>>>",
+    " 8 1 " -> "<<<string replace>>>",
+    " 8 2 " -> "BRAZIL",
+    " 8 3 " -> "AMERICA",
+    " 8 4 " -> "ECONOMY ANODIZED STEEL",
+    " 9 0 " -> "<<<string replace>>>",
+    " 9 1 " -> "green",
+    "10 0 " -> "1993-10-01",
+    "10 1 " -> "1993-10-01",
+    "11 0 " -> "GERMANY",
+    "11 1 " -> "0.0001",
+    "12 0 " -> "MAIL",
+    "12 1 " -> "SHIP",
+    "12 2 " -> "1994-01-01",
+    "12 3 " -> "1994-01-01",
+    "13 0 " -> "special",
+    "13 1 " -> "requests",
+    "14 0 " -> "1995-09-01",
+    "14 1 " -> "1995-09-01",
+    "15 0 " -> "_1",
+    "15v 0 " -> "_1",
+    "15v 1 " -> "1996-01-01",
+    "15v 2 " -> "1996-01-01",
+    "16 0 " -> "Brand#45",
+    "16 1 " -> "MEDIUM POLISHED",
+    "16 2 " -> "49",
+    "16 3 " -> "14",
+    "16 4 " -> "23",
+    "16 5 " -> "45",
+    "16 6 " -> "19",
+    "16 7 " -> "3",
+    "16 8 " -> "36",
+    "16 9 " -> "9",
+    "17 0 " -> "Brand#23",
+    "17 1 " -> "SM PACK",
+    "18 0 " -> "300",
+    "19 0 " -> "Brand#12",
+    "19 1 " -> "1",
+    "19 2 " -> "Brand#23",
+    "19 3 " -> "10",
+    "19 4 " -> "Brand#34",
+    "19 5 " -> "20",
+    "20 0 " -> "khaki",
+    "20 1 " -> "1994-01-01",
+    "20 2 " -> "1994-01-01",
+    "20 3 " -> "CANADA",
+    "21 0 " -> "VIETNAM",
+    "22 0 " -> "<<<<function override>>>>",
+    "22 1 " -> "13",
+    "22 2 " -> "31",
+    "22 3 " -> "23",
+    "22 4 " -> "29",
+    "22 5 " -> "30",
+    "22 6 " -> "18",
+    "22 7 " -> "17",
+    "" -> ""
+  )
+
+  def replace(qNum: String, tokens: QUERY_TYPE, queryStr: String, args: String*): String
+}
+
+
+trait DynamicQueryGetter extends TPCHBase {
+  self: Adapter =>
+
+  lazy val valAdapter: Adapter = self
+
+  final def deriveFromTokens(qNum: String, queryStr: String,
+      tokens: QUERY_TYPE, args: String*): String = {
+
+    val newArgs = if (args.isEmpty) args else {
+      tokens.zipWithIndex.sliding(2).flatMap(_.toList
+      match {
+        case (l, i) :: (r, _) :: Nil
+          if l.indexOf("date '[DATE]'") >= 0 && r.indexOf("date '[DATE] '") >= 0 =>
+          Seq(args(i), args(i))
+        case (_, i) :: _ if i < args.length =>
+          Seq(args(i))
+        case _ =>
+          Seq.empty
+      }).toList
+    }
+
+    def sideBySide(left: Seq[String], right: Seq[String]): Seq[String] = {
+      val maxLeftSize = left.map(_.length).max
+      val leftPadded = left ++ Seq.fill(math.max(right.size - left.size, 0))(" ")
+      val rightPadded = right ++ Seq.fill(math.max(left.size - right.size, 0))(" ")
+      leftPadded.zip(rightPadded).map {
+        case (l, r) => l + (" " * ((maxLeftSize - l.length) + 3)) + r
+      }
+    }
+
+    if (newArgs.nonEmpty && tokens.length != newArgs.length) {
+      val errorMessage = s"ERROR: Query $qNum has argument mismatch \n" +
+          s" ${sideBySide(tokens, newArgs).mkString("\n")} "
+      throw new Exception(errorMessage)
+    }
+
+    valAdapter.replace(qNum, tokens, queryStr, newArgs: _*)
+  }
+
+  /*
+    import scala.language.experimental.macros
+    def getFinalQueryString(qNum: Int, args: String*): String = macro TPCH.getQryStr_impl
+  */
+
+  def getFinalQueryString(qNum: String, args: String*): String = {
+    import scala.reflect.runtime.universe._
+    val _this = runtimeMirror(this.getClass.getClassLoader).reflect(this)
+    val qry = _this.symbol.typeSignature.member(s"q${qNum}": TermName)
+    val toks = _this.symbol.typeSignature.member(s"q${qNum}Tokens": TermName)
+
+    val qstr = _this.reflectMethod(qry.asMethod).apply()
+    val tokSeq = _this.reflectMethod(toks.asMethod).apply()
+
+    deriveFromTokens(qNum, qstr.asInstanceOf[String], tokSeq.asInstanceOf[QUERY_TYPE], args: _*)
+    /*
+        val ret = _this.reflectMethod(fn.asMethod)(qNum,
+          qstr.asInstanceOf[String], tokSeq.asInstanceOf[QUERY_TYPE],
+          args)
+
+        ret.asInstanceOf[String]
+    */
+  }
+
+  /*
+    def getFinalQueryString(qNum: Int, args: String*): String = {
+      import scala.reflect.runtime.universe._
+      import scala.tools.reflect.ToolBox
+
+      val tb = runtimeMirror(this.getClass.getClassLoader).mkToolBox()
+      val tokenTerm = typeOf[this.type].member(s"q${qNum}Tokens": TermName)
+      val queryTerm = typeOf[this.type].member(s"q${qNum}": TermName)
+      val deriveFromTokensTerm = typeOf[this.type].member("deriveFromTokens": TermName)
+      val self = q"this"
+
+      val ast =
+        q"""
+           $self.$deriveFromTokensTerm($qNum, $self.$tokenTerm, $self.$queryTerm, ..${args})
+         """
+      val xx = showCode(ast)
+
+      // scalastyle:off println
+      println(xx.toString)
+  /*
+      val compiled = tb.compile(tb.parse(s"""
+           $self.deriveFromTokensTerm($qNum, $self.q${qNum}Tokens, $self.q$qNum, ${args})
+         """))
+  */
+
+      val compiled = tb.compile(ast)
+      compiled().asInstanceOf[String]
+  /*
+      val dd = tb.compile(
+        q"""
+           $deriveFromTokensTerm($qNum, $tokenTerm, $queryTerm, ..${args})
+         """)
+      dd().asInstanceOf[String]
+  */
+    }
+  */
+
+}
+
+/*
+object TPCH {
+  import scala.reflect.macros.blackbox.Context
+  def getQryStr_impl(c: Context)(qNum: c.Expr[Int], args: c.Expr[String]*): c.Expr[String] = {
+    import c.universe._
+    reify(s
+             |      q${qNum}Tokens.zipWithIndex.foldLeft(q${qNum}) { case (src, (tok, i)) =>
+             |        replace($qNum, i, src, tok, ${args.tail: _*})
+             |      }
+     """)
+  }
+}
+*/

--- a/cluster/src/test/scala/io/snappydata/benchmark/snappy/TPCH_Snappy.scala
+++ b/cluster/src/test/scala/io/snappydata/benchmark/snappy/TPCH_Snappy.scala
@@ -84,7 +84,7 @@ object TPCH_Snappy {
     try {
       println(s"Started executing $queryNumber")
       if (isResultCollection) {
-        val resultSet = queryExecution(queryNumber, sqlContext, useIndex, true)
+        val (resultSet, _) = queryExecution(queryNumber, sqlContext, useIndex, true)
         println(s"$queryNumber : ${resultSet.length}")
 
         for (row <- resultSet) {
@@ -101,9 +101,9 @@ object TPCH_Snappy {
           val startTime = System.currentTimeMillis()
           var cnts: Array[Row] = null
           if (i == 1) {
-            cnts = queryExecution(queryNumber, sqlContext, useIndex, true)
+            cnts = queryExecution(queryNumber, sqlContext, useIndex, true)._1
           } else {
-            cnts = queryExecution(queryNumber, sqlContext, useIndex)
+            cnts = queryExecution(queryNumber, sqlContext, useIndex)._1
           }
           for (s <- cnts) {
             // just iterating over result
@@ -144,103 +144,103 @@ object TPCH_Snappy {
     // scalastyle:on println
   }
 
-  def queryExecution(queryNumber: String, sqlContext: SQLContext, useIndex: Boolean, genPlan:
-  Boolean = false):
-  scala.Array[org.apache.spark.sql.Row] = {
-    val cnts: scala.Array[org.apache.spark.sql.Row] = queryNumber match {
+  def queryExecution(queryNumber: String, sqlContext: SQLContext, useIndex: Boolean,
+      genPlan: Boolean = false): (scala.Array[org.apache.spark.sql.Row], DataFrame) = {
+    val df = queryNumber match {
       case "q1s" =>
-        val df = sqlContext.sql(getSampledQuery1)
-        df.collect()
+        sqlContext.sql(getSampledQuery1)
       case "q3s" =>
-        val df = sqlContext.sql(getSampledQuery3)
-        val cnt = df.collect()
-        cnt
+        sqlContext.sql(getSampledQuery3)
       case "q5s" =>
-        sqlContext.sql(getSampledQuery5).collect()
+        sqlContext.sql(getSampledQuery5)
       case "q6s" =>
-        sqlContext.sql(getSampledQuery6).collect()
+        sqlContext.sql(getSampledQuery6)
       case "q10s" =>
-        sqlContext.sql(getSampledQuery10).collect()
+        sqlContext.sql(getSampledQuery10)
       case "q1" =>
         val df = sqlContext.sql(getQuery1)
         if (genPlan) {
           printPlan(df, "Q1")
         }
-        df.collect()
+        df
       case "q2" =>
-        /*val result = sqlContext.sql(getTempQuery2())
+        /*
+        val result = sqlContext.sql(getTempQuery2())
         result.createOrReplaceTempView("ViewQ2")
-        val df = sqlContext.sql(getQuery2())*/
+        val df = sqlContext.sql(getQuery2())
+        */
         val df = sqlContext.sql(getQuery2_Original)
         if (genPlan) {
           printPlan(df, "Q2")
         }
-        df.collect()
+        df
       case "q3" =>
         val df = sqlContext.sql(getQuery3)
         if (genPlan) {
           printPlan(df, "Q3")
         }
-        df.collect()
+        df
       case "q4" =>
         val df = sqlContext.sql(getQuery4)
         if (genPlan) {
           printPlan(df, "Q4")
         }
-        df.collect()
+        df
       case "q5" =>
         val df = sqlContext.sql(getQuery5)
         if (genPlan) {
           printPlan(df, "Q5")
         }
-        df.collect()
+        df
       case "q6" =>
         val df = sqlContext.sql(getQuery6)
         if (genPlan) {
           printPlan(df, "Q6")
         }
-        df.collect()
+        df
       case "q7" =>
         val df = sqlContext.sql(getQuery7)
         if (genPlan) {
           printPlan(df, "Q7")
         }
-        df.collect()
+        df
       case "q8" =>
         val df = sqlContext.sql(getQuery8(useIndex))
         if (genPlan) {
           printPlan(df, "Q8")
         }
-        df.collect()
+        df
       case "q9" =>
         val df = sqlContext.sql(getQuery9(useIndex))
         if (genPlan) {
           printPlan(df, "Q9")
         }
-        df.collect()
+        df
       case "q10" =>
         val df = sqlContext.sql(getQuery10)
         if (genPlan) {
           printPlan(df, "Q10")
         }
-        df.collect()
+        df
       case "q11" =>
-       /*val result = sqlContext.sql(getTempQuery11)
-        val res: Array[Row] = result.collect()
-        var df: DataFrame = null
-        var res1: Array[Row] = null
-        df = sqlContext.sql(getQuery11(BigDecimal.apply(res(0).getDouble(0))))*/
+        /*
+         val result = sqlContext.sql(getTempQuery11)
+         val res: Array[Row] = result.collect()
+         var df: DataFrame = null
+         var res1: Array[Row] = null
+         df = sqlContext.sql(getQuery11(BigDecimal.apply(res(0).getDouble(0))))
+         */
         val df = sqlContext.sql(getQuery11_Original)
         if (genPlan) {
           printPlan(df, "Q11")
         }
-        df.collect()
+        df
       case "q12" =>
         val df = sqlContext.sql(getQuery12)
         if (genPlan) {
           printPlan(df, "Q12")
         }
-        df.collect()
+        df
       case "q13" =>
         /*
         val result = sqlContext.sql(getTempQuery13(useIndex))
@@ -251,13 +251,13 @@ object TPCH_Snappy {
         if (genPlan) {
           printPlan(df, "Q13")
         }
-        df.collect()
+        df
       case "q14" =>
         val df = sqlContext.sql(getQuery14(useIndex))
         if (genPlan) {
           printPlan(df, "Q14")
         }
-        df.collect()
+        df
       case "q15" =>
         val result = sqlContext.sql(getTempQuery15_1)
         result.createOrReplaceTempView("revenue")
@@ -266,34 +266,36 @@ object TPCH_Snappy {
         if (genPlan) {
           printPlan(df, "Q15")
         }
-        df.collect()
+        df
       case "q16" =>
         val df = sqlContext.sql(getQuery16)
         if (genPlan) {
           printPlan(df, "Q16")
         }
-        df.collect()
+        df
       case "q17" =>
-/*        val result = sqlContext.sql(getTempQuery17(useIndex))
+        /*
+        val result = sqlContext.sql(getTempQuery17(useIndex))
         result.createOrReplaceTempView("ViewQ17")
-        val df = sqlContext.sql(getQuery17(useIndex))*/
+        val df = sqlContext.sql(getQuery17(useIndex))
+        */
         val df = sqlContext.sql(getQuery17_Original)
         if (genPlan) {
           printPlan(df, "Q17")
         }
-        df.collect()
+        df
       case "q18" =>
         val df = sqlContext.sql(getQuery18)
         if (genPlan) {
           printPlan(df, "Q18")
         }
-        df.collect()
+        df
       case "q19" =>
         val df = sqlContext.sql(getQuery19(useIndex))
         if (genPlan) {
           printPlan(df, "Q19")
         }
-        df.collect()
+        df
       case "q20" =>
 //        val result = sqlContext.sql(getTempQuery20(useIndex))
 //        result.createOrReplaceTempView("ViewQ20")
@@ -301,21 +303,22 @@ object TPCH_Snappy {
         if (genPlan) {
           printPlan(df, "Q20")
         }
-        df.collect()
+        df
       case "q21" =>
         val df = sqlContext.sql(getQuery21)
         if (genPlan) {
           printPlan(df, "Q21")
         }
-        df.collect()
+        df
       case "q22" =>
         val df = sqlContext.sql(getQuery22_Original)
         if (genPlan) {
           printPlan(df, "Q22")
         }
-        df.collect()
+        df
     }
-    cnts
+
+    (df.collect(), df)
   }
 
 
@@ -1852,4 +1855,3 @@ object TPCH_Snappy {
   }
 
 }
-

--- a/cluster/src/test/scala/io/snappydata/benchmark/snappy/TPCH_Snappy.scala
+++ b/cluster/src/test/scala/io/snappydata/benchmark/snappy/TPCH_Snappy.scala
@@ -41,7 +41,7 @@ object TPCH_Snappy {
     val planFileName = if (isSnappy) "Plan_Snappy.out" else "Plan_Spark.out"
     val queryFileName = if (isSnappy) s"Snappy_${queryNumber}.out" else s"Spark_${queryNumber}.out"
 
-    if (planFileStream == null) {
+    if (planFileStream == null && planPrintStream == null) {
       planFileStream = new FileOutputStream(new File(planFileName))
       planPrintStream = new PrintStream(planFileStream)
     }
@@ -1327,7 +1327,7 @@ object TPCH_Snappy {
       "         p_size"
   }
 
-  def getQuery16Original: String = {
+  def getQuery16_Original: String = {
     //    1. BRAND = Brand#45.
     //    2. TYPE = MEDIUM POLISHED .
     //    3. SIZE1 = 49

--- a/cluster/src/test/scala/io/snappydata/benchmark/snappy/TPCH_Snappy.scala
+++ b/cluster/src/test/scala/io/snappydata/benchmark/snappy/TPCH_Snappy.scala
@@ -135,8 +135,12 @@ object TPCH_Snappy {
 
   def printPlan(df: DataFrame, query: String): Unit = {
     // scalastyle:off println
-    planPrintStream.println(query)
-    planPrintStream.println(df.queryExecution.executedPlan)
+    if (planPrintStream != null) {
+      planPrintStream.println(query)
+      planPrintStream.println(df.queryExecution.executedPlan)
+    } else {
+      df.explain(true)
+    }
     // scalastyle:on println
   }
 

--- a/cluster/src/test/scala/io/snappydata/benchmark/snappy/tpchmodifiers.scala
+++ b/cluster/src/test/scala/io/snappydata/benchmark/snappy/tpchmodifiers.scala
@@ -1,0 +1,155 @@
+/*
+ * Copyright (c) 2016 SnappyData, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License. You
+ * may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License. See accompanying
+ * LICENSE file.
+ */
+package io.snappydata.benchmark.snappy
+
+import scala.util.matching.Regex
+
+import org.apache.spark.sql.DataFrame
+import org.apache.spark.sql.catalyst.TableIdentifier
+import org.apache.spark.sql.catalyst.analysis.UnresolvedRelation
+import org.apache.spark.sql.catalyst.expressions.SubqueryExpression
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
+
+trait SnappyTPCH extends TPCH {
+  override def q3: String =
+    s"""
+       |${super.q3}
+       |limit 10
+     """.stripMargin
+}
+
+trait SnappyAdapter extends Adapter with DynamicQueryGetter {
+
+  type RETURN = (scala.Array[org.apache.spark.sql.Row], DataFrame)
+
+  protected val functionOverrides = Map(
+    " 1 0 " -> "DATE_SUB('1997-12-31',[VAL])",
+    " 7 0 " -> "between '1995-01-01' and '1996-12-31'",
+    " 8 0 " -> "between '1995-01-01' and '1996-12-31'",
+    "22 0 " -> "SUBSTR(C_PHONE,1,2)",
+    "" -> ""
+  )
+
+  override def replace(qNum: String, tokens: QUERY_TYPE, queryStr: String, args: String*):
+  String = {
+    tokens.zipWithIndex.foldLeft(queryStr) { case (src, (tok, i)) =>
+      replaceEach(qNum, i, src, tok, args: _*)
+    }
+  }
+
+  private def replaceEach(qNum: String,
+      tokNum: Int, query: String,
+      tok: String, args: String*): String = {
+
+    val qNumPattern(queryNumber, _) = qNum
+    val seek = (if (queryNumber.toInt < 10) " " else "") +
+        s"$qNum $tokNum" +
+        (if (tokNum < 10) " " else "")
+
+    def rep(newArg: String): String = query.replace(tok, newArg)
+
+    def modifyWith(arg: String) = {
+      functionModifier(tok).fold(rep(arg)) { r =>
+        rep(functionOverrides.getOrElse(seek, r)).replace("[VAL]", arg)
+      }
+    }
+
+    args.length match {
+      case 0 => modifyWith(defaults(seek))
+      case _ if tokNum < args.length => args(tokNum) match {
+        case s if s.isEmpty => modifyWith(defaults(seek))
+        case s => modifyWith(s)
+      }
+    }
+  }
+
+  private def functionModifier(tok: String): Option[String] = {
+    def find(elems: Array[String], str: String) = elems.indexWhere(_.indexOf(str) > 0)
+
+    tok match {
+      case t if t.startsWith("date") && t.indexOf("month") > 0 =>
+        val elems = t.split("'")
+        // println(s"${elems.mkString("--")} ${elems(find(elems, "interval") + 1)} ")
+        val interval = Integer.parseInt(elems(find(elems, "interval") + 1))
+        Some(s"ADD_MONTHS('[VAL]', $interval)")
+      case t if t.startsWith("date") && t.indexOf("year") > 0 =>
+        val elems = t.split("'")
+        // println(s"${elems.mkString("--")} ${elems(find(elems, "interval") + 1)} ")
+        val interval = 12 * Integer.parseInt(elems(find(elems, "interval") + 1))
+        Some(s"ADD_MONTHS('[VAL]', $interval)")
+      case t if t.startsWith("date") =>
+        Some("'[VAL]'")
+      case t if t.startsWith("substring") =>
+        Some("SUBSTR")
+      case t if t.startsWith("between") =>
+        Some("BETWEEN")
+      case t if t.startsWith("extract(year from ") =>
+        Some("YEAR(")
+      case _ => None
+    }
+  }
+
+  def estimateSizes(qNum: Int, tableSizes: Map[String, Long],
+      executor: (String) => DataFrame): Long = {
+    getQueryStrings(qNum, executor).foldLeft(0L) { case (sz, queryString) =>
+      // This is an indirect hack to estimate the size of each query's input by traversing the
+      // logical plan and adding up the sizes of all tables that appear in the plan. Note that this
+      // currently doesn't take WITH subqueries into account which might lead to fairly inaccurate
+      // per-row processing time for those cases.
+      val queryRelations = scala.collection.mutable.HashSet[String]()
+      executor(queryString).queryExecution.logical.map {
+        case ur@UnresolvedRelation(t: TableIdentifier, _) =>
+          queryRelations.add(t.table.toLowerCase)
+        case lp: LogicalPlan =>
+          lp.expressions.foreach {
+            _ foreach {
+              case subquery: SubqueryExpression =>
+                subquery.plan.foreach {
+                  case ur@UnresolvedRelation(t: TableIdentifier, _) =>
+                    queryRelations.add(t.table.toLowerCase)
+                  case _ =>
+                }
+              case _ =>
+            }
+          }
+        case _ =>
+      }
+      sz + queryRelations.map(tableSizes.getOrElse(_, 0L)).sum
+    }
+  }
+
+  def execute(qNum: Int, executor: (String) => DataFrame): RETURN = {
+    val df = executor(getQueryStrings(qNum, executor).last)
+    if (df == null) {
+      return (null, null)
+    }
+    (df.collect(), df)
+  }
+
+  private def getQueryStrings(qNum: Int, executor: (String) => DataFrame): Seq[String] = {
+    qNum match {
+      case 15 =>
+        val viewName(_, vn, _, viewQuery) = getFinalQueryString(s"${qNum}v")
+        val result = executor(viewQuery)
+        if (result == null) return "" :: Nil
+        result.createOrReplaceTempView(vn)
+        viewQuery :: getFinalQueryString(qNum.toString) :: Nil
+      case _ =>
+        getFinalQueryString(qNum.toString) :: Nil
+    }
+  }
+}

--- a/cluster/src/test/scala/org/apache/spark/sql/IndexTest.scala
+++ b/cluster/src/test/scala/org/apache/spark/sql/IndexTest.scala
@@ -1,0 +1,206 @@
+/*
+ * Copyright (c) 2016 SnappyData, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License. You
+ * may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License. See accompanying
+ * LICENSE file.
+ */
+package org.apache.spark.sql
+
+import java.util.TimeZone
+
+import com.pivotal.gemfirexd.internal.engine.db.FabricDatabase
+import io.snappydata.benchmark.snappy.{SnappyAdapter, SnappyTPCH, TPCH, TPCH_Snappy}
+import io.snappydata.{PlanTest, SnappyFunSuite}
+import org.scalatest.BeforeAndAfterEach
+
+import org.apache.spark.sql.catalyst.plans.logical.Sort
+import org.apache.spark.util.Benchmark
+
+class IndexTest extends SnappyFunSuite with PlanTest with BeforeAndAfterEach {
+  var existingSkipSPSCompile = false
+
+  override def beforeAll(): Unit = {
+    System.setProperty("org.codehaus.janino.source_debugging.enable", "true")
+    System.setProperty("spark.testing", "true")
+    existingSkipSPSCompile = FabricDatabase.SKIP_SPS_PRECOMPILE
+    FabricDatabase.SKIP_SPS_PRECOMPILE = true
+    super.beforeAll()
+  }
+
+  override def afterAll(): Unit = {
+    System.clearProperty("org.codehaus.janino.source_debugging.enable")
+    System.clearProperty("spark.testing")
+    FabricDatabase.SKIP_SPS_PRECOMPILE = existingSkipSPSCompile
+    super.afterAll()
+  }
+/*
+
+  test("dd") {
+    // scalastyle:off println
+    val toks = Seq("[dd]", "[dd1]", "date '[DATE]'", "date '[DATE]' + interval '1' year",
+      "[Quantity]", "[dd2]")
+
+    val args = Seq("y", "1-1-1999", "1", "zz")
+
+    val newArgs = toks.zipWithIndex.sliding(2).flatMap(_.toList match {
+      case (l, i) :: (r, _) :: Nil
+        if l.indexOf("date '[DATE]'") >= 0 && r.indexOf("date '[DATE]' ") >= 0 =>
+        Seq(args(i), args(i))
+      case (_, i) :: _ if i < args.length =>
+        Seq(args(i))
+      case x =>
+        Seq.empty
+    }).toList
+
+    def sideBySide(left: Seq[String], right: Seq[String]): Seq[String] = {
+      val maxLeftSize = left.map(_.length).max
+      val leftPadded = left ++ Seq.fill(math.max(right.size - left.size, 0))(" ")
+      val rightPadded = right ++ Seq.fill(math.max(left.size - right.size, 0))(" ")
+      leftPadded.zip(rightPadded).map {
+        case (l, r) => l + (" " * ((maxLeftSize - l.length) + 3)) + r
+      }
+    }
+
+    if(toks.length != newArgs.length) {
+      println(sideBySide(toks, newArgs).mkString("\n"))
+    }
+    println(newArgs)
+    // scalastyle:on println
+  }
+*/
+
+  test("tpch queries") {
+    // scalastyle:off println
+    val qryProvider = new TPCH with SnappyAdapter
+
+    val queries = Array("q1", "q2", "q3", "q4", "q5", "q6", "q7", "q8", "q9", "q10", "q11",
+      "q12", "q13", "q14", "q15", "q16", "q17", "q18", "q19",
+      "q20", "q21", "q22")
+
+    TPCHUtils.createAndLoadTables(snc, true)
+
+    val existing = snc.getConf(io.snappydata.Property.EnableExperimentalFeatures.name)
+    snc.setConf(io.snappydata.Property.EnableExperimentalFeatures.name, "true")
+
+    for ((q, i) <- queries.zipWithIndex)
+    {
+      val qNum = i + 1
+      val (expectedAnswer, _) = qryProvider.execute(qNum, str => {
+        snc.sql(str)
+      })
+      val (newAnswer, df) = TPCH_Snappy.queryExecution(q, snc, false, false)
+      val isSorted = df.logicalPlan.collect { case s: Sort => s }.nonEmpty
+      QueryTest.sameRows(expectedAnswer, newAnswer, isSorted).map { results =>
+        s"""
+           |Results do not match for query: $qNum
+           |Timezone: ${TimeZone.getDefault}
+           |Timezone Env: ${sys.env.getOrElse("TZ", "")}
+           |
+           |${df.queryExecution}
+           |== Results ==
+           |$results
+       """.stripMargin
+      }
+      println(s"Done $qNum")
+    }
+    snc.setConf(io.snappydata.Property.EnableExperimentalFeatures.name, existing)
+
+  }
+
+  test("Benchmark tpch") {
+
+    val queries = Array("q1", "q2", "q3", "q4", "q5", "q6", "q7", "q8", "q9", "q10", "q11",
+      "q12", "q13", "q14", "q15", "q16", "q17", "q18", "q19",
+      "q20", "q21", "q22")
+/*
+    val queries = Array("q1", "q2", "q3", "q4", "q5", "q6", "q7", "q8", "q9", "q10", "q11",
+      "q12", "q13", "q14", "q15", "q16", "q17", "q18", "q19",
+      "q20", "q21", "q22")
+*/
+
+    TPCHUtils.createAndLoadTables(snc, true)
+
+    snc.sql(s"""CREATE INDEX idx_orders_cust ON orders(o_custkey)
+             options (COLOCATE_WITH 'customer')
+          """)
+
+    snc.sql(s"""CREATE INDEX idx_lineitem_part ON lineitem(l_partkey)
+             options (COLOCATE_WITH 'part')
+          """)
+
+    val tables = Seq("nation", "region", "supplier", "customer", "orders", "lineitem", "part",
+      "partsupp")
+
+    val tableSizes = tables.map { tableName =>
+      (tableName, snc.table(tableName).count())
+    }.toMap
+
+    tableSizes.foreach(println)
+    queries.foreach(q => benchmark(q, tableSizes))
+
+    snc.sql(s"DROP INDEX idx_orders_cust")
+    snc.sql(s"DROP INDEX idx_lineitem_part")
+  }
+
+  private def benchmark(qNum: String, tableSizes: Map[String, Long]) = {
+
+    val qryProvider = new TPCH with SnappyAdapter
+    val query = qNum.substring(1).toInt
+    def executor(str: String) = snc.sql(str)
+
+    val size = qryProvider.estimateSizes(query, tableSizes, executor)
+    println(s"$qNum size $size")
+    val b = new Benchmark(s"JoinOrder optimization", size, minNumIters = 10)
+
+    def case1(): Unit = snc.setConf(io.snappydata.Property.EnableExperimentalFeatures.name,
+      "false")
+
+    def case2(): Unit = snc.setConf(io.snappydata.Property.EnableExperimentalFeatures.name,
+      "true")
+
+    def case3(): Unit = {
+      snc.setConf(io.snappydata.Property.EnableExperimentalFeatures.name,
+        "true")
+    }
+
+    def evalSnappyMods(genPlan: Boolean) = TPCH_Snappy.queryExecution(qNum, snc, useIndex = false,
+      genPlan = genPlan)._1.foreach(_ => ())
+
+    def evalBaseTPCH = qryProvider.execute(query, executor)
+
+
+    b.addCase(s"$qNum baseTPCH index = F", prepare = case1)(i => evalBaseTPCH)
+//    b.addCase(s"$qNum baseTPCH joinOrder = T", prepare = case2)(i => evalBaseTPCH)
+//    b.addCase(s"$qNum snappyMods joinOrder = F", prepare = case1)(i => evalSnappyMods(false))
+//    b.addCase(s"$qNum snappyMods joinOrder = T", prepare = case2)(i => evalSnappyMods(false))
+    b.addCase(s"$qNum baseTPCH index = T", prepare = case3)(i =>
+      evalBaseTPCH)
+    b.run()
+
+  }
+
+  test("northwind queries") {
+    println("")
+    //    val sctx = sc(c => c.set("spark.sql.inMemoryColumnarStorage.batchSize", "40000"))
+    //    val snc = getOrCreate(sctx)
+    //    NorthWindDUnitTest.createAndLoadColumnTables(snc)
+    //    val s = "select distinct shipcountry from orders"
+    //    snc.sql(s).show()
+    //    NWQueries.assertJoin(snc, NWQueries.Q42, "Q42", 22, 1, classOf[LocalJoin])
+    /*
+        Thread.sleep(1000 * 60 * 60)
+        NWQueries.assertJoin(snc, NWQueries.Q42, "Q42", 22, 1, classOf[LocalJoin])
+    */
+  }
+
+}

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -44,14 +44,25 @@ dependencies {
 
   // always use stock spark so that snappy extensions don't get accidently
   // included here in snappy-core code.
-  provided "org.apache.spark:spark-core_${scalaBinaryVersion}:${sparkVersion}"
-  provided "org.apache.spark:spark-catalyst_${scalaBinaryVersion}:${sparkVersion}"
-  provided "org.apache.spark:spark-sql_${scalaBinaryVersion}:${sparkVersion}"
-  provided "org.apache.spark:spark-hive_${scalaBinaryVersion}:${sparkVersion}"
-  provided "org.apache.spark:spark-streaming_${scalaBinaryVersion}:${sparkVersion}"
-  provided "org.apache.spark:spark-streaming-kafka-0-8_${scalaBinaryVersion}:${sparkVersion}"
-  provided "org.apache.spark:spark-mllib_${scalaBinaryVersion}:${sparkVersion}"
-  provided "org.eclipse.jetty:jetty-servlet:${jettyVersion}"
+  if (System.properties.containsKey('ideaBuild') && new File(rootDir, 'spark/build.gradle').exists()) {
+    compile project(':snappy-spark:snappy-spark-core_' + scalaBinaryVersion)
+    compile project(':snappy-spark:snappy-spark-catalyst_' + scalaBinaryVersion)
+    compile project(':snappy-spark:snappy-spark-sql_' + scalaBinaryVersion)
+    compile project(':snappy-spark:snappy-spark-hive_' + scalaBinaryVersion)
+    compile project(':snappy-spark:snappy-spark-streaming_' + scalaBinaryVersion)
+    compile project(':snappy-spark:snappy-spark-streaming-kafka-0.8_' + scalaBinaryVersion)
+    compile project(':snappy-spark:snappy-spark-mllib_' + scalaBinaryVersion)
+    provided "org.eclipse.jetty:jetty-servlet:${jettyVersion}"
+  } else {
+    provided "org.apache.spark:spark-core_${scalaBinaryVersion}:${sparkVersion}"
+    provided "org.apache.spark:spark-catalyst_${scalaBinaryVersion}:${sparkVersion}"
+    provided "org.apache.spark:spark-sql_${scalaBinaryVersion}:${sparkVersion}"
+    provided "org.apache.spark:spark-hive_${scalaBinaryVersion}:${sparkVersion}"
+    provided "org.apache.spark:spark-streaming_${scalaBinaryVersion}:${sparkVersion}"
+    provided "org.apache.spark:spark-streaming-kafka-0-8_${scalaBinaryVersion}:${sparkVersion}"
+    provided "org.apache.spark:spark-mllib_${scalaBinaryVersion}:${sparkVersion}"
+    provided "org.eclipse.jetty:jetty-servlet:${jettyVersion}"
+  }
 
   if (new File(rootDir, 'store/build.gradle').exists()) {
     compile project(':snappy-store:gemfirexd-client')

--- a/core/src/main/scala/io/snappydata/Literals.scala
+++ b/core/src/main/scala/io/snappydata/Literals.scala
@@ -318,17 +318,7 @@ object JOS extends Enumeration {
   val IncludeGeneratedPaths = Value("includeGeneratedPaths")
 
   /**
-   * Applies replicated table with filter conditions in the given order of preference in
-   * 'joinOrder' query hint comma separated values.
-   *
-   * for e.g. select * from tab --+ joinOrder(CWF, RWF, LCC, NCWF)
-   * will apply the rule in the mentioned order and rest of the rules will be skipped.
+   * Don't alter the join order provided by the user.
    */
-  val ReplicateWithFilters = Value("RWF")
-
-  val ColocatedWithFilters = Value("CWF")
-
-  val LargestColocationChain = Value("LCC")
-
-  val NonColocatedWithFilters = Value("NCWF")
+  val Fixed = Value("fixed")
 }

--- a/core/src/main/scala/org/apache/spark/sql/sources/RuleUtils.scala
+++ b/core/src/main/scala/org/apache/spark/sql/sources/RuleUtils.scala
@@ -26,12 +26,13 @@ import com.pivotal.gemfirexd.internal.engine.Misc
 import org.apache.spark.sql.hive.SnappyStoreHiveCatalog
 import org.apache.spark.sql.{AnalysisException, SnappySession}
 import org.apache.spark.sql.catalyst.analysis.{UnresolvedAlias, UnresolvedAttribute, UnresolvedFunction, UnresolvedGenerator, UnresolvedStar}
-import org.apache.spark.sql.catalyst.expressions.{AttributeReference, AttributeSet, Coalesce, Expression, Literal, PredicateHelper, SubqueryExpression, UnresolvedWindowExpression}
+import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeMap, AttributeReference, AttributeSet, Coalesce, Expression, Literal, PredicateHelper, SubqueryExpression, UnresolvedWindowExpression}
 import org.apache.spark.sql.catalyst.optimizer.ReorderJoin
 import org.apache.spark.sql.catalyst.planning.ExtractFiltersAndInnerJoins._
 import org.apache.spark.sql.catalyst.{expressions, plans}
 import org.apache.spark.sql.catalyst.plans.Inner
 import org.apache.spark.sql.catalyst.plans.logical.{Join, LogicalPlan, SubqueryAlias}
+import org.apache.spark.sql.collection.ToolsCallbackInit
 import org.apache.spark.sql.execution.columnar.impl.{BaseColumnFormatRelation, ColumnFormatRelation, IndexColumnFormatRelation}
 import org.apache.spark.sql.execution.datasources.LogicalRelation
 import org.apache.spark.sql.execution.row.RowFormatRelation
@@ -287,12 +288,22 @@ object Entity {
     )
   }.nonEmpty
 
+
+  def replaceAttribute(condition: Expression,
+      attributeMapping: Map[Attribute, Attribute]): Expression = {
+    condition.transformUp {
+      case a: Attribute =>
+        attributeMapping.find({
+          case (source, _) => source.exprId == a.exprId
+        }).map({ case (t, i) => i.withQualifier(t.qualifier) }).getOrElse(a)
+    }
+  }
 }
 
 object HasColocatedEntities {
 
   type ReturnType = (
-      Seq[(INDEX_RELATION, INDEX_RELATION)], Seq[ColocatedReplacements]
+      Seq[(INDEX_RELATION, INDEX_RELATION)], Seq[ReplacementSet]
       )
 
   def unapply(tables: (LogicalPlan, LogicalPlan))(implicit snappySession: SnappySession):
@@ -300,25 +311,25 @@ object HasColocatedEntities {
     val (left, right) = tables
 
     /** now doing a one-to-one mapping of lefttable and its indexes with
-      * right table and its indexes. Following example explains the combination
-      * generator.
-      *
-      * val l = Seq(1, 2, 3)
-      * val r = Seq(4, 5)
-      * l.zip(Seq.fill(l.length)(r)).flatMap {
-      * case (leftElement, rightList) => rightList.flatMap { e =>
-      * Seq((leftElement, e))
-      * }
-      * }.foreach(println)
-      * will output :
-      * (1, 4)
-      * (1, 5)
-      * (2, 4)
-      * (2, 5)
-      * (3, 4)
-      * (3, 5)
-      *
-      */
+     * right table and its indexes. Following example explains the combination
+     * generator.
+     *
+     * val l = Seq(1, 2, 3)
+     * val r = Seq(4, 5)
+     * l.zip(Seq.fill(l.length)(r)).flatMap {
+     * case (leftElement, rightList) => rightList.flatMap { e =>
+     * Seq((leftElement, e))
+     * }
+     * }.foreach(println)
+     * will output :
+     * (1, 4)
+     * (1, 5)
+     * (2, 4)
+     * (2, 5)
+     * (3, 4)
+     * (3, 5)
+     *
+     */
     val leftRightEntityMapping = for {
       (leftTable, leftIndexes) <- RuleUtils.fetchIndexes(snappySession, left)
       (rightTable, rightIndexes) <- RuleUtils.fetchIndexes(snappySession, right)
@@ -352,7 +363,7 @@ object HasColocatedEntities {
             Replacement(subquery, SubqueryAlias(alias, rightPlan))
         }
         ((leftRelation.get, rightRelation.get),
-            ColocatedReplacements(ArrayBuffer(leftReplacement, rightReplacement)))
+            ReplacementSet(ArrayBuffer(leftReplacement, rightReplacement), Seq.empty))
       }
     }
 
@@ -366,79 +377,169 @@ object HasColocatedEntities {
 }
 
 /**
-  * Table to table or Table to index replacement.
-  */
-case class Replacement(table: TABLE, index: INDEX) {
+ * Table to table or Table to index replacement.
+ */
+case class Replacement(table: TABLE, index: INDEX, isPartitioned: Boolean = true)
+    extends PredicateHelper {
+
+  def isReplacable: Boolean = table != index
+
+
+  val indexAttributes = index.output.collect { case ar: AttributeReference => ar }
+
+  val tableToIndexAttributeMap = AttributeMap(table.output.map {
+    case f: AttributeReference =>
+      val newA = indexAttributes.find(_.name.equalsIgnoreCase(f.name)).
+          getOrElse(throw new IllegalStateException(
+            s"Field $f not found in ${indexAttributes}"))
+      (f, newA)
+    case a => throw new AssertionError(s"UnHandled Attribute ${a} in table" +
+        s" ${table.output.mkString(",")}")
+  })
+
+  private var _replacedEntity: LogicalPlan = null
+
   def numPartitioningCols: Int = index match {
     case LogicalRelation(b: BaseColumnFormatRelation, _, _) => b.partitionColumns.length
     case _ => 0
   }
 
-  override def toString: String = (
-      table match {
-        case LogicalRelation(b: BaseColumnFormatRelation, _, _) => b.table
-        case _ => table.toString()
-      }) + " ----> " + (
-      index match {
-        case LogicalRelation(b: BaseColumnFormatRelation, _, _) => b.table
-        case LogicalRelation(r: RowFormatRelation, _, _) => r.table
-        case _ => index.toString()
-      })
-}
-
-object Replacement {
-  implicit val replacementOrd = Ordering[(Int, BigInt)].reverse.on[Replacement] { r => (
-      r.index.asInstanceOf[LogicalRelation].relation.asInstanceOf[BaseColumnFormatRelation]
-          .partitionColumns.length, r.index.statistics.sizeInBytes)
+  override def toString: String = {
+    "" + (table match {
+      case LogicalRelation(b: BaseColumnFormatRelation, _, _) => b.table
+      case _ => table.toString()
+    }) + " ----> " +
+        (index match {
+          case LogicalRelation(b: BaseColumnFormatRelation, _, _) => b.table
+          case LogicalRelation(r: RowFormatRelation, _, _) => r.table
+          case _ => index.toString()
+        })
   }
+
+  def mappedConditions(conditions: Seq[Expression]): Seq[Expression] =
+    conditions.map(Entity.replaceAttribute(_, tableToIndexAttributeMap))
+
+  protected[sources] def replacedPlan(conditions: Seq[Expression]): LogicalPlan = {
+    if (_replacedEntity == null) {
+      val tableConditions = conditions.filter(canEvaluate(_, table))
+      _replacedEntity = if (tableConditions.isEmpty) {
+        index
+      } else {
+        plans.logical.Filter(mappedConditions(tableConditions).reduce(expressions.And), index)
+      }
+    }
+    _replacedEntity
+  }
+
+  def estimatedSize(conditions: Seq[Expression]): BigInt =
+    replacedPlan(conditions).statistics.sizeInBytes
+
 }
 
-case class ColocatedReplacements private(chains: ArrayBuffer[Replacement]) {
+/**
+ * A set of possible replacements of table to indexes.
+ * <br>
+ * <strong>Note:</strong> The chain if consists of multiple partitioned tables, they must satisfy
+ * colocation criteria.
+ *
+ * @param chain      Multiple replacements.
+ * @param conditions user provided join + filter conditions.
+ */
+case class ReplacementSet(chain: ArrayBuffer[Replacement],
+    conditions: Seq[Expression])
+    extends Ordered[ReplacementSet] with PredicateHelper {
+
+  lazy val bestJoinOrder: Seq[Replacement] = {
+    val (part, rep) = chain.partition(_.isPartitioned)
+    // pick minimum number of replicated tables required to fulfill colocated join order.
+    val feasibleJoinPlan = Seq.range(0, chain.length - part.length + 1).flatMap(elem =>
+      rep.combinations(elem).map(part ++ _).
+        flatMap(_.permutations).filter(hasJoinConditions)).filter(_.nonEmpty)
+
+    if(feasibleJoinPlan.isEmpty) {
+      Seq.empty
+    } else {
+      val all = feasibleJoinPlan.sortBy { jo =>
+        estimateSize(jo)
+      }(implicitly[Ordering[BigInt]].reverse)
+
+      all.head
+    }
+  }
+
+  lazy val bestPlanEstimatedSize = estimateSize(bestJoinOrder)
+
+  lazy val bestJoinOrderConditions = joinConditions(bestJoinOrder)
+
+  private def joinConditions(joinOrder: Seq[Replacement]) = {
+    val refs = joinOrder.map(_.table.outputSet).reduce(_ ++ _)
+    conditions.filter(_.references.subsetOf(refs))
+  }
+
+  private def estimateSize(joinOrder: Seq[Replacement]): BigInt = {
+    if (joinOrder.isEmpty) {
+      return BigInt(0)
+    }
+    var newConditions = joinConditions(joinOrder)
+    newConditions = joinOrder.foldLeft(newConditions) { case (nc, e) =>
+      e.mappedConditions(nc)
+    }
+
+    val sz = joinOrder.map(_.replacedPlan(conditions)).zipWithIndex.foldLeft(BigInt(0)) {
+      case (tot, (table, depth)) if depth == 2 => tot + table.statistics.sizeInBytes
+      case (tot, (table, depth)) => tot + (table.statistics.sizeInBytes * depth)
+    }
+
+    sz
+  }
+
+  private def hasJoinConditions(replacements: Seq[Replacement]): Boolean = {
+    replacements.sliding(2).forall(_.toList match {
+      case table1 :: table2 :: _ =>
+        RuleUtils.getJoinKeys(table1.table, table2.table, conditions).nonEmpty
+      case _ => false
+    })
+  }
 
   override def equals(other: Any): Boolean = other match {
-    case cr: ColocatedReplacements if chains.nonEmpty & cr.chains.nonEmpty =>
-      Entity.isColocated(chains(0).index, cr.chains(0).index)
+    case cr: ReplacementSet if chain.nonEmpty & cr.chain.nonEmpty =>
+      Entity.isColocated(chain(0).index, cr.chain(0).index)
     case _ => false
   }
 
-  def merge(current: ColocatedReplacements): ColocatedReplacements = {
-    current.chains.foreach { r =>
-      chains.find(_.index == r.index) match {
-        case None => chains += r
+  def merge(current: ReplacementSet): ReplacementSet = {
+    current.chain.foreach { r =>
+      chain.find(_.index == r.index) match {
+        case None => chain += r
         case _ =>
       }
     }
-    chains.sorted
     this
   }
 
-  def numPartitioningColumns: Int = chains.headOption.map(_.numPartitioningCols).getOrElse(0)
+  def numPartitioningColumns: Int = chain.headOption.map(_.numPartitioningCols).getOrElse(0)
 
-  def estimatedSize: BigInt = chains.map(_.index.statistics.sizeInBytes).sum
+  override def toString: String = chain.mkString("\n")
 
-  override def toString: String = chains.mkString("\n")
+  override def compare(that: ReplacementSet): Int =
+    bestJoinOrder.length compareTo that.bestJoinOrder.length match {
+      case 0 => // for equal length chain, sort by smallest size
+        bestPlanEstimatedSize compare that.bestPlanEstimatedSize match {
+          // in case sizes are same (like in unit test we made it equal) pick the greater one
+          case 0 => -(bestJoinOrderConditions.length compare that.bestJoinOrderConditions.length)
+          case r => r
+        }
+      case c => -c // sort by largest chain
+    }
 }
 
 /**
-  * Captures chain of colocated group of table -> index replacements.
-  */
-object ColocatedReplacements {
-
-  val empty: ColocatedReplacements = new ColocatedReplacements(ArrayBuffer.empty[Replacement])
-
-  implicit val colocatedRepOrd = Ordering[(Int, Int, BigInt)].reverse.on[ColocatedReplacements] {
-    rep => (rep.chains.length, rep.numPartitioningColumns, rep.estimatedSize)
-  }
-
-}
-
-/**
-  * This we have to copy from spark patterns.scala because we want handle single table with
-  * filters as well.
-  *
-  * This will have another advantage later if we decide to move our rule to the last instead of
-  * injecting just after ReorderJoin, whereby additional nodes like Project requires handling.
-  */
+ * This we have to copy from spark patterns.scala because we want handle single table with
+ * filters as well.
+ *
+ * This will have another advantage later if we decide to move our rule to the last instead of
+ * injecting just after ReorderJoin, whereby additional nodes like Project requires handling.
+ */
 object ExtractFiltersAndInnerJoins extends PredicateHelper {
 
   // flatten all inner joins, which are next to each other
@@ -469,26 +570,26 @@ object ExtractFiltersAndInnerJoins extends PredicateHelper {
 }
 
 trait SubPlan {
-  def currentColocatedGroup: ColocatedReplacements =
+  def currentColocatedGroup: ReplacementSet =
     throw new AnalysisException("Unexpected call")
 }
 
 case class PartialPlan(curPlan: LogicalPlan, replaced: Seq[Replacement], outputSet: AttributeSet,
     input: Seq[LogicalPlan],
     conditions: Seq[Expression],
-    colocatedGroups: Seq[ColocatedReplacements],
+    colocatedGroups: Seq[ReplacementSet],
     partitioned: Seq[LogicalPlan],
     replicates: Seq[LogicalPlan],
     others: Seq[LogicalPlan]) extends SubPlan {
   var curColocatedIndex = 0
 
-  override def currentColocatedGroup: ColocatedReplacements = colocatedGroups(curColocatedIndex)
+  override def currentColocatedGroup: ReplacementSet = colocatedGroups(curColocatedIndex)
 
   override def toString: String = if (curPlan != null) curPlan.toString() else "No Plan yet"
 
   /**
-    * Apply on multiple entities one by one validating common conditions.
-    */
+   * Apply on multiple entities one by one validating common conditions.
+   */
   def /:[A](plansToApply: Seq[A])
       (specializedHandling: PartialFunction[(PartialPlan, A), PartialPlan])
       (implicit snappySession: SnappySession): SubPlan = {

--- a/core/src/main/scala/org/apache/spark/sql/sources/SnappyOptimizations.scala
+++ b/core/src/main/scala/org/apache/spark/sql/sources/SnappyOptimizations.scala
@@ -24,8 +24,9 @@ import io.snappydata.Constant
 import io.snappydata.QueryHint._
 
 import org.apache.spark.sql.SnappySession
-import org.apache.spark.sql.catalyst.expressions.{AttributeReference, AttributeSet, Expression,
-PredicateHelper}
+import org.apache.spark.sql.catalyst.expressions.{AttributeReference, AttributeSet, Expression, PredicateHelper}
+import org.apache.spark.sql.catalyst.optimizer.ReorderJoin
+import org.apache.spark.sql.catalyst.{expressions, plans}
 import org.apache.spark.sql.catalyst.plans.logical.{LogicalPlan, SubqueryAlias}
 import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.execution.PartitionedDataSourceScan
@@ -111,6 +112,18 @@ case class ResolveIndex(implicit val snappySession: SnappySession) extends Rule[
       conditions: Seq[Expression],
       visited: mutable.HashSet[LogicalPlan]): CompletePlan = {
 
+    if (input.size == 1) {
+      val table = input.head
+      val pTabOrIndex = RuleUtils.chooseIndexForFilter(table, conditions)
+      val replacement = if (conditions.nonEmpty) {
+        plans.logical.Filter(conditions.reduceLeft(expressions.And),
+          pTabOrIndex.map(_.index).getOrElse(table))
+      } else {
+        pTabOrIndex.map(_.index).getOrElse(table)
+      }
+      return CompletePlan(replacement, pTabOrIndex.toSeq)
+    }
+
     val joinOrderHints = JoinOrderStrategy.getJoinOrderHints
 
     type TableList = ArrayBuffer[LogicalPlan]
@@ -152,30 +165,75 @@ case class ResolveIndex(implicit val snappySession: SnappySession) extends Rule[
       joinPossibilities
     }
 
-    val colocationGroups = (ArrayBuffer.empty[ColocatedReplacements] /: colocationTrials) {
+    val colocationGroups = (ArrayBuffer.empty[ReplacementSet] /: colocationTrials) {
       case (mergedList, current) =>
-        mergedList.find(_ == current) match {
+        mergedList.find(_ equals current) match {
           case Some(existing) => existing.merge(current)
-          case None => mergedList += current
+          case None => mergedList += current.copy(conditions = conditions)
         }
         mergedList
-    }.sorted
+    }.sorted.toList
 
-    var curSubPlan: SubPlan = PartialPlan(null, Seq.empty, AttributeSet.empty, input,
-      conditions,
-      colocationGroups, partitioned, replicates, others)
-    for (rule <- joinOrderHints) {
-      val newPlan = rule(curSubPlan, true)
-      curSubPlan = newPlan
+    val (ncf, nonColocated) = partitioned.filterNot {
+      case _ if colocationGroups.isEmpty => false
+      case p => colocationGroups.head.chain.exists(_.table equals p)
+    }.partition(t => conditions.exists(canEvaluate(_, t)))
+
+
+    val nonColocatedWithFilters = ncf.map(r => RuleUtils.chooseIndexForFilter(r, conditions)
+        .getOrElse(Replacement(r, r)))
+
+    val replicatesWithColocated = ReplacementSet(replicates.map(r => Replacement(r, r, false)) ++
+        (if (colocationGroups.nonEmpty) colocationGroups.head.chain else Seq.empty), conditions)
+
+    val replicatesWithNonColocatedHavingFilters = nonColocatedWithFilters.map(nc =>
+      ReplacementSet(replicates.map(r => Replacement(r, r)) ++ Some(nc), conditions)).sorted
+
+    val smallerNC = replicatesWithNonColocatedHavingFilters.indexWhere(
+      _.bestPlanEstimatedSize < replicatesWithColocated.bestPlanEstimatedSize)
+
+    val finalJoinOrder = ArrayBuffer.empty[Replacement]
+    var newJoinConditions: Seq[Expression] = conditions
+
+    def mapReferences(conditions: Seq[Expression], r: Replacement): Seq[Expression] = {
+      r.mappedConditions(conditions)
     }
 
-    assert(curSubPlan.isInstanceOf[CompletePlan])
+    var curPlan = CompletePlan(null, Seq.empty)
+
+    // there are no Non-Colocated tables of lesser cost than colocation chain in consideration.
+    if (smallerNC == -1) {
+
+      finalJoinOrder ++= replicatesWithColocated.bestJoinOrder
+      curPlan = curPlan.copy(replaced = curPlan.replaced ++
+          replicatesWithColocated.bestJoinOrder.filter(_.isReplacable))
+      newJoinConditions = replicatesWithColocated.bestJoinOrder.
+          foldLeft(newJoinConditions)(mapReferences)
+
+      finalJoinOrder ++= nonColocatedWithFilters
+      curPlan = curPlan.copy(replaced = curPlan.replaced ++
+          nonColocatedWithFilters.filter(_.isReplacable))
+      newJoinConditions = nonColocatedWithFilters.foldLeft(newJoinConditions)(mapReferences)
+
+      finalJoinOrder ++= nonColocated.map(r => Replacement(r, r))
+    } else {
+      for (i <- 0 to smallerNC) {
+        // pack NC tables first.
+      }
+    }
+
+    val newInput = finalJoinOrder.map(_.index) ++
+        input.filterNot(i => finalJoinOrder.exists(_.table == i))
+
+    curPlan = curPlan.copy(plan = ReorderJoin.createOrderedJoin(newInput, newJoinConditions))
+
+
     // add to the visited list, as plan.flatMap is transformDown which results into child join
     // nodes coming in after outer join node is serviced by flattening. LogicalPlan is unique
     // objects and hence multiple aliasing to the same table shouldn't interfere with each other
     // in this lookup.
     input.foreach(visited += _)
-    curSubPlan.asInstanceOf[CompletePlan]
+    curPlan
   }
 
   /** Generating combinations of PRs 2 at a time and then evaluate colocation. if p1 -> p2 -> p3
@@ -426,10 +484,9 @@ case class ResolveIndex(implicit val snappySession: SnappySession) extends Rule[
     val visited = new mutable.HashSet[LogicalPlan]
 
     def notVisited(input: Seq[LogicalPlan]) = !input.exists(p => {
-      val rel = Entity.unwrapBaseColumnRelation(p)
       // already resolved to some index. lets not try anything here.
       // this is just for speed, where this rule gets executed so many times.
-      rel.isDefined && visited(p)
+      visited(p)
     })
 
     val newPlan = plan.transformDown {

--- a/core/src/main/scala/org/apache/spark/sql/sources/subrules.scala
+++ b/core/src/main/scala/org/apache/spark/sql/sources/subrules.scala
@@ -106,7 +106,7 @@ object JoinOrderStrategy {
   * largest colocated group.
   */
 case object Replicates extends JoinOrderStrategy {
-  override def shortName: String = JOS.ReplicateWithFilters
+  override def shortName: String = ""// JOS.ReplicateWithFilters
 
   implicit def addToDef(newPlan: PartialPlan, repTab: LogicalPlan): PartialPlan = newPlan.copy(
     replicates = newPlan.replicates.filterNot(_ == repTab))
@@ -120,7 +120,7 @@ case object Replicates extends JoinOrderStrategy {
   * Pick the current colocated group and put tables with filters with the currently built plan.
   */
 case object ColocatedWithFilters extends JoinOrderStrategy {
-  override def shortName: String = JOS.ColocatedWithFilters
+  override def shortName: String = ""// JOS.ColocatedWithFilters
 
   implicit def addToDef(newPlan: PartialPlan, replacement: Replacement): PartialPlan = newPlan
 
@@ -129,7 +129,7 @@ case object ColocatedWithFilters extends JoinOrderStrategy {
     if (partial.colocatedGroups.isEmpty) {
       partial
     } else {
-      (partial.currentColocatedGroup.chains /: partial) {
+      (partial.currentColocatedGroup.chain /: partial) {
         case a => RuleUtils.applyDefaultAction(a, true)
       }
     }
@@ -139,14 +139,14 @@ case object ColocatedWithFilters extends JoinOrderStrategy {
   * Put rest of the colocated table joins after applying ColocatedWithFilters.
   */
 case object LargestColocationChain extends JoinOrderStrategy {
-  override def shortName: String = JOS.LargestColocationChain
+  override def shortName: String = ""// JOS.LargestColocationChain
 
   override def apply(partial: PartialPlan, _ignored: Boolean)
       (implicit snappySession: SnappySession): SubPlan = {
     if (partial.colocatedGroups.isEmpty) {
       return partial
     }
-    (partial.currentColocatedGroup.chains /: partial) {
+    (partial.currentColocatedGroup.chain /: partial) {
       case (finalPlan, replacement: Replacement) =>
         val joinRefs = finalPlan.outputSet ++ replacement.table.outputSet
         val (pTabJoinConditions, otherJoinConditions) = RuleUtils.partitionBy(joinRefs,
@@ -172,7 +172,7 @@ case object LargestColocationChain extends JoinOrderStrategy {
   * join condition.
   */
 case object NonColocated extends JoinOrderStrategy {
-  override def shortName: String = JOS.NonColocatedWithFilters
+  override def shortName: String = ""// JOS.NonColocatedWithFilters
 
   implicit def addToDef(newPlan: PartialPlan, pTab: LogicalPlan): PartialPlan = newPlan.copy(
     partitioned = newPlan.partitioned.filterNot(_ == pTab))
@@ -186,7 +186,7 @@ case object NonColocated extends JoinOrderStrategy {
       // handling any of it because Spark is getting a CBO as we speak and we might have to redo
       // this logic anyway.
       val nonColocated = partial.partitioned.filter(p =>
-        !partial.currentColocatedGroup.chains.exists(_ != p))
+        !partial.currentColocatedGroup.chain.exists(_ != p))
 
       (nonColocated /: partial) { case a => RuleUtils.applyDefaultAction(a, withFilters) }
     } else {
@@ -221,12 +221,12 @@ case object ApplyRest extends JoinOrderStrategy {
   * This doesn't require any alteration to joinOrder as such.
   */
 case object ContinueOptimizations extends JoinOrderStrategy {
-  override def shortName: String = JOS.ContinueOptimizations
+  override def shortName: String = ""// JOS.ContinueOptimizations
 }
 
 /**
   * This hint too doesn't require any implementation as such.
   */
 case object IncludeGeneratedPaths extends JoinOrderStrategy {
-  override def shortName: String = JOS.IncludeGeneratedPaths
+  override def shortName: String = ""// JOS.IncludeGeneratedPaths
 }

--- a/core/src/test/scala/io/snappydata/SnappyFunSuite.scala
+++ b/core/src/test/scala/io/snappydata/SnappyFunSuite.scala
@@ -25,8 +25,6 @@ import io.snappydata.test.dunit.DistributedTestBase
 import io.snappydata.test.dunit.DistributedTestBase.{InitializeRun, WaitCriterion}
 import io.snappydata.util.TestUtils
 
-import org.apache.spark.SparkFunSuite
-import org.apache.spark.sql.catalyst.expressions.aggregate.AggregateExpression
 import org.apache.spark.sql.catalyst.expressions.{Alias, And, AttributeReference, EqualNullSafe, EqualTo, Exists, ExprId, Expression, ListQuery, PredicateHelper, PredicateSubquery, ScalarSubquery}
 import org.apache.spark.sql.catalyst.plans.logical.{Filter, Join, LogicalPlan, OneRowRelation, Sample}
 import org.apache.spark.sql.catalyst.util.sideBySide
@@ -219,8 +217,8 @@ trait PlanTest extends SnappyFunSuite with PredicateHelper {
         AttributeReference(a.name, a.dataType, a.nullable)(exprId = ExprId(0))
       case a: Alias =>
         Alias(a.child, a.name)(exprId = ExprId(0))
-      case ae: AggregateExpression =>
-        ae.copy(resultId = ExprId(0))
+//      case ae: AggregateExpression =>
+//        ae.copy(resultId = ExprId(0))
     }
   }
 

--- a/core/src/test/scala/io/snappydata/SnappyFunSuite.scala
+++ b/core/src/test/scala/io/snappydata/SnappyFunSuite.scala
@@ -24,6 +24,12 @@ import io.snappydata.core.{FileCleaner, LocalSparkConf}
 import io.snappydata.test.dunit.DistributedTestBase
 import io.snappydata.test.dunit.DistributedTestBase.{InitializeRun, WaitCriterion}
 import io.snappydata.util.TestUtils
+
+import org.apache.spark.SparkFunSuite
+import org.apache.spark.sql.catalyst.expressions.aggregate.AggregateExpression
+import org.apache.spark.sql.catalyst.expressions.{Alias, And, AttributeReference, EqualNullSafe, EqualTo, Exists, ExprId, Expression, ListQuery, PredicateHelper, PredicateSubquery, ScalarSubquery}
+import org.apache.spark.sql.catalyst.plans.logical.{Filter, Join, LogicalPlan, OneRowRelation, Sample}
+import org.apache.spark.sql.catalyst.util.sideBySide
 // scalastyle:off
 import org.scalatest.{BeforeAndAfterAll, FunSuite, Outcome, Retries}
 // scalastyle:on
@@ -183,5 +189,93 @@ abstract class SnappyFunSuite
     // scalastyle:off
     println(msg)
     // scalastyle:on
+  }
+}
+
+/**
+ * Provides helper methods for comparing plans.
+ * <br>
+ * <br><b>NOTE:</b></br> Copy of org.apache.spark.sql.catalyst.plans. PlanTest and converted to a
+ * trait for inclusion to SnappyFunSuite. Strictly speaking this should have been a trait in Spark
+ * itself but its an abstract class & parent to all spark tests. Later we can revisit how best
+ * we can reuse the spark test code.
+ */
+trait PlanTest extends SnappyFunSuite with PredicateHelper {
+  /**
+   * Since attribute references are given globally unique ids during analysis,
+   * we must normalize them to check if two different queries are identical.
+   */
+  protected def normalizeExprIds(plan: LogicalPlan) = {
+    plan transformAllExpressions {
+      case s: ScalarSubquery =>
+        s.copy(exprId = ExprId(0))
+      case e: Exists =>
+        e.copy(exprId = ExprId(0))
+      case l: ListQuery =>
+        l.copy(exprId = ExprId(0))
+      case p: PredicateSubquery =>
+        p.copy(exprId = ExprId(0))
+      case a: AttributeReference =>
+        AttributeReference(a.name, a.dataType, a.nullable)(exprId = ExprId(0))
+      case a: Alias =>
+        Alias(a.child, a.name)(exprId = ExprId(0))
+      case ae: AggregateExpression =>
+        ae.copy(resultId = ExprId(0))
+    }
+  }
+
+  /**
+   * Normalizes plans:
+   * - Filter the filter conditions that appear in a plan. For instance,
+   *   ((expr 1 && expr 2) && expr 3), (expr 1 && expr 2 && expr 3), (expr 3 && (expr 1 && expr 2)
+   *   etc., will all now be equivalent.
+   * - Sample the seed will replaced by 0L.
+   * - Join conditions will be resorted by hashCode.
+   */
+  private def normalizePlan(plan: LogicalPlan): LogicalPlan = {
+    plan transform {
+      case filter @ Filter(condition: Expression, child: LogicalPlan) =>
+        Filter(splitConjunctivePredicates(condition).map(rewriteEqual(_)).sortBy(_.hashCode())
+            .reduce(And), child)
+      case sample: Sample =>
+        sample.copy(seed = 0L)(true)
+      case join @ Join(left, right, joinType, condition) if condition.isDefined =>
+        val newCondition =
+          splitConjunctivePredicates(condition.get).map(rewriteEqual(_)).sortBy(_.hashCode())
+              .reduce(And)
+        Join(left, right, joinType, Some(newCondition))
+    }
+  }
+
+  /**
+   * Rewrite [[EqualTo]] and [[EqualNullSafe]] operator to keep order. The following cases will be
+   * equivalent:
+   * 1. (a = b), (b = a);
+   * 2. (a <=> b), (b <=> a).
+   */
+  private def rewriteEqual(condition: Expression): Expression = condition match {
+    case eq @ EqualTo(l: Expression, r: Expression) =>
+      Seq(l, r).sortBy(_.hashCode()).reduce(EqualTo)
+    case eq @ EqualNullSafe(l: Expression, r: Expression) =>
+      Seq(l, r).sortBy(_.hashCode()).reduce(EqualNullSafe)
+    case _ => condition // Don't reorder.
+  }
+
+  /** Fails the test if the two plans do not match */
+  protected def comparePlans(plan1: LogicalPlan, plan2: LogicalPlan) {
+    val normalized1 = normalizePlan(normalizeExprIds(plan1))
+    val normalized2 = normalizePlan(normalizeExprIds(plan2))
+    if (normalized1 != normalized2) {
+      fail(
+        s"""
+           |== FAIL: Plans do not match ===
+           |${sideBySide(normalized1.treeString, normalized2.treeString).mkString("\n")}
+         """.stripMargin)
+    }
+  }
+
+  /** Fails the test if the two expressions do not match */
+  protected def compareExpressions(e1: Expression, e2: Expression): Unit = {
+    comparePlans(Filter(e1, OneRowRelation), Filter(e2, OneRowRelation))
   }
 }

--- a/core/src/test/scala/org/apache/spark/sql/store/CreateIndexTest.scala
+++ b/core/src/test/scala/org/apache/spark/sql/store/CreateIndexTest.scala
@@ -26,7 +26,8 @@ import org.scalatest.BeforeAndAfterEach
 
 import org.apache.spark.sql.catalyst.expressions.{Ascending, Descending}
 import org.apache.spark.sql.execution.PartitionedPhysicalScan
-import org.apache.spark.sql.execution.columnar.impl.{ColumnFormatRelation, IndexColumnFormatRelation}
+import org.apache.spark.sql.execution.columnar.impl.{ColumnFormatRelation,
+IndexColumnFormatRelation}
 import org.apache.spark.sql.execution.datasources.LogicalRelation
 import org.apache.spark.sql.execution.joins.{LocalJoin, SortMergeJoinExec}
 import org.apache.spark.sql.execution.row.RowFormatRelation


### PR DESCRIPTION
## Changes proposed in this pull request

Fixing the join order determination based on cost per our discussion instead of heuristics based.
Added a generic way to compare base TPCH (per spec) with/without snappy changes with/without index in consideration.
Using spark benchmark framework for comparison .

## Patch testing

Compared with Snappy manual modified tpch queries and all are matching with results and plans show negligible impact.

Perf numbers generated using the checkedin set of csv data...

Table Sizes:
  (lineitem,4884)
  (nation,25)
  (supplier,10000)
  (customer,150000)
  (orders,200000)
  (region,5)
  (part,200000)
  (partsupp,200000)
```
  JoinOrder optimization:                  Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
  ------------------------------------------------------------------------------------------------
  q1 size 4884
  q1 baseTPCH index = F                           23 /   34          0.2        4711.7       1.0X
  q1 baseTPCH index = T                           21 /   35          0.2        4362.2       1.1X
  ------------------------------------------------------------------------------------------------
  q2 size 210030
  q2 baseTPCH index = F                           38 /   44          5.6         179.2       1.0X
  q2 baseTPCH index = T                           35 /   39          6.0         167.4       1.1X
  ------------------------------------------------------------------------------------------------
  q3 size 354884
  q3 baseTPCH index = F                           19 /   23         19.1          52.4       1.0X
  q3 baseTPCH index = T                           18 /   22         19.4          51.7       1.0X
  ------------------------------------------------------------------------------------------------
  q4 size 204884
  q4 baseTPCH index = F                           22 /   27          9.2         108.3       1.0X
  q4 baseTPCH index = T                           21 /   26          9.6         104.1       1.0X
  ------------------------------------------------------------------------------------------------
  q5 size 364914
  q5 baseTPCH index = F                           16 /   21         22.4          44.6       1.0X
  q5 baseTPCH index = T                           15 /   20         23.6          42.4       1.1X
  ------------------------------------------------------------------------------------------------
  q6 size 4884
  q6 baseTPCH index = F                            3 /    4          1.5         660.5       1.0X
  q6 baseTPCH index = T                            3 /    4          1.5         645.8       1.0X
  ------------------------------------------------------------------------------------------------
  q7 size 364909
  q7 baseTPCH index = F                           18 /   21         20.4          49.0       1.0X
  q7 baseTPCH index = T                           18 /   20         20.4          49.1       1.0X
  ------------------------------------------------------------------------------------------------
  q8 size 364914
  q8 baseTPCH index = F                           15 /   19         23.6          42.3       1.0X
  q8 baseTPCH index = T                           15 /   18         24.8          40.3       1.0X
  ------------------------------------------------------------------------------------------------
  q9 size 214909
  q9 baseTPCH index = F                           26 /   31          8.4         119.2       1.0X
  q9 baseTPCH index = T                           26 /   32          8.2         121.8       1.0X
  ------------------------------------------------------------------------------------------------
  q10 size 354909
  q10 baseTPCH index = F                          16 /   18         22.2          45.0       1.0X
  q10 baseTPCH index = T                          16 /   18         22.6          44.2       1.0X
  ------------------------------------------------------------------------------------------------
  q11 size 210025
  q11 baseTPCH index = F                          15 /   17         14.4          69.5       1.0X
  q11 baseTPCH index = T                          15 /   18         13.8          72.3       1.0X
  ------------------------------------------------------------------------------------------------
  q12 size 204884
  q12 baseTPCH index = F                          15 /   17         13.4          74.6       1.0X
  q12 baseTPCH index = T                          15 /   18         13.5          74.0       1.0X
  ------------------------------------------------------------------------------------------------
  q13 size 350000
  q13 baseTPCH index = F                          32 /   36         10.8          92.8       1.0X
  q13 baseTPCH index = T                          32 /   35         10.9          91.3       1.0X
  ------------------------------------------------------------------------------------------------
  q14 size 204884
  q14 baseTPCH index = F                          15 /   19         13.6          73.5       1.0X
  q14 baseTPCH index = T                          14 /   16         14.3          70.1       1.0X
  ------------------------------------------------------------------------------------------------
  q15 size 14884
  q15 baseTPCH index = F                          17 /   20          0.9        1148.9       1.0X
  q15 baseTPCH index = T                          17 /   22          0.9        1115.7       1.0X
  ------------------------------------------------------------------------------------------------
  q16 size 210000
  q16 baseTPCH index = F                          89 /   97          2.4         422.9       1.0X
  q16 baseTPCH index = T                          88 /   99          2.4         418.6       1.0X
  ------------------------------------------------------------------------------------------------
  q17 size 204884
  q17 baseTPCH index = F                          16 /   24         12.5          80.2       1.0X
  q17 baseTPCH index = T                          15 /   17         13.7          73.0       1.1X
  ------------------------------------------------------------------------------------------------
  q18 size 354884
  q18 baseTPCH index = F                           9 /   11         39.9          25.1       1.0X
  q18 baseTPCH index = T                           9 /   10         41.7          24.0       1.0X
  ------------------------------------------------------------------------------------------------
  q19 size 204884
  q19 baseTPCH index = F                           6 /    8         33.5          29.8       1.0X
  q19 baseTPCH index = T                           6 /    8         32.6          30.7       1.0X
  ------------------------------------------------------------------------------------------------
  q20 size 210025
  q20 baseTPCH index = F                           6 /    7         33.2          30.1       1.0X
  q20 baseTPCH index = T                           6 /    7         33.6          29.8       1.0X
  ------------------------------------------------------------------------------------------------
  q21 size 214909
  q21 baseTPCH index = F                          23 /   25          9.3         107.5       1.0X
  q21 baseTPCH index = T                          24 /   26          9.1         110.2       1.0X
  ------------------------------------------------------------------------------------------------
  q22 size 350000
  q22 baseTPCH index = F                         162 /  172          2.2         464.0       1.0X
  q22 baseTPCH index = T                         162 /  172          2.2         461.5       1.0X
```

## ReleaseNotes.txt changes

(Does this change require an entry in ReleaseNotes.txt? If yes, has it been added to it?)

## Other PRs 

(Does this change require changes in other projects- store, spark, spark-jobserver, aqp? Add the links of PR of the other subprojects that are related to this change)
