### PR TITLE
[SNAP-1372] Fixing two issues identified when running NorthWind Q27

### DIFF
--- a/core/src/main/scala/org/apache/spark/sql/execution/columnar/ColumnBatchCreator.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/columnar/ColumnBatchCreator.scala
@@ -111,7 +111,7 @@ final class ColumnBatchCreator(
         references(batchIdRef + 2) = tableName
         // no harm in passing a references array with an extra element at end
         val iter = gen._1.generate(references).asInstanceOf[BufferedRowIterator]
-        iter.init(0, Array(execRows.asInstanceOf[Iterator[InternalRow]]))
+        iter.init(bucketID, Array(execRows.asInstanceOf[Iterator[InternalRow]]))
         while (iter.hasNext) {
           iter.next() // ignore result which is number of inserted rows
         }

--- a/core/src/main/scala/org/apache/spark/sql/execution/columnar/ColumnInsertExec.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/columnar/ColumnInsertExec.scala
@@ -16,7 +16,6 @@
  */
 package org.apache.spark.sql.execution.columnar
 
-import org.apache.spark.TaskContext
 import org.apache.spark.sql.catalyst.expressions.codegen.{CodegenContext, ExprCode, GenerateUnsafeProjection}
 import org.apache.spark.sql.catalyst.expressions.{Attribute, BoundReference, Expression, Literal}
 import org.apache.spark.sql.catalyst.util.{SerializedArray, SerializedMap, SerializedRow}
@@ -181,7 +180,6 @@ case class ColumnInsertExec(_child: SparkPlan, partitionColumns: Seq[String],
     val sizeTerm = ctx.freshName("size")
 
     val encoderClass = classOf[ColumnEncoder].getName
-    val taskContextClass = classOf[TaskContext].getName
     val buffersCode = new StringBuilder
     val batchFunctionDeclarations = new StringBuilder
     val batchFunctionCall = new StringBuilder
@@ -211,7 +209,7 @@ case class ColumnInsertExec(_child: SparkPlan, partitionColumns: Seq[String],
     batchIdRef = ctx.references.length
     val batchUUID = ctx.addReferenceObj("batchUUID", None,
       classOf[Option[_]].getName)
-    val partitionIdCode = if (partitioned) s"$taskContextClass.getPartitionId()"
+    val partitionIdCode = if (partitioned) "partitionIndex"
     else {
       // check for bucketId variable if available
       batchBucketIdTerm.getOrElse(

--- a/core/src/main/scala/org/apache/spark/sql/execution/columnar/JDBCSourceAsStore.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/columnar/JDBCSourceAsStore.scala
@@ -97,6 +97,7 @@ class JDBCSourceAsStore(override val connProperties: ConnectionProperties,
           columnPosition += 1
         }
         stmt.executeUpdate()
+        connection.commit()
         stmt.close()
       }
     }

--- a/core/src/main/scala/org/apache/spark/sql/execution/columnar/JDBCSourceAsStore.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/columnar/JDBCSourceAsStore.scala
@@ -75,9 +75,8 @@ class JDBCSourceAsStore(override val connProperties: ConnectionProperties,
       closeOnSuccess = true, onExecutor = true)
   }
 
-  protected def getPartitionID(tableName: String,
-      partitionId: Int = -1): Int = {
-    rand.nextInt(numPartitions)
+  protected def getPartitionID(tableName: String, partitionId: Int): Int = {
+    if (partitionId < 0) rand.nextInt(numPartitions) else partitionId
   }
 
   protected def doInsert(tableName: String, batch: ColumnBatch,

--- a/core/src/main/scala/org/apache/spark/sql/execution/columnar/JDBCSourceAsStore.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/columnar/JDBCSourceAsStore.scala
@@ -97,7 +97,6 @@ class JDBCSourceAsStore(override val connProperties: ConnectionProperties,
           columnPosition += 1
         }
         stmt.executeUpdate()
-        connection.commit()
         stmt.close()
       }
     }

--- a/core/src/main/scala/org/apache/spark/sql/execution/columnar/impl/JDBCSourceAsColumnarStore.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/columnar/impl/JDBCSourceAsColumnarStore.scala
@@ -79,63 +79,60 @@ class JDBCSourceAsColumnarStore(_connProperties: ConnectionProperties,
       batchId: Option[String], partitionId: Int,
       maxDeltaRows: Int): (Connection => Any) = {
     (connection: Connection) => {
-      connectionType match {
+      val resolvedName = ExternalStoreUtils.lookupName(tableName,
+        connection.getSchema)
+      // split the batch and put into row buffer if it is small
+      if (false && maxDeltaRows > 0 && batch.numRows < math.max(maxDeltaRows / 10,
+        GfxdConstants.SNAPPY_MIN_COLUMN_DELTA_ROWS)) {
+        // the lookup key depends only on schema and not on the table
+        // name since the prepared statement specific to the table is
+        // passed in separately through the references object
+        val gen = CodeGeneration.compileCode(
+          "COLUMN_TABLE.DECOMPRESS", schema.fields, () => {
+            val schemaAttrs = schema.toAttributes
+            val tableScan = ColumnTableScan(schemaAttrs, dataRDD = null,
+              otherRDDs = Seq.empty, numBuckets = -1,
+              partitionColumns = Seq.empty, partitionColumnAliases = Seq.empty,
+              baseRelation = null, schema, allFilters = Seq.empty, schemaAttrs)
+            val insertPlan = RowInsertExec(tableScan, upsert = true,
+              Seq.empty, Seq.empty, -1, schema, None, onExecutor = true,
+              resolvedName = null, connProperties)
+            // now generate the code with the help of WholeStageCodegenExec
+            // this is only used for local code generation while its RDD
+            // semantics and related methods are all ignored
+            val (ctx, code) = ExternalStoreUtils.codeGenOnExecutor(
+              WholeStageCodegenExec(insertPlan), insertPlan)
+            val references = ctx.references
+            // also push the index of connection reference at the end which
+            // will be used by caller to update connection before execution
+            references += insertPlan.statementRef
+            (code, references.toArray)
+          })
+        val refs = gen._2.clone()
+        // set the statement object for current execution
+        val statementRef = refs(refs.length - 1).asInstanceOf[Int]
+        val putSQL = JdbcExtendedUtils.getInsertOrPutString(resolvedName,
+          schema, upsert = true)
+        val stmt = connection.prepareStatement(putSQL)
+        refs(statementRef) = stmt
+        // no harm in passing a references array with extra element at end
+        val iter = gen._1.generate(refs).asInstanceOf[BufferedRowIterator]
+        // put the single ColumnBatch in the iterator read by generated code
+        iter.init(partitionId, Array(Iterator[Any](new ResultSetTraversal(
+          conn = null, stmt = null, rs = null, context = null),
+          Iterator(batch)).asInstanceOf[Iterator[InternalRow]]))
+        // ignore the result which is the update count
+        while (iter.hasNext) {
+          iter.next()
+        }
+      } else connectionType match {
         case ConnectionType.Embedded =>
-          // split the batch and put into row buffer if it is small
-          if (maxDeltaRows > 0 && batch.numRows < math.max(maxDeltaRows / 10,
-              GfxdConstants.SNAPPY_MIN_COLUMN_DELTA_ROWS)) {
-            // the lookup key depends only on schema and not on the table
-            // name since the prepared statement specific to the table is
-            // passed in separately through the references object
-            val gen = CodeGeneration.compileCode(
-              "COLUMN_TABLE.DECOMPRESS", schema.fields, () => {
-                val schemaAttrs = schema.toAttributes
-                val tableScan = ColumnTableScan(schemaAttrs, dataRDD = null,
-                  otherRDDs = Seq.empty, numBuckets = -1,
-                  partitionColumns = Seq.empty, partitionColumnAliases = Seq.empty,
-                  baseRelation = null, schema, allFilters = Seq.empty, schemaAttrs)
-                val insertPlan = RowInsertExec(tableScan, upsert = true,
-                  Seq.empty, Seq.empty, -1, schema, None, onExecutor = true,
-                  resolvedName = null, connProperties)
-                // now generate the code with the help of WholeStageCodegenExec
-                // this is only used for local code generation while its RDD
-                // semantics and related methods are all ignored
-                val (ctx, code) = ExternalStoreUtils.codeGenOnExecutor(
-                  WholeStageCodegenExec(insertPlan), insertPlan)
-                val references = ctx.references
-                // also push the index of connection reference at the end which
-                // will be used by caller to update connection before execution
-                references += insertPlan.statementRef
-                (code, references.toArray)
-              })
-            val refs = gen._2.clone()
-            // set the statement object for current execution
-            val statementRef = refs(refs.length - 1).asInstanceOf[Int]
-            val resolvedName = ExternalStoreUtils.lookupName(tableName,
-              connection.getSchema)
-            val putSQL = JdbcExtendedUtils.getInsertOrPutString(resolvedName,
-              schema, upsert = true)
-            val stmt = connection.prepareStatement(putSQL)
-            refs(statementRef) = stmt
-            // no harm in passing a references array with extra element at end
-            val iter = gen._1.generate(refs).asInstanceOf[BufferedRowIterator]
-            // put the single ColumnBatch in the iterator read by generated code
-            iter.init(0, Array(Iterator[Any](new ResultSetTraversal(
-              conn = null, stmt = null, rs = null, context = null),
-              Iterator(batch)).asInstanceOf[Iterator[InternalRow]]))
-            // ignore the result which is the update count
-            while (iter.hasNext) {
-              iter.next()
-            }
-          } else {
-            val resolvedName = ExternalStoreUtils.lookupName(columnTableName,
-              connection.getSchema)
-            val region = Misc.getRegionForTable(resolvedName, true)
-                .asInstanceOf[PartitionedRegion]
-            val batchUUID = Some(batchId.getOrElse(region.newJavaUUID().toString))
-            super.doInsert(resolvedName, batch, batchUUID, partitionId,
-              maxDeltaRows)(connection)
-          }
+          val region = Misc.getRegionForTable(resolvedName, true)
+              .asInstanceOf[PartitionedRegion]
+          val batchUUID = Some(batchId.getOrElse(region.newJavaUUID().toString))
+          super.doInsert(resolvedName, batch, batchUUID, partitionId,
+            maxDeltaRows)(connection)
+
         case _ =>
           super.doInsert(columnTableName, batch, batchId, partitionId,
             maxDeltaRows)(connection)
@@ -144,7 +141,7 @@ class JDBCSourceAsColumnarStore(_connProperties: ConnectionProperties,
   }
 
   override protected def getPartitionID(tableName: String,
-      partitionId: Int = -1): Int = {
+      partitionId: Int): Int = {
     val connection = getConnection(tableName, onExecutor = true)
     try {
       connectionType match {
@@ -174,14 +171,13 @@ class JDBCSourceAsColumnarStore(_connProperties: ConnectionProperties,
           }
         // TODO: SW: for split mode, get connection to one of the
         // local servers and a bucket ID for only one of those
-        case _ => rand.nextInt(numPartitions)
+        case _ => super.getPartitionID(tableName, partitionId)
       }
     } finally {
       connection.close()
     }
   }
 }
-
 
 
 final class ColumnarStorePartitionedRDD(

--- a/core/src/main/scala/org/apache/spark/sql/execution/columnar/impl/JDBCSourceAsColumnarStore.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/columnar/impl/JDBCSourceAsColumnarStore.scala
@@ -82,7 +82,7 @@ class JDBCSourceAsColumnarStore(_connProperties: ConnectionProperties,
       val resolvedName = ExternalStoreUtils.lookupName(tableName,
         connection.getSchema)
       // split the batch and put into row buffer if it is small
-      if (false && maxDeltaRows > 0 && batch.numRows < math.max(maxDeltaRows / 10,
+      if (maxDeltaRows > 0 && batch.numRows < math.max(maxDeltaRows / 10,
         GfxdConstants.SNAPPY_MIN_COLUMN_DELTA_ROWS)) {
         // the lookup key depends only on schema and not on the table
         // name since the prepared statement specific to the table is

--- a/core/src/main/scala/org/apache/spark/sql/execution/row/RowInsertExec.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/row/RowInsertExec.scala
@@ -96,7 +96,6 @@ case class RowInsertExec(_child: SparkPlan, upsert: Boolean,
        |  if ($rowCount > 0) {
        |    $result += $stmt.executeBatch().length;
        |  }
-       |  $stmt.getConnection().commit();
        |  $stmt.close();
        |  ${consume(ctx, Seq(ExprCode("", "false", result)))}
        |} catch (java.sql.SQLException sqle) {

--- a/core/src/main/scala/org/apache/spark/sql/execution/row/RowInsertExec.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/row/RowInsertExec.scala
@@ -96,6 +96,7 @@ case class RowInsertExec(_child: SparkPlan, upsert: Boolean,
        |  if ($rowCount > 0) {
        |    $result += $stmt.executeBatch().length;
        |  }
+       |  $stmt.getConnection().commit();
        |  $stmt.close();
        |  ${consume(ctx, Seq(ExprCode("", "false", result)))}
        |} catch (java.sql.SQLException sqle) {


### PR DESCRIPTION
Three issues were identified for the failure noted in SNAP-1372:

a) incorrect join result with inserts from connector when there is an exchange in the join (and not broadcast)

b) small 1-2 row column batches being created in smart connector mode

c) hydra test run shows the plan with exchange which is unexpected given the table sizes

## Changes proposed in this pull request

- incorrect exchange join results when data is read from column store (works correctly when all data is from row buffer)
  - issue was incoming partitionId being ignored in JDBCSourceAsColumnarStore.getPartitionID in smart connector mode
  - also corrected it in base JDBCSourceAsStore (though will never be invoked in practise)

- small column batches (1-2 rows) being inserted into column store in smart connector mode
  - now blow up the batch into row buffer even in smart connector mode; the code to blow it
    up already worked for both cases but due to some mistaken assumption it was being invoked
    only for the embedded mode

## Patch testing

manually tested different scenarios for Q27, forcing exchange or not in connector mode; precheckin in progress

## ReleaseNotes.txt changes

NA

## Other PRs 

NA