### PR TITLE
CachedPlanHelper is now removed from the plan information for UI.

### DIFF
--- a/core/src/main/scala/org/apache/spark/sql/CachedDataFrame.scala
+++ b/core/src/main/scala/org/apache/spark/sql/CachedDataFrame.scala
@@ -72,7 +72,7 @@ class CachedDataFrame(df: Dataset[Row], var queryString: String,
   def queryExecutionString: String = queryExecution.toString()
 
   def queryPlanInfo: SparkPlanInfo = PartitionedPhysicalScan.getSparkPlanInfo(
-    plan = queryExecution.executedPlan transformAllExpressions {
+    queryExecution.executedPlan transformAllExpressions {
       case pl@ParamLiteral(_v, _dt, _p) =>
         val x = allLiterals.find(_.position == _p)
         val v = x match {
@@ -80,6 +80,8 @@ class CachedDataFrame(df: Dataset[Row], var queryString: String,
           case None => _v
         }
         Literal(v, _dt)
+    } transform {
+      case CachedPlanHelperExec(childPlan, _) => childPlan
     })
 
   private lazy val lastShuffleCleanups = new Array[Future[Unit]](


### PR DESCRIPTION
## Changes proposed in this pull request

CachedPlanHelperExec spark plan which has been introduced to facilitate Tokenization use to also show up in the dashboard UI. This is not useful to the user and so removing it from the dispaly by calling a simple transform.

## Patch testing

Manual.

## ReleaseNotes.txt changes

No.

## Other PRs 

None.
