### PR TITLE
Snap 1642

### DIFF
--- a/core/src/main/scala/org/apache/spark/sql/SnappyParser.scala
+++ b/core/src/main/scala/org/apache/spark/sql/SnappyParser.scala
@@ -817,15 +817,16 @@ class SnappyParser(session: SnappySession)
         UnresolvedRelation(r), input.sliceString(0, input.length)))
   }
 
-  // Only when wholeStageEnabled try for tokenization. It should be
-  // true
-  private var tokenize = session.sessionState.conf.wholeStageEnabled
+  // Only when wholeStageEnabled try for tokenization. It should be true
+  private val tokenizationDisabled = java.lang.Boolean.getBoolean("DISABLE_TOKENIZATION")
+
+  private var tokenize = !tokenizationDisabled && session.sessionState.conf.wholeStageEnabled
 
   private var isSelect = false
 
   protected final def TOKENIZE_BEGIN: Rule0 = rule {
     MATCH ~> (() =>
-      tokenize = isSelect && session.sessionState.conf.wholeStageEnabled)
+      tokenize = !tokenizationDisabled && isSelect && session.sessionState.conf.wholeStageEnabled)
   }
 
   protected final def TOKENIZE_END: Rule0 = rule {

--- a/core/src/main/scala/org/apache/spark/sql/SnappySession.scala
+++ b/core/src/main/scala/org/apache/spark/sql/SnappySession.scala
@@ -1892,6 +1892,11 @@ object SnappySession extends Logging {
       val invalidate = Array(false)
 
       def normalizeExprIds: PartialFunction[Expression, Expression] = {
+        /*
+         Fix for SNAP-1642. Not changing the exprId should have been enough
+         to not let it tokenize. But invalidating it explicitly so by chance
+         also we do not cache it. Will revisit this soon after 0.9
+         */
         case s: ScalarSubquery =>
           invalidate(0) = true
           // s.copy(exprId = ExprId(0))

--- a/core/src/main/scala/org/apache/spark/sql/SnappySession.scala
+++ b/core/src/main/scala/org/apache/spark/sql/SnappySession.scala
@@ -1889,7 +1889,7 @@ object SnappySession extends Logging {
     def apply(session: SnappySession, lp: LogicalPlan, sqlText: String, pls:
     ArrayBuffer[ParamLiteral]): CachedKey = {
 
-      val invalidate = Array(false)
+      var invalidate = false
 
       def normalizeExprIds: PartialFunction[Expression, Expression] = {
         /*
@@ -1898,7 +1898,7 @@ object SnappySession extends Logging {
          also we do not cache it. Will revisit this soon after 0.9
          */
         case s: ScalarSubquery =>
-          invalidate(0) = true
+          invalidate = true
           // s.copy(exprId = ExprId(0))
           s
         case e: Exists =>
@@ -1927,7 +1927,7 @@ object SnappySession extends Logging {
       val tlp = lp.transform(transformExprID)
       val key = new CachedKey(session, tlp,
         sqlText, session.queryHints.hashCode(), pls.sortBy(_.pos).toArray)
-      if (invalidate(0)) {
+      if (invalidate) {
         key.invalidatePlan()
       }
       key

--- a/core/src/test/scala/org/apache/spark/sql/store/DisableTokenizationTest.scala
+++ b/core/src/test/scala/org/apache/spark/sql/store/DisableTokenizationTest.scala
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) 2016 SnappyData, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License. You
+ * may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License. See accompanying
+ * LICENSE file.
+ */
+package org.apache.spark.sql.store
+
+import scala.collection.mutable.ArrayBuffer
+
+import io.snappydata.app.Data1
+import io.snappydata.{SnappyFunSuite, SnappyTableStatsProviderService}
+import io.snappydata.core.Data
+import org.scalatest.{BeforeAndAfter, BeforeAndAfterAll}
+
+import org.apache.spark.Logging
+import org.apache.spark.sql.SnappySession.CachedKey
+import org.apache.spark.sql._
+
+/**
+  * Tests for column tables in GFXD.
+  */
+class DisableTokenizationTest
+    extends SnappyFunSuite
+        with Logging
+        with BeforeAndAfter
+        with BeforeAndAfterAll {
+
+  val table  = "my_table"
+  val table2 = "my_table2"
+  val all_typetable = "my_table3"
+
+  override def beforeAll(): Unit = {
+    System.setProperty("DISABLE_TOKENIZATION", "true")
+    super.beforeAll()
+  }
+
+  override def afterAll(): Unit = {
+    System.setProperty("DISABLE_TOKENIZATION", "false")
+    super.afterAll()
+  }
+
+  after {
+    SnappyTableStatsProviderService.suspendCacheInvalidation = false
+    SnappySession.clearAllCache()
+    snc.dropTable(s"$table", ifExists = true)
+  }
+
+  test("test disable property") {
+    SnappyTableStatsProviderService.suspendCacheInvalidation = true
+    val numRows = 100
+    createSimpleTableAndPoupulateData(numRows, s"$table", true)
+
+    try {
+      // System.setProperty("DISABLE_TOKENIZATION", "true")
+      (0 to 10).foreach(i => {
+        val q = s"select b from $table where a = $i"
+        var result = snc.sql(q).collect()
+        println(s"q = $q and res(0) = ${result(0).get(0)}")
+        assert(result(0).get(0) == i)
+      })
+
+      val cacheMap = SnappySession.getPlanCache.asMap()
+      assert(cacheMap.size() == 11)
+
+      SnappyTableStatsProviderService.suspendCacheInvalidation = false
+    } finally {
+      System.setProperty("DISABLE_TOKENIZATION", "false")
+    }
+  }
+
+  private def createSimpleTableAndPoupulateData(numRows: Int, name: String,
+      dosleep: Boolean = false) = {
+    val data = ((0 to numRows), (0 to numRows), (0 to numRows)).zipped.toArray
+    val rdd = sc.parallelize(data, data.length)
+      .map(s => Data(s._1, s._2, s._3))
+    val dataDF = snc.createDataFrame(rdd)
+
+    snc.sql(s"Drop Table if exists $name")
+    snc.sql(s"Create Table $name (a INT, b INT, c INT) " +
+      "using column options()")
+    dataDF.write.insertInto(s"$name")
+    // This sleep was necessary as it has some dependency on the region size
+    // collector thread frequency. Can't remember right now.
+    if (dosleep) Thread.sleep(5000)
+  }
+
+  private def normalizeRow(rows: Array[Row]): Array[String] = {
+    val newBuffer: ArrayBuffer[String] = new ArrayBuffer
+    val sb = new StringBuilder
+    rows.foreach(r => {
+      r.toSeq.foreach {
+        case d: Double =>
+          // round to one decimal digit
+          sb.append(math.floor(d * 5.0 + 0.25) / 5.0).append(',')
+        case bd: java.math.BigDecimal =>
+          sb.append(bd.setScale(2, java.math.RoundingMode.HALF_UP)).append(',')
+        case v => sb.append(v).append(',')
+      }
+      newBuffer += sb.toString()
+      sb.clear()
+    })
+    newBuffer.sortWith(_ < _).toArray
+  }
+}

--- a/core/src/test/scala/org/apache/spark/sql/store/DisableTokenizationTest.scala
+++ b/core/src/test/scala/org/apache/spark/sql/store/DisableTokenizationTest.scala
@@ -36,9 +36,7 @@ class DisableTokenizationTest
         with BeforeAndAfter
         with BeforeAndAfterAll {
 
-  val table  = "my_table"
-  val table2 = "my_table2"
-  val all_typetable = "my_table3"
+  val table = "my_table"
 
   override def beforeAll(): Unit = {
     System.setProperty("DISABLE_TOKENIZATION", "true")
@@ -62,11 +60,9 @@ class DisableTokenizationTest
     createSimpleTableAndPoupulateData(numRows, s"$table", true)
 
     try {
-      // System.setProperty("DISABLE_TOKENIZATION", "true")
       (0 to 10).foreach(i => {
         val q = s"select b from $table where a = $i"
         var result = snc.sql(q).collect()
-        println(s"q = $q and res(0) = ${result(0).get(0)}")
         assert(result(0).get(0) == i)
       })
 
@@ -93,23 +89,5 @@ class DisableTokenizationTest
     // This sleep was necessary as it has some dependency on the region size
     // collector thread frequency. Can't remember right now.
     if (dosleep) Thread.sleep(5000)
-  }
-
-  private def normalizeRow(rows: Array[Row]): Array[String] = {
-    val newBuffer: ArrayBuffer[String] = new ArrayBuffer
-    val sb = new StringBuilder
-    rows.foreach(r => {
-      r.toSeq.foreach {
-        case d: Double =>
-          // round to one decimal digit
-          sb.append(math.floor(d * 5.0 + 0.25) / 5.0).append(',')
-        case bd: java.math.BigDecimal =>
-          sb.append(bd.setScale(2, java.math.RoundingMode.HALF_UP)).append(',')
-        case v => sb.append(v).append(',')
-      }
-      newBuffer += sb.toString()
-      sb.clear()
-    })
-    newBuffer.sortWith(_ < _).toArray
   }
 }


### PR DESCRIPTION
Not doing plan caching at all for queries with scalar subqueries  
Added a flag to disable Tokenization. By default it is still ON.

## Patch testing

Added unit test for both.

## ReleaseNotes.txt changes

None

## Other PRs 

No.
