### PR TITLE
Multigrid master

### DIFF
--- a/cluster/src/main/scala/io/snappydata/impl/LeadImpl.scala
+++ b/cluster/src/main/scala/io/snappydata/impl/LeadImpl.scala
@@ -27,7 +27,7 @@ import scala.collection.JavaConverters._
 import akka.actor.ActorSystem
 import com.gemstone.gemfire.distributed.internal.DistributionConfig
 import com.gemstone.gemfire.distributed.internal.locks.{DLockService, DistributedMemberLock}
-import com.gemstone.gemfire.internal.cache.GemFireCacheImpl
+import com.gemstone.gemfire.internal.cache.{GemFireCacheImpl, GemFireSparkConnectorCacheImpl}
 import com.pivotal.gemfirexd.FabricService.State
 import com.pivotal.gemfirexd.internal.engine.store.ServerGroupUtils
 import com.pivotal.gemfirexd.{FabricService, NetworkInterface}
@@ -126,6 +126,8 @@ class LeadImpl extends ServerImpl with Lead
           } else {
             Constant.STORE_PROPERTY_PREFIX + k
           }
+        } else if (k.startsWith(GemFireSparkConnectorCacheImpl.gfeGridPropPrefix)) {
+          Constant.STORE_PROPERTY_PREFIX + k
         }
         else {
           k

--- a/cluster/src/main/scala/io/snappydata/impl/LeadImpl.scala
+++ b/cluster/src/main/scala/io/snappydata/impl/LeadImpl.scala
@@ -27,7 +27,7 @@ import scala.collection.JavaConverters._
 import akka.actor.ActorSystem
 import com.gemstone.gemfire.distributed.internal.DistributionConfig
 import com.gemstone.gemfire.distributed.internal.locks.{DLockService, DistributedMemberLock}
-import com.gemstone.gemfire.internal.cache.{GemFireCacheImpl, GemFireSparkConnectorCacheImpl}
+import com.gemstone.gemfire.internal.cache.{GemFireCacheImpl}
 import com.pivotal.gemfirexd.FabricService.State
 import com.pivotal.gemfirexd.internal.engine.store.ServerGroupUtils
 import com.pivotal.gemfirexd.{FabricService, NetworkInterface}
@@ -126,9 +126,11 @@ class LeadImpl extends ServerImpl with Lead
           } else {
             Constant.STORE_PROPERTY_PREFIX + k
           }
-        } else if (k.startsWith(GemFireSparkConnectorCacheImpl.gfeGridPropPrefix)) {
+        } /*
+        else if (k.startsWith(GemFireSparkConnectorCacheImpl.gfeGridPropPrefix)) {
           Constant.STORE_PROPERTY_PREFIX + k
         }
+        */
         else {
           k
         }

--- a/cluster/src/main/scala/io/snappydata/impl/LeadImpl.scala
+++ b/cluster/src/main/scala/io/snappydata/impl/LeadImpl.scala
@@ -126,11 +126,7 @@ class LeadImpl extends ServerImpl with Lead
           } else {
             Constant.STORE_PROPERTY_PREFIX + k
           }
-        } /*
-        else if (k.startsWith(GemFireSparkConnectorCacheImpl.gfeGridPropPrefix)) {
-          Constant.STORE_PROPERTY_PREFIX + k
-        }
-        */
+        } 
         else {
           k
         }

--- a/core/src/main/scala/io/snappydata/util/ServiceUtils.scala
+++ b/core/src/main/scala/io/snappydata/util/ServiceUtils.scala
@@ -53,6 +53,8 @@ object ServiceUtils {
       case (k, v) if k.startsWith(Constant.SPARK_STORE_PREFIX) =>
         storeProps.setProperty(k.trim.replaceFirst(
           Constant.SPARK_STORE_PREFIX, ""), v)
+      case (k, v) if k.startsWith(Constant.SPARK_PREFIX) ||
+          k.startsWith(Constant.PROPERTY_PREFIX) => storeProps.setProperty(k, v)
       case _ => // ignore rest
     }
     storeProps


### PR DESCRIPTION
Requirement is to pass properties starting with  gemfire-grid.  to be passed to GemFireStore.
If the prefix is not done, it gets flitered in a function  ( because it is not belonging otherwise to store or snappy-spark).

(Fill in the changes here)

## Patch testing

(Fill in the details about how this patch was tested)

## ReleaseNotes.txt changes

(Does this change require an entry in ReleaseNotes.txt? If yes, has it been added to it?)

## Other PRs 

(Does this change require changes in other projects- store, spark, spark-jobserver, aqp? Add the links of PR of the other subprojects that are related to this change)
