### PR TITLE
Snap 1601

### DIFF
--- a/cluster/src/dunit/scala/org/apache/spark/sql/TPCHSuite.scala
+++ b/cluster/src/dunit/scala/org/apache/spark/sql/TPCHSuite.scala
@@ -29,14 +29,12 @@ import org.apache.spark.sql.internal.SQLConf
  */
 class TPCHSuite extends SnappyFunSuite with BeforeAndAfterAll  {
 
-  ignore("Test TPCH") {
+  test("Test TPCH") {
     val snc = SnappyContext(sc)
-    snc.conf.setConfString(SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key, "104857600")
-    Property.HashJoinSize.set(snc.conf, 1L * 1024 * 1024 * 1024)
     TPCHUtils.createAndLoadTables(snc, isSnappy = true)
-    TPCHUtils.queryExecution(snc, isSnappy = true)
-    // TPCHUtils.queryExecution(snc, isSnappy = true, warmup = 6, runsForAverage = 10,
-    //  isResultCollection = false)
-    TPCHUtils.validateResult(snc, isSnappy = true)
+    for (i <- 1 to 100) {
+      TPCHUtils.runtpchMultipleTimes(snc)
+    }
+
   }
 }

--- a/core/src/main/scala/org/apache/spark/sql/SnappySession.scala
+++ b/core/src/main/scala/org/apache/spark/sql/SnappySession.scala
@@ -1949,7 +1949,7 @@ object SnappySession extends Logging {
         cachedDF = evaluation._1
         queryHints = evaluation._2
       } else {
-        cachedDF.clearCachedShuffleDeps(session.sparkContext)
+        cachedDF.waitForLastShuffleCleanup
         cachedDF.reset()
       }
       cachedDF.queryString = sqlText


### PR DESCRIPTION
## Changes proposed in this pull request

 Clean up of dependencies of a shuffledRDD is now kicked off (asynchronously) immediately after query execution. Added code to wait for cleanup of dependencies when a cachedDataFrame is being re-used. This safeguards against the case if the cleanup of a previous execution is not yet complete

## Patch testing

Manual testing by setting thread.sleep inside BlockManagerSlaveEndpoint.scala (case RemoveShuffle).

Running precheckin. 