### PR TITLE
[SNAP-1542] Ensure that the size of buffer is at least the minimum required

### DIFF
--- a/core/src/main/scala/org/apache/spark/sql/execution/columnar/encoding/ColumnEncoding.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/columnar/encoding/ColumnEncoding.scala
@@ -310,7 +310,7 @@ trait ColumnEncoder extends ColumnEncoding {
     }
     if ((columnData eq null) || (columnData.limit() < (baseSize + defSize))) {
       var initByteSize = 0L
-      if (reuseUsedSize > baseSize) {
+      if (reuseUsedSize > baseSize + defSize) {
         initByteSize = reuseUsedSize
       } else {
         initByteSize = defSize.toLong * initSize + baseSize

--- a/core/src/main/scala/org/apache/spark/sql/execution/columnar/encoding/ColumnEncoding.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/columnar/encoding/ColumnEncoding.scala
@@ -304,15 +304,16 @@ trait ColumnEncoder extends ColumnEncoding {
     else if (numNullWords != 0) assert(assertion = false,
       s"Unexpected nulls=$numNullWords for withHeader=false")
 
-    if (columnData eq null) {
-      var initByteSize: Long = 0L
-      if (reuseUsedSize > 0) {
+    var baseSize: Long = numNullBytes
+    if (withHeader) {
+      baseSize += 8L /* typeId + nullsSize */
+    }
+    if ((columnData eq null) || (columnData.limit() < (baseSize + defSize))) {
+      var initByteSize = 0L
+      if (reuseUsedSize > baseSize) {
         initByteSize = reuseUsedSize
       } else {
-        initByteSize = defSize.toLong * initSize + numNullBytes
-        if (withHeader) {
-          initByteSize += 8L /* typeId + nullsSize */
-        }
+        initByteSize = defSize.toLong * initSize + baseSize
       }
       setSource(allocator.allocate(checkBufferSize(initByteSize)),
         releaseOld = true)
@@ -1129,7 +1130,7 @@ trait NullableEncoder extends NotNullEncoder {
     // trim trailing empty words
     val numWords = getNumNullWords
     // maximum number of null words that can be allowed to go waste in storage
-    val maxWastedWords = 50
+    val maxWastedWords = 8
     // check if the number of words to be written matches the space that
     // was left at initialization; as an optimization allow for larger
     // space left at initialization when one full data copy can be avoided
@@ -1149,8 +1150,7 @@ trait NullableEncoder extends NotNullEncoder {
       val numNullBytes = numWords << 3
       val initialNullBytes = initialNumWords << 3
       val oldSize = cursor - baseOffset
-      val newSize = math.min(Int.MaxValue - 1,
-        oldSize + numNullBytes - initialNullBytes).toInt
+      val newSize = checkBufferSize(oldSize + numNullBytes - initialNullBytes)
       val storageAllocator = this.storageAllocator
       val newColumnData = storageAllocator.allocate(newSize)
 

--- a/core/src/main/scala/org/apache/spark/sql/execution/columnar/encoding/DictionaryEncoding.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/columnar/encoding/DictionaryEncoding.scala
@@ -225,6 +225,7 @@ trait DictionaryEncoderBase extends ColumnEncoder with DictionaryEncoding {
       withHeader: Boolean, allocator: ColumnAllocator): Long = {
     assert(withHeader, "DictionaryEncoding not supported without header")
 
+    setAllocator(allocator)
     Utils.getSQLDataType(field.dataType) match {
       case StringType =>
         if (stringMap eq null) {
@@ -246,7 +247,6 @@ trait DictionaryEncoderBase extends ColumnEncoder with DictionaryEncoding {
         longArray = new TLongArrayList(mapSize)
         isIntMap = t.isInstanceOf[IntegerType]
     }
-    setAllocator(allocator)
     initializeLimits()
     initializeNulls(initSize)
     // start with the short dictionary having 2 byte indexes
@@ -407,7 +407,7 @@ trait DictionaryEncoderBase extends ColumnEncoder with DictionaryEncoding {
     // lastly copy the index bytes
     val position = columnData.position()
     columnData.position((cursor - baseOffset).toInt)
-    copyTo(columnData, 0, numIndexBytes)
+    copyTo(columnData, srcOffset = 0, numIndexBytes)
     columnData.position(position)
 
     // reuse this index data in next round if possible

--- a/dtests/src/test/scala/io/snappydata/hydra/SnappyTestUtils.scala
+++ b/dtests/src/test/scala/io/snappydata/hydra/SnappyTestUtils.scala
@@ -98,13 +98,13 @@ object SnappyTestUtils {
     val col1 = sparkDF.schema.fieldNames(0)
     val col = sparkDF.schema.fieldNames.filter(!_.equals(col1)).toSeq
     if (snappyFile.listFiles() == null) {
-      snappyDF = snappyDF.coalesce(1).orderBy(col1, col: _*)
+      snappyDF = snappyDF.repartition(1).sortWithinPartitions(col1, col: _*)
       writeToFile(snappyDF, snappyDest, snc)
       // scalastyle:off println
       pw.println(s"${queryNum} Result Collected in file $snappyDest")
     }
     if (sparkFile.listFiles() == null) {
-      sparkDF = sparkDF.coalesce(1).orderBy(col1, col: _*)
+      sparkDF = sparkDF.repartition(1).sortWithinPartitions(col1, col: _*)
       writeToFile(sparkDF, sparkDest, snc)
       pw.println(s"${queryNum} Result Collected in file $sparkDest")
     }


### PR DESCRIPTION
## Changes proposed in this pull request

- Reused buffer size should be at least the minimum required else create new one
- Also use repartition(1) in test result collection instead of coalesce(1)
so that the scan is parallel. Reduces its running time by an order of magnitude.

## Patch testing

hydra test mentioned in SNAP-1542 and precheckin

## ReleaseNotes.txt changes

NA

## Other PRs 

NA