### PR TITLE
SNAP-1351

### DIFF
--- a/cluster/src/main/scala/org/apache/spark/executor/SnappyCoarseGrainedExecutorBackend.scala
+++ b/cluster/src/main/scala/org/apache/spark/executor/SnappyCoarseGrainedExecutorBackend.scala
@@ -92,7 +92,7 @@ class SnappyCoarseGrainedExecutorBackend(
     if (executor != null) {
       // kill all the running tasks
       // InterruptThread is set as true.
-      executor.killAllTasks(true)
+      executor.killAllTasks(false)
       executor.stop()
     }
     // stop the actor system

--- a/cluster/src/main/scala/org/apache/spark/executor/SnappyCoarseGrainedExecutorBackend.scala
+++ b/cluster/src/main/scala/org/apache/spark/executor/SnappyCoarseGrainedExecutorBackend.scala
@@ -94,7 +94,7 @@ class SnappyCoarseGrainedExecutorBackend(
       // When tasks are killed, the task threads cannot be interrupted
       // as snappy may be writing to an oplog and it generates a
       // DiskAccessException. This DAE ends up closing the underlying regions.
-      executor.killAllTasks(false)
+      executor.killAllTasks(interruptThread = false)
       executor.stop()
     }
     // stop the actor system

--- a/cluster/src/main/scala/org/apache/spark/executor/SnappyCoarseGrainedExecutorBackend.scala
+++ b/cluster/src/main/scala/org/apache/spark/executor/SnappyCoarseGrainedExecutorBackend.scala
@@ -91,7 +91,9 @@ class SnappyCoarseGrainedExecutorBackend(
   def exitWithoutRestart(): Unit = {
     if (executor != null) {
       // kill all the running tasks
-      // InterruptThread is set as true.
+      // When tasks are killed, the task threads cannot be interrupted
+      // as snappy may be writing to an oplog and it generates a
+      // DiskAccessException. This DAE ends up closing the underlying regions.
       executor.killAllTasks(false)
       executor.stop()
     }


### PR DESCRIPTION
## Changes proposed in this pull request

When tasks are killed, the task threads are getting interrupted. This causes issues with snappy because snappy may be writing to an oplog and it generates a DiskAccessException. This DAE ends up closing the underlying regions.

Snappy threads cannot be interrupted.

## Patch testing

Tried out the scenario mentioned in the bug. Works fine. Precheckin. 

## Other PRs 
https://github.com/SnappyDataInc/spark-jobserver/pull/9
