### PR TITLE
[SNAP-303] Handle non-store hive tables in meta-data queries

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -303,8 +303,8 @@ subprojects {
     dependsOn ':cleanDUnit'
     dependsOn ':product'
     maxParallelForks = 1
-    minHeapSize '1g'
-    maxHeapSize '1g'
+    minHeapSize '2g'
+    maxHeapSize '2g'
 
     jvmArgs = ['-XX:+HeapDumpOnOutOfMemoryError', '-XX:MaxPermSize=384m',
                '-XX:+UseParNewGC', '-XX:+UseConcMarkSweepGC',

--- a/cluster/src/dunit/scala/io/snappydata/cluster/QueryRoutingDUnitTest.scala
+++ b/cluster/src/dunit/scala/io/snappydata/cluster/QueryRoutingDUnitTest.scala
@@ -474,6 +474,18 @@ class QueryRoutingDUnitTest(val s: String)
       assert(results.size == 3, s"Got size = ${results.size} but expected 3")
       assert(results.contains(s"APP.$colTable"))
       assert(results.contains(s"APP_PARQUET.$parquetTable"))
+      results.clear()
+
+      // check the columns
+      val columnsMd = dbmd.getColumns(null, "APP_PARQUET", null, null)
+      while (columnsMd.next()) {
+        results += columnsMd.getString(4)
+      }
+      assert(results.size == 3, s"Got columns = ${results.size} but expected 3")
+      assert(results.contains("COL1"), s"columns = $results")
+      assert(results.contains("COL2"))
+      assert(results.contains("COL3"))
+      results.clear()
 
       s.execute(s"DROP TABLE APP_PARQUET.$parquetTable")
 

--- a/cluster/src/dunit/scala/io/snappydata/cluster/QueryRoutingDUnitTest.scala
+++ b/cluster/src/dunit/scala/io/snappydata/cluster/QueryRoutingDUnitTest.scala
@@ -433,7 +433,8 @@ class QueryRoutingDUnitTest(val s: String)
 
       val dbmd = conn.getMetaData
       val rSet = dbmd.getTables(null, "APP", null,
-        Array[String]("TABLE", "SYSTEM TABLE", "COLUMN TABLE"))
+        Array[String]("TABLE", "SYSTEM TABLE", "COLUMN TABLE",
+          "EXTERNAL TABLE", "STREAM TABLE"))
       assert(rSet.next())
 
       s.execute(s"drop table $rowTable")
@@ -509,7 +510,8 @@ class QueryRoutingDUnitTest(val s: String)
 
     // Simulates 'SHOW TABLES' of ij
     var rSet = dbmd.getTables(null, "APP", null,
-      Array[String]("TABLE", "SYSTEM TABLE", "COLUMN TABLE"))
+      Array[String]("TABLE", "SYSTEM TABLE", "COLUMN TABLE",
+        "EXTERNAL TABLE", "STREAM TABLE"))
 
     var foundTable = false
     while (rSet.next()) {
@@ -521,7 +523,8 @@ class QueryRoutingDUnitTest(val s: String)
     assert(foundTable)
 
     val rSet2 = dbmd.getTables(null, INTERNAL_SCHEMA_NAME, null,
-      Array[String]("TABLE", "SYSTEM TABLE", "COLUMN TABLE"))
+      Array[String]("TABLE", "SYSTEM TABLE", "COLUMN TABLE",
+        "EXTERNAL TABLE", "STREAM TABLE"))
 
     foundTable = false
     while (rSet2.next()) {

--- a/core/src/main/java/io/snappydata/impl/SnappyHiveCatalog.java
+++ b/core/src/main/java/io/snappydata/impl/SnappyHiveCatalog.java
@@ -57,7 +57,8 @@ public class SnappyHiveCatalog implements ExternalCatalog {
 
   private ThreadLocal<HiveMetaStoreClient> hmClients = new ThreadLocal<>();
 
-  static final ThreadLocal<Boolean> IS_CATALOG_THREAD = new ThreadLocal<>();
+  public static final ThreadLocal<Boolean> SKIP_HIVE_TABLE_CALLS =
+      new ThreadLocal<>();
 
   private final ThreadLocal<HMSQuery> queries = new ThreadLocal<>();
 
@@ -109,7 +110,8 @@ public class SnappyHiveCatalog implements ExternalCatalog {
   public List<ExternalTableMetaData> getNonStoreTables(boolean skipLocks) {
     // skip if this is already the catalog lookup thread (Hive dropTable
     //   invokes getTables again)
-    if (Boolean.TRUE.equals(IS_CATALOG_THREAD.get())) {
+    if (Boolean.TRUE.equals(
+        SKIP_HIVE_TABLE_CALLS.get())) {
       return Collections.emptyList();
     }
     HMSQuery q = getHMSQuery();
@@ -216,7 +218,7 @@ public class SnappyHiveCatalog implements ExternalCatalog {
 
     @Override
     public Object call() throws Exception {
-      IS_CATALOG_THREAD.set(Boolean.TRUE);
+      SKIP_HIVE_TABLE_CALLS.set(Boolean.TRUE);
       try {
         if (this.skipLock) {
           GfxdDataDictionary.SKIP_LOCKS.set(true);

--- a/core/src/main/java/io/snappydata/impl/SnappyHiveCatalog.java
+++ b/core/src/main/java/io/snappydata/impl/SnappyHiveCatalog.java
@@ -103,6 +103,14 @@ public class SnappyHiveCatalog implements ExternalCatalog {
     return (Boolean)handleFutureResult(f);
   }
 
+  public List<ExternalTableMetaData> getNonStoreTables(boolean skipLocks) {
+    HMSQuery q = getHMSQuery();
+    q.resetValues(HMSQuery.GET_NON_STORE_TABLES, null, null, skipLocks);
+    Future<Object> f = this.hmsQueriesExecutorService.submit(q);
+    // noinspection unchecked
+    return (List<ExternalTableMetaData>)handleFutureResult(f);
+  }
+
   public String getColumnTableSchemaAsJson(String schema, String tableName,
       boolean skipLocks) {
     HMSQuery q = getHMSQuery();
@@ -182,7 +190,8 @@ public class SnappyHiveCatalog implements ExternalCatalog {
     private static final int GET_ALL_TABLES_MANAGED_IN_DD = 4;
     private static final int REMOVE_TABLE = 5;
     private static final int GET_COL_TABLE = 6;
-    // private static final int CLOSE_HMC = 4;
+    // private static final int CLOSE_HMC = 7;
+    private static final int GET_NON_STORE_TABLES = 8;
 
     // More to be added later
 
@@ -211,16 +220,47 @@ public class SnappyHiveCatalog implements ExternalCatalog {
         case ISROWTABLE_QUERY:
           HiveMetaStoreClient hmc = SnappyHiveCatalog.this.hmClients.get();
           String type = getType(hmc);
-          return type.equalsIgnoreCase(ExternalTableType.Row().toString());
+          return type.equalsIgnoreCase(ExternalTableType.Row().name());
 
         case ISCOLUMNTABLE_QUERY:
           hmc = SnappyHiveCatalog.this.hmClients.get();
           type = getType(hmc);
-          return !type.equalsIgnoreCase(ExternalTableType.Row().toString());
+          return !type.equalsIgnoreCase(ExternalTableType.Row().name());
 
         case COLUMNTABLE_SCHEMA:
           hmc = SnappyHiveCatalog.this.hmClients.get();
           return getSchema(hmc);
+
+        case GET_NON_STORE_TABLES: {
+          hmc = SnappyHiveCatalog.this.hmClients.get();
+          List<String> schemas = hmc.getAllDatabases();
+          ArrayList<ExternalTableMetaData> externalTables = new ArrayList<>();
+          for (String schema : schemas) {
+            List<String> tables = hmc.getAllTables(schema);
+            for (String tableName : tables) {
+              Table table = hmc.getTable(schema, tableName);
+              String tableType = table.getParameters().get(
+                  JdbcExtendedUtils.TABLETYPE_PROPERTY());
+              if (!ExternalTableType.Row().name().equalsIgnoreCase(tableType) &&
+                  !ExternalTableType.Column().name().equalsIgnoreCase(tableType) &&
+                  !ExternalTableType.Index().name().equalsIgnoreCase(tableType)) {
+                // TODO: FIX ME: should not convert to upper case blindly
+                // but unfortunately hive meta-store is not case-sensitive
+                ExternalTableMetaData metaData = new ExternalTableMetaData(
+                    Utils.toUpperCase(table.getTableName()),
+                    Utils.toUpperCase(table.getDbName()),
+                    tableType, null, -1, -1,
+                    null, null, null, null);
+                metaData.provider = table.getParameters().get(
+                    SnappyStoreHiveCatalog.HIVE_PROVIDER());
+                metaData.columns = ExternalStoreUtils.getColumnMetadata(
+                    ExternalStoreUtils.getTableSchema(table.getParameters()));
+                externalTables.add(metaData);
+              }
+            }
+          }
+          return externalTables;
+        }
 
         case GET_ALL_TABLES_MANAGED_IN_DD:
           hmc = SnappyHiveCatalog.this.hmClients.get();
@@ -232,11 +272,13 @@ public class SnappyHiveCatalog implements ExternalCatalog {
             List <String> upperCaseTableNames = new LinkedList<>();
             for (String t : tables) {
               Table hiveTab = hmc.getTable(db, t);
-              if (isTableInStoreDD(hiveTab)) {
-                upperCaseTableNames.add(t.toUpperCase());
+              String tableType = hiveTab.getParameters().get(
+                  JdbcExtendedUtils.TABLETYPE_PROPERTY());
+              if (isTableInStoreDD(tableType)) {
+                upperCaseTableNames.add(Utils.toUpperCase(t));
               }
             }
-            dbTablesMap.put(db.toUpperCase(), upperCaseTableNames);
+            dbTablesMap.put(Utils.toUpperCase(db), upperCaseTableNames);
           }
           return dbTablesMap;
         case REMOVE_TABLE:
@@ -246,9 +288,10 @@ public class SnappyHiveCatalog implements ExternalCatalog {
         case GET_COL_TABLE:
           hmc = SnappyHiveCatalog.this.hmClients.get();
           Table table = getTableWithRetry(hmc);
-          String fullyQualifiedName = table.getDbName().toUpperCase() +
-              "." + table.getTableName().toUpperCase();
-          StructType schema = ExternalStoreUtils.convertSchemaMap(table.getParameters());
+          String fullyQualifiedName = Utils.toUpperCase(table.getDbName()) +
+              "." + Utils.toUpperCase(table.getTableName());
+          StructType schema = ExternalStoreUtils.getTableSchema(
+              table.getParameters()).get();
           CaseInsensitiveMap parameters = new CaseInsensitiveMap(
               table.getSd().getSerdeInfo().getParameters());
           int partitions = ExternalStoreUtils.getAndSetTotalPartitions(
@@ -333,15 +376,14 @@ public class SnappyHiveCatalog implements ExternalCatalog {
         return t.getParameters().get(JdbcExtendedUtils.TABLETYPE_PROPERTY());
       } else {
         // assume ROW type in GemFireXD
-        return ExternalTableType.Row().toString();
+        return ExternalTableType.Row().name();
       }
     }
 
-    private boolean isTableInStoreDD(Table t) {
-      String type = t.getParameters().get(JdbcExtendedUtils.TABLETYPE_PROPERTY());
-      return type.equalsIgnoreCase(ExternalTableType.Row().toString()) ||
-          type.equalsIgnoreCase(ExternalTableType.Column().toString()) ||
-          type.equalsIgnoreCase(ExternalTableType.Sample().toString());
+    private boolean isTableInStoreDD(String type) {
+      return type.equalsIgnoreCase(ExternalTableType.Row().name()) ||
+          type.equalsIgnoreCase(ExternalTableType.Column().name()) ||
+          type.equalsIgnoreCase(ExternalTableType.Sample().name());
     }
 
     private Table getTableWithRetry(HiveMetaStoreClient hmc) throws SQLException {

--- a/core/src/main/scala/org/apache/spark/sql/SnappySession.scala
+++ b/core/src/main/scala/org/apache/spark/sql/SnappySession.scala
@@ -933,7 +933,6 @@ class SnappySession(@transient private val sc: SparkContext,
     }
 
     val schema = userSpecifiedSchema.map(sessionCatalog.normalizeSchema)
-    var relationSchema: Option[StructType] = None
     val source = if (isBuiltIn) SnappyContext.getProvider(provider,
       onlyBuiltIn = true) else provider
 
@@ -949,13 +948,12 @@ class SnappySession(@transient private val sc: SparkContext,
           className = source,
           options = params + (JdbcExtendedUtils.ALLOW_EXISTING_PROPERTY ->
               (mode != SaveMode.ErrorIfExists).toString)).resolveRelation(true)
-        relationSchema = Some(r.schema)
         r
     }
 
     val plan = LogicalRelation(relation)
     if (!SnappyContext.internalTableSources.exists(_.equals(source))) {
-      sessionCatalog.registerDataSourceTable(tableIdent, relationSchema,
+      sessionCatalog.registerDataSourceTable(tableIdent, schema,
         Array.empty[String], source, params, relation)
     }
     snappyContextFunctions.postRelationCreation(relation, this)
@@ -1014,9 +1012,10 @@ class SnappySession(@transient private val sc: SparkContext,
       }
     } else None
 
-    val (relation, schema) = schemaDDL match {
-      case Some(cols) => (JdbcExtendedUtils.externalResolvedDataSource(self,
-        cols, source, mode, params, Some(query)), None)
+    val schema = userSpecifiedSchema.map(sessionCatalog.normalizeSchema)
+    val relation = schemaDDL match {
+      case Some(cols) => JdbcExtendedUtils.externalResolvedDataSource(self,
+        cols, source, mode, params, Some(query))
 
       case None =>
         val data = Dataset.ofRows(this, query)
@@ -1045,7 +1044,7 @@ class SnappySession(@transient private val sc: SparkContext,
             try {
               ir.insert(data, overwrite)
               success = true
-              (ir, Some(ir.schema))
+              ir
             } finally {
               if (!success) ir match {
                 case dr: DestroyRelation =>
@@ -1054,12 +1053,11 @@ class SnappySession(@transient private val sc: SparkContext,
               }
             }
           case None =>
-            val r = DataSource(self,
+            DataSource(self,
               className = source,
               userSpecifiedSchema = userSpecifiedSchema,
               partitionColumns = partitionColumns,
               options = params).write(mode, df)
-            (r, Some(r.schema))
         }
     }
 

--- a/core/src/main/scala/org/apache/spark/sql/execution/columnar/ExternalStoreUtils.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/columnar/ExternalStoreUtils.scala
@@ -61,6 +61,7 @@ object ExternalStoreUtils extends Logging {
   final val COLUMN_MAX_DELTA_ROWS = "COLUMN_MAX_DELTA_ROWS"
   final val COMPRESSION_CODEC = "COMPRESSION_CODEC"
   final val RELATION_FOR_SAMPLE = "RELATION_FOR_SAMPLE"
+  // internal properties stored as hive table parameters
   final val USER_SPECIFIED_SCHEMA = "USER_SCHEMA"
 
   def lookupName(tableName: String, schema: String): String = {

--- a/core/src/main/scala/org/apache/spark/sql/execution/columnar/ExternalStoreUtils.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/columnar/ExternalStoreUtils.scala
@@ -24,6 +24,8 @@ import scala.collection.mutable
 
 import com.gemstone.gemfire.internal.cache.ExternalTableMetaData
 import com.pivotal.gemfirexd.internal.engine.Misc
+import com.pivotal.gemfirexd.internal.iapi.types.DataTypeDescriptor
+import com.pivotal.gemfirexd.internal.shared.common.reference.Limits
 import com.pivotal.gemfirexd.jdbc.ClientAttribute
 import io.snappydata.thrift.snappydataConstants
 import io.snappydata.util.ServiceUtils
@@ -33,7 +35,7 @@ import org.apache.spark.sql._
 import org.apache.spark.sql.catalyst.expressions.codegen.{CodeAndComment, CodeFormatter, CodegenContext}
 import org.apache.spark.sql.collection.Utils
 import org.apache.spark.sql.execution.columnar.impl.JDBCSourceAsColumnarStore
-import org.apache.spark.sql.execution.datasources.jdbc.DriverRegistry
+import org.apache.spark.sql.execution.datasources.jdbc.{DriverRegistry, JdbcUtils}
 import org.apache.spark.sql.execution.{BufferedRowIterator, CodegenSupport, CodegenSupportOnExecutor, ConnectionPool}
 import org.apache.spark.sql.hive.SnappyStoreHiveCatalog
 import org.apache.spark.sql.jdbc.{JdbcDialect, JdbcDialects}
@@ -59,7 +61,7 @@ object ExternalStoreUtils extends Logging {
   final val COLUMN_MAX_DELTA_ROWS = "COLUMN_MAX_DELTA_ROWS"
   final val COMPRESSION_CODEC = "COMPRESSION_CODEC"
   final val RELATION_FOR_SAMPLE = "RELATION_FOR_SAMPLE"
-  final val EXTERNAL_DATASOURCE = "EXTERNAL_DATASOURCE"
+  final val USER_SPECIFIED_SCHEMA = "USER_SCHEMA"
 
   def lookupName(tableName: String, schema: String): String = {
     if (tableName.indexOf('.') <= 0) {
@@ -138,7 +140,6 @@ object ExternalStoreUtils extends Logging {
     val table = parameters.remove(dbtableProp)
         .getOrElse(sys.error(s"Option '$dbtableProp' not specified"))
     parameters.remove(JdbcExtendedUtils.ALLOW_EXISTING_PROPERTY)
-    parameters.remove(JdbcExtendedUtils.SCHEMA_PROPERTY)
     parameters.remove("serialization.format")
     table
   }
@@ -166,7 +167,7 @@ object ExternalStoreUtils extends Logging {
     sparkContext match {
       case None => Constant.DEFAULT_EMBEDDED_URL + ";host-data=false;mcast-port=0"
       case Some(sc) =>
-       SnappyContext.getClusterMode(sc) match {
+        SnappyContext.getClusterMode(sc) match {
           case SnappyEmbeddedMode(_, _) =>
             // Already connected to SnappyData in embedded mode.
             Constant.DEFAULT_EMBEDDED_URL + ";host-data=false;mcast-port=0"
@@ -533,19 +534,24 @@ object ExternalStoreUtils extends Logging {
     (ctx, cleanedSource)
   }
 
-  def getExternalStoreOnExecutor(parameters : java.util.Map[String, String],
+  def getExternalStoreOnExecutor(parameters: java.util.Map[String, String],
       partitions: Int, tableName: String, schema: StructType): ExternalStore = {
     val connProperties: ConnectionProperties =
       ExternalStoreUtils.validateAndGetAllProps(None, parameters.asScala)
     new JDBCSourceAsColumnarStore(connProperties, partitions, tableName, schema)
   }
 
-  def convertSchemaMap(tableProps: java.util.Map[String, String]): StructType = {
-    val jsonString = tableProps.asScala.get(
+  def getTableSchemaString(
+      tableProps: java.util.Map[String, String]): Option[String] =
+    getTableSchemaString(tableProps.asScala)
+
+  def getTableSchemaString(
+      tableProps: scala.collection.Map[String, String]): Option[String] = {
+    tableProps.get(
       SnappyStoreHiveCatalog.HIVE_SCHEMA_NUMPARTS).map { numParts =>
       (0 until numParts.toInt).map { index =>
         val partProp = s"${SnappyStoreHiveCatalog.HIVE_SCHEMA_PART}.$index"
-        tableProps.asScala.get(partProp) match {
+        tableProps.get(partProp) match {
           case Some(part) => part
           case None => throw new AnalysisException("Could not read " +
               "schema from metastore because it is corrupted (missing " +
@@ -554,7 +560,55 @@ object ExternalStoreUtils extends Logging {
         // Stick all parts back to a single schema string.
       }.mkString
     }
-    StructType.fromString(jsonString.get)
+  }
+
+  def getTableSchema(
+      tableProps: java.util.Map[String, String]): Option[StructType] =
+    getTableSchema(tableProps.asScala)
+
+  def getTableSchema(
+      tableProps: scala.collection.Map[String, String]): Option[StructType] =
+    getTableSchemaString(tableProps).map(StructType.fromString)
+
+  def getColumnMetadata(
+      schema: Option[StructType]): java.util.List[ExternalTableMetaData.Column] = {
+    schema.toList.flatMap(_.map { f =>
+      val (dataType, typeName) = f.dataType match {
+        case u: UserDefinedType[_] =>
+          (Utils.getSQLDataType(u.sqlType), Some(u.userClass.getName))
+        case t => (t, None)
+      }
+      val (prec, scale) = dataType match {
+        case d: DecimalType => (d.precision, d.scale)
+        case StringType => if (f.metadata.contains(Constant.CHAR_TYPE_SIZE_PROP)) {
+          val p = math.min(f.metadata.getLong(Constant.CHAR_TYPE_SIZE_PROP),
+            Int.MaxValue).toInt
+          (p, -1)
+        } else (Limits.DB2_LOB_MAXWIDTH, -1)
+        case _: NumericType => (-1, 0)
+        case _ => (-1, -1)
+      }
+      val jdbcTypeOpt = GemFireXDDialect.getJDBCType(dataType).orElse(
+        JdbcUtils.getCommonJDBCType(dataType))
+      jdbcTypeOpt match {
+        case Some(jdbcType) =>
+          val (precision, width) = if (prec == -1) {
+            val dtd = DataTypeDescriptor.getBuiltInDataTypeDescriptor(
+              jdbcType.jdbcNullType, f.nullable)
+            if (dtd ne null) {
+              (dtd.getPrecision, dtd.getMaximumWidth)
+            } else (dataType.defaultSize, dataType.defaultSize)
+          } else (prec, prec)
+          new ExternalTableMetaData.Column(f.name, jdbcType.jdbcNullType,
+            typeName.getOrElse(jdbcType.databaseTypeDefinition),
+            precision, scale, width, f.nullable)
+        case None =>
+          val precision = if (prec == -1) dataType.defaultSize else prec
+          new ExternalTableMetaData.Column(f.name, java.sql.Types.OTHER,
+            typeName.getOrElse(dataType.simpleString),
+            precision, scale, precision, f.nullable)
+      }
+    }).asJava
   }
 
   def getExternalTableMetaData(schema: String, table: String): ExternalTableMetaData = {

--- a/core/src/main/scala/org/apache/spark/sql/execution/columnar/impl/ColumnFormatRelation.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/columnar/impl/ColumnFormatRelation.scala
@@ -18,6 +18,8 @@ package org.apache.spark.sql.execution.columnar.impl
 
 import java.sql.{Connection, PreparedStatement}
 
+import scala.util.control.NonFatal
+
 import com.gemstone.gemfire.internal.cache.{ExternalTableMetaData, PartitionedRegion}
 import com.pivotal.gemfirexd.internal.engine.Misc
 import io.snappydata.Constant
@@ -519,7 +521,7 @@ class ColumnFormatRelation(
       // SB: Now populate the index table from base table.
       df.write.insertInto(snappySession.getIndexTable(indexIdent).toString())
     } catch {
-      case e: Throwable =>
+      case NonFatal(e) =>
         snappySession.dropTable(indexIdent, ifExists = false)
         throw e
     }

--- a/core/src/main/scala/org/apache/spark/sql/execution/columnar/impl/StoreCallbacksImpl.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/columnar/impl/StoreCallbacksImpl.scala
@@ -86,7 +86,7 @@ object StoreCallbacksImpl extends StoreCallbacks with Logging with Serializable 
           val tableName = container.getQualifiedTableName
           // add weightage column for sample tables if required
           var schema = catalogEntry.schema.asInstanceOf[StructType]
-          if (catalogEntry.tableType == ExternalTableType.Sample.toString &&
+          if (catalogEntry.tableType == ExternalTableType.Sample.name &&
               schema(schema.length - 1).name != Utils.WEIGHTAGE_COLUMN_NAME) {
             schema = schema.add(Utils.WEIGHTAGE_COLUMN_NAME,
               LongType, nullable = false)

--- a/core/src/main/scala/org/apache/spark/sql/execution/row/RowFormatRelation.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/row/RowFormatRelation.scala
@@ -362,9 +362,9 @@ final class DefaultSource extends MutableRelationProvider {
 
       val catalog = sqlContext.sparkSession.asInstanceOf[SnappySession].sessionCatalog
       catalog.registerDataSourceTable(
-        catalog.newQualifiedTableName(tableName), None,
-        Array.empty[String], classOf[execution.row.DefaultSource].getCanonicalName,
-        options - JdbcExtendedUtils.SCHEMA_PROPERTY, relation)
+        catalog.newQualifiedTableName(tableName), None, Array.empty[String],
+        classOf[execution.row.DefaultSource].getCanonicalName,
+        options, relation)
       success = true
       relation
     } finally {

--- a/core/src/main/scala/org/apache/spark/sql/internal/SnappySharedState.scala
+++ b/core/src/main/scala/org/apache/spark/sql/internal/SnappySharedState.scala
@@ -16,6 +16,8 @@
  */
 package org.apache.spark.sql.internal
 
+import io.snappydata.impl.SnappyHiveCatalog
+
 import org.apache.spark.SparkContext
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.apache.spark.sql.execution.CacheManager
@@ -34,7 +36,15 @@ private[sql] class SnappySharedState(override val sparkContext: SparkContext,
   /**
    * A Hive client used to interact with the metastore.
    */
-  private[sql] lazy val metadataHive = new HiveClientUtil(sparkContext).client
+  private[sql] lazy val metadataHive = {
+    val oldFlag = SnappyHiveCatalog.SKIP_HIVE_TABLE_CALLS.get()
+    SnappyHiveCatalog.SKIP_HIVE_TABLE_CALLS.set(java.lang.Boolean.TRUE)
+    try {
+      new HiveClientUtil(sparkContext).client
+    } finally {
+      SnappyHiveCatalog.SKIP_HIVE_TABLE_CALLS.set(oldFlag)
+    }
+  }
 
 
   override lazy val externalCatalog =

--- a/core/src/main/scala/org/apache/spark/sql/row/GemFireXDDialect.scala
+++ b/core/src/main/scala/org/apache/spark/sql/row/GemFireXDDialect.scala
@@ -100,9 +100,8 @@ abstract class GemFireXDBaseDialect extends JdbcExtendedDialect {
     case StringType => Some(JdbcType("CLOB", java.sql.Types.CLOB))
     case BinaryType => Some(JdbcType("BLOB", java.sql.Types.BLOB))
     case BooleanType => Some(JdbcType("BOOLEAN", java.sql.Types.BOOLEAN))
-    // TODO: check if this should be INTEGER for GemFireXD for below two
-    case ByteType => Some(JdbcType("SMALLINT", java.sql.Types.INTEGER))
-    case ShortType => Some(JdbcType("SMALLINT", java.sql.Types.INTEGER))
+    case ByteType => Some(JdbcType("INTEGER", java.sql.Types.INTEGER))
+    case ShortType => Some(JdbcType("SMALLINT", java.sql.Types.SMALLINT))
     case d: DecimalType => Some(JdbcType(s"DECIMAL(${d.precision},${d.scale})",
       java.sql.Types.DECIMAL))
     case _: ArrayType | _: MapType | _: StructType =>

--- a/core/src/main/scala/org/apache/spark/sql/sources/MutableRelationProvider.scala
+++ b/core/src/main/scala/org/apache/spark/sql/sources/MutableRelationProvider.scala
@@ -81,7 +81,7 @@ abstract class MutableRelationProvider
       catalog.registerDataSourceTable(
         catalog.newQualifiedTableName(tableName), None, Array.empty[String],
         classOf[org.apache.spark.sql.row.DefaultSource].getCanonicalName,
-        options - JdbcExtendedUtils.SCHEMA_PROPERTY, relation)
+        options, relation)
       success = true
       relation
     } finally {

--- a/core/src/main/scala/org/apache/spark/sql/sources/jdbcExtensions.scala
+++ b/core/src/main/scala/org/apache/spark/sql/sources/jdbcExtensions.scala
@@ -74,7 +74,9 @@ abstract class JdbcExtendedDialect extends JdbcDialect {
 
 object JdbcExtendedUtils extends Logging {
 
-  val DBTABLE_PROPERTY = "DBTABLE"
+  // "dbtable" lower case since some other code including Spark's depends on it
+  val DBTABLE_PROPERTY = "dbtable"
+
   val SCHEMA_PROPERTY = "SCHEMADDL"
   val ALLOW_EXISTING_PROPERTY = "ALLOWEXISTING"
   val BASETABLE_PROPERTY = "BASETABLE"

--- a/core/src/main/scala/org/apache/spark/sql/sources/jdbcExtensions.scala
+++ b/core/src/main/scala/org/apache/spark/sql/sources/jdbcExtensions.scala
@@ -81,6 +81,7 @@ object JdbcExtendedUtils extends Logging {
   val ALLOW_EXISTING_PROPERTY = "ALLOWEXISTING"
   val BASETABLE_PROPERTY = "BASETABLE"
 
+  // internal properties will be stored as Hive table parameters
   val TABLETYPE_PROPERTY = "EXTERNAL_SNAPPY"
 
   def executeUpdate(sql: String, conn: Connection): Unit = {

--- a/core/src/main/scala/org/apache/spark/sql/sources/jdbcExtensions.scala
+++ b/core/src/main/scala/org/apache/spark/sql/sources/jdbcExtensions.scala
@@ -19,7 +19,7 @@ package org.apache.spark.sql.sources
 import java.sql.Connection
 import java.util.Properties
 
-import scala.collection.{Map => SMap}
+import scala.collection.{mutable, Map => SMap}
 import scala.util.control.NonFatal
 
 import org.apache.spark.Logging
@@ -134,7 +134,13 @@ object JdbcExtendedUtils extends Logging {
       options: SMap[String, String]): SMap[String, String] = {
     // split the string into parts for size limitation in hive metastore table
     val parts = value.grouped(3500).toSeq
-    var opts = options
+    val opts = options match {
+      case m: mutable.Map[String, String] => m
+      case _ =>
+        val m = new mutable.HashMap[String, String]
+        m ++= options
+        m
+    }
     opts += (s"$propertyName.numParts" -> parts.size.toString)
     parts.zipWithIndex.foreach { case (part, index) =>
       opts += (s"$propertyName.part.$index" -> part)

--- a/core/src/main/scala/org/apache/spark/sql/sources/jdbcExtensions.scala
+++ b/core/src/main/scala/org/apache/spark/sql/sources/jdbcExtensions.scala
@@ -25,7 +25,6 @@ import org.apache.spark.Logging
 import org.apache.spark.sql.catalyst.analysis.UnresolvedRelation
 import org.apache.spark.sql.catalyst.encoders.RowEncoder
 import org.apache.spark.sql.catalyst.plans.logical.{InsertIntoTable, LogicalPlan}
-import org.apache.spark.sql.execution.columnar.ExternalStoreUtils
 import org.apache.spark.sql.execution.datasources.{CaseInsensitiveMap, DataSource}
 import org.apache.spark.sql.jdbc.{JdbcDialect, JdbcType}
 import org.apache.spark.sql.types._
@@ -75,10 +74,10 @@ abstract class JdbcExtendedDialect extends JdbcDialect {
 
 object JdbcExtendedUtils extends Logging {
 
-  val DBTABLE_PROPERTY = "dbtable"
-  val SCHEMA_PROPERTY = "schemaddl"
-  val ALLOW_EXISTING_PROPERTY = "allowexisting"
-  val BASETABLE_PROPERTY = "basetable"
+  val DBTABLE_PROPERTY = "DBTABLE"
+  val SCHEMA_PROPERTY = "SCHEMADDL"
+  val ALLOW_EXISTING_PROPERTY = "ALLOWEXISTING"
+  val BASETABLE_PROPERTY = "BASETABLE"
 
   val TABLETYPE_PROPERTY = "EXTERNAL_SNAPPY"
 
@@ -229,8 +228,7 @@ object JdbcExtendedUtils extends Logging {
       case dataSource: ExternalSchemaRelationProvider =>
         // add schemaString as separate property for Hive persistence
         dataSource.createRelation(snappySession.snappyContext, mode,
-          new CaseInsensitiveMap(options + (SCHEMA_PROPERTY -> schemaString) +
-              (ExternalStoreUtils.EXTERNAL_DATASOURCE -> "true")),
+          new CaseInsensitiveMap(options + (SCHEMA_PROPERTY -> schemaString)),
           schemaString, data)
 
       case _ => throw new AnalysisException(

--- a/core/src/main/scala/org/apache/spark/sql/store/StoreUtils.scala
+++ b/core/src/main/scala/org/apache/spark/sql/store/StoreUtils.scala
@@ -91,8 +91,7 @@ object StoreUtils {
     PERSISTENT, SERVER_GROUPS, OFFHEAP, EXPIRE, OVERFLOW,
     GEM_INDEXED_TABLE, ExternalStoreUtils.INDEX_NAME,
     ExternalStoreUtils.COLUMN_BATCH_SIZE, ExternalStoreUtils.COLUMN_MAX_DELTA_ROWS,
-    ExternalStoreUtils.COMPRESSION_CODEC, ExternalStoreUtils.RELATION_FOR_SAMPLE,
-    JdbcExtendedUtils.SCHEMA_PROPERTY)
+    ExternalStoreUtils.COMPRESSION_CODEC, ExternalStoreUtils.RELATION_FOR_SAMPLE)
 
   val EMPTY_STRING = ""
   val NONE = "NONE"
@@ -421,7 +420,9 @@ object StoreUtils {
 
   def validateConnProps(parameters: mutable.Map[String, String]): Unit = {
     parameters.keys.forall(v => {
-      if (!ddlOptions.contains(Utils.toUpperCase(v.toString))) {
+      val u = Utils.toUpperCase(v)
+      if (!u.startsWith(JdbcExtendedUtils.SCHEMADDL_PROPERTY) &&
+          !ddlOptions.contains(u)) {
         throw new AnalysisException(
           s"Unknown options $v specified while creating table ")
       }

--- a/core/src/main/scala/org/apache/spark/sql/store/StoreUtils.scala
+++ b/core/src/main/scala/org/apache/spark/sql/store/StoreUtils.scala
@@ -92,7 +92,7 @@ object StoreUtils {
     GEM_INDEXED_TABLE, ExternalStoreUtils.INDEX_NAME,
     ExternalStoreUtils.COLUMN_BATCH_SIZE, ExternalStoreUtils.COLUMN_MAX_DELTA_ROWS,
     ExternalStoreUtils.COMPRESSION_CODEC, ExternalStoreUtils.RELATION_FOR_SAMPLE,
-    JdbcExtendedUtils.SCHEMA_PROPERTY, ExternalStoreUtils.USER_SPECIFIED_SCHEMA)
+    JdbcExtendedUtils.SCHEMA_PROPERTY)
 
   val EMPTY_STRING = ""
   val NONE = "NONE"

--- a/core/src/main/scala/org/apache/spark/sql/store/StoreUtils.scala
+++ b/core/src/main/scala/org/apache/spark/sql/store/StoreUtils.scala
@@ -28,6 +28,7 @@ import org.apache.spark.Partition
 import org.apache.spark.sql.collection.{MultiBucketExecutorPartition, ToolsCallbackInit, Utils}
 import org.apache.spark.sql.execution.columnar.ExternalStoreUtils
 import org.apache.spark.sql.hive.SnappyStoreHiveCatalog
+import org.apache.spark.sql.sources.JdbcExtendedUtils
 import org.apache.spark.sql.types._
 import org.apache.spark.sql.{AnalysisException, BlockAndExecutorId, SQLContext, SnappyContext, SnappySession}
 
@@ -91,7 +92,7 @@ object StoreUtils {
     GEM_INDEXED_TABLE, ExternalStoreUtils.INDEX_NAME,
     ExternalStoreUtils.COLUMN_BATCH_SIZE, ExternalStoreUtils.COLUMN_MAX_DELTA_ROWS,
     ExternalStoreUtils.COMPRESSION_CODEC, ExternalStoreUtils.RELATION_FOR_SAMPLE,
-    ExternalStoreUtils.EXTERNAL_DATASOURCE)
+    JdbcExtendedUtils.SCHEMA_PROPERTY, ExternalStoreUtils.USER_SPECIFIED_SCHEMA)
 
   val EMPTY_STRING = ""
   val NONE = "NONE"
@@ -420,7 +421,7 @@ object StoreUtils {
 
   def validateConnProps(parameters: mutable.Map[String, String]): Unit = {
     parameters.keys.forall(v => {
-      if (!ddlOptions.contains(v.toString.toUpperCase)) {
+      if (!ddlOptions.contains(Utils.toUpperCase(v.toString))) {
         throw new AnalysisException(
           s"Unknown options $v specified while creating table ")
       }

--- a/core/src/test/scala/org/apache/spark/streaming/SnappyStreamingContextSuite.scala
+++ b/core/src/test/scala/org/apache/spark/streaming/SnappyStreamingContextSuite.scala
@@ -16,25 +16,16 @@
  */
 package org.apache.spark.streaming
 
-import java.io.File
-
-import scala.reflect.ClassTag
-
 import io.snappydata.SnappyFunSuite
-import org.apache.commons.io.FileUtils
 import org.scalatest.concurrent.Eventually
-import org.scalatest.time.SpanSugar._
 import org.scalatest.{BeforeAndAfter, BeforeAndAfterAll}
 
-import org.apache.spark.rdd.RDD
-import org.apache.spark.streaming.dstream.{InputDStream, DStream}
-import org.apache.spark.streaming.scheduler.StreamInputInfo
 import org.apache.spark.util.Utils
 import org.apache.spark.{SparkConf, SparkContext}
 
 
-class SnappyStreamingContextSuite extends SnappyFunSuite with Eventually with BeforeAndAfter with BeforeAndAfterAll{
-
+class SnappyStreamingContextSuite extends SnappyFunSuite with Eventually
+    with BeforeAndAfter with BeforeAndAfterAll {
 
   def framework: String = this.getClass.getSimpleName
 
@@ -225,5 +216,4 @@ class SnappyStreamingContextSuite extends SnappyFunSuite with Eventually with Be
       assert(snsc.conf.get("someKey") === "someValue")
     }
   }
-
 }


### PR DESCRIPTION
Addressing long standing issue of external/stream and other table types not showing up in the JDBC/ODBC meta-data.

## Changes proposed in this pull request

- added executor-side query to SnappyHiveCatalog for non-store hive tables
- store schema for all cases in SnappyStoreHiveCatalog.registerDataSourceTable
- using just the name for ExternalTableType store/query and not toString()
- cleaning up and refacring code a bit to reduce duplication (e.g. getting schema
    from hive Table object is now in ExternalStoreUtils)

## Patch testing

precheckin in progress

## ReleaseNotes.txt changes

NA

## Other PRs 

see store side PR for SNAP-303