### PR TITLE
[GITHUB-534] Match against variable name for dictionary optimization

### DIFF
--- a/cluster/src/test/scala/io/snappydata/QueryTest.scala
+++ b/cluster/src/test/scala/io/snappydata/QueryTest.scala
@@ -19,8 +19,9 @@ package io.snappydata
 
 import scala.collection.JavaConverters._
 
+import org.apache.spark.sql.execution.benchmark.ColumnCacheBenchmark
 import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.{SnappyContext, SparkSession}
+import org.apache.spark.sql.{Row, SnappyContext, SparkSession}
 
 class QueryTest extends SnappyFunSuite {
 
@@ -89,5 +90,22 @@ class QueryTest extends SnappyFunSuite {
     if (result1 != result2) {
       fail(s"Expected result: $result2\nGot: $result1")
     }
+  }
+
+  /**
+   * Distinct query failure in code generation reported on github
+   * (https://github.com/SnappyDataInc/snappydata/issues/534)
+   */
+  test("GITHUB-534") {
+    val session = SnappyContext(sc).snappySession
+    session.sql("CREATE TABLE yes_with(device_id VARCHAR(200), " +
+        "sdk_version VARCHAR(200)) USING COLUMN OPTIONS(PARTITION_BY 'device_id')")
+    session.insert("yes_with", Row("id1", "v1"), Row("id1", "v2"),
+      Row("id2", "v1"), Row("id2", "v1"), Row("id2", "v3"))
+    val r = session.sql("select sdk_version, count(distinct device_id) from (" +
+        "select sdk_version,device_id from YES_WITH group by sdk_version, " +
+        "device_id) a group by sdk_version")
+    ColumnCacheBenchmark.collect(r,
+      Seq(Row("v1", 2), Row("v2", 1), Row("v3", 1)))
   }
 }

--- a/core/src/main/scala/org/apache/spark/sql/SnappyBaseParser.scala
+++ b/core/src/main/scala/org/apache/spark/sql/SnappyBaseParser.scala
@@ -289,7 +289,7 @@ object SnappyParserConsts {
   final val arithmeticOperator = CharPredicate('*', '/', '%', '&', '|', '^')
   final val exponent: CharPredicate = CharPredicate('e', 'E')
   final val numeric: CharPredicate = CharPredicate.Digit ++
-      CharPredicate('.') ++ exponent
+      CharPredicate('.')
   final val numericSuffix: CharPredicate = CharPredicate('D', 'L')
   final val plural: CharPredicate = CharPredicate('s', 'S')
 

--- a/core/src/main/scala/org/apache/spark/sql/SnappyParser.scala
+++ b/core/src/main/scala/org/apache/spark/sql/SnappyParser.scala
@@ -162,8 +162,8 @@ class SnappyParser(session: SnappySession)
   }
 
   protected final def numericLiteral: Rule1[Literal] = rule {
-    capture(plusOrMinus.? ~ Consts.numeric. + ~ (plusOrMinus ~
-        CharPredicate.Digit. +).? ~ Consts.numericSuffix.?) ~
+    capture(plusOrMinus.? ~ Consts.numeric. + ~ (Consts.exponent ~
+        plusOrMinus.? ~ CharPredicate.Digit. +).? ~ Consts.numericSuffix.?) ~
         delimiter ~> ((s: String) => toNumericLiteral(s))
   }
 

