### PR TITLE
[SNAP-1664] LowMemoryException during cluster restart

### DIFF
--- a/cluster/src/main/scala/org/apache/spark/memory/SnappyUnifiedMemoryManager.scala
+++ b/cluster/src/main/scala/org/apache/spark/memory/SnappyUnifiedMemoryManager.scala
@@ -495,7 +495,7 @@ class SnappyUnifiedMemoryManager private[memory](
       if (!enoughMemory) {
 
         // return immediately for OFF_HEAP with shouldEvict=false
-        if (offHeapNoEvict || tempManager) return false
+        if (offHeapNoEvict) return false
 
         if (!offHeap && SnappyMemoryUtils.isCriticalUp()) {
           logWarning(s"CRTICAL_UP event raised due to critical heap memory usage. " +

--- a/cluster/src/main/scala/org/apache/spark/memory/SnappyUnifiedMemoryManager.scala
+++ b/cluster/src/main/scala/org/apache/spark/memory/SnappyUnifiedMemoryManager.scala
@@ -606,6 +606,13 @@ class SnappyUnifiedMemoryManager private[memory](
     }
     memoryForObject.clear()
   }
+
+  // Recovery is a special case. If any of the storage pool has reached 90% of
+  // max storage pool size stop recovery.
+  override def shouldStopRecovery(): Boolean = synchronized {
+    (offHeapStorageMemoryPool.memoryUsed >= (maxOffHeapStorageSize * 0.90) ) ||
+        (onHeapStorageMemoryPool.memoryUsed >= (maxHeapStorageSize * 0.90))
+  }
 }
 
 object SnappyUnifiedMemoryManager extends Logging {

--- a/cluster/src/test/scala/org/apache/spark/memory/SnappyStorageEvictorSuite.scala
+++ b/cluster/src/test/scala/org/apache/spark/memory/SnappyStorageEvictorSuite.scala
@@ -77,9 +77,11 @@ class SnappyStorageEvictorSuite extends MemoryFunSuite {
     assert(SparkEnv.get.memoryManager.storageMemoryUsed == 0)
     val row = Row(1, 1, 1)
     snSession.insert("t1", row)
-    assert(SparkEnv.get.memoryManager.storageMemoryUsed > 0) // borrowed from execution memory
+    val afterInsertSize = SparkEnv.get.memoryManager.storageMemoryUsed
+    assert( afterInsertSize > 0) // borrowed from execution memory
     snSession.delete("t1", "col1=1")
-    assert(SparkEnv.get.memoryManager.storageMemoryUsed == 0)
+    val afterDeleteSize = SparkEnv.get.memoryManager.storageMemoryUsed
+    assert(afterDeleteSize < afterInsertSize)
     snSession.dropTable("t1")
   }
 

--- a/core/src/main/scala/org/apache/spark/memory/StoreUnifiedManager.scala
+++ b/core/src/main/scala/org/apache/spark/memory/StoreUnifiedManager.scala
@@ -58,6 +58,8 @@ trait StoreUnifiedManager {
 
   def logStats(): Unit
 
+  def shouldStopRecovery(): Boolean
+
   /**
     * Change the off-heap owner to mark it being used for storage.
     * Passing the owner as null allows moving ByteBuffers not allocated
@@ -120,6 +122,8 @@ class DefaultMemoryManager extends StoreUnifiedManager with Logging {
 
   override def changeOffHeapOwnerToStorage(buffer: ByteBuffer,
       allowNonAllocator: Boolean): Unit = {}
+
+  override def shouldStopRecovery(): Boolean = false
 }
 
 object MemoryManagerCallback extends Logging {

--- a/core/src/main/scala/org/apache/spark/sql/execution/columnar/impl/StoreCallbacksImpl.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/columnar/impl/StoreCallbacksImpl.scala
@@ -337,6 +337,9 @@ object StoreCallbacksImpl extends StoreCallbacks with Logging with Serializable 
 
   override def logMemoryStats(): Unit =
     MemoryManagerCallback.memoryManager.logStats()
+
+  override def shouldStopRecovery(): Boolean =
+    MemoryManagerCallback.memoryManager.shouldStopRecovery()
 }
 
 trait StoreCallback extends Serializable {


### PR DESCRIPTION


## Changes proposed in this pull request
When recovery was in progress it occupied almost all the off-heap memory available.
Also during recovery we use a temp UMM which has its limit set from defaults.
Also it can not do any eviction.But a side effect of exhausting all off-heap memory
in recovery is other messaging are not able to get any memory and restart hangs

## Patch testing

Manual

## ReleaseNotes.txt changes
NA

## Other PRs 
https://github.com/SnappyDataInc/snappy-store/pull/207
