### PR TITLE
Framework enhancement for supporting number of user specified properties and parameters

### DIFF
--- a/dtests/src/resources/scripts/northWind/nw_queries.sql
+++ b/dtests/src/resources/scripts/northWind/nw_queries.sql
@@ -209,23 +209,23 @@ select distinct b.ShipName, b.ShipAddress, b.ShipCity, b.ShipRegion, b.ShipPosta
 
 --This query is commented due to SNAP-1434
 
-   --  select a.ProductName,
-   --      d.CompanyName,
-   --      year(OrderDate) as OrderYear,
-   --      format_number(sum(case quarter(c.OrderDate) when '1'
-   --          then b.UnitPrice*b.Quantity*(1-b.Discount) else 0 end), 0) 'Qtr 1',
-   --      format_number(sum(case quarter(c.OrderDate) when '2'
-   --          then b.UnitPrice*b.Quantity*(1-b.Discount) else 0 end), 0) 'Qtr 2',
-   --      format_number(sum(case quarter(c.OrderDate) when '3'
-   --          then b.UnitPrice*b.Quantity*(1-b.Discount) else 0 end), 0) 'Qtr 3',
-   --      format_number(sum(case quarter(c.OrderDate) when '4'
-   --          then b.UnitPrice*b.Quantity*(1-b.Discount) else 0 end), 0) 'Qtr 4'
-   --  from Products a
-   --  inner join Order_Details b on a.ProductID = b.ProductID
-   --  inner join Orders c on c.OrderID = b.OrderID
-   --  inner join Customers d on d.CustomerID = c.CustomerID
-   --  where c.OrderDate between Cast('1997-01-01' as TIMESTAMP) and Cast('1997-12-31' as TIMESTAMP)
-   --  group by a.ProductName,
-   --      d.CompanyName,
-   --      year(OrderDate)
-   --  order by a.ProductName, d.CompanyName;
+     select a.ProductName,
+         d.CompanyName,
+         year(OrderDate) as OrderYear,
+         format_number(sum(case quarter(c.OrderDate) when '1'
+             then b.UnitPrice*b.Quantity*(1-b.Discount) else 0 end), 0) "Qtr_1",
+         format_number(sum(case quarter(c.OrderDate) when '2'
+             then b.UnitPrice*b.Quantity*(1-b.Discount) else 0 end), 0) "Qtr_2",
+         format_number(sum(case quarter(c.OrderDate) when '3'
+             then b.UnitPrice*b.Quantity*(1-b.Discount) else 0 end), 0) "Qtr_3",
+         format_number(sum(case quarter(c.OrderDate) when '4'
+             then b.UnitPrice*b.Quantity*(1-b.Discount) else 0 end), 0) "Qtr_4"
+     from Products a
+     inner join Order_Details b on a.ProductID = b.ProductID
+     inner join Orders c on c.OrderID = b.OrderID
+     inner join Customers d on d.CustomerID = c.CustomerID
+     where c.OrderDate between Cast('1997-01-01' as TIMESTAMP) and Cast('1997-12-31' as TIMESTAMP)
+     group by a.ProductName,
+         d.CompanyName,
+         year(OrderDate)
+     order by a.ProductName, d.CompanyName;

--- a/dtests/src/test/java/io/snappydata/hydra/cluster/SnappyPrms.java
+++ b/dtests/src/test/java/io/snappydata/hydra/cluster/SnappyPrms.java
@@ -21,586 +21,703 @@ import hydra.HydraVector;
 
 import java.util.Vector;
 
