### PR TITLE
[SNAP-1371]

### DIFF
--- a/core/src/main/scala/org/apache/spark/sql/execution/columnar/JDBCAppendableRelation.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/columnar/JDBCAppendableRelation.scala
@@ -318,9 +318,6 @@ class ColumnarRelationProvider extends SchemaRelationProvider
       relation
     } finally {
       if (!success && !relation.tableExists) {
-        val catalog = sqlContext.sparkSession.asInstanceOf[SnappySession].sessionCatalog
-        catalog.unregisterDataSourceTable(catalog.newQualifiedTableName(relation.table),
-          Some(relation))
         // destroy the relation
         relation.destroy(ifExists = true)
       }

--- a/core/src/main/scala/org/apache/spark/sql/execution/columnar/impl/ColumnFormatRelation.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/columnar/impl/ColumnFormatRelation.scala
@@ -704,11 +704,6 @@ final class DefaultSource extends ColumnarRelationProvider {
       relation
     } finally {
       if (!success && !relation.tableExists) {
-        if (!isRelationforSample) {
-          val catalog = sqlContext.sparkSession.asInstanceOf[SnappySession].sessionCatalog
-          catalog.unregisterDataSourceTable(catalog.newQualifiedTableName(tableName),
-            Some(relation))
-        }
         // destroy the relation
         relation.destroy(ifExists = true)
       }

--- a/core/src/main/scala/org/apache/spark/sql/execution/row/RowFormatRelation.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/row/RowFormatRelation.scala
@@ -369,9 +369,6 @@ final class DefaultSource extends MutableRelationProvider {
       relation
     } finally {
       if (!success && !relation.tableExists) {
-        val catalog = sqlContext.sparkSession.asInstanceOf[SnappySession].sessionCatalog
-        catalog.unregisterDataSourceTable(catalog.newQualifiedTableName(relation.table),
-          Some(relation))
         // destroy the relation
         relation.destroy(ifExists = true)
       }

--- a/core/src/main/scala/org/apache/spark/sql/sources/MutableRelationProvider.scala
+++ b/core/src/main/scala/org/apache/spark/sql/sources/MutableRelationProvider.scala
@@ -72,23 +72,20 @@ abstract class MutableRelationProvider
       relation.tableSchema = relation.createTable(mode)
 
       val catalog = sqlContext.sparkSession.asInstanceOf[SnappySession].sessionCatalog
-      catalog.registerDataSourceTable(
-        catalog.newQualifiedTableName(tableName), None, Array.empty[String],
-        classOf[org.apache.spark.sql.row.DefaultSource].getCanonicalName,
-        options - JdbcExtendedUtils.SCHEMA_PROPERTY, relation)
       data match {
         case Some(plan) =>
           relation.insert(Dataset.ofRows(sqlContext.sparkSession, plan),
             overwrite = false)
         case None =>
       }
+      catalog.registerDataSourceTable(
+        catalog.newQualifiedTableName(tableName), None, Array.empty[String],
+        classOf[org.apache.spark.sql.row.DefaultSource].getCanonicalName,
+        options - JdbcExtendedUtils.SCHEMA_PROPERTY, relation)
       success = true
       relation
     } finally {
       if (!success && !relation.tableExists) {
-        val catalog = sqlContext.sparkSession.asInstanceOf[SnappySession].sessionCatalog
-        catalog.unregisterDataSourceTable(catalog.newQualifiedTableName(relation.table),
-          Some(relation))
         // destroy the relation
         relation.destroy(ifExists = true)
       }


### PR DESCRIPTION
Removed the incorrect calls to unregisterDataSourceTables.

These calls are not required when the register of data source tables is done in the last.

