### PR TITLE
SNAP-1481 : Spark UI SQL tab needs to show the SQL query

### DIFF
--- a/ReleaseNotes.txt
+++ b/ReleaseNotes.txt
@@ -7,6 +7,12 @@
 # ADD THE JIRA TICKET ID, IF APPLICABLE.                                                           #
 ####################################################################################################
 
+Release 0.9
+
+- New Features/Fixed Issues
+
+  [SNAP-1481] SQL Tab on UI, Discrption column now displays actual SQL Query string executed inseted of handler 
+  description text.
 
 Release 0.8
 

--- a/ReleaseNotes.txt
+++ b/ReleaseNotes.txt
@@ -11,8 +11,8 @@ Release 0.9
 
 - New Features/Fixed Issues
 
-  [SNAP-1481] SQL Tab on UI, Discrption column now displays actual SQL Query string executed inseted of handler 
-  description text.
+  [SNAP-1481] SQL Tab on UI, Description column now displays actual SQL Query string executed
+  instead of handler description text.
 
 Release 0.8
 

--- a/core/src/main/scala/org/apache/spark/sql/execution/ExistingPlans.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/ExistingPlans.scala
@@ -194,7 +194,8 @@ case class ExecutePlan(child: SparkPlan, preAction: () => Unit = () => ())
   protected[sql] lazy val sideEffectResult: Array[InternalRow] = {
     preAction()
     val callSite = sqlContext.sparkContext.getCallSite()
-    CachedDataFrame.withNewExecutionId(sqlContext.sparkSession, callSite,
+    CachedDataFrame.withNewExecutionId(sqlContext.sparkSession,
+      callSite.shortForm, callSite.longForm,
       child.treeString(verbose = true), SparkPlanInfo.fromSparkPlan(child)) {
       child.executeCollect()
     }


### PR DESCRIPTION

## Changes proposed in this pull request

- UI SQL Tab now displays SQL Query string instead of CachedDataFrame handler in Description column.
- Queries executed from Snappy shell and spark shell will be displayed as actual query string under Description column.
- Queries executed using API will display CachedDataFrame handler description as per previous behavior.

## Patch testing

- Tested manually

## ReleaseNotes.txt changes

- SQL Tab on UI, Description column now displays actual SQL Query string executed instead of handler description text.

## Other PRs 

- None.
