### PR TITLE
Fix for SNAP-1641

### DIFF
--- a/core/src/main/scala/org/apache/spark/sql/hive/SnappyStoreHiveCatalog.scala
+++ b/core/src/main/scala/org/apache/spark/sql/hive/SnappyStoreHiveCatalog.scala
@@ -92,10 +92,10 @@ class SnappyStoreHiveCatalog(externalCatalog: SnappyExternalCatalog,
 
   // private val sessionTables = new ConcurrentHashMap[QualifiedTableName, LogicalPlan]().asScala
 
-  override def dropTable(name: TableIdentifier,
-      ignoreIfNotExists: Boolean): Unit = synchronized {
-    snappySession.dropTable(newQualifiedTableName(name), ignoreIfNotExists)
-  }
+//  override def dropTable(name: TableIdentifier,
+//      ignoreIfNotExists: Boolean): Unit = synchronized {
+//    snappySession.dropTable(newQualifiedTableName(name), ignoreIfNotExists)
+//  }
 
   protected var currentSchema: String = {
     val defaultName = Constant.DEFAULT_SCHEMA

--- a/core/src/test/scala/org/apache/spark/sql/store/SnappyCatalogSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/store/SnappyCatalogSuite.scala
@@ -70,6 +70,20 @@ class SnappyCatalogSuite extends SnappyFunSuite
     }
   }
 
+  after {
+    try {
+      snappySession.catalog.listDatabases().collect().foreach(db =>
+        snappySession.catalog.listTables(db.name).collect().foreach(
+          table => dropTable(table.name, Option(table.database))
+        )
+      )
+    } finally {
+    }
+  }
+
+  override def afterAll(): Unit = {
+  }
+
   private val utils = new CatalogTestUtils {
     override val tableInputFormat: String = "org.apache.hadoop.mapred.SequenceFileInputFormat"
     override val tableOutputFormat: String = "org.apache.hadoop.mapred.SequenceFileOutputFormat"
@@ -158,15 +172,14 @@ class SnappyCatalogSuite extends SnappyFunSuite
         Set("APP", "MY_DB2", "DEFAULT"))
   }
 
-  // SNAP-1641 is filed to enable this test
-  ignore("list tables") {
+  test("list tables") {
     assert(snappySession.catalog.listTables().collect().isEmpty)
     createTable("my_table1")
     createTable("my_table2")
     createTempTable("my_temp_table")
     assert(snappySession.catalog.listTables().collect().map(_.name.toLowerCase).toSet ==
         Set("my_table1", "my_table2", "my_temp_table"))
-    dropTable("my_table1")
+    dropTable("my_table1", Option("app"))
     assert(snappySession.catalog.listTables().collect().map(_.name.toLowerCase).toSet ==
         Set("my_table2", "my_temp_table"))
     dropTable("my_temp_table")
@@ -174,8 +187,7 @@ class SnappyCatalogSuite extends SnappyFunSuite
         .map(_.name.toLowerCase).toSet == Set("my_table2"))
   }
 
