### PR TITLE
SNAP-1651

### DIFF
--- a/cluster/src/main/scala/org/apache/spark/memory/SnappyUnifiedMemoryManager.scala
+++ b/cluster/src/main/scala/org/apache/spark/memory/SnappyUnifiedMemoryManager.scala
@@ -25,6 +25,7 @@ import scala.collection.mutable
 
 import com.gemstone.gemfire.distributed.internal.DistributionConfig
 import com.gemstone.gemfire.internal.cache.store.ManagedDirectBufferAllocator
+import com.gemstone.gemfire.internal.shared.BufferAllocator
 import com.gemstone.gemfire.internal.shared.unsafe.UnsafeHolder
 import com.gemstone.gemfire.internal.snappy.UMMMemoryTracker
 import com.pivotal.gemfirexd.internal.engine.Misc
@@ -63,6 +64,15 @@ class SnappyUnifiedMemoryManager private[memory](
            conf.getDouble("spark.memory.storageMaxFraction", 0.9)).toLong
 
   /**
+   * An estimate of the maximum result size handled by a single partition.
+   * There can be major skew so this does not use number of partitions as
+   * divisor, but even the divisor used may not compensate for the skew in some
+   * cases but it should be acceptable for those rare cases.
+   */
+  private val maxPartResultSize = Utils.getMaxResultSize(conf) /
+      math.min(8, Runtime.getRuntime.availableProcessors())
+
+  /**
    * If total heap size is small enough then try and use explicit GC to
    * release pending off-heap references before failing storage allocation.
    */
@@ -96,8 +106,9 @@ class SnappyUnifiedMemoryManager private[memory](
         if (!tempManager) {
           logInfo(s"Allocating boot time memory to $managerId ")
 
-          val bootTimeMap = MemoryManagerCallback.tempMemoryManager
-              .asInstanceOf[SnappyUnifiedMemoryManager]._memoryForObjectMap
+          val bootTimeManager = MemoryManagerCallback.tempMemoryManager
+              .asInstanceOf[SnappyUnifiedMemoryManager]
+          val bootTimeMap = bootTimeManager._memoryForObjectMap
           if (bootTimeMap ne null) {
             // Not null only for cluster mode. In local mode
             // as Spark is booted first temp memory manager is not used
@@ -106,12 +117,12 @@ class SnappyUnifiedMemoryManager private[memory](
               acquireStorageMemoryForObject(objectName,
                 MemoryManagerCallback.storageBlockId, entry.getLongValue, mode, null,
                 shouldEvict = true)
+              // TODO: SW: if above fails then this should throw exception
+              // and _memoryForObjectMap made null again?
             }
             logInfo(s"Total Memory used while booting = " +
-                MemoryManagerCallback.tempMemoryManager
-                    .asInstanceOf[SnappyUnifiedMemoryManager].storageMemoryUsed)
-            MemoryManagerCallback.tempMemoryManager
-                .asInstanceOf[SnappyUnifiedMemoryManager]._memoryForObjectMap.clear()
+                bootTimeManager.storageMemoryUsed)
+            bootTimeMap.clear()
           }
         }
 
