### PR TITLE
[SNAP-1437] NPE in SnappyUnifiedMemoryManagerDUnitTest

### DIFF
--- a/cluster/src/main/scala/org/apache/spark/memory/SnappyUnifiedMemoryManager.scala
+++ b/cluster/src/main/scala/org/apache/spark/memory/SnappyUnifiedMemoryManager.scala
@@ -313,8 +313,14 @@ class SnappyUnifiedMemoryManager private[memory](
   }
 
   override def releaseStorageMemory(numBytes: Long, memoryMode: MemoryMode): Unit = synchronized {
-    memoryForObject(SPARK_CACHE) -= numBytes
-    super.releaseStorageMemory(numBytes, memoryMode)
+    memTrace(s"releasing [SNAP] memory for $SPARK_CACHE $numBytes")
+    memoryForObject.get(SPARK_CACHE) match {
+      case Some(x) => {
+        memoryForObject(SPARK_CACHE) -= numBytes
+        super.releaseStorageMemory(numBytes, memoryMode)
+      }
+      case None => // Do nothing
+    }
   }
 
   override def dropStorageMemoryForObject(name: String,
@@ -349,12 +355,11 @@ class SnappyUnifiedMemoryManager private[memory](
     memoryForObject.clear()
   }
 
-  private def memTrace(msg : String) : Unit = {
-    if(java.lang.Boolean.getBoolean("snappydata.umm.memtrace")){
+  private def memTrace(msg: String): Unit = {
+    if (java.lang.Boolean.getBoolean("snappydata.umm.memtrace")) {
       logInfo(msg)
     }
   }
-
 }
 
 private object SnappyUnifiedMemoryManager extends Logging{


### PR DESCRIPTION


## Changes proposed in this pull request
  When Snappy executor is stopped it waits for 5 secs before closing the block managers. If driver starts another executor thread before the previous executor is stopped it shows many side errors.
While this is not a practical problem , this error may manifest in our tests. For now I have increased the restart time in test itself.

## Patch testing

UMM tests

## ReleaseNotes.txt changes



## Other PRs 