-  // SNAP-1641 is filed to enable this test
-  ignore("list tables with database") {
+  test("list tables with database") {
     assert(snappySession.catalog.listTables("default").collect().isEmpty)
     createDatabase("my_db1")
     createDatabase("my_db2")
@@ -262,8 +274,7 @@ class SnappyCatalogSuite extends SnappyFunSuite
     assert(e.getMessage.contains("unknown_db"))
   }
 
-  // SNAP-1641 is filed to enable this test
-  ignore("list columns") {
+  test("list columns") {
     createTable("tab1")
     testListColumns("tab1", dbName = None)
   }
@@ -273,8 +284,7 @@ class SnappyCatalogSuite extends SnappyFunSuite
     snappySession.catalog.listColumns("temp1")
   }
 
-  // SNAP-1641 is filed to enable this test
-  ignore("list columns in database") {
+  test("list columns in database") {
     createDatabase("db1")
     createTable("tab1", Some("db1"))
     testListColumns("tab1", dbName = Some("db1"))


### PR DESCRIPTION
SnappyCatalogSuite fails with following exception for "list tables" test

```
Failed to find data source: column. Please find packages at http://spark-packages.org
java.lang.ClassNotFoundException: Failed to find data source: column. Please find packages at http://spark-packages.org
	at org.apache.spark.sql.execution.datasources.DataSource.lookupDataSource(DataSource.scala:145)
	at org.apache.spark.sql.execution.datasources.DataSource.providingClass$lzycompute(DataSource.scala:78)
	at org.apache.spark.sql.execution.datasources.DataSource.providingClass(DataSource.scala:78)
	at org.apache.spark.sql.execution.datasources.DataSource.resolveRelation(DataSource.scala:310)
	at org.apache.spark.sql.hive.SnappyStoreHiveCatalog$$anon$1.load(SnappyStoreHiveCatalog.scala:179)
	at org.apache.spark.sql.hive.SnappyStoreHiveCatalog$$anon$1.load(SnappyStoreHiveCatalog.scala:158)
	at com.google.common.cache.LocalCache$LoadingValueReference.loadFuture(LocalCache.java:3599)
	at com.google.common.cache.LocalCache$Segment.loadSync(LocalCache.java:2379)
	at com.google.common.cache.LocalCache$Segment.lockedGetOrLoad(LocalCache.java:2342)
	at com.google.common.cache.LocalCache$Segment.get(LocalCache.java:2257)
	at com.google.common.cache.LocalCache.get(LocalCache.java:4000)
	at com.google.common.cache.LocalCache.getOrLoad(LocalCache.java:4004)
	at com.google.common.cache.LocalCache$LocalLoadingCache.get(LocalCache.java:4874)
	at com.google.common.cache.LocalCache$LocalLoadingCache.getUnchecked(LocalCache.java:4880)
	at com.google.common.cache.LocalCache$LocalLoadingCache.apply(LocalCache.java:4898)
	at org.apache.spark.sql.hive.SnappyStoreHiveCatalog.getCachedHiveTable(SnappyStoreHiveCatalog.scala:226)
	at org.apache.spark.sql.hive.SnappyStoreHiveCatalog.lookupRelation(SnappyStoreHiveCatalog.scala:435)
	at org.apache.spark.sql.SnappySession.dropTable(SnappySession.scala:1215)
	at org.apache.spark.sql.hive.SnappyStoreHiveCatalog.dropTable(SnappyStoreHiveCatalog.scala:97)
	at org.apache.spark.sql.store.SnappyCatalogSuite.org$apache$spark$sql$store$SnappyCatalogSuite$$dropTable(SnappyCatalogSuite.scala:97)
	at org.apache.spark.sql.store.SnappyCatalogSuite$$anonfun$4.apply$mcV$sp(SnappyCatalogSuite.scala:168)
	at org.apache.spark.sql.store.SnappyCatalogSuite$$anonfun$4.apply(SnappyCatalogSuite.scala:161)
	at org.apache.spark.sql.store.SnappyCatalogSuite$$anonfun$4.apply(SnappyCatalogSuite.scala:1
```

The tests in SnappyCatalogSuite create only Hive catalog entries and (not the real tables) by calling sessionCatalog.createTable() in SnappyCatalogSuite#createTable() function. However while dropping the table in SnappyCatalogSuite#dropTable(), the call to sessionCatalog.dropTable will actually execute SnappyStoreHiveCatalog#dropTable() since it overrides it. SnappyStoreHiveCatalog#dropTable() redirects the drop call to SnappySession which errors out as the table is only in Hive store.

As a fix, have commented out the SnappyStoreHiveCatalog#dropTable() so that  SessionCatalog.dropTable should get called for this test.  Also overriding afterAll() function so that SnappySession.dropTable() is not called when cleanup code is run in SnappyFunSuite#afterAll instead cleaning the table entries in after{ } implementation.

The problem was always there but was masked as earlier SnappySession.dropTable was ignoring the nonFatal exceptions thrown by sessionCatalog.lookupRelation. This code was changed not to ignore the exceptions https://github.com/SnappyDataInc/snappydata/pull/620

Let me know if there is a better way to fix it.

## Patch testing
core scalatests pass. Will run the precheckin.

## ReleaseNotes.txt changes
NA
## Other PRs 
NA