-
-/**
- * Created by swati on 11/3/16.
- */
 public class SnappyPrms extends BasePrms {
-    /**
-     * Parameter used to get the user specified script names.
-     * (VectosetValues of Strings) A list of values for script Names to execute.
-     */
-    public static Long sqlScriptNames;
-
-    /**
-     * Parameter used to get the user specified data location List for the sql scripts.
-     * (VectorsetValues of Strings) A list of values for dataLocation to be replaced in the sql scripts.
-     * If no parameter is required for sql script then expected value to be provided for param is : Empty String : " " in case if user don't want to maintain the sequence.
-     * Or else provide the script that does not require any parameter at the end in list of sqlScriptNames parameter.
-     * Framework will treat its corresponding parameter as " " string in this case.
-     */
-    public static Long dataLocation;
-
-    /**
-     * Parameter used to get the user specified persistence mode List for the sql scripts.
-     * (VectorsetValues of Strings) A list of values for persistenceMode to be replaced in the sql scripts.
-     * If no parameter is required for sql script then expected value to be provided for param is : Empty String : " " in case if user don't want to maintain the sequence.
-     * Or else provide the script that does not require any parameter at the end in list of sqlScriptNames parameter.
-     * Framework will treat its corresponding parameter as "async" in this case.
-     */
-    public static Long persistenceMode;
-
-    /**
-     * Parameter used to get the user specified PARTITION_BY option List for the sql scripts.
-     * (VectorsetValues of Strings) A list of values for PARTITION_BY option to be replaced in the sql scripts.
-     * If no parameter is required for sql script then expected value to be provided for param is : Empty String : " " in case if user don't want to maintain the sequence.
-     * Or else provide the script that does not require any parameter at the end in list of sqlScriptNames parameter.
-     * Framework will treat its corresponding parameter as " " string in this case.
-     */
-    public static Long partitionBy;
-
-    /**
-     * Parameter used to get the user specified BUCKETS option List for the sql scripts.
-     * (VectorsetValues of Strings) A list of values for BUCKETS option to be replaced in the sql scripts.
-     * If no parameter is required for sql script then expected value to be provided for param is : Empty String : " " in case if user don't want to maintain the sequence.
-     * Or else provide the script that does not require any parameter at the end in list of sqlScriptNames parameter.
-     * Framework will treat its corresponding parameter as "113 " in this case.
-     */
-    public static Long numPartitions;
-
-    /**
-     * Parameter used to get the user specified colocation option List for the sql scripts.
-     * (VectorsetValues of Strings) A list of values for COLOCATE_WITH option to be replaced in the sql scripts.
-     * If no parameter is required for sql script then expected value to be provided for param is : Empty String : " " in case if user don't want to maintain the sequence.
-     * Or else provide the script that does not require any parameter at the end in list of sqlScriptNames parameter.
-     * Framework will treat its corresponding parameter as "none" in this case.
-     */
-    public static Long colocateWith;
-
-    /**
-     * Parameter used to get the user specified REDUNDANCY option List for the sql scripts.
-     * (VectorsetValues of Strings) A list of values for REDUNDANCY option to be replaced in the sql scripts.
-     * If no parameter is required for sql script then expected value to be provided for param is : Empty String : " " in case if user don't want to maintain the sequence.
-     * Or else provide the script that does not require any parameter at the end in list of sqlScriptNames parameter.
-     * Framework will treat its corresponding parameter as " " string in this case.
-     */
-    public static Long redundancy;
-
-    /**
-     * Parameter used to get the user specified RECOVER_DELAY option List for the sql scripts.
-     * (VectorsetValues of Strings) A list of values for RECOVER_DELAY option to be replaced in the sql scripts.
-     * If no parameter is required for sql script then expected value to be provided for param is : Empty String : " " in case if user don't want to maintain the sequence.
-     * Or else provide the script that does not require any parameter at the end in list of sqlScriptNames parameter.
-     * Framework will treat its corresponding parameter as " " string in this case.
-     */
-    public static Long recoverDelay;
-
-    /**
-     * Parameter used to get the user specified MAX_PART_SIZE option List for the sql scripts.
-     * (VectorsetValues of Strings) A list of values for MAX_PART_SIZE option to be replaced in the sql scripts.
-     * If no parameter is required for sql script then expected value to be provided for param is : Empty String : " " in case if user don't want to maintain the sequence.
-     * Or else provide the script that does not require any parameter at the end in list of sqlScriptNames parameter.
-     * Framework will treat its corresponding parameter as " " string in this case.
-     */
-    public static Long maxPartitionSize;
-
-    /**
-     * Parameter used to get the user specified EVICTION_BY option List for the sql scripts.
-     * (VectorsetValues of Strings) A list of values for EVICTION_BY option to be replaced in the sql scripts.
-     * If no parameter is required for sql script then expected value to be provided for param is : Empty String : " " in case if user don't want to maintain the sequence.
-     * Or else provide the script that does not require any parameter at the end in list of sqlScriptNames parameter.
-     * Framework will treat its corresponding parameter as " " string in this case.
-     */
-    public static Long evictionBy;
-
-    /**
-     * Parameter used to get the user specified snappy job class names.
-     * (VectosetValues of Strings) A list of values for snappy-job Names to execute.
-     */
-    public static Long jobClassNames;
-
-    /**
-     * Parameter used to get the user specified spark job class names.
-     * (VectosetValues of Strings) A list of values for spark-job Names to execute.
-     */
-    public static Long sparkJobClassNames;
-
-    /**
-     * Parameter used to get the user specified snappy streaming job class names.
-     * (VectosetValues of Strings) A list of values for snappy-job Names to execute.
-     */
-    public static Long streamingJobClassNames;
-
-    /**
-     * (boolean) for testing HA
-     */
-    public static Long cycleVms;
-
-    /**
-     * (String) cycleVMTarget - which node to be cycled "store, lead" etc
-     */
-    public static Long cycleVMTarget;
-
-    /**
-     * (String) e.g. simulateFileStream
-     */
-    public static Long simulateStreamScriptName;
-
-    /**
-     * (String) - destination folder to copy the streaming data. e.g. /home/swati
-     */
-    public static Long simulateStreamScriptDestinationFolder;
-
-    /**
-     * (boolean) - whether snappy servers and locators needs to be started using rowstore option.
-     */
-    public static Long useRowStore;
-
-    /**
-     * (boolean) - whether thin client smart connector mode cluster needs to be started.
-     */
-    public static Long useThinClientSmartConnectorMode;
-
-    /**
-     * (boolean) - whether smart connector mode cluster needs to be started.
-     */
-    public static Long useSmartConnectorMode;
-
-    /**
-     * (boolean) - whether stop mode needs to be checked before deleting the config data if already exists.
-     * This is required in case user wants to start the cluster and then stop the same later on using different script.
-     * In this case, test should not delete the existing configuration data created by previous test.
-     */
-    public static Long isStopMode;
-
-    /**
-     * (boolean) - whether created tables to be replicated or partitioned. snappy hydra already sets the gemfirexd.table-default-partitioned to false.
-     */
-    public static Long tableDefaultPartitioned;
-
-    /**
-     * (boolean) - whether test is long running.
-     */
-    public static Long isLongRunningTest;
-
-    /**
-     * (boolean) - whether to enable time statistics. snappy hydra already sets the enable-time-statistics to true.
-     */
-    public static Long enableTimeStatistics;
-
-    /**
-     * (boolean) - whether to enable closedForm Estimates. Product default value will be used in case not provided.
-     */
-    public static Long closedFormEstimates;
-
-    /**
-     * (boolean) - whether to enable zeppelin Interpreter. Product default value will be used in case not provided.
-     */
-    public static Long zeppelinInterpreter;
-
-    /**
-     * (boolean) - whether to enable Java Flight Recorder (JFR) for collecting diagnostic and profiling data while launching server and lead members in cluster. Defaults to false if not provided.
-     */
-    public static Long enableFlightRecorder;
-
-    /**
-     * (boolean) - whether to enable GC options while launching server and lead members in cluster. Defaults to false if not provided.
-     */
-    public static Long enableGCFlags;
-
-    /**
-     * (String) log level to be applied while generating logs for snappy members. Defaults to config if not provided.
-     */
-    public static Long logLevel;
-
-    /**
-     * (String) userAppJar containing the user snappy job class. The wildcards in jar file name are supported in order to removes the hard coding of jar version.
-     * e.g. user can specify the jar file name as "snappydata-store-scala-tests*tests.jar" instead of full jar name as "snappydata-store-scala-tests-0.1.0-SNAPSHOT-tests.jar".
-     */
-    public static Long userAppJar;
-
-    /**
-     * (String) AppName for the user app jar containing snappy job class.
-     */
-    public static Long userAppName;
-
-    /**
-     * (String) A unique identifier for the JAR installation. The identifier you provide must specify a schema name delimiter. For example: APP.myjar.
-     */
-    public static Long jarIdentifier;
-
-    /**
-     * (String) args to be passed to the Spark App
-     */
-    public static Long userAppArgs;
-
-    /**
-     * (int) how long (milliseconds) it should wait for getting the job status
-     */
-    public static Long streamingJobExecutionTimeInMillis;
-
-    /**
-     * (int) how long (milliseconds) it should wait before Cycle VMs again
-     */
-    public static Long waitTimeBeforeNextCycleVM;
-
-    /**
-     * (int) how long (milliseconds) it should wait before retrieving snappy-job status
-     */
-    public static Long sleepTimeSecsForJobStatus;
-
-    /**
-     * (int) Number of times the test should retry submitting failed job in case of lead node failover.
-     */
-    public static Long numTimesToRetry;
-
-    /**
-     * (int) The number of VMs to stop (then restart) at a time.
-     */
-    public static Long numVMsToStop;
-
-    /**
-     * (int) The number of lead VMs to stop (then restart).
-     */
-    public static Long numLeadsToStop;
-
-    /**
-     * Parameter used to get the user APP_PROPS for snappy job.
-     * (VectosetValues of Strings) A list of values for snappy-job.
-     */
-    public static Long appPropsForJobServer;
-
-    /**
-     * (int) number of executor cores to be used in test
-     */
-    public static Long executorCores;
-
-    /**
-     * (String) Maximun Result Size for Driver. Product default value will be used in case not provided.
-     */
-    public static Long driverMaxResultSize;
-
-    /**
-     * (String) Local Memory. Defaults to 1GB if not provided.
-     */
-    public static Long locatorMemory;
-
-    /**
-     * (String) Memory to be used while starting the Server process. Defaults to 1GB if not provided.
-     */
-    public static Long serverMemory;
-
-    /**
-     * (String) criticalHeapPercentage to be used while starting the Server process. Defaults to 90% if not provided.
-     */
-    public static Long criticalHeapPercentage;
-
-    /**
-     * (String) evictionHeapPercentage to be used while starting the Server process. Defaults to 90% of critical-heap-percentage if not provided.
-     */
-    public static Long evictionHeapPercentage;
-
-    /**
-     * (String) Memory to be used while starting the Lead process. Defaults to 1GB if not provided.
-     */
-    public static Long leadMemory;
-
-    /**
-     * (String) sparkSchedulerMode. Product default value will be used in case not provided.
-     */
-    public static Long sparkSchedulerMode;
-
-    /**
-     * (int) sparkSqlBroadcastJoinThreshold
-     */
-    public static Long sparkSqlBroadcastJoinThreshold;
-
-    /**
-     * (boolean) - whether in-memory Columnar store needs to be compressed . Defaults to false if not provided.
-     */
-    public static Long compressedInMemoryColumnarStorage;
-
-    /**
-     * (long) columnBatchSize. Product default value will be used in case not provided
-     */
-    public static Long columnBatchSize;
-
-    /**
-     * (boolean) - whether to use conserveSockets. Product default value will be used in case not provided.
-     */
-    public static Long conserveSockets;
-
-    /**
-     * (int) number of BootStrap trials to be used in test.
-     */
-    public static Long numBootStrapTrials;
-
-    /**
-     * (int) number of shuffle partitions to be used in test
-     */
-    public static Long shufflePartitions;
-
-    /**
-     *
-     * (String) Memory to be used for spark executor while executing spark-submit. Defaults to
-     * 1GB if not provided.
-     */
-    public static Long executorMemory;
-
-    public static int getRetryCountForJob() {
-        Long key = numTimesToRetry;
-        return tasktab().intAt(key, tab().intAt(key, 5));
-    }
-
-    public static int getSleepTimeSecsForJobStatus() {
-        Long key = sleepTimeSecsForJobStatus;
-        return tasktab().intAt(key, tab().intAt(key, 120));
-    }
-
-    public static String getExecutorCores() {
-        String numExecutorCores = tasktab().stringAt(executorCores, tab().stringAt(executorCores, null));
-        if (numExecutorCores == null) return "";
-        String sparkExecutorCores = " -spark.executor.cores=" + numExecutorCores;
-        return sparkExecutorCores;
-    }
-
-    public static String getDriverMaxResultSize() {
-        String maxResultSize = tasktab().stringAt(driverMaxResultSize, tab().stringAt(driverMaxResultSize, null));
-        if (maxResultSize == null) return "";
-        String sparkDriverMaxResultSize = " -spark.driver.maxResultSize=" + maxResultSize;
-        return sparkDriverMaxResultSize;
-    }
-
-    public static String getLocatorMemory() {
-        Long key = locatorMemory;
-        return tab().stringAt(key, "1G");
-    }
-
-    public static String getServerMemory() {
-        Long key = serverMemory;
-        return tab().stringAt(key, "4G");
-    }
-
-    public static String getCriticalHeapPercentage() {
-        String criticalHeapPercentageString = " -critical-heap-percentage=" + tab().stringAt(criticalHeapPercentage, "90");
-        return criticalHeapPercentageString;
-    }
-
-    public static String calculateDefaultEvictionPercentage() {
-        int criticalHeapPercent = Integer.parseInt(tab().stringAt(criticalHeapPercentage, "90"));
-        int evictionHeapPercent = (criticalHeapPercent * 90) / 100;
-        String evictionHeapPercentString = String.valueOf(evictionHeapPercent);
-        return evictionHeapPercentString;
-    }
-
-    public static String getEvictionHeapPercentage() {
-        String evictionHeapPercentageString = " -eviction-heap-percentage=" + tab().stringAt(evictionHeapPercentage, calculateDefaultEvictionPercentage());
-        return evictionHeapPercentageString;
-    }
-
-    public static String getLeadMemory() {
-        Long key = leadMemory;
-        return tab().stringAt(key, "1G");
-    }
-
-    public static String getSparkSchedulerMode() {
-        String schedulerMode = tasktab().stringAt(sparkSchedulerMode, tab().stringAt(sparkSchedulerMode, null));
-        if (schedulerMode == null) return "";
-        String sparkSchedulerMode = " -spark.scheduler.mode=" + schedulerMode;
-        return sparkSchedulerMode;
-    }
-
-    public static String getSparkSqlBroadcastJoinThreshold() {
-        String broadcastJoinThreshold = tasktab().stringAt(sparkSqlBroadcastJoinThreshold, tab().stringAt(sparkSqlBroadcastJoinThreshold, null));
-        if (broadcastJoinThreshold == null) return "";
-        String sparkSqlBroadcastJoinThreshold = " -spark.sql.autoBroadcastJoinThreshold=" + broadcastJoinThreshold;
-        return sparkSqlBroadcastJoinThreshold;
-    }
-
-    public static boolean getCompressedInMemoryColumnarStorage() {
-        Long key = compressedInMemoryColumnarStorage;
-        return tasktab().booleanAt(key, tab().booleanAt(key, false));
-    }
-
-    public static String getColumnBatchSize() {
-        String snappyColumnBatchSize = tasktab().stringAt(columnBatchSize, tab().stringAt(columnBatchSize, null));
-        if (snappyColumnBatchSize == null) return "";
-        String columnBatchSize = " -snappydata.column.batchSize=" + snappyColumnBatchSize;
-        return columnBatchSize;
-    }
-
-    public static String getConserveSockets() {
-        String isConserveSockets = tasktab().stringAt(conserveSockets, tab().stringAt(conserveSockets, null));
-        if (isConserveSockets == null) return "";
-        String conserveSockets = " -conserve-sockets=" + isConserveSockets;
-        return conserveSockets;
-    }
-
-    public static int getShufflePartitions() {
-        Long key = shufflePartitions;
-        return tasktab().intAt(key, tab().intAt(key, 1));
-    }
-
-    public static String getCommaSepAPPProps() {
-        Long key = appPropsForJobServer;
-        return BasePrms.tasktab().stringAt(key, BasePrms.tab().stringAt(key, null));
-    }
-
-    public static boolean getTableDefaultDataPolicy() {
-        Long key = tableDefaultPartitioned;
-        return tasktab().booleanAt(key, tab().booleanAt(key, false));
-    }
-
-    public static String getTimeStatistics() {
-        boolean enableTimeStats = tasktab().booleanAt(enableTimeStatistics, tab().booleanAt(enableTimeStatistics, true));
-        String timeStatistics = " -enable-time-statistics=" + enableTimeStats + " -statistic-archive-file=statArchive.gfs";
-        return timeStatistics;
-    }
-
-    public static String getClosedFormEstimates() {
-        String enableClosedFormEstimates = tasktab().stringAt(closedFormEstimates, tab().stringAt(closedFormEstimates, null));
-        if (enableClosedFormEstimates == null) return "";
-        String closedFormEstimates = " -spark.sql.aqp.closedFormEstimates=" + enableClosedFormEstimates;
-        return closedFormEstimates;
-    }
-
-    public static String getZeppelinInterpreter() {
-        String enableZeppelinInterpreter = tasktab().stringAt(zeppelinInterpreter, tab().stringAt(zeppelinInterpreter, null));
-        if (enableZeppelinInterpreter == null) return "";
-        String zeppelinInterpreter = " -zeppelin.interpreter.enable=" + enableZeppelinInterpreter;
-        return zeppelinInterpreter;
-    }
-
-    public static String getFlightRecorderOptions(String dirPath) {
-        boolean flightRecorder = tasktab().booleanAt(enableFlightRecorder, tab().booleanAt(enableFlightRecorder, false));
-        if (flightRecorder) {
-            String flightRecorderOptions = " -J-XX:+UnlockCommercialFeatures -J-XX:+FlightRecorder -J-XX:FlightRecorderOptions=defaultrecording=true,disk=true,repository=" +
-                    dirPath + ",maxage=6h,dumponexit=true,dumponexitpath=flightRecorder.jfr";
-            return flightRecorderOptions;
-        } else return "";
-    }
-
-    public static String getGCOptions(String dirPath) {
-        boolean gcFlags = tasktab().booleanAt(enableGCFlags, tab().booleanAt(enableGCFlags, false));
-        if (gcFlags) {
-            String gcOptions = " -J-verbose:gc -J-Xloggc:" + dirPath + "/gc.out -J-XX:+PrintGCDetails -J-XX:+PrintGCTimeStamps  -J-XX:+PrintGCDateStamps";
-            return gcOptions;
-        } else return "";
-    }
-
-    public static String getNumBootStrapTrials() {
-        String bootStrapTrials = tasktab().stringAt(numBootStrapTrials, tab().stringAt(numBootStrapTrials, null));
-        if (bootStrapTrials == null) return "";
-        String numBootStrapTrials = " -spark.sql.aqp.numBootStrapTrials=" + bootStrapTrials;
-        return numBootStrapTrials;
-    }
-
-    public static String getLogLevel() {
-        String snappyLogLevel = " -log-level=" + tab().stringAt(logLevel, "config");
-        return snappyLogLevel;
-    }
-
-    public static Vector getSQLScriptNames() {
-        Long key = sqlScriptNames;
-        return BasePrms.tasktab().vecAt(key, BasePrms.tab().vecAt(key, null));
-    }
-
-    public static String getUserAppJar() {
-        Long key = userAppJar;
-        return BasePrms.tasktab().stringAt(key, BasePrms.tab().stringAt(key, null));
-    }
-
-    public static String getUserAppName() {
-        Long key = userAppName;
-        return BasePrms.tasktab().stringAt(key, BasePrms.tab().stringAt(key, "myApp"));
-    }
-
-    public static String getJarIdentifier() {
-        Long key = jarIdentifier;
-        return BasePrms.tasktab().stringAt(key, BasePrms.tab().stringAt(key, null));
-    }
-
-    public static String getUserAppArgs() {
-        Long key = userAppArgs;
-        return BasePrms.tasktab().stringAt(key, BasePrms.tab().stringAt(key, " "));
-    }
-
-    public static Vector getDataLocationList() {
-        Long key = dataLocation;
-        return BasePrms.tasktab().vecAt(key, BasePrms.tab().vecAt(key, new HydraVector()));
-    }
-
-    public static Vector getPersistenceModeList() {
-        Long key = persistenceMode;
-        return BasePrms.tasktab().vecAt(key, BasePrms.tab().vecAt(key, new HydraVector()));
-    }
-
-    public static Vector getColocateWithOptionList() {
-        Long key = colocateWith;
-        return BasePrms.tasktab().vecAt(key, BasePrms.tab().vecAt(key, new HydraVector()));
-    }
-
-    public static Vector getPartitionByOptionList() {
-        Long key = partitionBy;
-        return BasePrms.tasktab().vecAt(key, BasePrms.tab().vecAt(key, new HydraVector()));
-    }
-
-    public static Vector getNumPartitionsList() {
-        Long key = numPartitions;
-        return BasePrms.tasktab().vecAt(key, BasePrms.tab().vecAt(key, new HydraVector()));
-    }
-
-    public static Vector getRedundancyOptionList() {
-        Long key = redundancy;
-        return BasePrms.tasktab().vecAt(key, BasePrms.tab().vecAt(key, new HydraVector()));
-    }
-
-    public static Vector getRecoverDelayOptionList() {
-        Long key = recoverDelay;
-        return BasePrms.tasktab().vecAt(key, BasePrms.tab().vecAt(key, new HydraVector()));
-    }
-
-    public static Vector getMaxPartitionSizeList() {
-        Long key = maxPartitionSize;
-        return BasePrms.tasktab().vecAt(key, BasePrms.tab().vecAt(key, new HydraVector()));
-    }
-
-    public static Vector getEvictionByOptionList() {
-        Long key = evictionBy;
-        return BasePrms.tasktab().vecAt(key, BasePrms.tab().vecAt(key, new HydraVector()));
-    }
-
-    public static Vector getSnappyJobClassNames() {
-        Long key = jobClassNames;
-        return BasePrms.tasktab().vecAt(key, BasePrms.tab().vecAt(key, null));
-    }
-
-    public static Vector getSparkJobClassNames() {
-        Long key = sparkJobClassNames;
-        return BasePrms.tasktab().vecAt(key, BasePrms.tab().vecAt(key, null));
-    }
-
-    public static Vector getSnappyStreamingJobClassNames() {
-        Long key = streamingJobClassNames;
-        return BasePrms.tasktab().vecAt(key, BasePrms.tab().vecAt(key, null));
-    }
-
-    public static String getExecutorMemory() {
-      Long key = executorMemory;
-      String heapSize = tasktab().stringAt(key, BasePrms.tab().stringAt(key, null));
-      if (heapSize == null)
-          return "";
-      String executorMem = " --executor-memory " + heapSize;
-      return executorMem;
-
-    }
-
-
-    static {
-        BasePrms.setValues(SnappyPrms.class);
-    }
-
-    public static void main(String args[]) {
-        BasePrms.dumpKeys();
-    }
+  /**
+   * Parameter used to get the user specified script names.
+   * (VectosetValues of Strings) A list of values for script Names to execute.
+   */
+  public static Long sqlScriptNames;
+
+  /**
+   * Parameter used to get the user specified data location List for the sql scripts.
+   * (VectorsetValues of Strings) A list of values for dataLocation to be replaced in the
+   * sql scripts.
+   * If no parameter is required for sql script then expected value to be provided for param is :
+   * Empty String : " " in case if user don't want to maintain the sequence.
+   * Or else provide the script that does not require any parameter at the end in list of
+   * sqlScriptNames parameter.
+   * Framework will treat its corresponding parameter as " " string in this case.
+   */
+  public static Long dataLocation;
+
+  /**
+   * Parameter used to get the user specified persistence mode List for the sql scripts.
+   * (VectorsetValues of Strings) A list of values for persistenceMode to be replaced in the
+   * sql scripts.
+   * If no parameter is required for sql script then expected value to be provided for param is :
+   * Empty String : " " in case if user don't want to maintain the sequence.
+   * Or else provide the script that does not require any parameter at the end in list of
+   * sqlScriptNames parameter.
+   * Framework will treat its corresponding parameter as "async" in this case.
+   */
+  public static Long persistenceMode;
+
+  /**
+   * Parameter used to get the user specified PARTITION_BY option List for the sql scripts.
+   * (VectorsetValues of Strings) A list of values for PARTITION_BY option to be replaced in the
+   * sql scripts.
+   * If no parameter is required for sql script then expected value to be provided for param is :
+   * Empty String : " " in case if user don't want to maintain the sequence.
+   * Or else provide the script that does not require any parameter at the end in list of
+   * sqlScriptNames parameter.
+   * Framework will treat its corresponding parameter as " " string in this case.
+   */
+  public static Long partitionBy;
+
+  /**
+   * Parameter used to get the user specified BUCKETS option List for the sql scripts.
+   * (VectorsetValues of Strings) A list of values for BUCKETS option to be replaced in the
+   * sql scripts.
+   * If no parameter is required for sql script then expected value to be provided for param is :
+   * Empty String : " " in case if user don't want to maintain the sequence.
+   * Or else provide the script that does not require any parameter at the end in list of
+   * sqlScriptNames parameter.
+   * Framework will treat its corresponding parameter as "113 " in this case.
+   */
+  public static Long numPartitions;
+
+  /**
+   * Parameter used to get the user specified colocation option List for the sql scripts.
+   * (VectorsetValues of Strings) A list of values for COLOCATE_WITH option to be replaced in the
+   * sql scripts.
+   * If no parameter is required for sql script then expected value to be provided for param is :
+   * Empty String : " " in case if user don't want to maintain the sequence.
+   * Or else provide the script that does not require any parameter at the end in list of
+   * sqlScriptNames parameter.
+   * Framework will treat its corresponding parameter as "none" in this case.
+   */
+  public static Long colocateWith;
+
+  /**
+   * Parameter used to get the user specified REDUNDANCY option List for the sql scripts.
+   * (VectorsetValues of Strings) A list of values for REDUNDANCY option to be replaced in the
+   * sql scripts.
+   * If no parameter is required for sql script then expected value to be provided for param is :
+   * Empty String : " " in case if user don't want to maintain the sequence.
+   * Or else provide the script that does not require any parameter at the end in list of
+   * sqlScriptNames parameter.
+   * Framework will treat its corresponding parameter as " " string in this case.
+   */
+  public static Long redundancy;
+
+  /**
+   * Parameter used to get the user specified RECOVER_DELAY option List for the sql scripts.
+   * (VectorsetValues of Strings) A list of values for RECOVER_DELAY option to be replaced in the
+   * sql scripts.
+   * If no parameter is required for sql script then expected value to be provided for param is :
+   * Empty String : " " in case if user don't want to maintain the sequence.
+   * Or else provide the script that does not require any parameter at the end in list of
+   * sqlScriptNames parameter.
+   * Framework will treat its corresponding parameter as " " string in this case.
+   */
+  public static Long recoverDelay;
+
+  /**
+   * Parameter used to get the user specified MAX_PART_SIZE option List for the sql scripts.
+   * (VectorsetValues of Strings) A list of values for MAX_PART_SIZE option to be replaced in the
+   * sql scripts.
+   * If no parameter is required for sql script then expected value to be provided for param is :
+   * Empty String : " " in case if user don't want to maintain the sequence.
+   * Or else provide the script that does not require any parameter at the end in list of
+   * sqlScriptNames parameter.
+   * Framework will treat its corresponding parameter as " " string in this case.
+   */
+  public static Long maxPartitionSize;
+
+  /**
+   * Parameter used to get the user specified EVICTION_BY option List for the sql scripts.
+   * (VectorsetValues of Strings) A list of values for EVICTION_BY option to be replaced in the
+   * sql scripts.
+   * If no parameter is required for sql script then expected value to be provided for param is :
+   * Empty String : " " in case if user don't want to maintain the sequence.
+   * Or else provide the script that does not require any parameter at the end in list of
+   * sqlScriptNames parameter.
+   * Framework will treat its corresponding parameter as " " string in this case.
+   */
+  public static Long evictionBy;
+
+  /**
+   * Parameter used to get the user specified snappy job class names.
+   * (VectosetValues of Strings) A list of values for snappy-job Names to execute.
+   */
+  public static Long jobClassNames;
+
+  /**
+   * Parameter used to get the user specified spark job class names.
+   * (VectosetValues of Strings) A list of values for spark-job Names to execute.
+   */
+  public static Long sparkJobClassNames;
+
+  /**
+   * Parameter used to get the user specified snappy streaming job class names.
+   * (VectosetValues of Strings) A list of values for snappy-job Names to execute.
+   */
+  public static Long streamingJobClassNames;
+
+  /**
+   * (boolean) for testing HA
+   */
+  public static Long cycleVms;
+
+  /**
+   * (String) cycleVMTarget - which node to be cycled "store, lead" etc
+   */
+  public static Long cycleVMTarget;
+
+  /**
+   * (String) e.g. simulateFileStream
+   */
+  public static Long simulateStreamScriptName;
+
+  /**
+   * (String) - destination folder to copy the streaming data. e.g. /home/swati
+   */
+  public static Long simulateStreamScriptDestinationFolder;
+
+  /**
+   * (boolean) - whether snappy servers and locators needs to be started using rowstore option.
+   */
+  public static Long useRowStore;
+
+  /**
+   * (boolean) - whether thin client smart connector mode cluster needs to be started.
+   */
+  public static Long useThinClientSmartConnectorMode;
+
+  /**
+   * (boolean) - whether smart connector mode cluster needs to be started.
+   */
+  public static Long useSmartConnectorMode;
+
+  /**
+   * (boolean) - whether stop mode needs to be checked before deleting the config data if already
+   * exists.
+   * This is required in case user wants to start the cluster and then stop the same later on using
+   * different script.
+   * In this case, test should not delete the existing configuration data created by previous test.
+   */
+  public static Long isStopMode;
+
+  /**
+   * (boolean) - whether created tables to be replicated or partitioned. snappy hydra already sets
+   * the gemfirexd.table-default-partitioned to false.
+   */
+  public static Long tableDefaultPartitioned;
+
+  /**
+   * (boolean) - whether test is long running.
+   */
+  public static Long isLongRunningTest;
+
+  /**
+   * (boolean) - whether to enable time statistics. snappy hydra already sets the
+   * enable-time-statistics to true.
+   */
+  public static Long enableTimeStatistics;
+
+  /**
+   * (boolean) - whether to enable closedForm Estimates. Product default value will be used in
+   * case not provided.
+   */
+  public static Long closedFormEstimates;
+
+  /**
+   * (boolean) - whether to enable zeppelin Interpreter. Product default value will be used in
+   * case not provided.
+   */
+  public static Long zeppelinInterpreter;
+
+  /**
+   * (boolean) - whether to enable Java Flight Recorder (JFR) for collecting diagnostic and
+   * profiling data while launching server and lead members in cluster. Defaults to false if not
+   * provided.
+   */
+  public static Long enableFlightRecorder;
+
+  /**
+   * (boolean) - whether to enable GC options while launching server and lead members in cluster.
+   * Defaults to false if not provided.
+   */
+  public static Long enableGCFlags;
+
+  /**
+   * (String) log level to be applied while generating logs for snappy members.
+   * Defaults to config if not provided.
+   */
+  public static Long logLevel;
+
+  /**
+   * (String) userAppJar containing the user snappy job class. The wildcards in jar file name are
+   * supported in order to removes the hard coding of jar version.
+   * e.g. user can specify the jar file name as "snappydata-store-scala-tests*tests.jar" instead of
+   * full jar name as "snappydata-store-scala-tests-0.1.0-SNAPSHOT-tests.jar".
+   */
+  public static Long userAppJar;
+
+  /**
+   * (String) AppName for the user app jar containing snappy job class.
+   */
+  public static Long userAppName;
+
+  /**
+   * (String) A unique identifier for the JAR installation. The identifier you provide must
+   * specify a schema name delimiter. For example: APP.myjar.
+   */
+  public static Long jarIdentifier;
+
+  /**
+   * (String) args to be passed to the Spark App
+   */
+  public static Long userAppArgs;
+
+  /**
+   * (int) how long (milliseconds) it should wait for getting the job status
+   */
+  public static Long streamingJobExecutionTimeInMillis;
+
+  /**
+   * (int) how long (milliseconds) it should wait before Cycle VMs again
+   */
+  public static Long waitTimeBeforeNextCycleVM;
+
+  /**
+   * (int) how long (milliseconds) it should wait before retrieving snappy-job status
+   */
+  public static Long sleepTimeSecsForJobStatus;
+
+  /**
+   * (int) Number of times the test should retry submitting failed job in case of lead node failover.
+   */
+  public static Long numTimesToRetry;
+
+  /**
+   * (int) The number of VMs to stop (then restart) at a time.
+   */
+  public static Long numVMsToStop;
+
+  /**
+   * (int) The number of lead VMs to stop (then restart).
+   */
+  public static Long numLeadsToStop;
+
+  /**
+   * Parameter used to get the user APP_PROPS for snappy job.
+   * (VectosetValues of Strings) A list of values for snappy-job.
+   */
+  public static Long appPropsForJobServer;
+
+  /**
+   * Parameter used to get the leaderLauncher properties specified by user while launching
+   * the lead node.
+   * (VectosetValues of Strings) A space seperated list of values for leaderLauncher properties.
+   */
+  public static Long leaderLauncherProps;
+
+  /**
+   * Parameter used to get the serverLauncher properties specified by user while launching
+   * the dataStore node.
+   * (VectosetValues of Strings) A space seperated list of values for serverLauncher properties.
+   */
+  public static Long serverLauncherProps;
+
+  /**
+   * Parameter used to get the locatorLauncher properties specified by user while launching
+   * the locator node.
+   * (VectosetValues of Strings) A space seperated list of values for locatorLauncher properties.
+   */
+  public static Long locatorLauncherProps;
+
+  /**
+   * Parameter used to get the list of parameters specified by user for spark-submit
+   * (VectosetValues of Strings) A space seperated list of values of parameters for spark-submit.
+   */
+  public static Long sparkSubmitExtraPrms;
+
+  /**
+   * (int) number of executor cores to be used in test
+   */
+  public static Long executorCores;
+
+  /**
+   * (String) Maximun Result Size for Driver. Product default value will be used in case not
+   * provided.
+   */
+  public static Long driverMaxResultSize;
+
+  /**
+   * (String) Local Memory. Defaults to 1GB if not provided.
+   */
+  public static Long locatorMemory;
+
+  /**
+   * (String) Memory to be used while starting the Server process. Defaults to 1GB if not provided.
+   */
+  public static Long serverMemory;
+
+  /**
+   * (String) criticalHeapPercentage to be used while starting the Server process. Defaults to 90%
+   * if not provided.
+   */
+  public static Long criticalHeapPercentage;
+
+  /**
+   * (String) evictionHeapPercentage to be used while starting the Server process. Defaults to 90%
+   * of critical-heap-percentage if not provided.
+   */
+  public static Long evictionHeapPercentage;
+
+  /**
+   * (String) Memory to be used while starting the Lead process. Defaults to 1GB if not provided.
+   */
+  public static Long leadMemory;
+
+  /**
+   * (String) sparkSchedulerMode. Product default value will be used in case not provided.
+   */
+  public static Long sparkSchedulerMode;
+
+  /**
+   * (int) sparkSqlBroadcastJoinThreshold
+   */
+  public static Long sparkSqlBroadcastJoinThreshold;
+
+  /**
+   * (boolean) - whether in-memory Columnar store needs to be compressed . Defaults to false if not
+   * provided.
+   */
+  public static Long compressedInMemoryColumnarStorage;
+
+  /**
+   * (long) columnBatchSize. Product default value will be used in case not provided
+   */
+  public static Long columnBatchSize;
+
+  /**
+   * (boolean) - whether to use conserveSockets. Product default value will be used in case not
+   * provided.
+   */
+  public static Long conserveSockets;
+
+  /**
+   * (int) number of BootStrap trials to be used in test.
+   */
+  public static Long numBootStrapTrials;
+
+  /**
+   * (int) number of shuffle partitions to be used in test
+   */
+  public static Long shufflePartitions;
+
+  /**
+   * (String) Memory to be used for spark executor while executing spark-submit. Defaults to
+   * 1GB if not provided.
+   */
+  public static Long executorMemory;
+
+  public static int getRetryCountForJob() {
+    Long key = numTimesToRetry;
+    return tasktab().intAt(key, tab().intAt(key, 5));
+  }
+
+  public static int getSleepTimeSecsForJobStatus() {
+    Long key = sleepTimeSecsForJobStatus;
+    return tasktab().intAt(key, tab().intAt(key, 120));
+  }
+
+  public static String getExecutorCores() {
+    String numExecutorCores = tasktab().stringAt(executorCores, tab().stringAt(executorCores,
+        null));
+    if (numExecutorCores == null) return "";
+    String sparkExecutorCores = " -spark.executor.cores=" + numExecutorCores;
+    return sparkExecutorCores;
+  }
+
+  public static String getDriverMaxResultSize() {
+    String maxResultSize = tasktab().stringAt(driverMaxResultSize, tab().stringAt
+        (driverMaxResultSize, null));
+    if (maxResultSize == null) return "";
+    String sparkDriverMaxResultSize = " -spark.driver.maxResultSize=" + maxResultSize;
+    return sparkDriverMaxResultSize;
+  }
+
+  public static String getLocatorMemory() {
+    Long key = locatorMemory;
+    return tab().stringAt(key, "1G");
+  }
+
+  public static String getServerMemory() {
+    Long key = serverMemory;
+    return tab().stringAt(key, "4G");
+  }
+
+  public static String getCriticalHeapPercentage() {
+    String criticalHeapPercentageString = " -critical-heap-percentage=" + tab().stringAt
+        (criticalHeapPercentage, "90");
+    return criticalHeapPercentageString;
+  }
+
+  public static String calculateDefaultEvictionPercentage() {
+    int criticalHeapPercent = Integer.parseInt(tab().stringAt(criticalHeapPercentage, "90"));
+    int evictionHeapPercent = (criticalHeapPercent * 90) / 100;
+    String evictionHeapPercentString = String.valueOf(evictionHeapPercent);
+    return evictionHeapPercentString;
+  }
+
+  public static String getEvictionHeapPercentage() {
+    String evictionHeapPercentageString = " -eviction-heap-percentage=" + tab().stringAt
+        (evictionHeapPercentage, calculateDefaultEvictionPercentage());
+    return evictionHeapPercentageString;
+  }
+
+  public static String getLeadMemory() {
+    Long key = leadMemory;
+    return tab().stringAt(key, "1G");
+  }
+
+  public static String getSparkSchedulerMode() {
+    String schedulerMode = tasktab().stringAt(sparkSchedulerMode, tab().stringAt
+        (sparkSchedulerMode, null));
+    if (schedulerMode == null) return "";
+    String sparkSchedulerMode = " -spark.scheduler.mode=" + schedulerMode;
+    return sparkSchedulerMode;
+  }
+
+  public static String getSparkSqlBroadcastJoinThreshold() {
+    String broadcastJoinThreshold = tasktab().stringAt(sparkSqlBroadcastJoinThreshold, tab()
+        .stringAt(sparkSqlBroadcastJoinThreshold, null));
+    if (broadcastJoinThreshold == null) return "";
+    String sparkSqlBroadcastJoinThreshold = " -spark.sql.autoBroadcastJoinThreshold=" +
+        broadcastJoinThreshold;
+    return sparkSqlBroadcastJoinThreshold;
+  }
+
+  public static boolean getCompressedInMemoryColumnarStorage() {
+    Long key = compressedInMemoryColumnarStorage;
+    return tasktab().booleanAt(key, tab().booleanAt(key, false));
+  }
+
+  public static String getColumnBatchSize() {
+    String snappyColumnBatchSize = tasktab().stringAt(columnBatchSize, tab().stringAt
+        (columnBatchSize, null));
+    if (snappyColumnBatchSize == null) return "";
+    String columnBatchSize = " -snappydata.column.batchSize=" + snappyColumnBatchSize;
+    return columnBatchSize;
+  }
+
+  public static String getConserveSockets() {
+    String isConserveSockets = tasktab().stringAt(conserveSockets, tab().stringAt
+        (conserveSockets, null));
+    if (isConserveSockets == null) return "";
+    String conserveSockets = " -conserve-sockets=" + isConserveSockets;
+    return conserveSockets;
+  }
+
+  public static int getShufflePartitions() {
+    Long key = shufflePartitions;
+    return tasktab().intAt(key, tab().intAt(key, 1));
+  }
+
+  public static String getCommaSepAPPProps() {
+    Long key = appPropsForJobServer;
+    return BasePrms.tasktab().stringAt(key, BasePrms.tab().stringAt(key, null));
+  }
+
+  public static String getLeaderLauncherProps() {
+    Long key = leaderLauncherProps;
+    String leaderLauncherPropList = BasePrms.tasktab().stringAt(key, BasePrms.tab().stringAt(key,
+        null));
+    if (leaderLauncherPropList == null) return "";
+    else return leaderLauncherPropList;
+  }
+
+  public static String getServerLauncherProps() {
+    Long key = serverLauncherProps;
+    String serverLauncherPropList = BasePrms.tasktab().stringAt(key, BasePrms.tab().stringAt(key,
+        null));
+    if (serverLauncherPropList == null) return "";
+    else return serverLauncherPropList;
+  }
+
+  public static String getLocatorLauncherProps() {
+    Long key = locatorLauncherProps;
+    String locatorLauncherPropList = BasePrms.tasktab().stringAt(key, BasePrms.tab().stringAt(key,
+        null));
+    if (locatorLauncherPropList == null) return "";
+    else return locatorLauncherPropList;
+  }
+
+  public static String getSparkSubmitExtraPrms() {
+    Long key = sparkSubmitExtraPrms;
+    String sparkSubmitExtraPrmList = BasePrms.tasktab().stringAt(key, BasePrms.tab().stringAt(key,
+        null));
+    if (sparkSubmitExtraPrmList == null) return "";
+    else return sparkSubmitExtraPrmList;
+  }
+
+  public static boolean getTableDefaultDataPolicy() {
+    Long key = tableDefaultPartitioned;
+
+    return tasktab().booleanAt(key, tab().booleanAt(key, false));
+  }
+
+  public static String getTimeStatistics() {
+    boolean enableTimeStats = tasktab().booleanAt(enableTimeStatistics, tab().booleanAt
+        (enableTimeStatistics, true));
+    String timeStatistics = " -enable-time-statistics=" + enableTimeStats + " " +
+        "-statistic-archive-file=statArchive.gfs";
+    return timeStatistics;
+  }
+
+  public static String getClosedFormEstimates() {
+    String enableClosedFormEstimates = tasktab().stringAt(closedFormEstimates, tab().stringAt
+        (closedFormEstimates, null));
+    if (enableClosedFormEstimates == null) return "";
+    String closedFormEstimates = " -spark.sql.aqp.closedFormEstimates=" + enableClosedFormEstimates;
+    return closedFormEstimates;
+  }
+
+  public static String getZeppelinInterpreter() {
+    String enableZeppelinInterpreter = tasktab().stringAt(zeppelinInterpreter, tab().stringAt
+        (zeppelinInterpreter, null));
+    if (enableZeppelinInterpreter == null) return "";
+    String zeppelinInterpreter = " -zeppelin.interpreter.enable=" + enableZeppelinInterpreter;
+    return zeppelinInterpreter;
+  }
+
+  public static String getFlightRecorderOptions(String dirPath) {
+    boolean flightRecorder = tasktab().booleanAt(enableFlightRecorder, tab().booleanAt
+        (enableFlightRecorder, false));
+    if (flightRecorder) {
+      String flightRecorderOptions = " -J-XX:+UnlockCommercialFeatures -J-XX:+FlightRecorder  " +
+          "-J-XX:FlightRecorderOptions=defaultrecording=true,disk=true,repository=" +
+          dirPath + ",maxage=6h,dumponexit=true,dumponexitpath=flightRecorder.jfr";
+      return flightRecorderOptions;
+    } else return "";
+  }
+
+  public static String getGCOptions(String dirPath) {
+    boolean gcFlags = tasktab().booleanAt(enableGCFlags, tab().booleanAt(enableGCFlags, false));
+    if (gcFlags) {
+      String gcOptions = " -J-verbose:gc -J-Xloggc:" + dirPath + "/gc.out -J-XX:+PrintGCDetails " +
+          " -J-XX:+PrintGCTimeStamps  -J-XX:+PrintGCDateStamps";
+      return gcOptions;
+    } else return "";
+  }
+
+  public static String getNumBootStrapTrials() {
+    String bootStrapTrials = tasktab().stringAt(numBootStrapTrials, tab().stringAt
+        (numBootStrapTrials, null));
+    if (bootStrapTrials == null) return "";
+    String numBootStrapTrials = " -spark.sql.aqp.numBootStrapTrials=" + bootStrapTrials;
+    return numBootStrapTrials;
+  }
+
+  public static String getLogLevel() {
+    String snappyLogLevel = " -log-level=" + tab().stringAt(logLevel, "config");
+    return snappyLogLevel;
+  }
+
+  public static Vector getSQLScriptNames() {
+    Long key = sqlScriptNames;
+    return BasePrms.tasktab().vecAt(key, BasePrms.tab().vecAt(key, null));
+  }
+
+  public static String getUserAppJar() {
+    Long key = userAppJar;
+    return BasePrms.tasktab().stringAt(key, BasePrms.tab().stringAt(key, null));
+  }
+
+  public static String getUserAppName() {
+    Long key = userAppName;
+    return BasePrms.tasktab().stringAt(key, BasePrms.tab().stringAt(key, "myApp"));
+  }
+
+  public static String getJarIdentifier() {
+    Long key = jarIdentifier;
+    return BasePrms.tasktab().stringAt(key, BasePrms.tab().stringAt(key, null));
+  }
+
+  public static String getUserAppArgs() {
+    Long key = userAppArgs;
+    return BasePrms.tasktab().stringAt(key, BasePrms.tab().stringAt(key, " "));
+  }
+
+  public static Vector getDataLocationList() {
+    Long key = dataLocation;
+    return BasePrms.tasktab().vecAt(key, BasePrms.tab().vecAt(key, new HydraVector()));
+  }
+
+  public static Vector getPersistenceModeList() {
+    Long key = persistenceMode;
+    return BasePrms.tasktab().vecAt(key, BasePrms.tab().vecAt(key, new HydraVector()));
+  }
+
+  public static Vector getColocateWithOptionList() {
+    Long key = colocateWith;
+    return BasePrms.tasktab().vecAt(key, BasePrms.tab().vecAt(key, new HydraVector()));
+  }
+
+  public static Vector getPartitionByOptionList() {
+    Long key = partitionBy;
+    return BasePrms.tasktab().vecAt(key, BasePrms.tab().vecAt(key, new HydraVector()));
+  }
+
+  public static Vector getNumPartitionsList() {
+    Long key = numPartitions;
+    return BasePrms.tasktab().vecAt(key, BasePrms.tab().vecAt(key, new HydraVector()));
+  }
+
+  public static Vector getRedundancyOptionList() {
+    Long key = redundancy;
+    return BasePrms.tasktab().vecAt(key, BasePrms.tab().vecAt(key, new HydraVector()));
+  }
+
+  public static Vector getRecoverDelayOptionList() {
+    Long key = recoverDelay;
+    return BasePrms.tasktab().vecAt(key, BasePrms.tab().vecAt(key, new HydraVector()));
+  }
+
+  public static Vector getMaxPartitionSizeList() {
+    Long key = maxPartitionSize;
+    return BasePrms.tasktab().vecAt(key, BasePrms.tab().vecAt(key, new HydraVector()));
+  }
+
+  public static Vector getEvictionByOptionList() {
+    Long key = evictionBy;
+    return BasePrms.tasktab().vecAt(key, BasePrms.tab().vecAt(key, new HydraVector()));
+  }
+
+  public static Vector getSnappyJobClassNames() {
+    Long key = jobClassNames;
+    return BasePrms.tasktab().vecAt(key, BasePrms.tab().vecAt(key, null));
+  }
+
+  public static Vector getSparkJobClassNames() {
+    Long key = sparkJobClassNames;
+    return BasePrms.tasktab().vecAt(key, BasePrms.tab().vecAt(key, null));
+  }
+
+  public static Vector getSnappyStreamingJobClassNames() {
+    Long key = streamingJobClassNames;
+    return BasePrms.tasktab().vecAt(key, BasePrms.tab().vecAt(key, null));
+  }
+
+  public static String getExecutorMemory() {
+    Long key = executorMemory;
+    String heapSize = tasktab().stringAt(key, BasePrms.tab().stringAt(key, null));
+    if (heapSize == null)
+      return "";
+    String executorMem = " --executor-memory " + heapSize;
+    return executorMem;
+
+  }
+
+
+  static {
+    BasePrms.setValues(SnappyPrms.class);
+  }
+
+  public static void main(String args[]) {
+    BasePrms.dumpKeys();
+  }
 }

