### PR TITLE
[SNAP-1384] : Column Table Inserts can fail if generated code is big

### DIFF
--- a/core/src/main/scala/org/apache/spark/sql/execution/columnar/ColumnInsertExec.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/columnar/ColumnInsertExec.scala
@@ -516,6 +516,7 @@ case class ColumnInsertExec(_child: SparkPlan, partitionColumns: Seq[String],
       genMultipleStatsMethods(ctx, "writeStats", statsCode, statsSchema, stats)
 
     ctx.INPUT_ROW = statsRowTerm
+    ctx.currentVars = null
     val statsEv = GenerateUnsafeProjection.createCode(ctx, statsExprs)
     val statsRow = statsEv.value
 

--- a/core/src/main/scala/org/apache/spark/sql/execution/columnar/ColumnInsertExec.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/columnar/ColumnInsertExec.scala
@@ -447,7 +447,7 @@ case class ColumnInsertExec(_child: SparkPlan, partitionColumns: Seq[String],
       val dataType = field.dataType
       val evaluationCode = input(i)
       evaluationCode.code +
-      s"""
+        s"""
          if (${evaluationCode.isNull}) {
            $mutableRow.setNullAt($i);
          } else {


### PR DESCRIPTION
## Changes proposed in this pull request
Modified ColumnInsertExec to handle wide schema to 1012 columns.

* Have separated out the methods handling wide schema so as not to impact performance of existing code and narrow schema
* Chunked the code to different methods to make java function size well withing 64K

## Patch testing

pre-checkin yet to run

## ReleaseNotes.txt changes

NA

## Other PRs 

NA
