### PR TITLE
Snap 1450 Stats not available in thin client smart connector mode

### DIFF
--- a/cluster/src/dunit/scala/io/snappydata/cluster/ClusterManagerTestBase.scala
+++ b/cluster/src/dunit/scala/io/snappydata/cluster/ClusterManagerTestBase.scala
@@ -73,6 +73,7 @@ class ClusterManagerTestBase(s: String)
 
   val locatorNetPort: Int = 0
   val locatorNetProps = new Properties()
+  val stopNetServersInTearDown = true
 
   // SparkContext is initialized on the lead node and hence,
   // this can be used only by jobs running on Lead node
@@ -153,8 +154,10 @@ class ClusterManagerTestBase(s: String)
     cleanupTestData(getClass.getName, getName)
     Array(vm3, vm2, vm1, vm0).foreach(_.invoke(getClass, "cleanupTestData",
       Array[AnyRef](getClass.getName, getName)))
-    Array(vm3, vm2, vm1, vm0).foreach(_.invoke(getClass, "stopNetworkServers"))
-    stopNetworkServers()
+    if (stopNetServersInTearDown) {
+      Array(vm3, vm2, vm1, vm0).foreach(_.invoke(getClass, "stopNetworkServers"))
+      stopNetworkServers
+    }
     bootProps.clear()
   }
 

--- a/cluster/src/dunit/scala/io/snappydata/cluster/ClusterManagerTestBase.scala
+++ b/cluster/src/dunit/scala/io/snappydata/cluster/ClusterManagerTestBase.scala
@@ -156,7 +156,7 @@ class ClusterManagerTestBase(s: String)
       Array[AnyRef](getClass.getName, getName)))
     if (stopNetServersInTearDown) {
       Array(vm3, vm2, vm1, vm0).foreach(_.invoke(getClass, "stopNetworkServers"))
-      stopNetworkServers
+      stopNetworkServers()
     }
     bootProps.clear()
   }

--- a/cluster/src/dunit/scala/io/snappydata/cluster/SnappyTableStatsProviderDUnitTest.scala
+++ b/cluster/src/dunit/scala/io/snappydata/cluster/SnappyTableStatsProviderDUnitTest.scala
@@ -27,7 +27,7 @@ import com.gemstone.gemfire.management.internal.SystemManagementService
 import com.pivotal.gemfirexd.internal.engine.Misc
 import com.pivotal.gemfirexd.internal.engine.ui.SnappyRegionStats
 import com.pivotal.gemfirexd.tools.sizer.GemFireXDInstrumentation
-import io.snappydata.{Constant, SnappyTableStatsProviderService}
+import io.snappydata.{SnappyEmbeddedTableStatsProviderService, Constant, SnappyTableStatsProviderService}
 import io.snappydata.test.dunit.SerializableRunnable
 
 import org.apache.spark.sql.collection.Utils