@@ -293,7 +304,8 @@ class SnappyUnifiedMemoryManager private[memory](
 
   private def getMinOffHeapEviction(required: Long): Long = {
     // off-heap calculations are precise so evict exactly as much as required
-    (required * threadsWaitingForStorage.get()) - offHeapStorageMemoryPool.memoryFree
+    (required * math.max(1, math.min(4, threadsWaitingForStorage.get()))) -
+        offHeapStorageMemoryPool.memoryFree
   }
 
   /**
@@ -457,8 +469,10 @@ class SnappyUnifiedMemoryManager private[memory](
       // Evict only limited amount for owners marked as non-evicting.
       // TODO: this can be removed once these calls are moved to execution
       val doEvict = if (shouldEvict &&
-          ManagedDirectBufferAllocator.nonEvictingOwners.contains(objectName)) {
-        numBytes < storagePool.memoryFree * 2
+          objectName.endsWith(BufferAllocator.STORE_DATA_FRAME_OUTPUT)) {
+        // don't use more than 30% of pool size for one partition result
+        numBytes < math.min(0.3 * storagePool.poolSize,
+          math.max(maxPartResultSize, storagePool.memoryFree))
       } else shouldEvict
 
       if (numBytes > maxMemory) {

--- a/cluster/src/test/scala/org/apache/spark/memory/SnappyMemoryAccountingSuite.scala
+++ b/cluster/src/test/scala/org/apache/spark/memory/SnappyMemoryAccountingSuite.scala
@@ -21,20 +21,20 @@ import java.nio.charset.StandardCharsets
 import java.sql.SQLException
 import java.util.Properties
 
-import com.gemstone.gemfire.cache.LowMemoryException
 import scala.actors.Futures._
 
+import com.gemstone.gemfire.cache.LowMemoryException
 import com.gemstone.gemfire.internal.cache.{GemFireCacheImpl, LocalRegion}
 import com.pivotal.gemfirexd.internal.engine.Misc
 import io.snappydata.cluster.ClusterManagerTestBase
 import io.snappydata.externalstore.Data
 import io.snappydata.test.dunit.DistributedTestBase.InitializeRun
 
-import org.apache.spark.{SparkEnv, TaskContext, TaskContextImpl}
 import org.apache.spark.sql.catalyst.expressions.{SpecificMutableRow, UnsafeProjection, UnsafeRow}
 import org.apache.spark.sql.types._
 import org.apache.spark.sql.{CachedDataFrame, Row, SnappyContext, SnappySession}
 import org.apache.spark.unsafe.types.UTF8String
+import org.apache.spark.{SparkEnv, TaskContextImpl}
 
 
 class SnappyMemoryAccountingSuite extends MemoryFunSuite {
@@ -455,7 +455,8 @@ class SnappyMemoryAccountingSuite extends MemoryFunSuite {
     assert(SparkEnv.get.memoryManager.storageMemoryUsed > 0) // borrowed from execution memory
     snSession.delete("t1", "col1=1")
     // we need to wait for atleast OLD_ENTRIES_CLEANER_TIME_INTERVAL
-    ClusterManagerTestBase.waitForCriterion((SparkEnv.get.memoryManager.storageMemoryUsed == afterCreateTable),
+    ClusterManagerTestBase.waitForCriterion(
+      (SparkEnv.get.memoryManager.storageMemoryUsed == afterCreateTable),
       s"The memory after delete is not same even after waiting for oldEntryRemoval",
       2 * Misc.getGemFireCache.getOldEntryRemovalPerid, 500, true)
     snSession.dropTable("t1")
@@ -489,10 +490,11 @@ class SnappyMemoryAccountingSuite extends MemoryFunSuite {
     assert(SparkEnv.get.memoryManager.storageMemoryUsed > 0) // borrowed from execution memory
     snSession.delete("t1", "col1=1")
     // we need to wait for atleast OLD_ENTRIES_CLEANER_TIME_INTERVAL
-    ClusterManagerTestBase.waitForCriterion((SparkEnv.get.memoryManager.storageMemoryUsed == afterCreateTable),
+    ClusterManagerTestBase.waitForCriterion(
+      (SparkEnv.get.memoryManager.storageMemoryUsed == afterCreateTable),
       s"The memory after delete is not same even after waiting for oldEntryRemoval",
       2 * Misc.getGemFireCache.getOldEntryRemovalPerid, 500, true)
-    //assert(afterDelete == afterCreateTable)
+    // assert(afterDelete == afterCreateTable)
     snSession.dropTable("t1")
   }
 
@@ -603,6 +605,8 @@ class SnappyMemoryAccountingSuite extends MemoryFunSuite {
 
   test("CachedDataFrame accounting") {
     val sparkSession = createSparkSession(1, 0, 1000)
+    // create SnappySession to boot GemFireCache which is required for SnappyUMM
+    new SnappySession(sparkSession.sparkContext)
     val fieldTypes: Array[DataType] = Array(LongType, StringType, BinaryType)
     val converter = UnsafeProjection.create(fieldTypes)
 
@@ -613,8 +617,8 @@ class SnappyMemoryAccountingSuite extends MemoryFunSuite {
 
     val unsafeRow: UnsafeRow = converter.apply(row)
 
-    SparkEnv.get.memoryManager
-      .acquireStorageMemory(MemoryManagerCallback.storageBlockId, 800, memoryMode)
+    assert(SparkEnv.get.memoryManager
+      .acquireStorageMemory(MemoryManagerCallback.storageBlockId, 200, memoryMode))
 
     val taskContext =
       new TaskContextImpl(0, 0, taskAttemptId = 1, 0, null, new Properties, null)
@@ -622,7 +626,7 @@ class SnappyMemoryAccountingSuite extends MemoryFunSuite {
       CachedDataFrame(taskContext, Seq(unsafeRow).iterator)
       assert(false , "Should not have obtained memory")
     } catch {
-      case lme : LowMemoryException => //Success
+      case lme : LowMemoryException => // Success
     }
   }
 

--- a/core/src/main/scala/io/snappydata/Literals.scala
+++ b/core/src/main/scala/io/snappydata/Literals.scala
@@ -229,6 +229,15 @@ object Property extends Enumeration {
     "The join would be converted into a hash join if the table is of size less " +
         "than hashJoinSize. Default value is 100 MB.", Some(100L * 1024 * 1024))
 
+  val HashAggregateSize = SQLVal[String](s"${Constant.PROPERTY_PREFIX}hashAggregateSize",
+    "Aggregation will use optimized hash aggregation plan but one that does not " +
+        "overflow to disk and can cause OOME if the result of aggregation is large. " +
+        "The limit specifies the input data size (with b/k/m/g/t/p suffixes for units) " +
+        "and not the output size. Set this only if there are known to be queries " +
+        "that can return very large number of rows in aggregation results. " +
+        "Default value is 0b meaning no limit on the size so the optimized " +
+        "hash aggregation is always used.", Some("0b"))
+
   val EnableExperimentalFeatures = SQLVal[Boolean](
     s"${Constant.PROPERTY_PREFIX}enable-experimental-features",
     "SQLConf property that enables snappydata experimental features like distributed index " +

--- a/core/src/main/scala/org/apache/spark/memory/StoreUnifiedManager.scala
+++ b/core/src/main/scala/org/apache/spark/memory/StoreUnifiedManager.scala
@@ -18,9 +18,9 @@ package org.apache.spark.memory
 
 import java.nio.ByteBuffer
 
-import com.gemstone.gemfire.internal.cache.GemFireCacheImpl
 import com.gemstone.gemfire.internal.shared.BufferAllocator
 import com.gemstone.gemfire.internal.snappy.UMMMemoryTracker
+
 import org.apache.spark.storage.{BlockId, TestBlockId}
 import org.apache.spark.util.Utils
 import org.apache.spark.{Logging, SparkConf, SparkEnv}
@@ -130,7 +130,7 @@ object MemoryManagerCallback extends Logging {
   val ummClass = "org.apache.spark.memory.SnappyUnifiedMemoryManager"
 
   // This memory manager will be used while GemXD is booting up and SparkEnv is not ready.
-  lazy val tempMemoryManager = {
+  private[memory] lazy val tempMemoryManager = {
     try {
       val conf = new SparkConf()
       Utils.classForName(ummClass)
@@ -190,14 +190,11 @@ object MemoryManagerCallback extends Logging {
           snappyUnifiedManager = unifiedManager
           unifiedManager
         case _ =>
-          // For testing purpose if we want to disable SnappyUnifiedManager
+          // if SnappyUnifiedManager is disabled or for local mode
           defaultManager
       }
     } else { // Spark.env will be null only with gemxd boot time
       tempMemoryManager
     }
   }
-
 }
-
-

--- a/core/src/main/scala/org/apache/spark/sql/internal/SnappySessionState.scala
+++ b/core/src/main/scala/org/apache/spark/sql/internal/SnappySessionState.scala
@@ -337,7 +337,8 @@ class SnappyConf(@transient val session: SnappySession)
   private def keyUpdateActions(key: String, doSet: Boolean): Unit = key match {
     // clear plan cache when some size related key that effects plans changes
     case SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key |
-         Property.HashJoinSize.name => session.clearPlanCache()
+         Property.HashJoinSize.name |
+         Property.HashAggregateSize.name => session.clearPlanCache()
     case SQLConf.SHUFFLE_PARTITIONS.key =>
       // stop dynamic determination of shuffle partitions
       if (doSet) {


### PR DESCRIPTION
## Changes proposed in this pull request

Patch From @sumwale 

This PR combines the fixes for the two issues:

a) the OOME with large aggregates: new property "snappydata.hashAggregateSize" which is expressed as a string with b/k/m/g units. Kishor, when running with this (hopefully checked in when you run) then do not need the separate patch (the one titled 1651). Set the property to something like 4g: "snappydata.hashAggregateSize=4g"

b) SNAP-1651: it now reads spark driver size and estimates the maximum size to use for a partition result allowing eviction till that point. Rishi, I have removed the array of nonEvictingOwners and added a specific check for partition result to indicate that the workaround only works for partition result (because it applies a specific size limit for eviction and not zero eviction). Also have applied the same to the heap byte[] created at the end because that too can fail with LME frequently.

## Patch testing

Manual testing. Volume testing. Running precheckin. 

## Other PRs
https://github.com/SnappyDataInc/snappy-store/pull/208