### PR TITLE
[SNAP-1555] filter out the DDL options in connection properties

### DIFF
--- a/cluster/src/dunit/scala/org/apache/spark/sql/ColumnBatchScanDUnitTest.scala
+++ b/cluster/src/dunit/scala/org/apache/spark/sql/ColumnBatchScanDUnitTest.scala
@@ -38,7 +38,7 @@ class ColumnBatchScanDUnitTest(s: String) extends ClusterManagerTestBase(s) {
     // reduce the batch size to ensure that multiple are created
 
     snc.sql(s"create table if not exists airline ($ddlStr) " +
-        s" using column options (Buckets '2', COLUMN_BATCH_SIZE '4')")
+        s" using column options (Buckets '2', COLUMN_BATCH_SIZE '400')")
 
     import snc.implicits._
 

--- a/cluster/src/dunit/scala/org/apache/spark/sql/TPCHSuite.scala
+++ b/cluster/src/dunit/scala/org/apache/spark/sql/TPCHSuite.scala
@@ -31,7 +31,6 @@ class TPCHSuite extends SnappyFunSuite with BeforeAndAfterAll  {
 
   ignore("Test TPCH") {
     val snc = SnappyContext(sc)
-    snc.conf.setConfString(SQLConf.COLUMN_BATCH_SIZE.key, "10000")
     snc.conf.setConfString(SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key, "104857600")
     Property.HashJoinSize.set(snc.conf, 1L * 1024 * 1024 * 1024)
     TPCHUtils.createAndLoadTables(snc, isSnappy = true)

--- a/cluster/src/main/scala/io/snappydata/cluster/ExecutorInitiator.scala
+++ b/cluster/src/main/scala/io/snappydata/cluster/ExecutorInitiator.scala
@@ -16,7 +16,6 @@
  */
 package io.snappydata.cluster
 
-import java.io.File
 import java.net.URL
 import java.util
 
@@ -34,6 +33,7 @@ import io.snappydata.gemxd.ClusterCallbacksImpl
 
 import org.apache.spark.deploy.SparkHadoopUtil
 import org.apache.spark.executor.SnappyCoarseGrainedExecutorBackend
+import org.apache.spark.memory.SnappyUnifiedMemoryManager
 import org.apache.spark.sql.SnappyContext
 import org.apache.spark.sql.collection.Utils
 import org.apache.spark.{Logging, SparkCallbacks, SparkConf, SparkEnv}
@@ -45,7 +45,7 @@ import org.apache.spark.{Logging, SparkCallbacks, SparkConf, SparkEnv}
  */
 object ExecutorInitiator extends Logging {
 
-  val SNAPPY_MEMORY_MANAGER = "org.apache.spark.memory.SnappyUnifiedMemoryManager"
+  val SNAPPY_MEMORY_MANAGER: String = classOf[SnappyUnifiedMemoryManager].getName
 
   var executorRunnable: ExecutorRunnable = new ExecutorRunnable
 

--- a/cluster/src/test/scala/io/snappydata/QueryTest.scala
+++ b/cluster/src/test/scala/io/snappydata/QueryTest.scala
@@ -68,7 +68,7 @@ class QueryTest extends SnappyFunSuite {
 
   test("SNAP-1159_1482") {
     val session = SnappyContext(sc).snappySession
-    session.sql(s"set ${SQLConf.COLUMN_BATCH_SIZE.key}=10")
+    session.sql(s"set ${Property.ColumnBatchSize.name}=100")
     session.sql(s"set ${SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key}=1")
     val data1 = session.range(20).selectExpr("id")
     val data2 = session.range(80).selectExpr("id", "cast ((id / 4) as long) as k",

--- a/core/src/main/scala/org/apache/spark/sql/execution/columnar/ExternalStoreUtils.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/columnar/ExternalStoreUtils.scala
@@ -64,6 +64,9 @@ object ExternalStoreUtils extends Logging {
   // internal properties stored as hive table parameters
   final val USER_SPECIFIED_SCHEMA = "USER_SCHEMA"
 
+  val ddlOptions: Seq[String] = Seq(INDEX_NAME, COLUMN_BATCH_SIZE,
+    COLUMN_MAX_DELTA_ROWS, COMPRESSION_CODEC, RELATION_FOR_SAMPLE)
+
   def lookupName(tableName: String, schema: String): String = {
     if (tableName.indexOf('.') <= 0) {
       schema + '.' + tableName
@@ -238,8 +241,10 @@ object ExternalStoreUtils extends Logging {
     val connProps = new Properties()
     val executorConnProps = new Properties()
     parameters.foreach { kv =>
-      connProps.setProperty(kv._1, kv._2)
-      executorConnProps.setProperty(kv._1, kv._2)
+      if (!ddlOptions.contains(Utils.toUpperCase(kv._1))) {
+        connProps.setProperty(kv._1, kv._2)
+        executorConnProps.setProperty(kv._1, kv._2)
+      }
     }
     connProps.remove("poolProperties")
     executorConnProps.remove("poolProperties")

--- a/core/src/main/scala/org/apache/spark/sql/store/StoreUtils.scala
+++ b/core/src/main/scala/org/apache/spark/sql/store/StoreUtils.scala
@@ -86,12 +86,10 @@ object StoreUtils {
   val MAP_TYPE = 14
   val STRUCT_TYPE = 15
 
-  val ddlOptions = Seq(PARTITION_BY, REPLICATE, BUCKETS, COLOCATE_WITH,
+  val ddlOptions: Seq[String] = Seq(PARTITION_BY, REPLICATE, BUCKETS, COLOCATE_WITH,
     REDUNDANCY, RECOVERYDELAY, MAXPARTSIZE, EVICTION_BY,
     PERSISTENT, SERVER_GROUPS, OFFHEAP, EXPIRE, OVERFLOW,
-    GEM_INDEXED_TABLE, ExternalStoreUtils.INDEX_NAME,
-    ExternalStoreUtils.COLUMN_BATCH_SIZE, ExternalStoreUtils.COLUMN_MAX_DELTA_ROWS,
-    ExternalStoreUtils.COMPRESSION_CODEC, ExternalStoreUtils.RELATION_FOR_SAMPLE)
+    GEM_INDEXED_TABLE) ++ ExternalStoreUtils.ddlOptions
 
   val EMPTY_STRING = ""
   val NONE = "NONE"

--- a/core/src/test/scala/org/apache/spark/sql/execution/AggregationSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/execution/AggregationSuite.scala
@@ -18,7 +18,6 @@ package org.apache.spark.sql.execution
 
 import io.snappydata.SnappyFunSuite
 
-import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.{DataFrame, QueryTest, Row, SnappySession, SparkSession}
 
 class AggregationSuite extends SnappyFunSuite {
@@ -33,7 +32,6 @@ class AggregationSuite extends SnappyFunSuite {
   test("AVG plan failure for nullables") {
     val spark = new SparkSession(sc)
     val snappy = new SnappySession(sc)
-    snappy.sql(s"set ${SQLConf.COLUMN_BATCH_SIZE.key}=1000")
 
     val checkDF = spark.range(10000).selectExpr("id", "(id * 12) as k",
       "concat('val', cast((id % 100) as string)) as s")

--- a/core/src/test/scala/org/apache/spark/sql/store/CreateIndexTest.scala
+++ b/core/src/test/scala/org/apache/spark/sql/store/CreateIndexTest.scala
@@ -21,13 +21,12 @@ import java.util.concurrent.atomic.AtomicReference
 import scala.collection.mutable.ListBuffer
 
 import io.snappydata.app.{Data1, Data2, Data3}
-import io.snappydata.{QueryHint, SnappyFunSuite}
+import io.snappydata.{Property, QueryHint, SnappyFunSuite}
 import org.scalatest.BeforeAndAfterEach
 
 import org.apache.spark.sql.catalyst.expressions.{Ascending, Descending}
 import org.apache.spark.sql.execution.PartitionedPhysicalScan
-import org.apache.spark.sql.execution.columnar.impl.{ColumnFormatRelation,
-IndexColumnFormatRelation}
+import org.apache.spark.sql.execution.columnar.impl.{ColumnFormatRelation, IndexColumnFormatRelation}
 import org.apache.spark.sql.execution.datasources.LogicalRelation
 import org.apache.spark.sql.execution.joins.{HashJoinExec, SortMergeJoinExec}
 import org.apache.spark.sql.execution.row.RowFormatRelation
@@ -596,8 +595,7 @@ class CreateIndexTest extends SnappyFunSuite with BeforeAndAfterEach {
     val index31 = s"${table3}_IdxOne"
 
     val snContext = context.get
-    // snc.sessionState.conf.setConf(SQLConf.COLUMN_BATCH_SIZE, batchSize)
-    snContext.setConf(SQLConf.COLUMN_BATCH_SIZE.key, "3")
+    Property.ColumnBatchSize.set(snContext.conf, 30)
 
     createBase3Tables(snContext, table1, table2, table3)
 

--- a/core/src/test/scala/org/apache/spark/sql/store/UnifiedPartitionerTest.scala
+++ b/core/src/test/scala/org/apache/spark/sql/store/UnifiedPartitionerTest.scala
@@ -26,7 +26,7 @@ import com.pivotal.gemfirexd.TestUtil
 import com.pivotal.gemfirexd.internal.engine.Misc
 import com.pivotal.gemfirexd.internal.engine.ddl.resolver.GfxdPartitionByExpressionResolver
 import com.pivotal.gemfirexd.internal.iapi.types._
-import io.snappydata.SnappyFunSuite
+import io.snappydata.{Property, SnappyFunSuite}
 import io.snappydata.core.{Data1, Data4, TestData2}
 import org.scalatest.{BeforeAndAfter, BeforeAndAfterAll}
 
@@ -329,7 +329,7 @@ class UnifiedPartitionerTest extends SnappyFunSuite
 
   test("Test PR for Int type column") {
     val snc = SnappyContext(sc)
-    snc.sql(s"set ${SQLConf.COLUMN_BATCH_SIZE.key}=3")
+    snc.sql(s"set ${Property.ColumnBatchSize.name}=30")
     snc.sql(s"set ${SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key}=1")
     snc.sql(s"CREATE TABLE $ColumnTableName1(OrderId INT ,ItemId INT, ItemRef INT) " +
         "USING column " +

--- a/dtests/src/test/java/io/snappydata/hydra/snapshotIsolation/columnTableExtn.inc
+++ b/dtests/src/test/java/io/snappydata/hydra/snapshotIsolation/columnTableExtn.inc
@@ -5,7 +5,7 @@ io.snappydata.hydra.snapshotIsolation.SnapshotIsolationPrms-snappyDDLExtn =
 " USING row OPTIONS(partition_by 'City,Country', buckets '19', redundancy '${redundantCopies}',PERSISTENT '${persistenceMode}')"
 " USING column OPTIONS(partition_by 'City,Country', buckets '19', colocate_with 'employees',redundancy '${redundantCopies}', PERSISTENT '${persistenceMode}')"
 " USING column OPTIONS(partition_by 'OrderID', buckets '13', redundancy '${redundantCopies}', PERSISTENT '${persistenceMode}')"
-" USING column OPTIONS(partition_by 'OrderID', buckets '13', COLOCATE_WITH 'orders', redundancy '${redundantCopies}', PERSISTENT '${persistenceMode}',COLUMN_MAX_DELTA_ROWS '100')"
+" USING column OPTIONS(partition_by 'OrderID', buckets '13', COLOCATE_WITH 'orders', redundancy '${redundantCopies}', PERSISTENT '${persistenceMode}',COLUMN_MAX_DELTA_ROWS '100',COLUMN_BATCH_SIZE '20000')"
 " USING column OPTIONS(partition_by 'ProductID,SupplierID', buckets '17', redundancy '${redundantCopies}', PERSISTENT '${persistenceMode}')"
 " USING column OPTIONS(PARTITION_BY 'SupplierID', buckets '37',redundancy '${redundantCopies}', PERSISTENT '${persistenceMode}')"
 " USING column OPTIONS(partition_by 'TerritoryID', buckets '3', redundancy '${redundantCopies}', PERSISTENT '${persistenceMode}')"

--- a/dtests/src/test/java/io/snappydata/hydra/snapshotIsolation/columnTableExtn.inc
+++ b/dtests/src/test/java/io/snappydata/hydra/snapshotIsolation/columnTableExtn.inc
@@ -5,7 +5,7 @@ io.snappydata.hydra.snapshotIsolation.SnapshotIsolationPrms-snappyDDLExtn =
 " USING row OPTIONS(partition_by 'City,Country', buckets '19', redundancy '${redundantCopies}',PERSISTENT '${persistenceMode}')"
 " USING column OPTIONS(partition_by 'City,Country', buckets '19', colocate_with 'employees',redundancy '${redundantCopies}', PERSISTENT '${persistenceMode}')"
 " USING column OPTIONS(partition_by 'OrderID', buckets '13', redundancy '${redundantCopies}', PERSISTENT '${persistenceMode}')"
-" USING column OPTIONS(partition_by 'OrderID', buckets '13', COLOCATE_WITH 'orders', redundancy '${redundantCopies}', PERSISTENT '${persistenceMode}',COLUMN_MAX_DELTA_ROWS '100',COLUMN_BATCH_SIZE '20000')"
+" USING column OPTIONS(partition_by 'OrderID', buckets '13', COLOCATE_WITH 'orders', redundancy '${redundantCopies}', PERSISTENT '${persistenceMode}',COLUMN_MAX_DELTA_ROWS '100')"
 " USING column OPTIONS(partition_by 'ProductID,SupplierID', buckets '17', redundancy '${redundantCopies}', PERSISTENT '${persistenceMode}')"
 " USING column OPTIONS(PARTITION_BY 'SupplierID', buckets '37',redundancy '${redundantCopies}', PERSISTENT '${persistenceMode}')"
 " USING column OPTIONS(partition_by 'TerritoryID', buckets '3', redundancy '${redundantCopies}', PERSISTENT '${persistenceMode}')"


### PR DESCRIPTION
## Changes proposed in this pull request

- skip DDL options in ExternalStoreUtils when creating the set of connection properties
- corrected remaining instances of column batch size settings in tests to mean byte size (instead of number of rows)

## Patch testing

precheckin

## ReleaseNotes.txt changes

NA

## Other PRs 

NA