### PR TITLE
SNAP-1663

### DIFF
--- a/core/src/main/java/io/snappydata/impl/SnappyHiveCatalog.java
+++ b/core/src/main/java/io/snappydata/impl/SnappyHiveCatalog.java
@@ -48,7 +48,6 @@ import org.apache.spark.sql.execution.columnar.ExternalStoreUtils;
 import org.apache.spark.sql.execution.datasources.jdbc.DriverRegistry;
 import org.apache.spark.sql.hive.ExternalTableType;
 import org.apache.spark.sql.hive.SnappyStoreHiveCatalog;
-import org.apache.spark.sql.row.GemFireXDDialect;
 import org.apache.spark.sql.sources.JdbcExtendedUtils;
 import org.apache.spark.sql.store.StoreUtils;
 import org.apache.spark.sql.types.StructType;
@@ -92,7 +91,6 @@ public class SnappyHiveCatalog implements ExternalCatalog {
     } catch (Exception e) {
       throw new RuntimeException(e);
     }
-    GemFireXDDialect.init();
   }
 
   public Table getTable(String schema, String tableName, boolean skipLocks) {

--- a/core/src/main/java/io/snappydata/impl/SnappyHiveCatalog.java
+++ b/core/src/main/java/io/snappydata/impl/SnappyHiveCatalog.java
@@ -48,6 +48,7 @@ import org.apache.spark.sql.execution.columnar.ExternalStoreUtils;
 import org.apache.spark.sql.execution.datasources.jdbc.DriverRegistry;
 import org.apache.spark.sql.hive.ExternalTableType;
 import org.apache.spark.sql.hive.SnappyStoreHiveCatalog;
+import org.apache.spark.sql.row.GemFireXDDialect;
 import org.apache.spark.sql.sources.JdbcExtendedUtils;
 import org.apache.spark.sql.store.StoreUtils;
 import org.apache.spark.sql.types.StructType;
@@ -91,6 +92,7 @@ public class SnappyHiveCatalog implements ExternalCatalog {
     } catch (Exception e) {
       throw new RuntimeException(e);
     }
+    GemFireXDDialect.init();
   }
 
   public Table getTable(String schema, String tableName, boolean skipLocks) {

--- a/core/src/main/scala/io/snappydata/impl/ServerImpl.scala
+++ b/core/src/main/scala/io/snappydata/impl/ServerImpl.scala
@@ -22,6 +22,8 @@ import java.util.Properties
 import com.pivotal.gemfirexd.internal.engine.fabricservice.FabricServerImpl
 import io.snappydata.{ProtocolOverrides, Server}
 
+import org.apache.spark.sql.row.GemFireXDDialect
+
 /**
   * This class ties up few things that is Snappy specific.
   * for e.g. Connection url & ClusterCallback
@@ -29,7 +31,10 @@ import io.snappydata.{ProtocolOverrides, Server}
 class ServerImpl extends FabricServerImpl with Server with ProtocolOverrides {
 
   @throws(classOf[SQLException])
-  override def start(bootProperties: Properties): Unit = start(bootProperties, false)
+  override def start(bootProperties: Properties): Unit = {
+    GemFireXDDialect.init()
+    start(bootProperties, false)
+  }
 
   override def isServer: Boolean = true
 }


### PR DESCRIPTION
SNAP-1663: JDBCSourceAsColumnarStore#doInsert gets connectionType as unknown. This was observed by SachinJ  while working TX issues

In this case, JDBCSourceAsColumnarStore is created thru following code path on server (executor). GemFireXDDialect is not initialized because of which incorrect dialect gets set in ConnectionProperties in ExternalStoreUtils#validateAndGetAllProps called from ExternalStoreUtils#getExternalStoreOnExecutor

```
at java.lang.Thread.dumpStack(Thread.java:1333)
at org.apache.spark.sql.execution.columnar.impl.JDBCSourceAsColumnarStore.<init>(JDBCSourceAsColumnarStore.scala:74)
at org.apache.spark.sql.execution.columnar.ExternalStoreUtils$.getExternalStoreOnExecutor(ExternalStoreUtils.scala:562)
at org.apache.spark.sql.execution.columnar.ExternalStoreUtils.getExternalStoreOnExecutor(ExternalStoreUtils.scala)
at io.snappydata.impl.SnappyHiveCatalog$HMSQuery.call(SnappyHiveCatalog.java:348)
at java.util.concurrent.FutureTask.run(FutureTask.java:266)
at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
at java.lang.Thread.run(Thread.java:745)
```

As a fix Initializing GemFireXDDialect in SnappyHiveCatalog#SnappyHiveCatalog

@sumwale Let mw know if this fix can be committed as all tests seem to be passing without it but probably there is perf impact as JDBCSourceAsColumnarStore#doInsert always calls doGFXDInsert() instead of doSnappyInsert() in this case.

## Patch testing
precheckin to be run

## ReleaseNotes.txt changes
NA
## Other PRs 
NA