### PR TITLE
Fix for SNAP-1385

### DIFF
--- a/core/src/main/scala/org/apache/spark/sql/SnappyDDLParser.scala
+++ b/core/src/main/scala/org/apache/spark/sql/SnappyDDLParser.scala
@@ -292,9 +292,9 @@ abstract class SnappyDDLParser(session: SnappySession)
             .getOrElse(Map.empty[String, String])
         val options = indexType.asInstanceOf[Option[Boolean]] match {
           case Some(false) =>
-            parameters + (ExternalStoreUtils.INDEX_TYPE -> "unique")
-          case Some(true) =>
             parameters + (ExternalStoreUtils.INDEX_TYPE -> "global hash")
+          case Some(true) =>
+            parameters + (ExternalStoreUtils.INDEX_TYPE -> "unique")
           case None => parameters
         }
         CreateIndex(indexName, tableName, cols, options)

--- a/core/src/test/scala/org/apache/spark/sql/store/CreateIndexTest.scala
+++ b/core/src/test/scala/org/apache/spark/sql/store/CreateIndexTest.scala
@@ -651,6 +651,16 @@ class CreateIndexTest extends SnappyFunSuite with BeforeAndAfterEach {
     snContext.createTable(tableName, "row", dataDF.schema, props)
     dataDF.write.format("row").mode(SaveMode.Append).options(props).saveAsTable(tableName)
 
+    snContext.sql("create unique index uidx on " + tableName + " (COL1)")
+    // drop it
+    snContext.sql("drop index uidx")
+    // first try and create a unique index on col1 -- SNAP-1385
+    val tableNameRowReplicated = s"${tableName}_rep"
+    snContext.createTable(tableNameRowReplicated,
+      "row", dataDF.schema, Map.empty[String, String])
+    snContext.sql(s"create unique index uidx_rep on ${tableNameRowReplicated} (COL1)")
+    snContext.sql("drop index uidx_rep")
+
     doPrint("Verify index create and drop for various index types")
     snContext.sql("create index test1 on " + tableName + " (COL1)")
     snContext.sql("drop index test1")


### PR DESCRIPTION
Unique index was not getting created on replicated table through snappy session

## Changes proposed in this pull request

Fixed a small parser action issue to take care of this.

## Patch testing

Added this case in an existing test.

## ReleaseNotes.txt changes

None.

## Other PRs 

No.
