### PR TITLE
Snap 1459

### DIFF
--- a/core/src/main/scala/org/apache/spark/sql/SnappySession.scala
+++ b/core/src/main/scala/org/apache/spark/sql/SnappySession.scala
@@ -300,12 +300,6 @@ class SnappySession(@transient private val sc: SparkContext,
    */
   def getClass(ctx: CodegenContext, baseTypes: Seq[(DataType, Boolean)],
       keyTypes: Seq[(DataType, Boolean)],
-      types: Seq[(DataType, Boolean)]): Option[(String, String)] = {
-    getClass(ctx, baseTypes, keyTypes, types, false)
-  }
-
-  def getClass(ctx: CodegenContext, baseTypes: Seq[(DataType, Boolean)],
-      keyTypes: Seq[(DataType, Boolean)],
       types: Seq[(DataType, Boolean)], multimap: Boolean): Option[(String, String)] = {
     getContextObject[(String, String)](ctx, "C", (baseTypes, keyTypes, types, multimap))
   }

--- a/core/src/main/scala/org/apache/spark/sql/SnappySession.scala
+++ b/core/src/main/scala/org/apache/spark/sql/SnappySession.scala
@@ -301,17 +301,22 @@ class SnappySession(@transient private val sc: SparkContext,
   def getClass(ctx: CodegenContext, baseTypes: Seq[(DataType, Boolean)],
       keyTypes: Seq[(DataType, Boolean)],
       types: Seq[(DataType, Boolean)]): Option[(String, String)] = {
-    getContextObject[(String, String)](ctx, "C", (baseTypes, keyTypes, types))
+    getClass(ctx, baseTypes, keyTypes, types, false)
   }
 
+  def getClass(ctx: CodegenContext, baseTypes: Seq[(DataType, Boolean)],
+      keyTypes: Seq[(DataType, Boolean)],
+      types: Seq[(DataType, Boolean)], multimap: Boolean): Option[(String, String)] = {
+    getContextObject[(String, String)](ctx, "C", (baseTypes, keyTypes, types, multimap))
+  }
   /**
    * Register code generated for a new class (for <code>CodegenSupport</code>).
    */
   private[sql] def addClass(ctx: CodegenContext,
       baseTypes: Seq[(DataType, Boolean)], keyTypes: Seq[(DataType, Boolean)],
       types: Seq[(DataType, Boolean)], baseClassName: String,
-      className: String): Unit = {
-    addContextObject(ctx, "C", (baseTypes, keyTypes, types),
+      className: String, multiMap: Boolean): Unit = {
+    addContextObject(ctx, "C", (baseTypes, keyTypes, types, multiMap),
       baseClassName -> className)
   }
 

--- a/core/src/main/scala/org/apache/spark/sql/execution/ObjectHashMapAccessor.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/ObjectHashMapAccessor.scala
@@ -149,7 +149,7 @@ case class ObjectHashMapAccessor(@transient session: SnappySession,
     val valClassTypes = if (multiMap) valueTypes else Nil
     // check for existing class with same schema
     val (valueClass, entryClass, exists) = session.getClass(ctx,
-      valClassTypes, keyTypes, entryTypes) match {
+      valClassTypes, keyTypes, entryTypes, multiMap) match {
       case Some((v, e)) => (v, e, true)
       case None =>
         val entryClass = ctx.freshName(classPrefix)
@@ -217,7 +217,7 @@ case class ObjectHashMapAccessor(@transient session: SnappySession,
       }
       ctx.addNewFunction(entryClass, classCode)
       session.addClass(ctx, valClassTypes, keyTypes, entryTypes,
-        valueClass, entryClass)
+        valueClass, entryClass, multiMap)
     }
 
     (entryClass, valueClass, entryVars ++ valClassVars, numNulls)


### PR DESCRIPTION
## Changes proposed in this pull request


For queries that have a join and an aggregate - During code generation, SnappyHashAggregate creates a class for the KeyBuffer. Then HashJoin creates a class for LocalMap. 

For queries such as 

select ORIGIN
from airline a, airlineref ar
where a.uniquecarrier = ar.code
GROUP BY origin

The types of class created by HashJoin i.e. LocalMap, is same as the types of the class created by hash aggregate i.e. KeyBuffer, because the query only has the group by column and no aggregates. And hence the LocalMap class is not registered and the already registered class of SnappyHashAggregate is returned. This is a problem because the structure of these classes is different.

To overcome this issue, registering the classes with a multimap parameter which differentiates between the hashjoin and hashaggregate.

## Patch testing

precheckin. Failing query passed. 

## ReleaseNotes.txt changes

(Does this change require an entry in ReleaseNotes.txt? If yes, has it been added to it?)

## Other PRs 

(Does this change require changes in other projects- store, spark, spark-jobserver, aqp? Add the links of PR of the other subprojects that are related to this change)