--- a/core/src/main/scala/org/apache/spark/sql/execution/DictionaryOptimizedMapAccessor.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/DictionaryOptimizedMapAccessor.scala
@@ -73,21 +73,21 @@ object DictionaryOptimizedMapAccessor {
 
   def checkSingleKeyCase(keyExpressions: Seq[Expression],
       keyVars: => Seq[ExprCode], ctx: CodegenContext,
-      session: SnappySession): Option[ExprCodeEx] = {
+      session: SnappySession): Option[DictionaryCode] = {
     if (canHaveSingleKeyCase(keyExpressions)) {
-      session.getExCode(ctx, keyVars.head.value :: Nil, keyExpressions) match {
-        case e@Some(ExprCodeEx(_, _, _, dict, _, _)) if dict.nonEmpty => e
+      session.getDictionaryCode(ctx, keyVars.head.value) match {
+        case e@Some(DictionaryCode(_, _, dict, _, _)) if dict.nonEmpty => e
         case _ => None
       }
     } else None
   }
 
   def dictionaryArrayGetOrInsert(ctx: CodegenContext, keyExpr: Seq[Expression],
-      keyVar: ExprCode, keyVarEx: ExprCodeEx, arrayVar: String,
+      keyVar: ExprCode, keyDictVar: DictionaryCode, arrayVar: String,
       resultVar: String, valueInit: String, continueOnNull: Boolean,
       accessor: ObjectHashMapAccessor): String = {
     val key = keyVar.value
-    val keyIndex = keyVarEx.dictionaryIndex
+    val keyIndex = keyDictVar.dictionaryIndex
     val keyNull = keyVar.isNull != "false"
     val keyEv = ExprCode("", if (keyNull) s"($key == null)" else "false", key)
     val className = accessor.getClassName
@@ -115,7 +115,7 @@ object DictionaryOptimizedMapAccessor {
     val hashExprCode = if (keyNull) s"$key != null ? $key.hashCode() : -1"
     else s"$key.hashCode()"
     // if hash has already been calculated then use it
-    val hashExpr = keyVarEx.hash match {
+    val hashExpr = accessor.session.getHashVar(ctx, keyVar.value :: Nil) match {
       case Some(h) =>
         hash = h
         s"if ($h == 0) $h = $hashExprCode;"
@@ -128,11 +128,12 @@ object DictionaryOptimizedMapAccessor {
     else {
       // in this case replace the keyVar code to skip dictionary index get
       if (keyVar.isNull.isEmpty || keyVar.isNull == "false") {
-        keyVar.code = s"$key = ${keyVarEx.assignCode};"
-        s"$key = ${keyVarEx.dictionary}[$keyIndex];"
+        keyVar.code = s"$key = ${keyDictVar.valueAssignCode};"
+        s"$key = ${keyDictVar.dictionary}[$keyIndex];"
       } else {
-        keyVar.code = s"$key = ${keyVar.isNull} ? null : ${keyVarEx.assignCode};"
-        s"$key = ${keyVarEx.dictionary}[$keyIndex];"
+        keyVar.code =
+            s"$key = ${keyVar.isNull} ? null : ${keyDictVar.valueAssignCode};"
+        s"$key = ${keyDictVar.dictionary}[$keyIndex];"
       }
     }
     s"""if ($arrayVar != null) {

--- a/core/src/main/scala/org/apache/spark/sql/execution/ExistingPlans.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/ExistingPlans.scala
@@ -376,13 +376,12 @@ trait BatchConsumer extends CodegenSupport {
 }
 
 /**
- * Extended information for ExprCode to also hold the hashCode variable,
- * variable having dictionary reference and its index when dictionary
- * encoding is being used.
+ * Extended information for ExprCode variable to also hold the variable having
+ * dictionary reference and its index when dictionary encoding is being used.
  */
-case class ExprCodeEx(var hash: Option[String],
-    private var dictionaryCode: String, assignCode: String,
-    dictionary: String, dictionaryIndex: String, dictionaryLen: String) {
+case class DictionaryCode(private var dictionaryCode: String,
+    valueAssignCode: String, dictionary: String, dictionaryIndex: String,
+    dictionaryLen: String) {
 
   def evaluateDictionaryCode(ev: ExprCode): String = {
     if (ev.code.isEmpty) ""

--- a/core/src/main/scala/org/apache/spark/sql/execution/ObjectHashMapAccessor.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/ObjectHashMapAccessor.scala
@@ -18,8 +18,7 @@ package org.apache.spark.sql.execution
 
 import scala.collection.mutable
 
-import com.gemstone.gemfire.internal.shared.{ClientResolverUtils, ClientSharedUtils}
-import com.gemstone.gemfire.internal.util.ArrayUtils
+import com.gemstone.gemfire.internal.shared.ClientResolverUtils
 
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.SnappySession
@@ -899,7 +898,7 @@ case class ObjectHashMapAccessor(@transient session: SnappySession,
       valueInit = null)
     val preEvalKeys = if (initFilterCode.isEmpty) ""
     else evaluateVariables(streamKeyVars)
-    initDictionaryCodeForSingleKeyCase(dictArrayInitVar, streamKeyVars,
+    initDictionaryCodeForSingleKeyCase(dictArrayInitVar, input,
       streamKeys, streamOutput)
     var mapLookupCode = dictionaryKey match {
       case Some(dictKey) =>

--- a/core/src/main/scala/org/apache/spark/sql/execution/ObjectHashMapAccessor.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/ObjectHashMapAccessor.scala
@@ -90,7 +90,7 @@ case class ObjectHashMapAccessor(@transient session: SnappySession,
 
   private[execution] val keyExpressions = keyExprs.map(_.canonicalized)
   private[execution] val valueExpressions = valueExprs.map(_.canonicalized)
-  private[execution] var dictionaryKey: Option[ExprCodeEx] = None
+  private[execution] var dictionaryKey: Option[DictionaryCode] = None
 
   private[this] val valueIndex = keyExpressions.length
 
@@ -414,19 +414,18 @@ case class ObjectHashMapAccessor(@transient session: SnappySession,
     // check if hash has already been generated for keyExpressions
     var doRegister = register
     val vars = keyVars.map(_.value)
-    val (prefix, suffix) = if (doRegister) session.getExCode(ctx, vars,
-      keyExpressions) match {
-      case Some(ExprCodeEx(Some(h), _, _, _, _, _)) =>
+    val (prefix, suffix) = session.getHashVar(ctx, vars) match {
+      case Some(h) =>
         hashVar(0) = h
         hash = h
         doRegister = false
         (s"if ($hash == 0) {\n", "}\n")
       case _ => (hashDeclaration, "")
-    } else (hashDeclaration, "")
+    }
 
     // register the hash variable for the key expressions
     if (doRegister) {
-      session.addExCodeHash(ctx, vars, keyExpressions, hash)
+      session.addHashVar(ctx, vars, hash)
     }
 
     // optimize for first column to use fast hashing
@@ -693,33 +692,31 @@ case class ObjectHashMapAccessor(@transient session: SnappySession,
         s"$skipInit);$updateMapVars"
   }
 
-  def initDictionaryCodeForSingleKeyCase(dictionaryArrayTerm: String,
+  private def initDictionaryCodeForSingleKeyCase(dictionaryArrayInit: String,
       input: Seq[ExprCode], keyExpressions: Seq[Expression] = keyExpressions,
-      output: Seq[Attribute] = output): String = {
-    // make a copy of input variables since this is used only for lookup
-    // and the ExprCode's code should not be cleared
-    val vars = input.map(_.copy())
+      output: Seq[Attribute] = output): Boolean = {
+    // make a copy of input key variables if required since this is used
+    // only for lookup and the ExprCode's code should not be cleared
     dictionaryKey = DictionaryOptimizedMapAccessor.checkSingleKeyCase(
-      keyExpressions, getExpressionVars(keyExpressions, vars, output),
-      ctx, session)
+      keyExpressions, getExpressionVars(keyExpressions, input.map(_.copy()),
+        output), ctx, session)
     dictionaryKey match {
-      case Some(ExprCodeEx(_, _, _, dictionary, _, dictionaryLen)) =>
+      case Some(DictionaryCode(_, _, dictionary, _, dictionaryLen)) =>
         // initialize or reuse the array at batch level for join
         // null key will be placed at the last index of dictionary
         // and dictionary index will be initialized to that by ColumnTableScan
-        s"""
-           |if ($dictionary != null) {
-           |  if ($dictionaryArrayTerm != null
-           |      && $dictionaryArrayTerm.length >= $dictionaryLen) {
-           |    java.util.Arrays.fill($dictionaryArrayTerm, null);
-           |  } else {
-           |    $dictionaryArrayTerm = new $className[$dictionaryLen];
-           |  }
-           |} else {
-           |  $dictionaryArrayTerm = null;
-           |}
-        """.stripMargin
-      case None => ""
+        ctx.addNewFunction(dictionaryArrayInit,
+          s"""
+             |public $className[] $dictionaryArrayInit() {
+             |  if ($dictionary != null) {
+             |    return new $className[$dictionaryLen];
+             |  } else {
+             |    return null;
+             |  }
+             |}
+           """.stripMargin)
+        true
+      case None => false
     }
   }
 
@@ -728,7 +725,7 @@ case class ObjectHashMapAccessor(@transient session: SnappySession,
    */
   def generateMapGetOrInsert(objVar: String, valueInitVars: Seq[ExprCode],
       valueInitCode: String, input: Seq[ExprCode],
-      dictArrayVar: String): String = {
+      dictArrayVar: String, dictArrayInitVar: String): String = {
     val hashVar = Array(ctx.freshName("hash"))
     val valueInit = valueInitCode + '\n' + generateUpdate(objVar, Nil,
       valueInitVars, forKey = false, doCopy = false)
@@ -736,6 +733,7 @@ case class ObjectHashMapAccessor(@transient session: SnappySession,
     // optimized path for single key string column if dictionary is present
     def mapLookupCode(keyVars: Seq[ExprCode]): String = mapLookup(objVar,
       hashVar(0), keyExpressions, keyVars, valueInit)
+    initDictionaryCodeForSingleKeyCase(dictArrayInitVar, input)
     dictionaryKey match {
       case Some(dictKey) =>
         val keyVars = getExpressionVars(keyExpressions, input)
@@ -749,7 +747,7 @@ case class ObjectHashMapAccessor(@transient session: SnappySession,
             // evaluate the key expressions
             ${if (keyVar.code.isEmpty) "" else keyVar.code.trim}
             // evaluate hash code of the lookup key
-            ${generateHashCode(hashVar, keyVars, keyExpressions)}
+            ${generateHashCode(hashVar, keyVars, keyExpressions, register = false)}
             ${mapLookupCode(keyVars)}
           }
         """
@@ -777,8 +775,9 @@ case class ObjectHashMapAccessor(@transient session: SnappySession,
       keyIsUnique: String, numRows: String, nullMaskVars: Array[String],
       initCode: String, checkCond: (Option[ExprCode], String),
       streamKeys: Seq[Expression], streamKeyVars: Seq[ExprCode],
-      buildKeyVars: Seq[ExprCode], buildVars: Seq[ExprCode], input: Seq[ExprCode],
-      resultVars: Seq[ExprCode], dictArrayVar: String,
+      streamOutput: Seq[Attribute], buildKeyVars: Seq[ExprCode],
+      buildVars: Seq[ExprCode], input: Seq[ExprCode],
+      resultVars: Seq[ExprCode], dictArrayVar: String, dictArrayInitVar: String,
       joinType: JoinType, buildSide: BuildSide): String = {
     // scalastyle:on
 
@@ -900,6 +899,8 @@ case class ObjectHashMapAccessor(@transient session: SnappySession,
       valueInit = null)
     val preEvalKeys = if (initFilterCode.isEmpty) ""
     else evaluateVariables(streamKeyVars)
+    initDictionaryCodeForSingleKeyCase(dictArrayInitVar, streamKeyVars,
+      streamKeys, streamOutput)
     var mapLookupCode = dictionaryKey match {
       case Some(dictKey) =>
         val keyVar = streamKeyVars.head

--- a/core/src/main/scala/org/apache/spark/sql/execution/aggregate/SnappyHashAggregateExec.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/aggregate/SnappyHashAggregateExec.scala
@@ -583,8 +583,10 @@ case class SnappyHashAggregateExec(
       initVars, initCode, input, dictionaryArrayTerm, dictionaryArrayInit)
 
     ctx.currentVars = bufferVars ++ input
+    // pre-evaluate input variables used by child expressions and updateExpr
     val inputCodes = evaluateRequiredVariables(child.output,
-      ctx.currentVars.takeRight(child.output.length), child.references)
+      ctx.currentVars.takeRight(child.output.length),
+      child.references ++ AttributeSet(updateExpr))
     val boundUpdateExpr = updateExpr.map(BindReferences.bindReference(_,
       inputAttr))
     val subExprs = ctx.subexpressionEliminationForWholeStageCodegen(

--- a/core/src/main/scala/org/apache/spark/sql/execution/aggregate/SnappyHashAggregateExec.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/aggregate/SnappyHashAggregateExec.scala
@@ -245,15 +245,11 @@ case class SnappyHashAggregateExec(
 
   override def canConsume(plan: SparkPlan): Boolean = {
     if (groupingExpressions.isEmpty) return false
-    // check the outputs of the plan
-    val planOutput = plan.output
     // check for possible optimized dictionary code path;
-    // linear search is enough instead of map create/lookup like in intersect;
     // below is a loose search while actual decision will be taken as per
     // availability of ExprCodeEx with DictionaryCode in doConsume
     DictionaryOptimizedMapAccessor.canHaveSingleKeyCase(
-      keyBufferAccessor.keyExpressions) && keyBufferAccessor.output.forall(
-      a => planOutput.exists(_.semanticEquals(a)))
+      keyBufferAccessor.keyExpressions)
   }
 
   override def batchConsume(ctx: CodegenContext, plan: SparkPlan,

--- a/core/src/main/scala/org/apache/spark/sql/execution/columnar/ColumnTableScan.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/columnar/ColumnTableScan.scala
@@ -660,16 +660,17 @@ private[sql] final case class ColumnTableScan(
         s"$col = $decoder.read$typeName($buffer, $cursorVar);"
       case StringType =>
         dictionary = ctx.freshName("dictionary")
-        dictIndex = ctx.freshName("dictionaryIndex")
         dictionaryLen = ctx.freshName("dictionaryLength")
+        dictIndex = ctx.freshName("dictionaryIndex")
+        ctx.addMutableState("UTF8String[]", dictionary, "")
+        ctx.addMutableState("int", dictionaryLen, "")
         // initialize index to dictionaryLength - 1 where null value will
         // reside in case there are nulls in the current batch
         jtDecl = s"UTF8String $col; int $dictIndex = $dictionaryLen - 1;"
         bufferInit =
             s"""
-               |final UTF8String[] $dictionary = $decoder.getStringDictionary();
-               |final int $dictionaryLen =
-               |    $dictionary != null ? $dictionary.length : -1;
+               |$dictionary = $decoder.getStringDictionary();
+               |$dictionaryLen = $dictionary != null ? $dictionary.length : -1;
             """.stripMargin
         dictionaryAssignCode =
             s"$dictIndex = $decoder.readDictionaryIndex($buffer, $cursorVar);"
@@ -739,14 +740,14 @@ private[sql] final case class ColumnTableScan(
               }
             }
           """
-        session.foreach(_.addExCode(ctx, col :: Nil, attr :: Nil, ExprCodeEx(None,
+        session.foreach(_.addDictionaryCode(ctx, col, DictionaryCode(
           dictionaryCode, assignCode, dictionary, dictIndex, dictionaryLen)))
       }
       (ExprCode(code, nullVar, col), bufferInit)
     } else {
       if (!dictionary.isEmpty) {
         val dictionaryCode = jtDecl + '\n' + dictionaryAssignCode
-        session.foreach(_.addExCode(ctx, col :: Nil, attr :: Nil, ExprCodeEx(None,
+        session.foreach(_.addDictionaryCode(ctx, col, DictionaryCode(
           dictionaryCode, assignCode, dictionary, dictIndex, dictionaryLen)))
       }
       var code = jtDecl + '\n' + colAssign + '\n'

--- a/core/src/main/scala/org/apache/spark/sql/execution/joins/HashJoinExec.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/joins/HashJoinExec.scala
@@ -423,15 +423,10 @@ case class HashJoinExec(leftKeys: Seq[Expression],
   }
 
   override def canConsume(plan: SparkPlan): Boolean = {
-    // check the outputs of the plan
-    val planOutput = plan.output
     // check for possible optimized dictionary code path;
-    // linear search is enough instead of map create/lookup like in intersect;
     // below is a loose search while actual decision will be taken as per
     // availability of ExprCodeEx with DictionaryCode in doConsume
-    DictionaryOptimizedMapAccessor.canHaveSingleKeyCase(
-      streamSideKeys) && streamedPlan.output.forall(
-      a => planOutput.exists(_.semanticEquals(a)))
+    DictionaryOptimizedMapAccessor.canHaveSingleKeyCase(streamSideKeys)
   }
 
   override def batchConsume(ctx: CodegenContext,

--- a/core/src/main/scala/org/apache/spark/sql/execution/joins/HashJoinExec.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/joins/HashJoinExec.scala
@@ -70,6 +70,7 @@ case class HashJoinExec(leftKeys: Seq[Expression],
   @transient private var keyIsUniqueTerm: String = _
   @transient private var numRowsTerm: String = _
   @transient private var dictionaryArrayTerm: String = _
+  @transient private var dictionaryArrayInit: String = _
 
   @transient val (metricAdd, _): (String => String, String => String) =
     Utils.metricMethods
@@ -351,14 +352,6 @@ case class HashJoinExec(leftKeys: Seq[Expression],
     // consumed all the rows, so `copyResult` should be reset to `false`.
     ctx.copyResult = false
 
-    // check for possible optimized dictionary code path
-    val dictInit = if (DictionaryOptimizedMapAccessor.canHaveSingleKeyCase(
-      streamSideKeys)) {
-      // this array will be used at batch level for grouping if possible
-      dictionaryArrayTerm = ctx.freshName("dictionaryArray")
-      s"$entryClass[] $dictionaryArrayTerm = null;"
-    } else ""
-
     val buildTime = metricTerm(ctx, "buildTime")
     val numOutputRows = metricTerm(ctx, "numOutputRows")
     // initialization of min/max for integral keys
@@ -388,7 +381,6 @@ case class HashJoinExec(leftKeys: Seq[Expression],
       $initMinMaxVars
       final int $maskTerm = $hashMapTerm.mask();
       final $entryClass[] $mapDataTerm = ($entryClass[])$hashMapTerm.data();
-      $dictInit
       long $numRowsTerm = 0L;
       try {
         ${session.evaluateFinallyCode(ctx, produced)}
@@ -396,7 +388,6 @@ case class HashJoinExec(leftKeys: Seq[Expression],
         $numOutputRows.${metricAdd(numRowsTerm)};
       }
     """
-
   }
 
   override def doConsume(ctx: CodegenContext, input: Seq[ExprCode],
@@ -426,30 +417,39 @@ case class HashJoinExec(leftKeys: Seq[Expression],
     val streamKeyVars = ctx.generateExpressions(streamKeys)
 
     mapAccessor.generateMapLookup(entryVar, localValueVar, keyIsUniqueTerm,
-      numRowsTerm, nullMaskVars, initCode, checkCondition,
-      streamSideKeys, streamKeyVars, buildKeyVars, buildVars, input,
-      resultVars, dictionaryArrayTerm, joinType, buildSide)
+      numRowsTerm, nullMaskVars, initCode, checkCondition, streamSideKeys,
+      streamKeyVars, streamedPlan.output, buildKeyVars, buildVars, input,
+      resultVars, dictionaryArrayTerm, dictionaryArrayInit, joinType, buildSide)
   }
 
   override def canConsume(plan: SparkPlan): Boolean = {
     // check the outputs of the plan
     val planOutput = plan.output
-    // linear search is enough instead of map create/lookup like in intersect
-    streamedPlan.output.forall(a => planOutput.exists(_.semanticEquals(a)))
+    // check for possible optimized dictionary code path;
+    // linear search is enough instead of map create/lookup like in intersect;
+    // below is a loose search while actual decision will be taken as per
+    // availability of ExprCodeEx with DictionaryCode in doConsume
+    DictionaryOptimizedMapAccessor.canHaveSingleKeyCase(
+      streamSideKeys) && streamedPlan.output.forall(
+      a => planOutput.exists(_.semanticEquals(a)))
   }
 
   override def batchConsume(ctx: CodegenContext,
       plan: SparkPlan, input: Seq[ExprCode]): String = {
-    // pluck out the variables from input as per the plan output
-    val planOutput = plan.output
-    val streamedOutput = streamedPlan.output
-    val streamedInput = streamedOutput.map { a =>
-      // we expect it to exist as per the check in canConsume
-      input(planOutput.indexWhere(_.semanticEquals(a)))
-    }
-    // check for optimized dictionary code path
-    mapAccessor.initDictionaryCodeForSingleKeyCase(
-      dictionaryArrayTerm, streamedInput, streamSideKeys, streamedOutput)
+    // create an empty method to populate the dictionary array
+    // which will be actually filled with code in consume if the dictionary
+    // optimization is possible using the incoming ExprCodeEx
+    val className = mapAccessor.getClassName
+    // this array will be used at batch level for grouping if possible
+    dictionaryArrayTerm = ctx.freshName("dictionaryArray")
+    dictionaryArrayInit = ctx.freshName("dictionaryArrayInit")
+    ctx.addNewFunction(dictionaryArrayInit,
+      s"""
+         |private $className[] $dictionaryArrayInit() {
+         |  return null;
+         |}
+         """.stripMargin)
+    s"final $className[] $dictionaryArrayTerm = $dictionaryArrayInit();"
   }
 
   /**


### PR DESCRIPTION
Failing query:

select sdk_version, count(distinct device_id) from (select sdk_version,
    device_id from YES_WITH group by sdk_version, device_id) a group by sdk_version

(this fails only if the table YES_WITH is partitioned on device_id when EXCHANGE is avoided)

Fixes #534. The issue is due to hashjoin/aggregate referring to dictionary
variables that are not in its scope. Ideally the information about dictionary
variables should be transmitted through additional fields ExprCode() but
an extension to that does not work since Expression.genCode creates new
ExprCode objects without copying the incoming ones if possible
(in particular the simple BoundReference also ends up losing the
   original extension class object)

So the code resorts to using context objects via SnappySession. The lookup
key in current code consists of AttributeReference match but that breaks
down in this case since the AttributeReference refers to the table scan
column but actually comes from inner GROUP BY grouping key which
cannot come directly from table scan.

## Changes proposed in this pull request

- now using lookup against the incoming variable in consume(..input)
- to allow initializing the dictionary array before ColumnBatch iteration,
  the batchConsume now creates a function to initialize it which returns null;
  the doConsume(..input) code overwrites this function with actual array
  if possible (i.e. when the key column comes from dictionary)
- for clarity removing old ExprCodeEx class and changing to DictionaryCode
  while hash variable for a set of keys is tracked separately
- added test of the reported query in QueryTest

## Patch testing

precheckin

## ReleaseNotes.txt changes

NA

## Other PRs 

NA