--- a/dtests/src/test/java/io/snappydata/hydra/cluster/SnappyPrms.java
+++ b/dtests/src/test/java/io/snappydata/hydra/cluster/SnappyPrms.java
@@ -442,12 +442,20 @@ public class SnappyPrms extends BasePrms {
 
   public static String getLocatorMemory() {
     Long key = locatorMemory;
-    return tab().stringAt(key, "1G");
+    String locatorHeapSize = BasePrms.tasktab().stringAt(key, BasePrms.tab().stringAt(key,
+        null));
+    if (locatorHeapSize == null) return "";
+    locatorHeapSize = " -heap-size=" + locatorHeapSize;
+    return locatorHeapSize;
   }
 
   public static String getServerMemory() {
     Long key = serverMemory;
-    return tab().stringAt(key, "4G");
+    String serverHeapSize = BasePrms.tasktab().stringAt(key, BasePrms.tab().stringAt(key,
+        null));
+    if (serverHeapSize == null) return "";
+    serverHeapSize = " -heap-size=" + serverHeapSize;
+    return serverHeapSize;
   }
 
   public static String getCriticalHeapPercentage() {
@@ -471,7 +479,11 @@ public class SnappyPrms extends BasePrms {
 
   public static String getLeadMemory() {
     Long key = leadMemory;
-    return tab().stringAt(key, "1G");
+    String leadHeapSize = BasePrms.tasktab().stringAt(key, BasePrms.tab().stringAt(key,
+        null));
+    if (leadHeapSize == null) return "";
+    leadHeapSize = " -heap-size=" + leadHeapSize;
+    return leadHeapSize;
   }
 
   public static String getSparkSchedulerMode() {

--- a/dtests/src/test/java/io/snappydata/hydra/cluster/SnappyTest.java
+++ b/dtests/src/test/java/io/snappydata/hydra/cluster/SnappyTest.java
@@ -158,6 +158,28 @@ public class SnappyTest implements Serializable {
     }
   }
 
+
+  public static void initSnappyArtifacts() {
+    snappyTest = new SnappyTest();
+    HostDescription hd = TestConfig.getInstance().getMasterDescription()
+        .getVmDescription().getHostDescription();
+    char sep = hd.getFileSep();
+    String gemfireHome = hd.getGemFireHome() + sep;
+    String productDir = gemfireHome + ".." + sep + "snappy" + sep;
+    String productConfDirPath = productDir + "conf" + sep;
+    String productLibsDir = productDir + "lib" + sep;
+    String productSbinDir = productDir + "sbin" + sep;
+    String productBinDir = productDir + "bin" + sep;
+    String SnappyShellPath = productBinDir + "snappy-sql";
+    String dtests = gemfireHome + ".." + sep + ".." + sep + ".." + sep + "dtests" + sep;
+    String dtestsLibsDir = dtests + "build-artifacts" + sep + "scala-2.11" + sep + "libs" + sep;
+    String dtestsResourceLocation = dtests + "src" + sep + "resources" + sep;
+    String dtestsScriptLocation = dtestsResourceLocation + "scripts" + sep;
+    String dtestsDataLocation = dtestsResourceLocation + "data" + sep;
+    String quickstartScriptLocation = productDir + "quickstart" + sep + "scripts" + sep;
+    String quickstartDataLocation = productDir + "quickstart" + sep + "data" + sep;
+  }
+
   protected String getStoreTestsJar() {
     String storeTestsJar = hd.getTestDir() + hd.getFileSep() + ".." + hd.getFileSep() + ".." +
         hd.getFileSep() + "libs" + hd.getFileSep() + "snappydata-store-hydra-tests-" +
@@ -317,7 +339,7 @@ public class SnappyTest implements Serializable {
       case SERVER:
         locatorsList = getLocatorsList("locators");
         nodeLogDir = HostHelper.getLocalHost() + locators + locatorsList + " -dir=" +
-            dirPath + clientPort + port + " -heap-size=" + SnappyPrms.getServerMemory()
+            dirPath + clientPort + port + SnappyPrms.getServerMemory()
             + SnappyPrms.getConserveSockets() +
             " -J-Dgemfirexd.table-default-partitioned=" +
             SnappyPrms.getTableDefaultDataPolicy() + SnappyPrms.getTimeStatistics() +
@@ -326,6 +348,7 @@ public class SnappyTest implements Serializable {
             " -J-Dgemfire.CacheServerLauncher.SHUTDOWN_WAIT_TIME_MS=50000" +
             SnappyPrms.getFlightRecorderOptions(dirPath) +
             " -J-XX:+DisableExplicitGC" +
+            " -J-XX:+HeapDumpOnOutOfMemoryError -J-XX:HeapDumpPath=" + dirPath +
             SnappyPrms.getGCOptions(dirPath) + " " +
             SnappyPrms.getServerLauncherProps() +
             " -classpath=" + getStoreTestsJar();
@@ -343,7 +366,7 @@ public class SnappyTest implements Serializable {
         nodeLogDir = HostHelper.getLocalHost() + locators + locatorsList +
             SnappyPrms.getExecutorCores() + SnappyPrms.getDriverMaxResultSize() +
             //" -spark.local.dir=" + snappyTest.getTempDir("temp") +
-            " -dir=" + dirPath + clientPort + port + " -heap-size=" +
+            " -dir=" + dirPath + clientPort + port +
             SnappyPrms.getLeadMemory() + SnappyPrms.getSparkSqlBroadcastJoinThreshold()
             + " -spark.jobserver.port=" + leadPort + SnappyPrms.getSparkSchedulerMode()
             + /*" -spark.sql.inMemoryColumnarStorage.compressed="
@@ -351,6 +374,7 @@ public class SnappyTest implements Serializable {
             SnappyPrms.getColumnBatchSize() + SnappyPrms.getConserveSockets() +
             " -table-default-partitioned=" + SnappyPrms.getTableDefaultDataPolicy() +
             " -J-XX:+DisableExplicitGC" + SnappyPrms.getTimeStatistics() +
+            " -J-XX:+HeapDumpOnOutOfMemoryError -J-XX:HeapDumpPath=" + dirPath +
             SnappyPrms.getLogLevel() + SnappyPrms.getNumBootStrapTrials() +
             SnappyPrms.getClosedFormEstimates() + SnappyPrms.getZeppelinInterpreter() +
             " -classpath=" + getStoreTestsJar() +
@@ -2315,6 +2339,7 @@ public class SnappyTest implements Serializable {
   public static synchronized void HydraTask_stopSparkCluster() {
     File log = null;
     try {
+      initSnappyArtifacts();
       ProcessBuilder pb = new ProcessBuilder(snappyTest.getScriptLocation("stop-all.sh"));
       log = new File(".");
       String dest = log.getCanonicalPath() + File.separator + "sparkSystem.log";
@@ -2393,6 +2418,7 @@ public class SnappyTest implements Serializable {
   public static synchronized void HydraTask_stopSnappyCluster() {
     File log = null;
     try {
+      initSnappyArtifacts();
       ProcessBuilder pb = new ProcessBuilder(snappyTest.getScriptLocation("snappy-stop-all.sh"));
       log = new File(".");
       String dest = log.getCanonicalPath() + File.separator + "snappySystem.log";

--- a/dtests/src/test/java/io/snappydata/hydra/cluster/SnappyTest.java
+++ b/dtests/src/test/java/io/snappydata/hydra/cluster/SnappyTest.java
@@ -159,14 +159,17 @@ public class SnappyTest implements Serializable {
   }
 
   protected String getStoreTestsJar() {
-    String storeTestsJar = hd.getTestDir() + hd.getFileSep() + ".." + hd.getFileSep() + ".." + hd.getFileSep() + "libs" + hd.getFileSep() + "snappydata-store-hydra-tests-" +
-        ProductVersionHelper.getInfo().getProperty(ProductVersionHelper.SNAPPYRELEASEVERSION) + "-all.jar";
+    String storeTestsJar = hd.getTestDir() + hd.getFileSep() + ".." + hd.getFileSep() + ".." +
+        hd.getFileSep() + "libs" + hd.getFileSep() + "snappydata-store-hydra-tests-" +
+        ProductVersionHelper.getInfo().getProperty(ProductVersionHelper.SNAPPYRELEASEVERSION) +
+        "-all.jar";
     return storeTestsJar;
   }
 
   protected String getSnappyTestsJar() {
-    String snappyTestsJar = getUserAppJarLocation("snappydata-store-scala-tests*.jar", hd.getGemFireHome() + hd.getFileSep() + ".." + hd.getFileSep() + ".." + hd.getFileSep() + ".." + hd.getFileSep() + "dtests" + hd.getFileSep() +
-        "build-artifacts" + hd.getFileSep() + "scala-2.11" + hd.getFileSep() + "libs");
+    String snappyTestsJar = getUserAppJarLocation("snappydata-store-scala-tests*.jar",
+        hd.getGemFireHome() + hd.getFileSep() + ".." + hd.getFileSep() + ".." +
+            hd.getFileSep() + ".." + hd.getFileSep() + "dtests" + hd.getFileSep());
     return snappyTestsJar;
   }
 
@@ -287,15 +290,23 @@ public class SnappyTest implements Serializable {
         int locPort;
         do locPort = PortHelper.getRandomPort();
         while (locPort < 0 || locPort > 65535);
-        nodeLogDir = HostHelper.getLocalHost() + " -dir=" + dirPath + clientPort + port + locPortString + locPort + SnappyPrms.getTimeStatistics() + SnappyPrms.getLogLevel();
-        SnappyBB.getBB().getSharedMap().put("locatorHost" + "_" + RemoteTestModule.getMyVmid(), HostHelper.getLocalHost());
-        SnappyBB.getBB().getSharedMap().put("locatorPort" + "_" + RemoteTestModule.getMyVmid(), Integer.toString(port));
-        SnappyBB.getBB().getSharedMap().put("locatorMcastPort" + "_" + RemoteTestModule.getMyVmid(), Integer.toString(locPort));
-        SnappyBB.getBB().getSharedMap().put("locators" + "_" + RemoteTestModule.getMyVmid(), HostHelper.getLocalHost() + ":" + Integer.toString(locPort));
+        nodeLogDir = HostHelper.getLocalHost() + " -dir=" + dirPath + clientPort + port +
+            locPortString + locPort + SnappyPrms.getTimeStatistics() + SnappyPrms.getLogLevel() +
+            " " + SnappyPrms.getLocatorLauncherProps();
+        SnappyBB.getBB().getSharedMap().put("locatorHost" + "_" + RemoteTestModule.getMyVmid(),
+            HostHelper.getLocalHost());
+        SnappyBB.getBB().getSharedMap().put("locatorPort" + "_" + RemoteTestModule.getMyVmid(),
+            Integer.toString(port));
+        SnappyBB.getBB().getSharedMap().put("locatorMcastPort" + "_" + RemoteTestModule.getMyVmid
+            (), Integer.toString(locPort));
+        SnappyBB.getBB().getSharedMap().put("locators" + "_" + RemoteTestModule.getMyVmid(),
+            HostHelper.getLocalHost() + ":" + Integer.toString(locPort));
         SnappyBB.getBB().getSharedMap().put(Integer.toString(locPort), HostHelper.getLocalHost());
         Log.getLogWriter().info("Generated locator endpoint: " + endpoint);
-        SnappyNetworkServerBB.getBB().getSharedMap().put("locator" + "_" + RemoteTestModule.getMyVmid(), endpoint);
-        int num = (int) SnappyBB.getBB().getSharedCounters().incrementAndRead(SnappyBB.primaryLocatorStarted);
+        SnappyNetworkServerBB.getBB().getSharedMap().put("locator" + "_" + RemoteTestModule
+            .getMyVmid(), endpoint);
+        int num = (int) SnappyBB.getBB().getSharedCounters().incrementAndRead(SnappyBB
+            .primaryLocatorStarted);
         if (num == 1) {
           primaryLocator = endpoint;
           hostnameForPrimaryLocator = HostHelper.getLocalHost();
@@ -315,11 +326,13 @@ public class SnappyTest implements Serializable {
             " -J-Dgemfire.CacheServerLauncher.SHUTDOWN_WAIT_TIME_MS=50000" +
             SnappyPrms.getFlightRecorderOptions(dirPath) +
             " -J-XX:+DisableExplicitGC" +
-            SnappyPrms.getGCOptions(dirPath) +
+            SnappyPrms.getGCOptions(dirPath) + " " +
+            SnappyPrms.getServerLauncherProps() +
             " -classpath=" + getStoreTestsJar();
         Log.getLogWriter().info("Generated peer server endpoint: " + endpoint);
         SnappyBB.getBB().getSharedCounters().increment(SnappyBB.numServers);
-        SnappyNetworkServerBB.getBB().getSharedMap().put("server" + "_" + RemoteTestModule.getMyVmid(), endpoint);
+        SnappyNetworkServerBB.getBB().getSharedMap().put("server" + "_" + RemoteTestModule
+            .getMyVmid(), endpoint);
         break;
       case LEAD:
         locatorsList = getLocatorsList("locators");
@@ -343,7 +356,8 @@ public class SnappyTest implements Serializable {
             " -classpath=" + getStoreTestsJar() +
             " -J-Dgemfire.CacheServerLauncher.SHUTDOWN_WAIT_TIME_MS=50000" +
             SnappyPrms.getFlightRecorderOptions(dirPath) +
-            SnappyPrms.getGCOptions(dirPath) +
+            SnappyPrms.getGCOptions(dirPath) + " " +
+            SnappyPrms.getLeaderLauncherProps() +
             " -spark.driver.extraClassPath=" + getStoreTestsJar() +
             " -spark.executor.extraClassPath=" + getStoreTestsJar();
         try {
@@ -360,11 +374,15 @@ public class SnappyTest implements Serializable {
       case WORKER:
         nodeLogDir = HostHelper.getLocalHost();
         String sparkLogDir = "SPARK_LOG_DIR=" + hd.getUserDir();
+        String sparkWorkerDir = "SPARK_WORKER_DIR=" + hd.getUserDir();
         SnappyBB.getBB().getSharedMap().put("sparkLogDir" + "_" + snappyTest.getMyTid(), sparkLogDir);
+        SnappyBB.getBB().getSharedMap().put("sparkWorkerDir" + "_" + snappyTest.getMyTid(), sparkWorkerDir);
         break;
     }
-    SnappyBB.getBB().getSharedMap().put(logDir + "_" + RemoteTestModule.getMyVmid() + "_" + snappyTest.getMyTid(), nodeLogDir);
-    SnappyBB.getBB().getSharedMap().put("logDir_" + RemoteTestModule.getMyClientName() + "_" + RemoteTestModule.getMyVmid(), dirPath);
+    SnappyBB.getBB().getSharedMap().put(logDir + "_" + RemoteTestModule.getMyVmid() + "_" +
+        snappyTest.getMyTid(), nodeLogDir);
+    SnappyBB.getBB().getSharedMap().put("logDir_" + RemoteTestModule.getMyClientName() + "_" +
+        RemoteTestModule.getMyVmid(), dirPath);
     Log.getLogWriter().info("nodeLogDir is : " + nodeLogDir);
     logDirExists = true;
   }
@@ -396,7 +414,8 @@ public class SnappyTest implements Serializable {
     return tempDir.getAbsolutePath();
   }
 
-  protected static ArrayList<String> getWorkerFileContents(String userKey, ArrayList<String> fileContents) {
+  protected static ArrayList<String> getWorkerFileContents(String userKey, ArrayList<String>
+      fileContents) {
     Set<String> keys = SnappyBB.getBB().getSharedMap().getMap().keySet();
     for (String key : keys) {
       if (key.startsWith(userKey)) {
@@ -518,6 +537,7 @@ public class SnappyTest implements Serializable {
   public static void HydraTask_writeWorkerConfigData() {
     snappyTest.writeWorkerConfigData("slaves", "workerLogDir");
     snappyTest.writeConfigData("spark-env.sh", "sparkLogDir");
+    snappyTest.writeConfigData("spark-env.sh", "sparkWorkerDir");
   }
 
   protected void writeConfigData(String fileName, String logDir) {
@@ -1777,7 +1797,7 @@ public class SnappyTest implements Serializable {
   }
 
   public void executeSnappyJob(Vector jobClassNames, String logFileName, String userAppJar,
-      String jarPath, String appName) {
+                               String jarPath, String appName) {
     String snappyJobScript = getScriptLocation("snappy-job.sh");
     File log = null, logFile = null;
 //        userAppJar = SnappyPrms.getUserAppJar();
@@ -1810,14 +1830,17 @@ public class SnappyTest implements Serializable {
       if (retry && jobSubmissionCount <= SnappyPrms.getRetryCountForJob()) {
         jobSubmissionCount++;
         Thread.sleep(6000);
-        Log.getLogWriter().info("Job failed due to primary lead node failover. Resubmitting the job to new primary lead node.....");
+        Log.getLogWriter().info("Job failed due to primary lead node failover. Resubmitting" +
+            " the job to new primary lead node.....");
         retrievePrimaryLeadHost();
         HydraTask_executeSnappyJob();
       }
     } catch (IOException e) {
-      throw new TestException("IOException occurred while retriving destination logFile path " + log + "\nError Message:" + e.getMessage());
+      throw new TestException("IOException occurred while retriving destination logFile path " +
+          log + "\nError Message:" + e.getMessage());
     } catch (InterruptedException e) {
-      throw new TestException("Exception occurred while waiting for the snappy streaming job process re-execution." + "\nError Message:" + e.getMessage());
+      throw new TestException("Exception occurred while waiting for the snappy streaming job  " +
+          "process re-execution." + "\nError Message:" + e.getMessage());
     }
   }
 
@@ -1839,14 +1862,21 @@ public class SnappyTest implements Serializable {
           command = snappyJobScript + " --class " + userJob +
               " --master spark://" + masterHost + ":" + MASTER_PORT + " " +
               SnappyPrms.getExecutorMemory() + " " +
+              SnappyPrms.getSparkSubmitExtraPrms() + " " +
+              " --conf spark.executor.extraJavaOptions=-XX:+HeapDumpOnOutOfMemoryError" +
               " --conf spark.extraListeners=io.snappydata.hydra.SnappyCustomSparkListener" +
-              " " + snappyTest.getUserAppJarLocation(userAppJar, jarPath) + " " + SnappyPrms.getUserAppArgs() + " " + primaryLocatorHost + ":" + primaryLocatorPort;
+              " " + snappyTest.getUserAppJarLocation(userAppJar, jarPath) + " " +
+              SnappyPrms.getUserAppArgs() + " " + primaryLocatorHost + ":" + primaryLocatorPort;
         } else {
           command = snappyJobScript + " --class " + userJob +
-              " --master spark://" + masterHost + ":" + MASTER_PORT + " --conf snappydata.store.locators=" + locatorsList + " " +
+              " --master spark://" + masterHost + ":" + MASTER_PORT +
+              " --conf snappydata.store.locators=" + locatorsList + " " +
               SnappyPrms.getExecutorMemory() + " " +
+              SnappyPrms.getSparkSubmitExtraPrms() + " " +
+              " --conf spark.executor.extraJavaOptions=-XX:+HeapDumpOnOutOfMemoryError" +
               " --conf spark.extraListeners=io.snappydata.hydra.SnappyCustomSparkListener" +
-              " " + snappyTest.getUserAppJarLocation(userAppJar, jarPath) + " " + SnappyPrms.getUserAppArgs();
+              " " + snappyTest.getUserAppJarLocation(userAppJar, jarPath) + " " +
+              SnappyPrms.getUserAppArgs();
         }
         Log.getLogWriter().info("spark-submit command is : " + command);
         log = new File(".");
@@ -1855,15 +1885,19 @@ public class SnappyTest implements Serializable {
         pb = new ProcessBuilder("/bin/bash", "-c", command);
         snappyTest.executeProcess(pb, logFile);
         String searchString = "Spark ApplicationEnd: ";
-        String expression = "cat " + logFile + " | grep -e Exception -e '" + searchString + "' | grep -v java.net.BindException" + " | wc -l)\"";
+        String expression = "cat " + logFile + " | grep -e Exception -e '" + searchString + "' |" +
+            " grep -v java.net.BindException" + " | wc -l)\"";
         String searchCommand = "while [ \"$(" + expression + " -le  0 ] ; do sleep 1 ; done";
         pb = new ProcessBuilder("/bin/bash", "-c", searchCommand);
-        Log.getLogWriter().info("spark job " + userJob + " starts at: " + System.currentTimeMillis());
+        Log.getLogWriter().info("spark job " + userJob + " starts at: " + System
+            .currentTimeMillis());
         executeProcess(pb, logFile);
-        Log.getLogWriter().info("spark job " + userJob + " finishes at:  " + System.currentTimeMillis());
+        Log.getLogWriter().info("spark job " + userJob + " finishes at:  " + System
+            .currentTimeMillis());
       }
     } catch (IOException e) {
-      throw new TestException("IOException occurred while retriving destination logFile path " + log + "\nError Message:" + e.getMessage());
+      throw new TestException("IOException occurred while retriving destination logFile path " +
+          log + "\nError Message:" + e.getMessage());
     }
   }
 
@@ -1888,14 +1922,16 @@ public class SnappyTest implements Serializable {
    * Returns the output file containing collective output for all threads executing Snappy job in CLOSETASK.
    */
   public static void HydraTask_getSnappyJobOutputCollectivelyForCloseTask() {
-    snappyTest.getSnappyJobOutputCollectively("logFilesForJobs_", "snappyJobCollectiveOutputForCloseTask.log");
+    snappyTest.getSnappyJobOutputCollectively("logFilesForJobs_",
+        "snappyJobCollectiveOutputForCloseTask.log");
   }
 
   /**
    * Returns the output file containing collective output for all threads executing Snappy job in TASK.
    */
   public static void HydraTask_getSnappyJobOutputCollectivelyForTask() {
-    snappyTest.getSnappyJobOutputCollectively("logFilesForJobs_", "snappyJobCollectiveOutputForTask.log");
+    snappyTest.getSnappyJobOutputCollectively("logFilesForJobs_",
+        "snappyJobCollectiveOutputForTask.log");
   }
 
   protected void getSnappyJobOutputCollectively(String logFilekey, String fileName) {
@@ -1981,9 +2017,12 @@ public class SnappyTest implements Serializable {
       inputFile.close();
       for (String str : jobIds) {
         File log = new File(".");
-        String dest = log.getCanonicalPath() + File.separator + "jobStatus_" + RemoteTestModule.getCurrentThread().getThreadId() + "_" + System.currentTimeMillis() + ".log";
+        String dest = log.getCanonicalPath() + File.separator + "jobStatus_" + RemoteTestModule
+            .getCurrentThread().getThreadId() + "_" + System.currentTimeMillis() + ".log";
         File commandOutput = new File(dest);
-        String expression = snappyJobScript + " status --lead " + leadHost + ":" + leadPort + " --job-id " + str + " > " + commandOutput + " 2>&1 ; grep -e '\"status\": \"FINISHED\"' -e 'curl:' -e '\"status\": \"ERROR\"' " + commandOutput + " | wc -l)\"";
+        String expression = snappyJobScript + " status --lead " + leadHost + ":" + leadPort + " " +
+            "--job-id " + str + " > " + commandOutput + " 2>&1 ; grep -e '\"status\": " +
+            "\"FINISHED\"' -e 'curl:' -e '\"status\": \"ERROR\"' " + commandOutput + " | wc -l)\"";
         String command = "while [ \"$(" + expression + " -le  0 ] ; do rm " +
             commandOutput + " ;  touch " + commandOutput + "   ;  sleep " +
             SnappyPrms.getSleepTimeSecsForJobStatus() + " ; done";

--- a/dtests/src/test/java/io/snappydata/hydra/cluster/stopDualModeCluster.conf
+++ b/dtests/src/test/java/io/snappydata/hydra/cluster/stopDualModeCluster.conf
@@ -21,14 +21,14 @@ INITTASK    taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = H
 CLOSETASK   taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = HydraTask_stopSnappy
             threadGroups = snappyThreads;
 
-CLOSETASK   taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = HydraTask_stopSparkCluster
-            threadGroups = snappyThreads;
+ENDTASK     taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = HydraTask_stopSparkCluster
+            clientNames = snappy1;
 
-CLOSETASK   taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = HydraTask_stopSnappyCluster
-            threadGroups = snappyThreads;
+ENDTASK     taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = HydraTask_stopSnappyCluster
+            clientNames = snappy1;
 
-CLOSETASK   taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = HydraTask_deleteSnappyConfig
-            threadGroups = snappyThreads;
+ENDTASK     taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = HydraTask_deleteSnappyConfig
+            clientNames = snappy1;
 
 ENDTASK     taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = HydraTask_cleanUpSnappyProcessesOnFailure
             clientNames = snappy1;

--- a/dtests/src/test/java/io/snappydata/hydra/northwind/nwPartitionedRowTablesWithEvictionOverflowTest.conf
+++ b/dtests/src/test/java/io/snappydata/hydra/northwind/nwPartitionedRowTablesWithEvictionOverflowTest.conf
@@ -14,13 +14,13 @@ INITTASK    taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = H
             threadGroups = snappyThreads
             ;
 
-TASK        taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = HydraTask_executeSnappyJob
+INITTASK    taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = HydraTask_executeSnappyJob
             io.snappydata.hydra.cluster.SnappyPrms-jobClassNames = io.snappydata.hydra.northwind.ValidateNWQueriesJob
             io.snappydata.hydra.cluster.SnappyPrms-appPropsForJobServer =
                         "dataFilesLocation=${dataFilesLocation},tableType=${tableType},fullResultSetValidation=${fullResultSetValidation},isSmokeRun=${isSmokeRun},numRowsValidation=${numRowsValidation}"
             io.snappydata.hydra.cluster.SnappyPrms-userAppJar = snappydata-store-scala-tests*tests.jar
             threadGroups = snappyStoreThreads
-            maxThreads = 1;
+            ;
 
 TASK        taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = HydraTask_executeSparkJob
             io.snappydata.hydra.cluster.SnappyPrms-sparkJobClassNames = io.snappydata.hydra.northwind.ValidateNWQueriesApp

--- a/dtests/src/test/java/io/snappydata/hydra/northwind/nwPartitionedRowTablesWithEvictionTest.conf
+++ b/dtests/src/test/java/io/snappydata/hydra/northwind/nwPartitionedRowTablesWithEvictionTest.conf
@@ -14,13 +14,13 @@ INITTASK    taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = H
             threadGroups = snappyThreads
             ;
 
-TASK        taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = HydraTask_executeSnappyJob
+INITTASK    taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = HydraTask_executeSnappyJob
             io.snappydata.hydra.cluster.SnappyPrms-jobClassNames = io.snappydata.hydra.northwind.ValidateNWQueriesJob
             io.snappydata.hydra.cluster.SnappyPrms-appPropsForJobServer =
                         "dataFilesLocation=${dataFilesLocation},tableType=${tableType},fullResultSetValidation=${fullResultSetValidation},isSmokeRun=${isSmokeRun},numRowsValidation=${numRowsValidation}"
             io.snappydata.hydra.cluster.SnappyPrms-userAppJar = snappydata-store-scala-tests*tests.jar
             threadGroups = snappyStoreThreads
-            maxThreads = 1;
+            ;
 
 TASK        taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = HydraTask_executeSparkJob
             io.snappydata.hydra.cluster.SnappyPrms-sparkJobClassNames = io.snappydata.hydra.northwind.ValidateNWQueriesApp

--- a/dtests/src/test/java/io/snappydata/hydra/northwind/nwPersistentColocatedTablesTest.conf
+++ b/dtests/src/test/java/io/snappydata/hydra/northwind/nwPersistentColocatedTablesTest.conf
@@ -14,6 +14,13 @@ INITTASK    taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = H
             threadGroups = snappyThreads
             ;
 
+INITTASK    taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = HydraTask_executeSparkJob
+            io.snappydata.hydra.cluster.SnappyPrms-sparkJobClassNames = io.snappydata.hydra.northwind.ValidateNWQueriesApp
+            io.snappydata.hydra.cluster.SnappyPrms-userAppArgs = "${dataFilesLocation} ${tableType} ${fullResultSetValidation} ${useThinClientSmartConnectorMode} ${isSmokeRun} ${numRowsValidation}"
+            io.snappydata.hydra.cluster.SnappyPrms-userAppJar = snappydata-store-scala-tests*tests.jar
+            threadGroups = snappyThreads
+            ;
+
 TASK        taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = HydraTask_executeSnappyJob
             io.snappydata.hydra.cluster.SnappyPrms-jobClassNames = io.snappydata.hydra.northwind.ValidateNWQueriesJob
             io.snappydata.hydra.cluster.SnappyPrms-appPropsForJobServer =
@@ -21,13 +28,6 @@ TASK        taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = H
             io.snappydata.hydra.cluster.SnappyPrms-userAppJar = snappydata-store-scala-tests*tests.jar
             threadGroups = snappyStoreThreads
             maxThreads = 1;
-
-TASK        taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = HydraTask_executeSparkJob
-            io.snappydata.hydra.cluster.SnappyPrms-sparkJobClassNames = io.snappydata.hydra.northwind.ValidateNWQueriesApp
-            io.snappydata.hydra.cluster.SnappyPrms-userAppArgs = "${dataFilesLocation} ${tableType} ${fullResultSetValidation} ${useThinClientSmartConnectorMode} ${isSmokeRun} ${numRowsValidation}"
-            io.snappydata.hydra.cluster.SnappyPrms-userAppJar = snappydata-store-scala-tests*tests.jar
-            threadGroups = leadThreads
-            ;
 
 TASK        taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = HydraTask_executeSQLScripts
             io.snappydata.hydra.cluster.SnappyPrms-sqlScriptNames = nw_queries.sql

--- a/dtests/src/test/java/io/snappydata/hydra/northwind/nwPersistentColumnTablesTest.conf
+++ b/dtests/src/test/java/io/snappydata/hydra/northwind/nwPersistentColumnTablesTest.conf
@@ -14,6 +14,13 @@ INITTASK    taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = H
             threadGroups = snappyThreads
             ;
 
+INITTASK    taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = HydraTask_executeSparkJob
+            io.snappydata.hydra.cluster.SnappyPrms-sparkJobClassNames = io.snappydata.hydra.northwind.ValidateNWQueriesApp
+            io.snappydata.hydra.cluster.SnappyPrms-userAppArgs = "${dataFilesLocation} ${tableType} ${fullResultSetValidation} ${useThinClientSmartConnectorMode} ${isSmokeRun} ${numRowsValidation}"
+            io.snappydata.hydra.cluster.SnappyPrms-userAppJar = snappydata-store-scala-tests*tests.jar
+            threadGroups = snappyThreads
+            ;
+
 TASK        taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = HydraTask_executeSnappyJob
             io.snappydata.hydra.cluster.SnappyPrms-jobClassNames = io.snappydata.hydra.northwind.ValidateNWQueriesJob
             io.snappydata.hydra.cluster.SnappyPrms-appPropsForJobServer =
@@ -21,14 +28,6 @@ TASK        taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = H
             io.snappydata.hydra.cluster.SnappyPrms-userAppJar = snappydata-store-scala-tests*tests.jar
             maxThreads = 1
             threadGroups = snappyStoreThreads;
-
-TASK        taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = HydraTask_executeSparkJob
-            io.snappydata.hydra.cluster.SnappyPrms-sparkJobClassNames = io.snappydata.hydra.northwind.ValidateNWQueriesApp
-            io.snappydata.hydra.cluster.SnappyPrms-userAppArgs = "${dataFilesLocation} ${tableType} ${fullResultSetValidation} ${useThinClientSmartConnectorMode} ${isSmokeRun} ${numRowsValidation}"
-            io.snappydata.hydra.cluster.SnappyPrms-userAppJar = snappydata-store-scala-tests*tests.jar
-            maxThreads = 1
-            threadGroups = leadThreads
-            ;
 
 TASK        taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = HydraTask_executeSQLScripts
             io.snappydata.hydra.cluster.SnappyPrms-sqlScriptNames = nw_queries.sql

--- a/dtests/src/test/java/io/snappydata/hydra/northwind/nwPersistentPartitionedRowTablesTest.conf
+++ b/dtests/src/test/java/io/snappydata/hydra/northwind/nwPersistentPartitionedRowTablesTest.conf
@@ -14,6 +14,13 @@ INITTASK    taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = H
             threadGroups = snappyThreads
             ;
 
+INITTASK    taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = HydraTask_executeSparkJob
+            io.snappydata.hydra.cluster.SnappyPrms-sparkJobClassNames = io.snappydata.hydra.northwind.ValidateNWQueriesApp
+            io.snappydata.hydra.cluster.SnappyPrms-userAppArgs = "${dataFilesLocation} ${tableType} ${fullResultSetValidation} ${useThinClientSmartConnectorMode} ${isSmokeRun} ${numRowsValidation}"
+            io.snappydata.hydra.cluster.SnappyPrms-userAppJar = snappydata-store-scala-tests*tests.jar
+            threadGroups = snappyThreads
+            ;
+
 TASK        taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = HydraTask_executeSnappyJob
             io.snappydata.hydra.cluster.SnappyPrms-jobClassNames = io.snappydata.hydra.northwind.ValidateNWQueriesJob
             io.snappydata.hydra.cluster.SnappyPrms-appPropsForJobServer =
@@ -21,14 +28,6 @@ TASK        taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = H
             io.snappydata.hydra.cluster.SnappyPrms-userAppJar = snappydata-store-scala-tests*tests.jar
             maxThreads = 1
             threadGroups = snappyStoreThreads;
-
-TASK        taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = HydraTask_executeSparkJob
-            io.snappydata.hydra.cluster.SnappyPrms-sparkJobClassNames = io.snappydata.hydra.northwind.ValidateNWQueriesApp
-            io.snappydata.hydra.cluster.SnappyPrms-userAppArgs = "${dataFilesLocation} ${tableType} ${fullResultSetValidation} ${useThinClientSmartConnectorMode} ${isSmokeRun} ${numRowsValidation}"
-            io.snappydata.hydra.cluster.SnappyPrms-userAppJar = snappydata-store-scala-tests*tests.jar
-            maxThreads = 1
-            threadGroups = leadThreads
-            ;
 
 TASK        taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = HydraTask_executeSQLScripts
             io.snappydata.hydra.cluster.SnappyPrms-sqlScriptNames = nw_queries.sql

--- a/dtests/src/test/java/io/snappydata/hydra/northwind/nwPersistentPartitionedRowTablesWithEvictionOverflowTest.conf
+++ b/dtests/src/test/java/io/snappydata/hydra/northwind/nwPersistentPartitionedRowTablesWithEvictionOverflowTest.conf
@@ -14,6 +14,13 @@ INITTASK    taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = H
             threadGroups = snappyThreads
             ;
 
+INITTASK    taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = HydraTask_executeSparkJob
+            io.snappydata.hydra.cluster.SnappyPrms-sparkJobClassNames = io.snappydata.hydra.northwind.ValidateNWQueriesApp
+            io.snappydata.hydra.cluster.SnappyPrms-userAppArgs = "${dataFilesLocation} ${tableType} ${fullResultSetValidation} ${useThinClientSmartConnectorMode} ${isSmokeRun} ${numRowsValidation}"
+            io.snappydata.hydra.cluster.SnappyPrms-userAppJar = snappydata-store-scala-tests*tests.jar
+            threadGroups = leadThreads
+            ;
+
 TASK        taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = HydraTask_executeSnappyJob
             io.snappydata.hydra.cluster.SnappyPrms-jobClassNames = io.snappydata.hydra.northwind.ValidateNWQueriesJob
             io.snappydata.hydra.cluster.SnappyPrms-appPropsForJobServer =
@@ -21,13 +28,6 @@ TASK        taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = H
             io.snappydata.hydra.cluster.SnappyPrms-userAppJar = snappydata-store-scala-tests*tests.jar
             threadGroups = snappyStoreThreads
             maxThreads = 1;
-
-TASK        taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = HydraTask_executeSparkJob
-            io.snappydata.hydra.cluster.SnappyPrms-sparkJobClassNames = io.snappydata.hydra.northwind.ValidateNWQueriesApp
-            io.snappydata.hydra.cluster.SnappyPrms-userAppArgs = "${dataFilesLocation} ${tableType} ${fullResultSetValidation} ${useThinClientSmartConnectorMode} ${isSmokeRun} ${numRowsValidation}"
-            io.snappydata.hydra.cluster.SnappyPrms-userAppJar = snappydata-store-scala-tests*tests.jar
-            threadGroups = leadThreads
-            ;
 
 TASK        taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = HydraTask_executeSQLScripts
             io.snappydata.hydra.cluster.SnappyPrms-sqlScriptNames = nw_queries.sql

--- a/dtests/src/test/java/io/snappydata/hydra/northwind/nwPersistentReplicatedRowTablesTest.conf
+++ b/dtests/src/test/java/io/snappydata/hydra/northwind/nwPersistentReplicatedRowTablesTest.conf
@@ -15,6 +15,13 @@ INITTASK    taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = H
             threadGroups = snappyThreads
             ;
 
+INITTASK    taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = HydraTask_executeSparkJob
+            io.snappydata.hydra.cluster.SnappyPrms-sparkJobClassNames = io.snappydata.hydra.northwind.ValidateNWQueriesApp
+            io.snappydata.hydra.cluster.SnappyPrms-userAppArgs = "${dataFilesLocation} ${tableType} ${fullResultSetValidation} ${useThinClientSmartConnectorMode} ${isSmokeRun} ${numRowsValidation}"
+            io.snappydata.hydra.cluster.SnappyPrms-userAppJar = snappydata-store-scala-tests*tests.jar
+            threadGroups = snappyThreads
+            ;
+
 TASK        taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = HydraTask_executeSnappyJob
             io.snappydata.hydra.cluster.SnappyPrms-jobClassNames = io.snappydata.hydra.northwind.ValidateNWQueriesJob
             io.snappydata.hydra.cluster.SnappyPrms-appPropsForJobServer =
@@ -22,14 +29,6 @@ TASK        taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = H
             io.snappydata.hydra.cluster.SnappyPrms-userAppJar = snappydata-store-scala-tests*tests.jar
             maxThreads = 1
             threadGroups = snappyStoreThreads;
-
-TASK        taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = HydraTask_executeSparkJob
-            io.snappydata.hydra.cluster.SnappyPrms-sparkJobClassNames = io.snappydata.hydra.northwind.ValidateNWQueriesApp
-            io.snappydata.hydra.cluster.SnappyPrms-userAppArgs = "${dataFilesLocation} ${tableType} ${fullResultSetValidation} ${useThinClientSmartConnectorMode} ${isSmokeRun} ${numRowsValidation}"
-            io.snappydata.hydra.cluster.SnappyPrms-userAppJar = snappydata-store-scala-tests*tests.jar
-            maxThreads = 1
-            threadGroups = leadThreads
-            ;
 
 TASK        taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = HydraTask_executeSQLScripts
             io.snappydata.hydra.cluster.SnappyPrms-sqlScriptNames = nw_queries.sql

--- a/dtests/src/test/java/io/snappydata/hydra/northwind/stopDualModeCluster.conf
+++ b/dtests/src/test/java/io/snappydata/hydra/northwind/stopDualModeCluster.conf
@@ -4,14 +4,14 @@ hydra.Prms-testDescription = "This test stops the snappy embedded as well as spl
 CLOSETASK   taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = HydraTask_stopSnappy
             threadGroups = snappyThreads;
 
-CLOSETASK   taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = HydraTask_stopSparkCluster
-            threadGroups = snappyThreads;
+ENDTASK     taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = HydraTask_stopSparkCluster
+            clientNames = locator1;
 
-CLOSETASK   taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = HydraTask_stopSnappyCluster
-            threadGroups = snappyThreads;
+ENDTASK     taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = HydraTask_stopSnappyCluster
+            clientNames = locator1;
 
-CLOSETASK   taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = HydraTask_deleteSnappyConfig
-            threadGroups = snappyThreads;
+ENDTASK     taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = HydraTask_deleteSnappyConfig
+            clientNames = locator1;
 
 ENDTASK     taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = HydraTask_cleanUpSnappyProcessesOnFailure
             clientNames = locator1;

--- a/dtests/src/test/scala/io/snappydata/hydra/northwind/NWQueries.scala
+++ b/dtests/src/test/scala/io/snappydata/hydra/northwind/NWQueries.scala
@@ -412,13 +412,13 @@ object NWQueries {
       " d.CompanyName," +
       " year(OrderDate) as OrderYear," +
       " format_number(sum(case quarter(c.OrderDate) when '1'" +
-      " then b.UnitPrice*b.Quantity*(1-b.Discount) else 0 end), 0) \"Qtr_1\"," +
+      " then b.UnitPrice*b.Quantity*(1-b.Discount) else 0 end), 0) as Qtr_1, " +
       " format_number(sum(case quarter(c.OrderDate) when '2'" +
-      " then b.UnitPrice*b.Quantity*(1-b.Discount) else 0 end), 0) \"Qtr_2\"," +
+      " then b.UnitPrice*b.Quantity*(1-b.Discount) else 0 end), 0) as Qtr_2, " +
       " format_number(sum(case quarter(c.OrderDate) when '3'" +
-      " then b.UnitPrice*b.Quantity*(1-b.Discount) else 0 end), 0) \"Qtr_3\"," +
+      " then b.UnitPrice*b.Quantity*(1-b.Discount) else 0 end), 0) as Qtr_3, " +
       " format_number(sum(case quarter(c.OrderDate) when '4'" +
-      " then b.UnitPrice*b.Quantity*(1-b.Discount) else 0 end), 0) \"Qtr_4\"" +
+      " then b.UnitPrice*b.Quantity*(1-b.Discount) else 0 end), 0) as Qtr_4 " +
       " from Products a" +
       " inner join Order_Details b on a.ProductID = b.ProductID" +
       " inner join Orders c on c.OrderID = b.OrderID" +

--- a/dtests/src/test/scala/io/snappydata/hydra/northwind/NWQueries.scala
+++ b/dtests/src/test/scala/io/snappydata/hydra/northwind/NWQueries.scala
@@ -412,13 +412,13 @@ object NWQueries {
       " d.CompanyName," +
       " year(OrderDate) as OrderYear," +
       " format_number(sum(case quarter(c.OrderDate) when '1'" +
-      " then b.UnitPrice*b.Quantity*(1-b.Discount) else 0 end), 0) 'Qtr 1'," +
+      " then b.UnitPrice*b.Quantity*(1-b.Discount) else 0 end), 0) \"Qtr_1\"," +
       " format_number(sum(case quarter(c.OrderDate) when '2'" +
-      " then b.UnitPrice*b.Quantity*(1-b.Discount) else 0 end), 0) 'Qtr 2'," +
+      " then b.UnitPrice*b.Quantity*(1-b.Discount) else 0 end), 0) \"Qtr_2\"," +
       " format_number(sum(case quarter(c.OrderDate) when '3'" +
-      " then b.UnitPrice*b.Quantity*(1-b.Discount) else 0 end), 0) 'Qtr 3'," +
+      " then b.UnitPrice*b.Quantity*(1-b.Discount) else 0 end), 0) \"Qtr_3\"," +
       " format_number(sum(case quarter(c.OrderDate) when '4'" +
-      " then b.UnitPrice*b.Quantity*(1-b.Discount) else 0 end), 0) 'Qtr 4'" +
+      " then b.UnitPrice*b.Quantity*(1-b.Discount) else 0 end), 0) \"Qtr_4\"" +
       " from Products a" +
       " inner join Order_Details b on a.ProductID = b.ProductID" +
       " inner join Orders c on c.OrderID = b.OrderID" +
@@ -489,8 +489,8 @@ object NWQueries {
     "Q56" -> Q56,
     "Q57" -> Q57,
     "Q58" -> Q58,
-    "Q59" -> Q59
-    // "Q60" -> Q60
+    "Q59" -> Q59,
+    "Q60" -> Q60
   )
 
   def regions(sqlContext: SQLContext): DataFrame = sqlContext.read.format("com.databricks.spark" +

--- a/dtests/src/test/scala/io/snappydata/hydra/northwind/NWTestUtil.scala
+++ b/dtests/src/test/scala/io/snappydata/hydra/northwind/NWTestUtil.scala
@@ -272,7 +272,7 @@ object NWTestUtil {
         case "Q57" => assertJoin(snc, NWQueries.Q57, 120, "Q57", tableType, pw)
         case "Q58" => assertJoin(snc, NWQueries.Q58, 1, "Q58", tableType, pw)
         case "Q59" => assertJoin(snc, NWQueries.Q59, 1, "Q59", tableType, pw)
-        // case "Q60" => assertJoin(snc, NWQueries.Q60, 947, "Q60", tableType, pw)
+        case "Q60" => assertJoin(snc, NWQueries.Q60, 947, "Q60", tableType, pw)
         // scalastyle:off println
         case _ => println("OK")
         // scalastyle:on println
@@ -402,8 +402,8 @@ object NWTestUtil {
           tableType, pw, sqlContext)
         case "Q59" => SnappyTestUtils.assertQueryFullResultSet(snc, NWQueries.Q59, "Q59",
           tableType, pw, sqlContext)
-        // case "Q60" => SnappyTestUtils.assertQueryFullResultSet(snc, NWQueries.Q60,"Q60",
-        // tableType, pw, sqlContext)
+        case "Q60" => SnappyTestUtils.assertQueryFullResultSet(snc, NWQueries.Q60, "Q60",
+          tableType, pw, sqlContext)
         // scalastyle:off println
         case _ => println("OK")
       }


### PR DESCRIPTION
## Changes proposed in this pull request

- Modified the Q60 from northWind schema to work in snappy
- Added support to start the locator server and lead nodes with user specified launcher properties
- Added support for generating the executor logs in test directory (SPARK_WORKER_DIR set to testLogDir)
- Added support for providing the user specified paramerts for spark-submit
- Added support to use product defaults for lead, locator and server memory in case not provided by user
- Added support to collect heap dump on OutOfMemoryError in server and lead members
- Modified the test code to include the cluster stop and cleanup in ENDTASK to make sure that task will always get executed
- Minor code refactoring changes done

## Patch testing

Verified the changes by running few tests from northWind.bt

## ReleaseNotes.txt changes

NA

## Other PRs 

No
