### PR TITLE
Fix for SNAP-1505

### DIFF
--- a/core/src/dunit/scala/io/snappydata/cluster/SplitClusterDUnitTestBase.scala
+++ b/core/src/dunit/scala/io/snappydata/cluster/SplitClusterDUnitTestBase.scala
@@ -116,11 +116,11 @@ trait SplitClusterDUnitTestBase extends Logging {
   def doTestTableFormChanges(skewNetworkServers: Boolean): Unit = {
     // StandAlone Spark Cluster Operations
     // row table
-    vm3.invoke(getClass, "createDropTablesInSplitMode",
+    vm3.invoke(getClass, "createTablesInSplitMode",
       startArgs
           :+ Int.box(locatorClientPort) :+ "ROW")
 
-    testObject.createDropEmbeddedModeTables("ROW")
+    testObject.dropAndCreateTablesInEmbeddedMode("ROW")
 
     vm3.invoke(getClass, "verifyTableFormInSplitMOde",
       startArgs
@@ -128,11 +128,11 @@ trait SplitClusterDUnitTestBase extends Logging {
 
     // StandAlone Spark Cluster Operations
     // column table
-    vm3.invoke(getClass, "createDropTablesInSplitMode",
+    vm3.invoke(getClass, "createTablesInSplitMode",
       startArgs
           :+ Int.box(locatorClientPort) :+ "COLUMN")
 
-    testObject.createDropEmbeddedModeTables("COLUMN")
+    testObject.dropAndCreateTablesInEmbeddedMode("COLUMN")
 
     vm3.invoke(getClass, "verifyTableFormInSplitMOde",
       startArgs
@@ -154,8 +154,7 @@ trait SplitClusterDUnitTestBase extends Logging {
   }
 
 
-  // snap-1505 is filed to enable this test
-  final def DISABLEDtestTableFormChanges(): Unit = {
+  final def testTableFormChanges(): Unit = {
     doTestTableFormChanges(skewNetworkServers)
   }
 
@@ -174,10 +173,10 @@ trait SplitClusterDUnitTestObject extends Logging {
 
   def assertTableNotCachedInHiveCatalog(tableName: String): Unit
 
-  def createDropEmbeddedModeTables(tableType: String): Unit = {
+  def dropAndCreateTablesInEmbeddedMode(tableType: String): Unit = {
   }
 
-  def createDropTablesInSplitMode(locatorPort: Int,
+  def createTablesInSplitMode(locatorPort: Int,
       prop: Properties,
       locatorClientPort: Int,
       tableType: String): Unit = {

--- a/core/src/main/scala/org/apache/spark/sql/SmartConnectorHelper.scala
+++ b/core/src/main/scala/org/apache/spark/sql/SmartConnectorHelper.scala
@@ -101,9 +101,12 @@ class SmartConnectorHelper(snappySession: SnappySession) extends Logging {
       options: Map[String, String],
       isBuiltIn: Boolean): LogicalPlan = {
 
+    snappySession.sessionCatalog.invalidateTable(tableIdent)
+
     runStmtWithExceptionHandling(executeCreateTableStmt(tableIdent,
       provider, userSpecifiedSchema, schemaDDL, mode, options, isBuiltIn))
 
+    SnappySession.clearAllCache()
     snappySession.sessionCatalog.lookupRelation(tableIdent)
   }
 
@@ -128,6 +131,7 @@ class SmartConnectorHelper(snappySession: SnappySession) extends Logging {
     snappySession.sessionCatalog.invalidateTable(tableIdent)
     runStmtWithExceptionHandling(executeDropTableStmt(tableIdent, ifExists))
     SnappyStoreHiveCatalog.registerRelationDestroy()
+    SnappySession.clearAllCache()
   }
 
   private def executeDropTableStmt(tableIdent: QualifiedTableName,


### PR DESCRIPTION
Fixing a failure in SplitClusterDUnitTestBase#testTableFormChanges. 

Calling the SnappySession.clearAllCache() in  SmartConnectorHelper.createTable and dropTable functions (this already happens when tables are created/dropped in embedded mode)

The test creates a row table in connector mode, drops it in embedded mode and then creates column table with same name on the connector side.Since the cache wasn't getting cleared when table was dropped / created older cached objects were getting used.
 The test earlier was present in ThinConnectorSnappyDUnitTest (now gets called in SplitSnappyClusterDUnitTest)

The test modifications in the PR are mainly for readability.
  
## Patch testing
precheckin 

## ReleaseNotes.txt changes
NA
## Other PRs 
NA