### PR TITLE
If the ColumnBatchBuffer created is for sample table insertion, then …

### DIFF
--- a/core/src/main/scala/org/apache/spark/sql/execution/columnar/ColumnBatchCreator.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/columnar/ColumnBatchCreator.scala
@@ -167,7 +167,6 @@ trait ColumnBatchRowsBuffer {
 
   def endRows(): Unit
 
-  def setIsSampleData(): Unit
 }
 
 /**
@@ -183,7 +182,6 @@ case class CallbackColumnInsert(_schema: StructType)
 
   var bucketIdTerm: String = _
   var resetInsertions: String = _
-  var isSampleDataTerm: String = _
 
   override def inputRDDs(): Seq[RDD[InternalRow]] =
     throw new UnsupportedOperationException("unexpected invocation")
@@ -198,9 +196,7 @@ case class CallbackColumnInsert(_schema: StructType)
     // add bucketId variable set to -1 by default
     bucketIdTerm = ctx.freshName("bucketId")
     resetInsertions = ctx.freshName("resetInsertionsCount")
-    isSampleDataTerm = ctx.freshName("isSampleDataFlag")
     ctx.addMutableState("int", bucketIdTerm, s"$bucketIdTerm = -1;")
-    ctx.addMutableState("boolean", isSampleDataTerm, s"$isSampleDataTerm = false;")
     val columnsExpr = output.zipWithIndex.map { case (a, i) =>
       BoundReference(i, a.dataType, a.nullable)
     }
@@ -270,10 +266,6 @@ case class CallbackColumnInsert(_schema: StructType)
        |      // invoke the parent's processNext() that will just insert
        |      // the column batch created so far
        |      processNext();
-       |    }
-       |
-       |    public void setIsSampleData() {
-       |      $isSampleDataTerm = true;
        |    }
        |  };
        |}

--- a/core/src/main/scala/org/apache/spark/sql/execution/columnar/ColumnInsertExec.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/columnar/ColumnInsertExec.scala
@@ -61,6 +61,8 @@ case class ColumnInsertExec(_child: SparkPlan, partitionColumns: Seq[String],
 
   @transient private var batchBucketIdTerm: Option[String] = None
 
+  @transient private var isSampleDataTerm: Option[String] = None
+
   def columnBatchSize: Int = batchParams._1
 
   def columnMaxDeltaRows: Int = batchParams._2
@@ -110,6 +112,7 @@ case class ColumnInsertExec(_child: SparkPlan, partitionColumns: Seq[String],
              |}
           """.stripMargin)
         batchBucketIdTerm = Some(c.bucketIdTerm)
+        isSampleDataTerm = Some(c.isSampleDataTerm)
       case _ =>
     }
 
@@ -264,7 +267,8 @@ case class ColumnInsertExec(_child: SparkPlan, partitionColumns: Seq[String],
     }
     storeColumnBatchArgs = s"$batchSizeTerm, ${batchFunctionCall.toString()}"
     s"""
-       |if ($columnBatchSize > 0 && ($batchSizeTerm & $checkMask) == 0 &&
+       |if ( ${isSampleDataTerm.map(x => s"!$x && ").getOrElse("")}$columnBatchSize > 0 &&
+       |($batchSizeTerm & $checkMask) == 0 &&
        |    $batchSizeTerm > 0) {
        |  // check if batch size has exceeded max allowed
        |  long $sizeTerm = 0L;

--- a/core/src/main/scala/org/apache/spark/sql/execution/columnar/ColumnInsertExec.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/columnar/ColumnInsertExec.scala
@@ -61,8 +61,6 @@ case class ColumnInsertExec(_child: SparkPlan, partitionColumns: Seq[String],
 
   @transient private var batchBucketIdTerm: Option[String] = None
 
-  @transient private var isSampleDataTerm: Option[String] = None
-
   def columnBatchSize: Int = batchParams._1
 
   def columnMaxDeltaRows: Int = batchParams._2
@@ -112,7 +110,6 @@ case class ColumnInsertExec(_child: SparkPlan, partitionColumns: Seq[String],
              |}
           """.stripMargin)
         batchBucketIdTerm = Some(c.bucketIdTerm)
-        isSampleDataTerm = Some(c.isSampleDataTerm)
       case _ =>
     }
 
@@ -267,8 +264,7 @@ case class ColumnInsertExec(_child: SparkPlan, partitionColumns: Seq[String],
     }
     storeColumnBatchArgs = s"$batchSizeTerm, ${batchFunctionCall.toString()}"
     s"""
-       |if ( ${isSampleDataTerm.map(x => s"!$x && ").getOrElse("")}$columnBatchSize > 0 &&
-       |($batchSizeTerm & $checkMask) == 0 &&
+       |if ($columnBatchSize > 0 &&($batchSizeTerm & $checkMask) == 0 &&
        |    $batchSizeTerm > 0) {
        |  // check if batch size has exceeded max allowed
        |  long $sizeTerm = 0L;


### PR DESCRIPTION
…skipping the code of intermediate CachedBatch creation during processing of the rows, due to size limit violation
From the code of sampling , it appears to me that at the end of  folding of each segment of the reservoir, a new column batch is being created.  So the only thing needed is that during the processing of the segment , a new CachedBatch should not get created. For that setting a Flag in ColumnBatchBuffer which if true, will by pass the code of storage of the StoreColumnBatch on violation of the size . This flag is set to true in the ColumnFormatSamplingRelation.
 
The pull request in AQP is 
[AQP-273](https://github.com/SnappyDataInc/snappy-aqp/pull/140)
## Changes proposed in this pull request

(Fill in the changes here)

## Patch testing

(Fill in the details about how this patch was tested)

## ReleaseNotes.txt changes

(Does this change require an entry in ReleaseNotes.txt? If yes, has it been added to it?)

## Other PRs 

(Does this change require changes in other projects- store, spark, spark-jobserver, aqp? Add the links of PR of the other subprojects that are related to this change)
