### PR TITLE
Disaabling UMM tests for intermittent failures.

### DIFF
--- a/cluster/src/dunit/scala/org/apache/spark/memory/SnappyUnifiedMemoryManagerDUnitTest.scala
+++ b/cluster/src/dunit/scala/org/apache/spark/memory/SnappyUnifiedMemoryManagerDUnitTest.scala
@@ -338,7 +338,7 @@ class SnappyUnifiedMemoryManagerDUnitTest(s: String) extends ClusterManagerTestB
   }
 
 
-  def testMemoryAfterRecovery_ColumnTable(): Unit = {
+  def IGNORE_testMemoryAfterRecovery_ColumnTable(): Unit = {
 
     val props = bootProps.clone().asInstanceOf[java.util.Properties]
     val port = ClusterManagerTestBase.locPort
@@ -374,7 +374,7 @@ class SnappyUnifiedMemoryManagerDUnitTest(s: String) extends ClusterManagerTestB
   }
 
 
-  def testMemoryAfterRecovery_RowTable(): Unit = {
+  def IGNORE_testMemoryAfterRecovery_RowTable(): Unit = {
 
     val props = bootProps.clone().asInstanceOf[java.util.Properties]
     val port = ClusterManagerTestBase.locPort


### PR DESCRIPTION
## Changes proposed in this pull request
Disaabling UMM tests for intermittent failures. 
These tests need to be enabled again, once the intermittent failures are resolved.

## Patch testing

NA

## ReleaseNotes.txt changes

NA

## Other PRs 

NA