### PR TITLE
SmartConnector support in one NWtest

### DIFF
--- a/cluster/src/dunit/scala/org/apache/spark/sql/NorthWindDUnitTest.scala
+++ b/cluster/src/dunit/scala/org/apache/spark/sql/NorthWindDUnitTest.scala
@@ -17,6 +17,7 @@
 package org.apache.spark.sql
 
 import java.io.{File, FileOutputStream, PrintWriter}
+import java.net.InetAddress
 import java.sql.{ResultSet, Statement}
 
 import scala.io.Source
@@ -24,6 +25,7 @@ import scala.io.Source
 import io.snappydata.cluster.ClusterManagerTestBase
 import io.snappydata.test.dunit.AvailablePortHelper
 
+import org.apache.spark.{SparkConf, SparkContext}
 import org.apache.spark.sql.catalyst.encoders.RowEncoder
 import org.apache.spark.sql.collection.Utils
 import org.apache.spark.sql.execution.columnar.ColumnTableScan
@@ -32,6 +34,21 @@ import org.apache.spark.sql.execution.row.RowTableScan
 import org.apache.spark.sql.execution.{FilterExec, ProjectExec}
 
 class NorthWindDUnitTest(s: String) extends ClusterManagerTestBase(s) {
+
+  override val locatorNetPort: Int = AvailablePortHelper.getRandomAvailableTCPPort
+  protected val productDir = SmartConnectorFunctions.getEnvironmentVariable("SNAPPY_HOME")
+
+
+  override def beforeClass(): Unit = {
+    super.beforeClass()
+    startNetworkServersOnAllVMs()
+    vm3.invoke(classOf[ClusterManagerTestBase], "startSparkCluster", productDir)
+  }
+
+  override def afterClass(): Unit = {
+    super.afterClass()
+    vm3.invoke(classOf[ClusterManagerTestBase], "stopSparkCluster", productDir)
+  }
 
   def testReplicatedTableQueries(): Unit = {
     val snc = SnappyContext(sc)
@@ -87,7 +104,13 @@ class NorthWindDUnitTest(s: String) extends ClusterManagerTestBase(s) {
       NorthWindDUnitTest.createAndLoadColocatedTables(snc)
       NorthWindDUnitTest.createAndLoadSparkTables(sqlContext)
       // validateColocatedTableQueries(snc)
+
       NorthWindDUnitTest.validateQueriesFullResultSet(snc, "ColocatedTable", pw, sqlContext)
+
+      // verify the colocated table queries in smart connector mode
+      val params = Array(ClusterManagerTestBase.locPort, "ColocatedTable").
+          asInstanceOf[Array[AnyRef]]
+      vm3.invoke(classOf[SmartConnectorFunctions], "nwQueryValidationOnConnector", params)
     } finally {
       pw.close()
     }

--- a/cluster/src/main/scala/io/snappydata/impl/LeadImpl.scala
+++ b/cluster/src/main/scala/io/snappydata/impl/LeadImpl.scala
@@ -369,7 +369,7 @@ class LeadImpl extends ServerImpl with Lead
 
   def getConfig(args: Array[String]): Config = {
 
-    System.setProperty("config.trace", "loads")
+    System.setProperty("config.trace", "substitutions")
     val notConfigurable = ConfigFactory.parseProperties(getDynamicOverrides).
         withFallback(ConfigFactory.parseResources("jobserver-overrides.conf"))
 
@@ -382,7 +382,7 @@ class LeadImpl extends ServerImpl with Lead
 
     val finalConf = snappyDefaults.withFallback(builtIn).resolve()
 
-    logInfo("Passing JobServer with config " + finalConf.root.render())
+    logDebug("Passing JobServer with config " + finalConf.root.render())
 
     finalConf
   }


### PR DESCRIPTION
## Changes proposed in this pull request

1. For NW tests, run the colocated table queries in smart connector mode and verify.

2. Reduce the logging level of job server's configuration parameter.

## Patch testing

Ran the NW tests. Did manual testing for point 2. 

## Other PRs 

https://github.com/SnappyDataInc/spark-jobserver/pull/8