@@ -275,7 +275,7 @@ object SnappyTableStatsProviderDUnitTest {
 
   def verifyResults(snc: SnappyContext, table: String,
       tableType: String = "C", expectedRowCount: Int = 7000): Unit = {
-    SnappyTableStatsProviderService.getService.publishColumnTableRowCountStats()
+    SnappyEmbeddedTableStatsProviderService.publishColumnTableRowCountStats()
     val isColumnTable = if (tableType.equals("C")) true else false
     val isReplicatedTable = if (tableType.equals("R")) true else false
     def expected = SnappyTableStatsProviderDUnitTest.getExpectedResult(snc, table,

--- a/cluster/src/dunit/scala/io/snappydata/cluster/SnappyTableStatsProviderDUnitTest.scala
+++ b/cluster/src/dunit/scala/io/snappydata/cluster/SnappyTableStatsProviderDUnitTest.scala
@@ -275,12 +275,12 @@ object SnappyTableStatsProviderDUnitTest {
 
   def verifyResults(snc: SnappyContext, table: String,
       tableType: String = "C", expectedRowCount: Int = 7000): Unit = {
-    SnappyTableStatsProviderService.publishColumnTableRowCountStats()
+    SnappyTableStatsProviderService.getService.publishColumnTableRowCountStats()
     val isColumnTable = if (tableType.equals("C")) true else false
     val isReplicatedTable = if (tableType.equals("R")) true else false
     def expected = SnappyTableStatsProviderDUnitTest.getExpectedResult(snc, table,
       isReplicatedTable, isColumnTable)
-    def actual = SnappyTableStatsProviderService.
+    def actual = SnappyTableStatsProviderService.getService.
         getAggregatedStatsOnDemand._1(table)
 
     assert(actual.getRegionName == expected.getRegionName)

--- a/cluster/src/dunit/scala/io/snappydata/cluster/SplitSnappyClusterDUnitTest.scala
+++ b/cluster/src/dunit/scala/io/snappydata/cluster/SplitSnappyClusterDUnitTest.scala
@@ -61,7 +61,7 @@ class SplitSnappyClusterDUnitTest(s: String)
 
   override def beforeClass(): Unit = {
     super.beforeClass()
-    startNetworkServers
+    startNetworkServers()
     vm3.invoke(classOf[ClusterManagerTestBase], "startSparkCluster", productDir)
   }
 

--- a/cluster/src/dunit/scala/io/snappydata/cluster/SplitSnappyClusterDUnitTest.scala
+++ b/cluster/src/dunit/scala/io/snappydata/cluster/SplitSnappyClusterDUnitTest.scala
@@ -218,7 +218,6 @@ class SplitSnappyClusterDUnitTest(s: String)
   }
 
   def testCTAS(): Unit = {
-//    startNetworkServers()
     val snc = SnappyContext(sc)
     // StandAlone Spark Cluster Operations
     vm3.invoke(getClass, "splitModeCreateTableUsingCTAS",
@@ -241,7 +240,6 @@ class SplitSnappyClusterDUnitTest(s: String)
   }
 
   def doTestUDF(skewServerDistribution: Boolean): Unit = {
-//    startNetworkServers()
     testObject.createUDFInEmbeddedMode()
 
     // StandAlone Spark Cluster Operations

--- a/cluster/src/dunit/scala/io/snappydata/cluster/SplitSnappyClusterDUnitTest.scala
+++ b/cluster/src/dunit/scala/io/snappydata/cluster/SplitSnappyClusterDUnitTest.scala
@@ -48,6 +48,8 @@ class SplitSnappyClusterDUnitTest(s: String)
 
   override val locatorNetPort = testObject.locatorNetPort
 
+  override val stopNetServersInTearDown = false
+
   val currenyLocatorPort = ClusterManagerTestBase.locPort
 
   override protected val productDir =
@@ -59,12 +61,15 @@ class SplitSnappyClusterDUnitTest(s: String)
 
   override def beforeClass(): Unit = {
     super.beforeClass()
+    startNetworkServers
     vm3.invoke(classOf[ClusterManagerTestBase], "startSparkCluster", productDir)
   }
 
   override def afterClass(): Unit = {
-    super.afterClass()
+    Array(vm2, vm1, vm0).foreach(_.invoke(getClass, "stopNetworkServers"))
+    ClusterManagerTestBase.stopNetworkServers()
     vm3.invoke(classOf[ClusterManagerTestBase], "stopSparkCluster", productDir)
+    super.afterClass()
   }
 
   override protected def locatorClientPort = { locatorNetPort }
@@ -76,7 +81,7 @@ class SplitSnappyClusterDUnitTest(s: String)
   override protected def testObject = SplitSnappyClusterDUnitTest
 
   def testCollocatedJoinInSplitModeRowTable(): Unit = {
-    startNetworkServers()
+//    startNetworkServers()
     testObject.createRowTableForCollocatedJoin()
     vm3.invoke(getClass, "checkCollocatedJoins", startArgs :+ locatorProperty :+
         "PR_TABLE1" :+ "PR_TABLE2" :+ Boolean.box(useThinClientConnector) :+
@@ -84,14 +89,14 @@ class SplitSnappyClusterDUnitTest(s: String)
   }
 
   def testCollocatedJoinInSplitModeColumnTable(): Unit = {
-    startNetworkServers()
+//    startNetworkServers()
     testObject.createColumnTableForCollocatedJoin()
     vm3.invoke(getClass, "checkCollocatedJoins", startArgs :+ locatorProperty :+
         "PR_TABLE3" :+ "PR_TABLE4" :+ Boolean.box(useThinClientConnector) :+
         Int.box(locatorClientPort))
   }
   def testColumnTableStatsInSplitMode(): Unit = {
-    startNetworkServers()
+//    startNetworkServers()
     vm3.invoke(getClass, "checkStatsForSplitMode", startArgs :+ locatorProperty :+
         "1" :+ Boolean.box(useThinClientConnector) :+ Int.box(locatorClientPort))
     vm3.invoke(getClass, "checkStatsForSplitMode", startArgs :+ locatorProperty :+
@@ -103,7 +108,7 @@ class SplitSnappyClusterDUnitTest(s: String)
   }
 
   def doTestBatchSize(): Unit = {
-    startNetworkServers()
+//    startNetworkServers()
     val snc = SnappyContext(sc)
     val tblBatchSizeSmall = "APP.tblBatchSizeSmall_embedded"
     val tblSizeBig = "APP.tblBatchSizeBig_embedded"
@@ -180,7 +185,7 @@ class SplitSnappyClusterDUnitTest(s: String)
   }
 
   def testColumnTableStatsInSplitModeWithHA(): Unit = {
-    startNetworkServers()
+//    startNetworkServers()
     vm3.invoke(getClass, "checkStatsForSplitMode", startArgs :+ locatorProperty :+
         "1" :+ Boolean.box(useThinClientConnector) :+ Int.box(locatorClientPort))
     val props = bootProps
@@ -191,14 +196,14 @@ class SplitSnappyClusterDUnitTest(s: String)
     }
 
     vm0.invoke(classOf[ClusterManagerTestBase], "stopAny")
-    var stats = SnappyTableStatsProviderService.
+    var stats = SnappyTableStatsProviderService.getService.
         getAggregatedStatsOnDemand._1("APP.SNAPPYTABLE")
 
     Assert.assertEquals(10000100, stats.getRowCount)
     vm0.invoke(restartServer)
 
     vm1.invoke(classOf[ClusterManagerTestBase], "stopAny")
-    var stats1 = SnappyTableStatsProviderService.
+    var stats1 = SnappyTableStatsProviderService.getService.
         getAggregatedStatsOnDemand._1("APP.SNAPPYTABLE")
     Assert.assertEquals(10000100, stats1.getRowCount)
     vm1.invoke(restartServer)
@@ -207,18 +212,18 @@ class SplitSnappyClusterDUnitTest(s: String)
     vm3.invoke(getClass, "checkStatsForSplitMode", startArgs :+ port.toString :+
         "5" :+ Boolean.box(useThinClientConnector) :+ Int.box(locatorClientPort))
     vm0.invoke(classOf[ClusterManagerTestBase], "stopAny")
-    var stats2 = SnappyTableStatsProviderService.
+    var stats2 = SnappyTableStatsProviderService.getService.
         getAggregatedStatsOnDemand._1("APP.SNAPPYTABLE")
     Assert.assertEquals(10000100, stats2.getRowCount)
     val snc = SnappyContext(sc)
     snc.sql("insert into snappyTable values(1,'Test')")
-    var stats3 = SnappyTableStatsProviderService.
+    var stats3 = SnappyTableStatsProviderService.getService.
         getAggregatedStatsOnDemand._1("APP.SNAPPYTABLE")
     vm0.invoke(restartServer)
   }
 
   def testCTAS(): Unit = {
-    startNetworkServers()
+//    startNetworkServers()
     val snc = SnappyContext(sc)
     // StandAlone Spark Cluster Operations
     vm3.invoke(getClass, "splitModeCreateTableUsingCTAS",
@@ -241,7 +246,7 @@ class SplitSnappyClusterDUnitTest(s: String)
   }
 
   def doTestUDF(skewServerDistribution: Boolean): Unit = {
-    startNetworkServers()
+//    startNetworkServers()
     testObject.createUDFInEmbeddedMode()
 
     // StandAlone Spark Cluster Operations
@@ -510,16 +515,11 @@ object SplitSnappyClusterDUnitTest
     val snc: SnappyContext = getSnappyContextForConnector(locatorPort,
       locatorProp, useThinConnectorMode = useThinClientConnector, locatorClientPort)
 
-    val testJoins = {
-      if (useThinClientConnector) {
-        // TODO: Fix this. For thin client connector, there is
-        // a shuffle introduced because of which if ClusterSnappyJoinSuite
-        // is used test fails
-        new SnappyJoinSuite()
-      } else {
-        new ClusterSnappyJoinSuite()
-      }
-    }
+    // force the stats to be populated
+    SnappyTableStatsProviderService.getService.getTableStatsFromService("APP." + table1)
+    SnappyTableStatsProviderService.getService.getTableStatsFromService("APP." + table2)
+
+    val testJoins = new ClusterSnappyJoinSuite()
     testJoins.partitionToPartitionJoinAssertions(snc, table1, table2)
 
     logInfo("Successful")
@@ -632,13 +632,13 @@ object SplitSnappyClusterDUnitTest
     val testDF = snc.range(10000000).selectExpr("id", "concat('sym', cast((id % 100) as varchar" +
         "(10))) as sym")
     testDF.write.insertInto("snappyTable")
-    val stats = SnappyTableStatsProviderService.
+    val stats = SnappyTableStatsProviderService.getService.
         getAggregatedStatsOnDemand._1("APP.SNAPPYTABLE")
     Assert.assertEquals(10000000, stats.getRowCount)
     for (i <- 1 to 100) {
       snc.sql(s"insert into snappyTable values($i,'Test$i')")
     }
-    val stats1 = SnappyTableStatsProviderService.
+    val stats1 = SnappyTableStatsProviderService.getService.
         getAggregatedStatsOnDemand._1("APP.SNAPPYTABLE")
     Assert.assertEquals(10000100, stats1.getRowCount)
     logInfo("Successful")

--- a/cluster/src/main/scala/io/snappydata/gemxd/ClusterCallbacksImpl.scala
+++ b/cluster/src/main/scala/io/snappydata/gemxd/ClusterCallbacksImpl.scala
@@ -24,7 +24,7 @@ import com.gemstone.gemfire.internal.shared.Version
 import com.pivotal.gemfirexd.internal.iapi.types.DataValueDescriptor
 import com.pivotal.gemfirexd.internal.impl.sql.execute.ValueRow
 import com.pivotal.gemfirexd.internal.snappy.{CallbackFactoryProvider, ClusterCallbacks, LeadNodeExecutionContext, SparkSQLExecute}
-import io.snappydata.SnappyTableStatsProviderService
+import io.snappydata.{SnappyEmbeddedTableStatsProviderService, SnappyTableStatsProviderService}
 import io.snappydata.cluster.ExecutorInitiator
 import io.snappydata.impl.LeadImpl
 
@@ -108,6 +108,6 @@ object ClusterCallbacksImpl extends ClusterCallbacks with Logging {
   }
 
   override def publishColumnTableStats(): Unit = {
-    SnappyTableStatsProviderService.publishColumnTableRowCountStats()
+    SnappyEmbeddedTableStatsProviderService.publishColumnTableRowCountStats()
   }
 }

--- a/cluster/src/main/scala/org/apache/spark/ui/SnappyDashboardPage.scala
+++ b/cluster/src/main/scala/org/apache/spark/ui/SnappyDashboardPage.scala
@@ -49,7 +49,7 @@ private[ui] class SnappyDashboardPage (parent: SnappyDashboardTab)
     clusterStatsMap += ("numClients" -> 0)
     clusterStatsMap += ("memoryUsage" -> 0)
 
-    val allMembers = SnappyTableStatsProviderService.getMembersStatsFromService
+    val allMembers = SnappyTableStatsProviderService.getService.getMembersStatsFromService
 
     var clusterMembers = scala.collection.mutable.HashMap.empty[String, mutable.Map[String, Any]]
     var sparkConnectors = scala.collection.mutable.HashMap.empty[String, mutable.Map[String, Any]]
@@ -68,7 +68,7 @@ private[ui] class SnappyDashboardPage (parent: SnappyDashboardTab)
       }
     })
 
-    val (tableBuff,indexBuff) =  SnappyTableStatsProviderService.getAggregatedStatsOnDemand
+    val (tableBuff,indexBuff) =  SnappyTableStatsProviderService.getService.getAggregatedStatsOnDemand
 
     updateClusterStats(clusterStatsMap, clusterMembers, tableBuff)
 

--- a/cluster/src/main/scala/org/apache/spark/ui/SnappyStatsPage.scala
+++ b/cluster/src/main/scala/org/apache/spark/ui/SnappyStatsPage.scala
@@ -36,7 +36,7 @@ private[ui] class SnappyStatsPage(parent: SnappyStatsTab)
   val numFormatter = java.text.NumberFormat.getIntegerInstance
 
   def render(request: HttpServletRequest): Seq[Node] = {
-    val uiDisplayInfo = SnappyTableStatsProviderService
+    val uiDisplayInfo = SnappyTableStatsProviderService.getService
         .getAggregatedStatsOnDemand
 
     val uiTableInfo = uiDisplayInfo._1

--- a/cluster/src/test/scala/org/apache/spark/memory/SnappyLocalIndexAccountingSuite.scala
+++ b/cluster/src/test/scala/org/apache/spark/memory/SnappyLocalIndexAccountingSuite.scala
@@ -119,7 +119,7 @@ class SnappyLocalIndexAccountingSuite extends MemoryFunSuite {
     (1 to 10).map(i => snSession.insert("t1", Row(i, i, i)))
     val afterPutWithoutIndex = SparkEnv.get.memoryManager.storageMemoryUsed
     SparkEnv.get.memoryManager.asInstanceOf[SnappyUnifiedMemoryManager].dropAllObjects(memoryMode)
-    SnappyTableStatsProviderService.getAggregatedStatsOnDemand
+    SnappyTableStatsProviderService.getService.getAggregatedStatsOnDemand
     (1 to 10).map(i => snSession.insert("t1", Row(i, i, i)))
     val afterPutWitIndex = SparkEnv.get.memoryManager.storageMemoryUsed
     assert(afterPutWitIndex > afterPutWithoutIndex)

--- a/core/src/dunit/scala/io/snappydata/cluster/SplitClusterDUnitTestBase.scala
+++ b/core/src/dunit/scala/io/snappydata/cluster/SplitClusterDUnitTestBase.scala
@@ -68,7 +68,7 @@ trait SplitClusterDUnitTestBase extends Logging {
   protected def startNetworkServers(): Unit
 
   def doTestColumnTableCreation(): Unit = {
-    startNetworkServers()
+//    startNetworkServers()
 
     // Embedded Cluster Operations
     testObject.createTablesAndInsertData("column")
@@ -93,7 +93,7 @@ trait SplitClusterDUnitTestBase extends Logging {
   }
 
   def doTestRowTableCreation(): Unit = {
-    startNetworkServers()
+//    startNetworkServers()
 
     // Embedded Cluster Operations
     testObject.createTablesAndInsertData("row")
@@ -109,7 +109,7 @@ trait SplitClusterDUnitTestBase extends Logging {
   }
 
   def doTestComplexTypesForColumnTables_SNAP643(): Unit = {
-    startNetworkServers()
+//    startNetworkServers()
 
     // Embedded Cluster Operations
     val props = Map("buckets" -> "7")
@@ -125,7 +125,7 @@ trait SplitClusterDUnitTestBase extends Logging {
   }
 
   def doTestTableFormChanges(skewNetworkServers: Boolean): Unit = {
-    startNetworkServers()
+//    startNetworkServers()
 
     // StandAlone Spark Cluster Operations
     // row table

--- a/core/src/dunit/scala/io/snappydata/cluster/SplitClusterDUnitTestBase.scala
+++ b/core/src/dunit/scala/io/snappydata/cluster/SplitClusterDUnitTestBase.scala
@@ -68,8 +68,6 @@ trait SplitClusterDUnitTestBase extends Logging {
   protected def startNetworkServers(): Unit
 
   def doTestColumnTableCreation(): Unit = {
-//    startNetworkServers()
-
     // Embedded Cluster Operations
     testObject.createTablesAndInsertData("column")
 
@@ -93,8 +91,6 @@ trait SplitClusterDUnitTestBase extends Logging {
   }
 
   def doTestRowTableCreation(): Unit = {
-//    startNetworkServers()
-
     // Embedded Cluster Operations
     testObject.createTablesAndInsertData("row")
 
@@ -109,8 +105,6 @@ trait SplitClusterDUnitTestBase extends Logging {
   }
 
   def doTestComplexTypesForColumnTables_SNAP643(): Unit = {
-//    startNetworkServers()
-
     // Embedded Cluster Operations
     val props = Map("buckets" -> "7")
     testObject.createComplexTablesAndInsertData(props)
@@ -125,8 +119,6 @@ trait SplitClusterDUnitTestBase extends Logging {
   }
 
   def doTestTableFormChanges(skewNetworkServers: Boolean): Unit = {
-//    startNetworkServers()
-
     // StandAlone Spark Cluster Operations
     // row table
     vm3.invoke(getClass, "createDropTablesInSplitMode",

--- a/core/src/main/scala/io/snappydata/SnappyTableStatsProviderService.scala
+++ b/core/src/main/scala/io/snappydata/SnappyTableStatsProviderService.scala
@@ -19,10 +19,32 @@
 
 package io.snappydata
 
+import scala.collection.mutable
 import scala.language.implicitConversions
+import scala.collection.JavaConverters._
+
+import com.gemstone.gemfire.CancelException
+import com.gemstone.gemfire.cache.DataPolicy
+import com.gemstone.gemfire.cache.execute.FunctionService
+import com.gemstone.gemfire.i18n.LogWriterI18n
+import com.gemstone.gemfire.internal.SystemTimer
+import com.gemstone.gemfire.internal.cache.execute.InternalRegionFunctionContext
+import com.gemstone.gemfire.internal.cache.{PartitionedRegion, LocalRegion}
+import com.pivotal.gemfirexd.internal.engine.Misc
+import com.pivotal.gemfirexd.internal.engine.distributed.{GfxdMessage, GfxdListResultCollector}
+import com.pivotal.gemfirexd.internal.engine.distributed.GfxdListResultCollector.ListResultCollectorValue
+import com.pivotal.gemfirexd.internal.engine.sql.execute.MemberStatisticsMessage
+import com.pivotal.gemfirexd.internal.engine.store.{CompactCompositeKey, GemFireContainer}
+import com.pivotal.gemfirexd.internal.engine.ui.{SnappyRegionStatsCollectorFunction, SnappyRegionStatsCollectorResult, SnappyIndexStats, SnappyRegionStats}
+import com.pivotal.gemfirexd.internal.iapi.types.RowLocation
+import io.snappydata.Constant._
 
 import org.apache.spark.SparkContext
+import org.apache.spark.sql.catalyst.expressions.UnsafeRow
+import org.apache.spark.sql.execution.columnar.{JDBCSourceAsStore, JDBCAppendableRelation}
+import org.apache.spark.sql.execution.columnar.encoding.ColumnStatsSchema
 import org.apache.spark.sql.{SnappyContext, ThinClientConnectorMode}
+import org.apache.spark.unsafe.Platform
 
 /*
 * Object that encapsulates the actual stats provider service. Stats provider service
@@ -57,6 +79,9 @@ object SnappyTableStatsProviderService {
   }
 
   def getService: TableStatsProviderService = {
+    if (statsProviderService == null) {
+      throw new IllegalStateException("SnappyTableStatsProviderService not started")
+    }
     statsProviderService
   }
 
@@ -64,7 +89,141 @@ object SnappyTableStatsProviderService {
 }
 
 object SnappyEmbeddedTableStatsProviderService extends TableStatsProviderService {
-  override def start(sc: SparkContext, url: String): Unit = {
-    throw new IllegalStateException("This is expected to be called for ThinClientConnectorMode only")
+
+  def start(sc: SparkContext): Unit = {
+    val delay = sc.getConf.getLong(Constant.SPARK_SNAPPY_PREFIX +
+        "calcTableSizeInterval", DEFAULT_CALC_TABLE_SIZE_SERVICE_INTERVAL)
+    doRun = true
+    Misc.getGemFireCache.getCCPTimer.schedule(
+      new SystemTimer.SystemTimerTask {
+        private val logger: LogWriterI18n = Misc.getGemFireCache.getLoggerI18n
+
+        override def run2(): Unit = {
+          try {
+            if (doRun) {
+              aggregateStats()
+            }
+          } catch {
+            case _: CancelException => // ignore
+            case e: Exception => if (!e.getMessage.contains(
+              "com.gemstone.gemfire.cache.CacheClosedException")) {
+              logger.warning(e)
+            } else {
+              logger.error(e)
+            }
+          }
+        }
+
+        override def getLoggerI18n: LogWriterI18n = {
+          logger
+        }
+      },
+      delay, delay)
   }
+
+  override def start(sc: SparkContext, url: String): Unit = {
+    throw new IllegalStateException("This is expected to be called for " +
+        "ThinClientConnectorMode only")
+  }
+
+  override def fillAggregatedMemberStatsOnDemand(): Unit = {
+
+    val existingMembers = membersInfo.keys.toArray
+    val collector = new GfxdListResultCollector(null, true)
+    val msg = new MemberStatisticsMessage(collector)
+
+    msg.executeFunction()
+
+    val memStats = collector.getResult
+
+    val itr = memStats.iterator()
+
+    val members = mutable.Map.empty[String, mutable.Map[String, Any]]
+    while (itr.hasNext) {
+      val o = itr.next().asInstanceOf[ListResultCollectorValue]
+      val memMap = o.resultOfSingleExecution.asInstanceOf[java.util.HashMap[String, Any]]
+      val map = mutable.HashMap.empty[String, Any]
+      val keyItr = memMap.keySet().iterator()
+
+      while (keyItr.hasNext) {
+        val key = keyItr.next()
+        map.put(key, memMap.get(key))
+      }
+      map.put("status", "Running")
+
+      val dssUUID = memMap.get("diskStoreUUID").asInstanceOf[java.util.UUID]
+      if (dssUUID != null) {
+        members.put(dssUUID.toString, map)
+      } else {
+        members.put(memMap.get("id").asInstanceOf[String], map)
+      }
+    }
+    membersInfo ++= members
+    // mark members no longer running as stopped
+    existingMembers.filterNot(members.contains).foreach(m =>
+      membersInfo(m).put("status", "Stopped"))
+  }
+
+  override def getStatsFromAllServers: (Seq[SnappyRegionStats], Seq[SnappyIndexStats]) = {
+    var result = new java.util.ArrayList[SnappyRegionStatsCollectorResult]().asScala
+    val dataServers = GfxdMessage.getAllDataStores
+    if( dataServers != null && dataServers.size() > 0 ){
+      result = FunctionService.onMembers(dataServers)
+          .withCollector(new GfxdListResultCollector())
+          .execute(SnappyRegionStatsCollectorFunction.ID).getResult().
+          asInstanceOf[java.util.ArrayList[SnappyRegionStatsCollectorResult]]
+          .asScala
+    }
+    (result.flatMap(_.getRegionStats.asScala), result.flatMap(_.getIndexStats.asScala))
+  }
+
+  def publishColumnTableRowCountStats(): Unit = {
+    def asSerializable[C](c: C) = c.asInstanceOf[C with Serializable]
+
+    val regions = asSerializable(Misc.getGemFireCache.getApplicationRegions.asScala)
+    for (region: LocalRegion <- regions) {
+      if (region.getDataPolicy == DataPolicy.PARTITION ||
+          region.getDataPolicy == DataPolicy.PERSISTENT_PARTITION) {
+        val table = Misc.getFullTableNameFromRegionPath(region.getFullPath)
+        val pr = region.asInstanceOf[PartitionedRegion]
+        val container = pr.getUserAttribute.asInstanceOf[GemFireContainer]
+        if (table.startsWith(Constant.INTERNAL_SCHEMA_NAME) &&
+            table.endsWith(Constant.SHADOW_TABLE_SUFFIX)) {
+          if (container != null) {
+            val bufferTable = JDBCAppendableRelation.getTableName(table)
+            val numColumnsInBaseTbl = (Misc.getMemStore.getAllContainers.asScala.find(c => {
+              c.getQualifiedTableName.equalsIgnoreCase(bufferTable)}).get.getNumColumns) - 1
+
+            val numColumnsInStatBlob = numColumnsInBaseTbl * ColumnStatsSchema.NUM_STATS_PER_COLUMN
+            val itr = pr.localEntriesIterator(null.asInstanceOf[InternalRegionFunctionContext],
+              true, false, true, null).asInstanceOf[PartitionedRegion#PRLocalScanIterator]
+            // Resetting PR Numrows in cached batch as this will be calculated every time.
+            // TODO: Decrement count using deleted rows bitset in case of deletes in columntable
+            var rowsInColumnBatch: Long = 0
+            while (itr.hasNext) {
+              val rl = itr.next().asInstanceOf[RowLocation]
+              val key = rl.getKeyCopy.asInstanceOf[CompactCompositeKey]
+              val x = key.getKeyColumn(2).getInt
+              val currentBucketRegion = itr.getHostedBucketRegion
+              if (x == JDBCSourceAsStore.STATROW_COL_INDEX) {
+                val v = currentBucketRegion.get(key)
+                if (v ne null) {
+                  val currentVal = v.asInstanceOf[Array[Array[Byte]]]
+                  val rowFormatter = container.
+                      getRowFormatter(currentVal(0))
+                  val statBytes = rowFormatter.getLob(currentVal, 4)
+                  val unsafeRow = new UnsafeRow(numColumnsInStatBlob)
+                  unsafeRow.pointTo(statBytes, Platform.BYTE_ARRAY_OFFSET,
+                    statBytes.length)
+                  rowsInColumnBatch += unsafeRow.getInt(ColumnStatsSchema.COUNT_INDEX_IN_SCHEMA)
+                }
+              }
+            }
+            pr.getPrStats.setPRNumRowsInColumnBatches(rowsInColumnBatch)
+          }
+        }
+      }
+    }
+  }
+
 }

--- a/core/src/main/scala/io/snappydata/SnappyTableStatsProviderService.scala
+++ b/core/src/main/scala/io/snappydata/SnappyTableStatsProviderService.scala
@@ -19,282 +19,50 @@
 
 package io.snappydata
 
-import com.gemstone.gemfire.CancelException
-import com.gemstone.gemfire.cache.DataPolicy
-import com.gemstone.gemfire.cache.execute.FunctionService
-import com.gemstone.gemfire.i18n.LogWriterI18n
-import com.gemstone.gemfire.internal.SystemTimer
-import com.gemstone.gemfire.internal.cache.execute.InternalRegionFunctionContext
-import com.gemstone.gemfire.internal.cache.{LocalRegion, PartitionedRegion}
-import com.pivotal.gemfirexd.internal.engine.Misc
-import com.pivotal.gemfirexd.internal.engine.distributed.GfxdListResultCollector.ListResultCollectorValue
-import com.pivotal.gemfirexd.internal.engine.distributed.{GfxdListResultCollector, GfxdMessage}
-import com.pivotal.gemfirexd.internal.engine.sql.execute.MemberStatisticsMessage
-import com.pivotal.gemfirexd.internal.engine.store.{CompactCompositeKey, GemFireContainer}
-import com.pivotal.gemfirexd.internal.engine.ui.{SnappyIndexStats, SnappyRegionStats, SnappyRegionStatsCollectorFunction, SnappyRegionStatsCollectorResult}
-import com.pivotal.gemfirexd.internal.iapi.types.RowLocation
-import io.snappydata.Constant._
-import org.apache.spark.sql.catalyst.expressions.UnsafeRow
-import org.apache.spark.sql.collection.Utils
-import org.apache.spark.sql.execution.columnar.encoding.ColumnStatsSchema
-import org.apache.spark.sql.execution.columnar.{JDBCAppendableRelation, JDBCSourceAsStore}
-import org.apache.spark.sql.{SnappyContext, SnappySession}
-import org.apache.spark.unsafe.Platform
-import org.apache.spark.{Logging, SparkContext}
-
-import scala.collection.JavaConverters._
-import scala.collection.concurrent.TrieMap
-import scala.collection.mutable
 import scala.language.implicitConversions
 
-object SnappyTableStatsProviderService extends Logging {
+import org.apache.spark.SparkContext
+import org.apache.spark.sql.{SnappyContext, ThinClientConnectorMode}
 
-  @volatile
-  private var tableSizeInfo = Map.empty[String, SnappyRegionStats]
-  private val membersInfo = TrieMap.empty[String, mutable.Map[String, Any]]
-
-  private var _snc: Option[SnappyContext] = None
-
-  private def snc: SnappyContext = synchronized {
-    _snc.getOrElse {
-      val context = SnappyContext()
-      _snc = Option(context)
-      context
-    }
-  }
-
-  @volatile private var doRun: Boolean = false
-  @volatile private var running: Boolean = false
-
+/*
+* Object that encapsulates the actual stats provider service. Stats provider service
+* will either be SnappyEmbeddedTableStatsProviderService or SnappyThinConnectorTableStatsProvider
+ */
+object SnappyTableStatsProviderService {
+  // var that points to the actual stats provider service
+  private var statsProviderService: TableStatsProviderService = null
 
   def start(sc: SparkContext): Unit = {
-    val delay = sc.getConf.getLong(Constant.SPARK_SNAPPY_PREFIX +
-        "calcTableSizeInterval", DEFAULT_CALC_TABLE_SIZE_SERVICE_INTERVAL)
-    doRun = true
-    Misc.getGemFireCache.getCCPTimer.schedule(
-      new SystemTimer.SystemTimerTask {
-        private val logger: LogWriterI18n = Misc.getGemFireCache.getLoggerI18n
-
-        override def run2(): Unit = {
-          try {
-            if (doRun) {
-              aggregateStats()
-            }
-          } catch {
-            case _: CancelException => // ignore
-            case e: Exception => if (!e.getMessage.contains(
-              "com.gemstone.gemfire.cache.CacheClosedException")) {
-              logger.warning(e)
-            } else {
-              logger.error(e)
-            }
-          }
-        }
-
-        override def getLoggerI18n: LogWriterI18n = {
-          logger
-        }
-      },
-      delay, delay)
-  }
-
-  private def aggregateStats(): Unit = synchronized {
-    try {
-      if (doRun) {
-        val prevTableSizeInfo = tableSizeInfo
-        running = true
-        try {
-          val (tableStats, indexStats) = getAggregatedStatsOnDemand
-          tableSizeInfo = tableStats
-          // get members details
-          fillAggregatedMemberStatsOnDemand()
-        } finally {
-          running = false
-          notifyAll()
-        }
-        // check if there has been a substantial change in table
-        // stats, and clear the plan cache if so
-        if (prevTableSizeInfo.size != tableSizeInfo.size) {
-          SnappySession.clearAllCache(onlyQueryPlanCache = true)
-        } else {
-          val prevTotalRows = prevTableSizeInfo.values.map(_.getRowCount).sum
-          val newTotalRows = tableSizeInfo.values.map(_.getRowCount).sum
-          if (math.abs(newTotalRows - prevTotalRows) > 0.1 * prevTotalRows) {
-            SnappySession.clearAllCache(onlyQueryPlanCache = true)
-          }
-        }
-      }
-    } catch {
-      case _: CancelException => // ignore
-      case e: Exception => if (!e.getMessage.contains(
-        "com.gemstone.gemfire.cache.CacheClosedException")) {
-        logWarning(e.getMessage, e)
-      } else {
-        logError(e.getMessage, e)
-      }
+    SnappyContext.getClusterMode(sc) match {
+      case ThinClientConnectorMode(_, _) =>
+        throw new IllegalStateException("Not expected to be called for ThinClientConnectorMode")
+      case _ =>
+        statsProviderService = SnappyEmbeddedTableStatsProviderService
     }
+    statsProviderService.start(sc)
   }
 
-  def fillAggregatedMemberStatsOnDemand(): Unit = {
-
-    val existingMembers = membersInfo.keys.toArray
-    val collector = new GfxdListResultCollector(null, true)
-    val msg = new MemberStatisticsMessage(collector)
-
-    msg.executeFunction()
-
-    val memStats = collector.getResult
-
-    val itr = memStats.iterator()
-
-    val members = mutable.Map.empty[String, mutable.Map[String, Any]]
-    while (itr.hasNext) {
-      val o = itr.next().asInstanceOf[ListResultCollectorValue]
-      val memMap = o.resultOfSingleExecution.asInstanceOf[java.util.HashMap[String, Any]]
-      val map = mutable.HashMap.empty[String, Any]
-      val keyItr = memMap.keySet().iterator()
-
-      while (keyItr.hasNext) {
-        val key = keyItr.next()
-        map.put(key, memMap.get(key))
-      }
-      map.put("status", "Running")
-
-      val dssUUID = memMap.get("diskStoreUUID").asInstanceOf[java.util.UUID]
-      if (dssUUID != null) {
-        members.put(dssUUID.toString, map)
-      } else {
-        members.put(memMap.get("id").asInstanceOf[String], map)
-      }
+  def start(sc: SparkContext, url: String): Unit = {
+    SnappyContext.getClusterMode(sc) match {
+      case ThinClientConnectorMode(_, _) =>
+        statsProviderService = SnappyThinConnectorTableStatsProvider
+      case _ =>
+        throw new IllegalStateException("This is expected to be called for ThinClientConnectorMode only")
     }
-    membersInfo ++= members
-    // mark members no longer running as stopped
-    existingMembers.filterNot(members.contains).foreach(m =>
-      membersInfo(m).put("status", "Stopped"))
+    statsProviderService.start(sc, url)
   }
-
-  def getMembersStatsFromService: mutable.Map[String, mutable.Map[String, Any]] = {
-    membersInfo
-  }
-
 
   def stop(): Unit = {
-    doRun = false
-    // wait for it to end for sometime
-    synchronized {
-      if (running) wait(20000)
-    }
-    _snc = None
+    statsProviderService.stop()
   }
 
-
-  def getTableStatsFromService(
-      fullyQualifiedTableName: String): Option[SnappyRegionStats] = {
-    val tableSizes = this.tableSizeInfo
-    if (tableSizes.isEmpty || !tableSizes.contains(fullyQualifiedTableName)) {
-      // force run
-      aggregateStats()
-    }
-    tableSizeInfo.get(fullyQualifiedTableName)
+  def getService: TableStatsProviderService = {
+    statsProviderService
   }
+}
 
-  def publishColumnTableRowCountStats(): Unit = {
-    def asSerializable[C](c: C) = c.asInstanceOf[C with Serializable]
-
-    val regions = asSerializable(Misc.getGemFireCache.getApplicationRegions.asScala)
-    for (region: LocalRegion <- regions) {
-      if (region.getDataPolicy == DataPolicy.PARTITION ||
-          region.getDataPolicy == DataPolicy.PERSISTENT_PARTITION) {
-        val table = Misc.getFullTableNameFromRegionPath(region.getFullPath)
-        val pr = region.asInstanceOf[PartitionedRegion]
-        val container = pr.getUserAttribute.asInstanceOf[GemFireContainer]
-        if (table.startsWith(Constant.INTERNAL_SCHEMA_NAME) &&
-            table.endsWith(Constant.SHADOW_TABLE_SUFFIX)) {
-          if (container != null) {
-            val bufferTable = JDBCAppendableRelation.getTableName(table)
-            val numColumnsInBaseTbl = (Misc.getMemStore.getAllContainers.asScala.find(c => {
-              c.getQualifiedTableName.equalsIgnoreCase(bufferTable)}).get.getNumColumns) - 1
-
-            val numColumnsInStatBlob = numColumnsInBaseTbl * ColumnStatsSchema.NUM_STATS_PER_COLUMN
-            val itr = pr.localEntriesIterator(null.asInstanceOf[InternalRegionFunctionContext],
-              true, false, true, null).asInstanceOf[PartitionedRegion#PRLocalScanIterator]
-            // Resetting PR Numrows in cached batch as this will be calculated every time.
-            // TODO: Decrement count using deleted rows bitset in case of deletes in columntable
-            var rowsInColumnBatch: Long = 0
-            while (itr.hasNext) {
-              val rl = itr.next().asInstanceOf[RowLocation]
-              val key = rl.getKeyCopy.asInstanceOf[CompactCompositeKey]
-              val x = key.getKeyColumn(2).getInt
-              val currentBucketRegion = itr.getHostedBucketRegion
-              if (x == JDBCSourceAsStore.STATROW_COL_INDEX) {
-                val v = currentBucketRegion.get(key)
-                if (v ne null) {
-                  val currentVal = v.asInstanceOf[Array[Array[Byte]]]
-                  val rowFormatter = container.
-                      getRowFormatter(currentVal(0))
-                  val statBytes = rowFormatter.getLob(currentVal, 4)
-                  val unsafeRow = new UnsafeRow(numColumnsInStatBlob);
-                  unsafeRow.pointTo(statBytes, Platform.BYTE_ARRAY_OFFSET,
-                    statBytes.length);
-                  rowsInColumnBatch += unsafeRow.getInt(ColumnStatsSchema.COUNT_INDEX_IN_SCHEMA);
-                }
-              }
-            }
-            pr.getPrStats.setPRNumRowsInColumnBatches(rowsInColumnBatch)
-          }
-        }
-      }
-    }
+object SnappyEmbeddedTableStatsProviderService extends TableStatsProviderService {
+  override def start(sc: SparkContext, url: String): Unit = {
+    throw new IllegalStateException("This is expected to be called for ThinClientConnectorMode only")
   }
-
-  def getAggregatedStatsOnDemand: (Map[String, SnappyRegionStats],
-    Map[String, SnappyIndexStats]) = {
-    val snc = this.snc
-    if (snc == null) return (Map.empty, Map.empty)
-    val (tableStats, indexStats) = getStatsFromAllServers
-
-    val aggregatedStats = scala.collection.mutable.Map[String, SnappyRegionStats]()
-    val aggregatedStatsIndex = scala.collection.mutable.Map[String, SnappyIndexStats]()
-    if (!doRun) return (Map.empty, Map.empty)
-    // val samples = getSampleTableList(snc)
-    tableStats.foreach { stat =>
-      aggregatedStats.get(stat.getRegionName) match {
-        case Some(oldRecord) =>
-          aggregatedStats.put(stat.getRegionName, oldRecord.getCombinedStats(stat))
-        case None =>
-          aggregatedStats.put(stat.getRegionName, stat)
-      }
-    }
-
-    indexStats.foreach { stat =>
-      aggregatedStatsIndex.put(stat.getIndexName, stat)
-    }
-    (Utils.immutableMap(aggregatedStats), Utils.immutableMap(aggregatedStatsIndex))
-  }
-
-  /*
-  private def getSampleTableList(snc: SnappyContext): Seq[String] = {
-    try {
-      snc.sessionState.catalog
-          .getDataSourceTables(Seq(ExternalTableType.Sample)).map(_.toString())
-    } catch {
-      case tnfe: org.apache.spark.sql.TableNotFoundException =>
-        Seq.empty[String]
-    }
-  }
-  */
-
-  private def getStatsFromAllServers: (Seq[SnappyRegionStats], Seq[SnappyIndexStats]) = {
-    var result = new java.util.ArrayList[SnappyRegionStatsCollectorResult]().asScala
-    val dataServers = GfxdMessage.getAllDataStores
-    if( dataServers != null && dataServers.size() > 0 ){
-      result = FunctionService.onMembers(dataServers)
-        .withCollector(new GfxdListResultCollector())
-        .execute(SnappyRegionStatsCollectorFunction.ID).getResult().
-        asInstanceOf[java.util.ArrayList[SnappyRegionStatsCollectorResult]]
-        .asScala
-    }
-    (result.flatMap(_.getRegionStats.asScala), result.flatMap(_.getIndexStats.asScala))
-  }
-
 }

--- a/core/src/main/scala/io/snappydata/SnappyThinConnectorTableStatsProvider.scala
+++ b/core/src/main/scala/io/snappydata/SnappyThinConnectorTableStatsProvider.scala
@@ -1,0 +1,116 @@
+/*
+ * Changes for SnappyData data platform.
+ *
+ * Portions Copyright (c) 2017 SnappyData, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License. You
+ * may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License. See accompanying
+ * LICENSE file.
+ */
+
+package io.snappydata
+
+import java.sql.{SQLException, CallableStatement, Connection}
+import java.util.{Properties, Timer, TimerTask}
+
+import scala.collection.JavaConversions
+
+import com.gemstone.gemfire.CancelException
+import com.pivotal.gemfirexd.internal.engine.ui.{SnappyIndexStats, SnappyRegionStats}
+import io.snappydata.Constant._
+
+import org.apache.spark.SparkContext
+import org.apache.spark.sql.SmartConnectorHelper
+import org.apache.spark.sql.collection.Utils
+import org.apache.spark.sql.execution.datasources.jdbc.JdbcUtils
+
+object SnappyThinConnectorTableStatsProvider extends TableStatsProviderService {
+
+  private var conn: Connection = null
+  private var getStatsStmt: CallableStatement = null
+  private var _url: String = null
+
+  def initializeConnection(): Unit = {
+    conn = JdbcUtils.createConnectionFactory(
+      _url + ";route-query=false;" , new Properties())()
+    getStatsStmt = conn.prepareCall("call sys.GET_SNAPPY_TABLE_STATS(?)")
+  }
+
+  def start(sc: SparkContext, url: String): Unit = {
+    _url = url
+    initializeConnection()
+    val delay = sc.getConf.getLong(Constant.SPARK_SNAPPY_PREFIX +
+        "calcTableSizeInterval", DEFAULT_CALC_TABLE_SIZE_SERVICE_INTERVAL)
+    doRun = true
+    new Timer("SnappyThinConnectorTableStatsProvider", true).schedule(
+      new TimerTask {
+        override def run(): Unit = {
+          try {
+            if (doRun) {
+              aggregateStats()
+            }
+          } catch {
+            case _: CancelException => // ignore
+            case e: Exception => logError("SnappyThinConnectorTableStatsProvider", e)
+          }
+        }
+      }, delay, delay)
+  }
+
+//  override def getAggregatedStatsOnDemand: (Map[String, SnappyRegionStats],
+//      Map[String, SnappyIndexStats]) = {
+//    val (tableStats, indexStats) = getStatsFromAllServers
+//
+//    val aggregatedStats = scala.collection.mutable.Map[String, SnappyRegionStats]()
+//    val aggregatedStatsIndex = scala.collection.mutable.Map[String, SnappyIndexStats]()
+//    if (!doRun) return (Map.empty, Map.empty)
+//    // val samples = getSampleTableList(snc)
+//    tableStats.foreach { stat =>
+//      aggregatedStats.get(stat.getRegionName) match {
+//        case Some(oldRecord) =>
+//          aggregatedStats.put(stat.getRegionName, oldRecord.getCombinedStats(stat))
+//        case None =>
+//          aggregatedStats.put(stat.getRegionName, stat)
+//      }
+//    }
+//
+//    indexStats.foreach { stat =>
+//      aggregatedStatsIndex.put(stat.getIndexName, stat)
+//    }
+//    (Utils.immutableMap(aggregatedStats), Utils.immutableMap(aggregatedStatsIndex))
+//  }
+
+  def executeStatsStmt(): Unit = {
+    if (conn == null) initializeConnection()
+    getStatsStmt.registerOutParameter(1, java.sql.Types.BLOB)
+    getStatsStmt.execute()
+  }
+
+  override protected def getStatsFromAllServers: (Seq[SnappyRegionStats], Seq[SnappyIndexStats]) = {
+    try {
+      executeStatsStmt()
+    } catch {
+      case e: Exception =>
+        logWarning("SnappyThinConnectorTableStatsProvider: exception while retrieving stats " +
+            "from Snappy embedded cluster. Check whether the embedded cluster is stopped ")
+        logDebug("Exception stack trace: ", e)
+        conn = null
+        return (Seq.empty[SnappyRegionStats], Seq.empty[SnappyIndexStats])
+    }
+    val value = getStatsStmt.getBlob(1)
+    val regionStats: java.util.List[SnappyRegionStats] =
+      SmartConnectorHelper.deserialize(
+        value.getBytes(1, value.length().asInstanceOf[Int])).asInstanceOf[java.util.ArrayList[SnappyRegionStats]]
+    (JavaConversions.asScalaBuffer(regionStats).toSeq, Seq.empty[SnappyIndexStats])
+  }
+
+}

--- a/core/src/main/scala/io/snappydata/SnappyThinConnectorTableStatsProvider.scala
+++ b/core/src/main/scala/io/snappydata/SnappyThinConnectorTableStatsProvider.scala
@@ -19,7 +19,7 @@
 
 package io.snappydata
 
-import java.sql.{SQLException, CallableStatement, Connection}
+import java.sql.{CallableStatement, Connection}
 import java.util.{Properties, Timer, TimerTask}
 
 import scala.collection.JavaConversions
@@ -30,7 +30,6 @@ import io.snappydata.Constant._
 
 import org.apache.spark.SparkContext
 import org.apache.spark.sql.SmartConnectorHelper
-import org.apache.spark.sql.collection.Utils
 import org.apache.spark.sql.execution.datasources.jdbc.JdbcUtils
 
 object SnappyThinConnectorTableStatsProvider extends TableStatsProviderService {
@@ -65,29 +64,6 @@ object SnappyThinConnectorTableStatsProvider extends TableStatsProviderService {
         }
       }, delay, delay)
   }
-
-//  override def getAggregatedStatsOnDemand: (Map[String, SnappyRegionStats],
-//      Map[String, SnappyIndexStats]) = {
-//    val (tableStats, indexStats) = getStatsFromAllServers
-//
-//    val aggregatedStats = scala.collection.mutable.Map[String, SnappyRegionStats]()
-//    val aggregatedStatsIndex = scala.collection.mutable.Map[String, SnappyIndexStats]()
-//    if (!doRun) return (Map.empty, Map.empty)
-//    // val samples = getSampleTableList(snc)
-//    tableStats.foreach { stat =>
-//      aggregatedStats.get(stat.getRegionName) match {
-//        case Some(oldRecord) =>
-//          aggregatedStats.put(stat.getRegionName, oldRecord.getCombinedStats(stat))
-//        case None =>
-//          aggregatedStats.put(stat.getRegionName, stat)
-//      }
-//    }
-//
-//    indexStats.foreach { stat =>
-//      aggregatedStatsIndex.put(stat.getIndexName, stat)
-//    }
-//    (Utils.immutableMap(aggregatedStats), Utils.immutableMap(aggregatedStatsIndex))
-//  }
 
   def executeStatsStmt(): Unit = {
     if (conn == null) initializeConnection()

--- a/core/src/main/scala/io/snappydata/TableStatsProviderService.scala
+++ b/core/src/main/scala/io/snappydata/TableStatsProviderService.scala
@@ -1,0 +1,293 @@
+package io.snappydata
+
+import scala.collection.concurrent.TrieMap
+import scala.collection.mutable
+import scala.collection.JavaConverters._
+import scala.language.implicitConversions
+
+import com.gemstone.gemfire.CancelException
+import com.gemstone.gemfire.cache.DataPolicy
+import com.gemstone.gemfire.cache.execute.FunctionService
+import com.gemstone.gemfire.i18n.LogWriterI18n
+import com.gemstone.gemfire.internal.SystemTimer
+import com.gemstone.gemfire.internal.cache.execute.InternalRegionFunctionContext
+import com.gemstone.gemfire.internal.cache.{PartitionedRegion, LocalRegion}
+import com.pivotal.gemfirexd.internal.engine.Misc
+import com.pivotal.gemfirexd.internal.engine.distributed.{GfxdMessage, GfxdListResultCollector}
+import com.pivotal.gemfirexd.internal.engine.distributed.GfxdListResultCollector.ListResultCollectorValue
+import com.pivotal.gemfirexd.internal.engine.sql.execute.MemberStatisticsMessage
+import com.pivotal.gemfirexd.internal.engine.store.{CompactCompositeKey, GemFireContainer}
+import com.pivotal.gemfirexd.internal.engine.ui.{SnappyRegionStatsCollectorFunction, SnappyRegionStatsCollectorResult, SnappyIndexStats, SnappyRegionStats}
+import com.pivotal.gemfirexd.internal.iapi.types.RowLocation
+import io.snappydata.Constant._
+
+import org.apache.spark.sql.catalyst.expressions.UnsafeRow
+import org.apache.spark.sql.collection.Utils
+import org.apache.spark.sql.execution.columnar.{JDBCSourceAsStore, JDBCAppendableRelation}
+import org.apache.spark.sql.execution.columnar.encoding.ColumnStatsSchema
+import org.apache.spark.unsafe.Platform
+import org.apache.spark.{SparkContext, Logging}
+import org.apache.spark.sql.{SnappySession, SnappyContext}
+
+trait TableStatsProviderService extends Logging {
+
+  @volatile
+  private var tableSizeInfo = Map.empty[String, SnappyRegionStats]
+  private val membersInfo = TrieMap.empty[String, mutable.Map[String, Any]]
+
+  private var _snc: Option[SnappyContext] = None
+
+  protected def snc: SnappyContext = synchronized {
+    _snc.getOrElse {
+      val context = SnappyContext()
+      _snc = Option(context)
+      context
+    }
+  }
+
+  @volatile protected var doRun: Boolean = false
+  @volatile private var running: Boolean = false
+
+
+  def start(sc: SparkContext): Unit = {
+    val delay = sc.getConf.getLong(Constant.SPARK_SNAPPY_PREFIX +
+        "calcTableSizeInterval", DEFAULT_CALC_TABLE_SIZE_SERVICE_INTERVAL)
+    doRun = true
+    Misc.getGemFireCache.getCCPTimer.schedule(
+      new SystemTimer.SystemTimerTask {
+        private val logger: LogWriterI18n = Misc.getGemFireCache.getLoggerI18n
+
+        override def run2(): Unit = {
+          try {
+            if (doRun) {
+              aggregateStats()
+            }
+          } catch {
+            case _: CancelException => // ignore
+            case e: Exception => if (!e.getMessage.contains(
+              "com.gemstone.gemfire.cache.CacheClosedException")) {
+              logger.warning(e)
+            } else {
+              logger.error(e)
+            }
+          }
+        }
+
+        override def getLoggerI18n: LogWriterI18n = {
+          logger
+        }
+      },
+      delay, delay)
+  }
+
+  def start(sc: SparkContext, url: String): Unit
+
+  protected def aggregateStats(): Unit = synchronized {
+    try {
+      if (doRun) {
+        val prevTableSizeInfo = tableSizeInfo
+        running = true
+        try {
+          val (tableStats, indexStats) = getAggregatedStatsOnDemand
+          tableSizeInfo = tableStats
+          // get members details
+          fillAggregatedMemberStatsOnDemand()
+        } finally {
+          running = false
+          notifyAll()
+        }
+        // check if there has been a substantial change in table
+        // stats, and clear the plan cache if so
+        if (prevTableSizeInfo.size != tableSizeInfo.size) {
+          SnappySession.clearAllCache(onlyQueryPlanCache = true)
+        } else {
+          val prevTotalRows = prevTableSizeInfo.values.map(_.getRowCount).sum
+          val newTotalRows = tableSizeInfo.values.map(_.getRowCount).sum
+          if (math.abs(newTotalRows - prevTotalRows) > 0.1 * prevTotalRows) {
+            SnappySession.clearAllCache(onlyQueryPlanCache = true)
+          }
+        }
+      }
+    } catch {
+      case _: CancelException => // ignore
+      case e: Exception => if (!e.getMessage.contains(
+        "com.gemstone.gemfire.cache.CacheClosedException")) {
+        logWarning(e.getMessage, e)
+      } else {
+        logError(e.getMessage, e)
+      }
+    }
+  }
+
+  def fillAggregatedMemberStatsOnDemand(): Unit = {
+
+    val existingMembers = membersInfo.keys.toArray
+    val collector = new GfxdListResultCollector(null, true)
+    val msg = new MemberStatisticsMessage(collector)
+
+    msg.executeFunction()
+
+    val memStats = collector.getResult
+
+    val itr = memStats.iterator()
+
+    val members = mutable.Map.empty[String, mutable.Map[String, Any]]
+    while (itr.hasNext) {
+      val o = itr.next().asInstanceOf[ListResultCollectorValue]
+      val memMap = o.resultOfSingleExecution.asInstanceOf[java.util.HashMap[String, Any]]
+      val map = mutable.HashMap.empty[String, Any]
+      val keyItr = memMap.keySet().iterator()
+
+      while (keyItr.hasNext) {
+        val key = keyItr.next()
+        map.put(key, memMap.get(key))
+      }
+      map.put("status", "Running")
+
+      val dssUUID = memMap.get("diskStoreUUID").asInstanceOf[java.util.UUID]
+      if (dssUUID != null) {
+        members.put(dssUUID.toString, map)
+      } else {
+        members.put(memMap.get("id").asInstanceOf[String], map)
+      }
+    }
+    membersInfo ++= members
+    // mark members no longer running as stopped
+    existingMembers.filterNot(members.contains).foreach(m =>
+      membersInfo(m).put("status", "Stopped"))
+  }
+
+  def getMembersStatsFromService: mutable.Map[String, mutable.Map[String, Any]] = {
+    membersInfo
+  }
+
+
+  def stop(): Unit = {
+    doRun = false
+    // wait for it to end for sometime
+    synchronized {
+      if (running) wait(20000)
+    }
+    _snc = None
+  }
+
+  def getTableSizeStats(): Map[String, SnappyRegionStats] = {
+    val tableSizes = this.tableSizeInfo
+    if (tableSizes.isEmpty) {
+      // force run
+      aggregateStats()
+    }
+    tableSizeInfo
+  }
+
+  def getTableStatsFromService(
+      fullyQualifiedTableName: String): Option[SnappyRegionStats] = {
+    val tableSizes = this.tableSizeInfo
+    if (tableSizes.isEmpty || !tableSizes.contains(fullyQualifiedTableName)) {
+      // force run
+      aggregateStats()
+    }
+    tableSizeInfo.get(fullyQualifiedTableName)
+  }
+
+  def publishColumnTableRowCountStats(): Unit = {
+    def asSerializable[C](c: C) = c.asInstanceOf[C with Serializable]
+
+    val regions = asSerializable(Misc.getGemFireCache.getApplicationRegions.asScala)
+    for (region: LocalRegion <- regions) {
+      if (region.getDataPolicy == DataPolicy.PARTITION ||
+          region.getDataPolicy == DataPolicy.PERSISTENT_PARTITION) {
+        val table = Misc.getFullTableNameFromRegionPath(region.getFullPath)
+        val pr = region.asInstanceOf[PartitionedRegion]
+        val container = pr.getUserAttribute.asInstanceOf[GemFireContainer]
+        if (table.startsWith(Constant.INTERNAL_SCHEMA_NAME) &&
+            table.endsWith(Constant.SHADOW_TABLE_SUFFIX)) {
+          if (container != null) {
+            val bufferTable = JDBCAppendableRelation.getTableName(table)
+            val numColumnsInBaseTbl = (Misc.getMemStore.getAllContainers.asScala.find(c => {
+              c.getQualifiedTableName.equalsIgnoreCase(bufferTable)}).get.getNumColumns) - 1
+
+            val numColumnsInStatBlob = numColumnsInBaseTbl * ColumnStatsSchema.NUM_STATS_PER_COLUMN
+            val itr = pr.localEntriesIterator(null.asInstanceOf[InternalRegionFunctionContext],
+              true, false, true, null).asInstanceOf[PartitionedRegion#PRLocalScanIterator]
+            // Resetting PR Numrows in cached batch as this will be calculated every time.
+            // TODO: Decrement count using deleted rows bitset in case of deletes in columntable
+            var rowsInColumnBatch: Long = 0
+            while (itr.hasNext) {
+              val rl = itr.next().asInstanceOf[RowLocation]
+              val key = rl.getKeyCopy.asInstanceOf[CompactCompositeKey]
+              val x = key.getKeyColumn(2).getInt
+              val currentBucketRegion = itr.getHostedBucketRegion
+              if (x == JDBCSourceAsStore.STATROW_COL_INDEX) {
+                val v = currentBucketRegion.get(key)
+                if (v ne null) {
+                  val currentVal = v.asInstanceOf[Array[Array[Byte]]]
+                  val rowFormatter = container.
+                      getRowFormatter(currentVal(0))
+                  val statBytes = rowFormatter.getLob(currentVal, 4)
+                  val unsafeRow = new UnsafeRow(numColumnsInStatBlob);
+                  unsafeRow.pointTo(statBytes, Platform.BYTE_ARRAY_OFFSET,
+                    statBytes.length);
+                  rowsInColumnBatch += unsafeRow.getInt(ColumnStatsSchema.COUNT_INDEX_IN_SCHEMA);
+                }
+              }
+            }
+            pr.getPrStats.setPRNumRowsInColumnBatches(rowsInColumnBatch)
+          }
+        }
+      }
+    }
+  }
+
+  def getAggregatedStatsOnDemand: (Map[String, SnappyRegionStats],
+      Map[String, SnappyIndexStats]) = {
+    val snc = this.snc
+    if (snc == null) return (Map.empty, Map.empty)
+    val (tableStats, indexStats) = getStatsFromAllServers
+
+    val aggregatedStats = scala.collection.mutable.Map[String, SnappyRegionStats]()
+    val aggregatedStatsIndex = scala.collection.mutable.Map[String, SnappyIndexStats]()
+    if (!doRun) return (Map.empty, Map.empty)
+    // val samples = getSampleTableList(snc)
+    tableStats.foreach { stat =>
+      aggregatedStats.get(stat.getRegionName) match {
+        case Some(oldRecord) =>
+          aggregatedStats.put(stat.getRegionName, oldRecord.getCombinedStats(stat))
+        case None =>
+          aggregatedStats.put(stat.getRegionName, stat)
+      }
+    }
+
+    indexStats.foreach { stat =>
+      aggregatedStatsIndex.put(stat.getIndexName, stat)
+    }
+    (Utils.immutableMap(aggregatedStats), Utils.immutableMap(aggregatedStatsIndex))
+  }
+
+  /*
+  private def getSampleTableList(snc: SnappyContext): Seq[String] = {
+    try {
+      snc.sessionState.catalog
+          .getDataSourceTables(Seq(ExternalTableType.Sample)).map(_.toString())
+    } catch {
+      case tnfe: org.apache.spark.sql.TableNotFoundException =>
+        Seq.empty[String]
+    }
+  }
+  */
+
+  protected def getStatsFromAllServers: (Seq[SnappyRegionStats], Seq[SnappyIndexStats]) = {
+    var result = new java.util.ArrayList[SnappyRegionStatsCollectorResult]().asScala
+    val dataServers = GfxdMessage.getAllDataStores
+    if( dataServers != null && dataServers.size() > 0 ){
+      result = FunctionService.onMembers(dataServers)
+          .withCollector(new GfxdListResultCollector())
+          .execute(SnappyRegionStatsCollectorFunction.ID).getResult().
+          asInstanceOf[java.util.ArrayList[SnappyRegionStatsCollectorResult]]
+          .asScala
+    }
+    (result.flatMap(_.getRegionStats.asScala), result.flatMap(_.getIndexStats.asScala))
+  }
+
+
+}

--- a/core/src/main/scala/org/apache/spark/sql/SmartConnectorHelper.scala
+++ b/core/src/main/scala/org/apache/spark/sql/SmartConnectorHelper.scala
@@ -75,7 +75,7 @@ class SmartConnectorHelper(snappySession: SnappySession) extends Logging {
     try {
       function
     } catch {
-      case e: SQLException if SmartConnectorHelper.isConnectionException(e) =>
+      case e: SQLException if isConnectionException(e) =>
         // attempt to create a new connection if connection
         // is closed
         SmartConnectorHelper.close()
@@ -84,7 +84,10 @@ class SmartConnectorHelper(snappySession: SnappySession) extends Logging {
     }
   }
 
-
+  def isConnectionException(e: SQLException): Boolean = {
+    e.getSQLState.startsWith(SQLState.CONNECTIVITY_PREFIX) ||
+        e.getSQLState.startsWith(SQLState.LANG_DEAD_STATEMENT)
+  }
 
   def createTable(
       tableIdent: QualifiedTableName,
@@ -294,10 +297,5 @@ object SmartConnectorHelper {
     val baip = new ByteArrayInputStream(value)
     val ois = new ObjectInputStream(baip)
     ois.readObject()
-  }
-
-  def isConnectionException(e: SQLException): Boolean = {
-    e.getSQLState.startsWith(SQLState.CONNECTIVITY_PREFIX) ||
-        e.getSQLState.startsWith(SQLState.LANG_DEAD_STATEMENT)
   }
 }

--- a/core/src/main/scala/org/apache/spark/sql/SmartConnectorHelper.scala
+++ b/core/src/main/scala/org/apache/spark/sql/SmartConnectorHelper.scala
@@ -75,7 +75,7 @@ class SmartConnectorHelper(snappySession: SnappySession) extends Logging {
     try {
       function
     } catch {
-      case e: SQLException if isConnectionException(e) =>
+      case e: SQLException if SmartConnectorHelper.isConnectionException(e) =>
         // attempt to create a new connection if connection
         // is closed
         SmartConnectorHelper.close()
@@ -84,10 +84,7 @@ class SmartConnectorHelper(snappySession: SnappySession) extends Logging {
     }
   }
 
-  private def isConnectionException(e: SQLException): Boolean = {
-    e.getSQLState.startsWith(SQLState.CONNECTIVITY_PREFIX) ||
-    e.getSQLState.startsWith(SQLState.LANG_DEAD_STATEMENT)
-  }
+
 
   def createTable(
       tableIdent: QualifiedTableName,
@@ -297,5 +294,10 @@ object SmartConnectorHelper {
     val baip = new ByteArrayInputStream(value)
     val ois = new ObjectInputStream(baip)
     ois.readObject()
+  }
+
+  def isConnectionException(e: SQLException): Boolean = {
+    e.getSQLState.startsWith(SQLState.CONNECTIVITY_PREFIX) ||
+        e.getSQLState.startsWith(SQLState.LANG_DEAD_STATEMENT)
   }
 }

--- a/core/src/main/scala/org/apache/spark/sql/SmartConnectorHelper.scala
+++ b/core/src/main/scala/org/apache/spark/sql/SmartConnectorHelper.scala
@@ -84,9 +84,9 @@ class SmartConnectorHelper(snappySession: SnappySession) extends Logging {
     }
   }
 
-  def isConnectionException(e: SQLException): Boolean = {
+  private def isConnectionException(e: SQLException): Boolean = {
     e.getSQLState.startsWith(SQLState.CONNECTIVITY_PREFIX) ||
-        e.getSQLState.startsWith(SQLState.LANG_DEAD_STATEMENT)
+    e.getSQLState.startsWith(SQLState.LANG_DEAD_STATEMENT)
   }
 
   def createTable(

--- a/core/src/main/scala/org/apache/spark/sql/SnappyContext.scala
+++ b/core/src/main/scala/org/apache/spark/sql/SnappyContext.scala
@@ -27,7 +27,7 @@ import scala.reflect.runtime.{universe => u}
 
 import com.pivotal.gemfirexd.internal.engine.Misc
 import io.snappydata.util.ServiceUtils
-import io.snappydata.{Constant, Property, SnappyTableStatsProviderService}
+import io.snappydata.{SnappyThinConnectorTableStatsProvider, Constant, Property, SnappyTableStatsProviderService}
 
 import org.apache.spark.annotation.{DeveloperApi, Experimental}
 import org.apache.spark.api.java.JavaSparkContext
@@ -1055,7 +1055,6 @@ object SnappyContext extends Logging {
     }
   }
 
-
   private def invokeServices(sc: SparkContext): Unit = {
     SnappyContext.getClusterMode(sc) match {
       case SnappyEmbeddedMode(_, _) =>
@@ -1069,9 +1068,8 @@ object SnappyContext extends Logging {
       case SplitClusterMode(_, _) =>
         ServiceUtils.invokeStartFabricServer(sc, hostData = false)
         SnappyTableStatsProviderService.start(sc)
-      case ThinClientConnectorMode(_, _) =>
-        // do nothing
-//        SnappyTableStatsProviderService.start(sc)
+      case ThinClientConnectorMode(_, url) =>
+        SnappyTableStatsProviderService.start(sc, url)
       case ExternalEmbeddedMode(_, url) =>
         SnappyContext.urlToConf(url, sc)
         ServiceUtils.invokeStartFabricServer(sc, hostData = false)

--- a/core/src/main/scala/org/apache/spark/sql/execution/columnar/ColumnInsertExec.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/columnar/ColumnInsertExec.scala
@@ -16,6 +16,7 @@
  */
 package org.apache.spark.sql.execution.columnar
 
+import io.snappydata.Property
 import org.apache.spark.sql.catalyst.expressions.codegen.{CodegenContext, ExprCode, GenerateUnsafeProjection}
 import org.apache.spark.sql.catalyst.expressions.{Attribute, BoundReference, Expression, Literal}
 import org.apache.spark.sql.catalyst.util.{SerializedArray, SerializedMap, SerializedRow}
@@ -156,7 +157,8 @@ case class ColumnInsertExec(_child: SparkPlan, partitionColumns: Seq[String],
        |  int $defaultRowSize = 0;
        |  ${declarations.mkString("\n")}
        |  $defaultBatchSizeTerm = Math.max(
-       |    (${math.abs(columnBatchSize)} - 8) / $defaultRowSize, 16);
+       |    (${math.abs( if (columnBatchSize > 0) columnBatchSize else Property.ColumnBatchSize.
+            defaultValue.get)} - 8) / $defaultRowSize, 16);
        |  // ceil to nearest multiple of $checkFrequency since size is checked
        |  // every $checkFrequency rows
        |  $defaultBatchSizeTerm = ((($defaultBatchSizeTerm - 1) / $checkFrequency) + 1)

--- a/core/src/main/scala/org/apache/spark/sql/execution/columnar/JDBCAppendableRelation.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/columnar/JDBCAppendableRelation.scala
@@ -74,13 +74,10 @@ abstract case class JDBCAppendableRelation(
   def numBuckets: Int = -1
 
   override def sizeInBytes: Long = {
-    logInfo(s"JDBCAppendableRelation.sizeInBytes sdeshmukh looking size of table $table")
-    val size = SnappyTableStatsProviderService.getService.getTableStatsFromService(table) match {
+    SnappyTableStatsProviderService.getService.getTableStatsFromService(table) match {
       case Some(s) => s.getTotalSize
       case None => super.sizeInBytes
     }
-    logInfo(s"JDBCAppendableRelation.sizeInBytes sdeshmukh $table size is $size")
-    size
   }
 
   protected final def dialect: JdbcDialect = connProperties.dialect

--- a/core/src/main/scala/org/apache/spark/sql/execution/columnar/JDBCAppendableRelation.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/columnar/JDBCAppendableRelation.scala
@@ -19,7 +19,7 @@ package org.apache.spark.sql.execution.columnar
 import java.sql.Connection
 import java.util.concurrent.locks.ReentrantReadWriteLock
 
-import _root_.io.snappydata.{Constant, SnappyTableStatsProviderService}
+import io.snappydata.{SnappyThinConnectorTableStatsProvider, Constant, SnappyTableStatsProviderService}
 
 import org.apache.spark.Logging
 import org.apache.spark.rdd.RDD
@@ -74,12 +74,14 @@ abstract case class JDBCAppendableRelation(
   def numBuckets: Int = -1
 
   override def sizeInBytes: Long = {
-    SnappyTableStatsProviderService.getTableStatsFromService(table) match {
+    logInfo(s"JDBCAppendableRelation.sizeInBytes sdeshmukh looking size of table $table")
+    val size = SnappyTableStatsProviderService.getService.getTableStatsFromService(table) match {
       case Some(s) => s.getTotalSize
       case None => super.sizeInBytes
     }
+    logInfo(s"JDBCAppendableRelation.sizeInBytes sdeshmukh $table size is $size")
+    size
   }
-
 
   protected final def dialect: JdbcDialect = connProperties.dialect
 

--- a/core/src/main/scala/org/apache/spark/sql/execution/columnar/impl/StoreCallbacksImpl.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/columnar/impl/StoreCallbacksImpl.scala
@@ -16,7 +16,7 @@
  */
 package org.apache.spark.sql.execution.columnar.impl
 
-import java.lang
+import java.{util, lang}
 import java.util.{Collections, UUID}
 
 import scala.collection.JavaConverters._
@@ -26,12 +26,13 @@ import com.gemstone.gemfire.internal.snappy.{CallbackFactoryProvider, StoreCallb
 import com.pivotal.gemfirexd.internal.engine.Misc
 import com.pivotal.gemfirexd.internal.engine.distributed.utils.GemFireXDUtils
 import com.pivotal.gemfirexd.internal.engine.store.{AbstractCompactExecRow, GemFireContainer}
+import com.pivotal.gemfirexd.internal.engine.ui.SnappyRegionStats
 import com.pivotal.gemfirexd.internal.iapi.sql.conn.LanguageConnectionContext
 import com.pivotal.gemfirexd.internal.iapi.store.access.TransactionController
 import com.pivotal.gemfirexd.internal.impl.jdbc.EmbedConnection
 import com.pivotal.gemfirexd.internal.snappy.LeadNodeSmartConnectorOpContext
 import com.pivotal.gemfirexd.tools.sizer.GemFireXDInstrumentation
-import io.snappydata.Constant
+import io.snappydata.{SnappyTableStatsProviderService, Constant}
 
 import org.apache.spark.memory.{MemoryManagerCallback, MemoryMode}
 import org.apache.spark.sql.catalyst.FunctionIdentifier
@@ -178,6 +179,13 @@ object StoreCallbacksImpl extends StoreCallbacks with Logging with Serializable 
 
   override def registerRelationDestroyForHiveStore(): Unit = {
     SnappyStoreHiveCatalog.registerRelationDestroy()
+  }
+
+  def getSnappyTableStats: AnyRef = {
+    val c = SnappyTableStatsProviderService.getService.getTableSizeStats().values.asJavaCollection
+    val list: java.util.List[SnappyRegionStats] = new util.ArrayList(c.size())
+    list.addAll(c)
+    list
   }
 
   override def performConnectorOp(ctx: Object): Unit = {

--- a/core/src/main/scala/org/apache/spark/sql/execution/columnar/impl/StoreCallbacksImpl.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/columnar/impl/StoreCallbacksImpl.scala
@@ -16,7 +16,7 @@
  */
 package org.apache.spark.sql.execution.columnar.impl
 
-import java.{util, lang}
+import java.lang
 import java.util.{Collections, UUID}
 
 import scala.collection.JavaConverters._
@@ -183,7 +183,7 @@ object StoreCallbacksImpl extends StoreCallbacks with Logging with Serializable 
 
   def getSnappyTableStats: AnyRef = {
     val c = SnappyTableStatsProviderService.getService.getTableSizeStats().values.asJavaCollection
-    val list: java.util.List[SnappyRegionStats] = new util.ArrayList(c.size())
+    val list: java.util.List[SnappyRegionStats] = new java.util.ArrayList(c.size())
     list.addAll(c)
     list
   }

--- a/core/src/main/scala/org/apache/spark/sql/row/JDBCMutableRelation.scala
+++ b/core/src/main/scala/org/apache/spark/sql/row/JDBCMutableRelation.scala
@@ -64,7 +64,8 @@ case class JDBCMutableRelation(
   override val needConversion: Boolean = false
 
   override def sizeInBytes: Long = {
-    SnappyTableStatsProviderService.getTableStatsFromService(table) match {
+    logInfo(s"JDBCMutableRelation.sizeInBytes sdeshmukh looking size of table $table")
+    SnappyTableStatsProviderService.getService.getTableStatsFromService(table) match {
       case Some(s) => s.getTotalSize
       case None => super.sizeInBytes
     }

--- a/core/src/main/scala/org/apache/spark/sql/row/JDBCMutableRelation.scala
+++ b/core/src/main/scala/org/apache/spark/sql/row/JDBCMutableRelation.scala
@@ -64,7 +64,6 @@ case class JDBCMutableRelation(
   override val needConversion: Boolean = false
 
   override def sizeInBytes: Long = {
-    logInfo(s"JDBCMutableRelation.sizeInBytes sdeshmukh looking size of table $table")
     SnappyTableStatsProviderService.getService.getTableStatsFromService(table) match {
       case Some(s) => s.getTotalSize
       case None => super.sizeInBytes

--- a/core/src/test/scala/org/apache/spark/sql/store/ColumnTableTest.scala
+++ b/core/src/test/scala/org/apache/spark/sql/store/ColumnTableTest.scala
@@ -934,7 +934,7 @@ class ColumnTableTest
 
     val region = Misc.getRegionForTable(
       ColumnFormatRelation.columnBatchTableName(tableName).toUpperCase, true)
-    SnappyTableStatsProviderService.publishColumnTableRowCountStats()
+    SnappyTableStatsProviderService.getService.publishColumnTableRowCountStats()
     val entries = region.asInstanceOf[PartitionedRegion].getPrStats
         .getPRNumRowsInColumnBatches
 

--- a/core/src/test/scala/org/apache/spark/sql/store/ColumnTableTest.scala
+++ b/core/src/test/scala/org/apache/spark/sql/store/ColumnTableTest.scala
@@ -26,7 +26,7 @@ import com.pivotal.gemfirexd.internal.engine.Misc
 import com.pivotal.gemfirexd.internal.impl.jdbc.EmbedConnection
 import com.pivotal.gemfirexd.internal.impl.sql.compile.ParserImpl
 import io.snappydata.core.{Data, TestData, TestData2}
-import io.snappydata.{Property, SnappyFunSuite, SnappyTableStatsProviderService}
+import io.snappydata.{SnappyEmbeddedTableStatsProviderService, Property, SnappyFunSuite, SnappyTableStatsProviderService}
 import org.apache.hadoop.hive.ql.parse.ParseDriver
 import org.scalatest.{BeforeAndAfter, BeforeAndAfterAll}
 
@@ -934,7 +934,7 @@ class ColumnTableTest
 
     val region = Misc.getRegionForTable(
       ColumnFormatRelation.columnBatchTableName(tableName).toUpperCase, true)
-    SnappyTableStatsProviderService.getService.publishColumnTableRowCountStats()
+    SnappyEmbeddedTableStatsProviderService.publishColumnTableRowCountStats()
     val entries = region.asInstanceOf[PartitionedRegion].getPrStats
         .getPRNumRowsInColumnBatches
 


### PR DESCRIPTION
## Changes proposed in this pull request
Re factored SnappyTableStatsProviderService to run in thin connector mode as well.
Moved the existing functionality of   SnappyTableStatsProviderService into a trait  TableStatsProviderService.  Created two objects SnappyEmbeddedTableStatsProviderService and SnappyThinConnectorTableStatsProvider that derive from it.

SnappyThinConnectorTableStatsProvider will get the stats from embedded cluster by executing a stored procedure GET_SNAPPY_TABLE_STATS. This proc gets the stats from leader by sending a message and sends those back to connector.

## Patch testing
Precheckin

## Other PRs 
Refer to https://github.com/SnappyDataInc/snappy-store/pull/165 for store side changes
