### PR TITLE
(SNAP-1684) Add client driver classname as a driver property when creating a connection factory

### DIFF
--- a/core/src/main/scala/io/snappydata/SnappyThinConnectorTableStatsProvider.scala
+++ b/core/src/main/scala/io/snappydata/SnappyThinConnectorTableStatsProvider.scala
@@ -40,8 +40,10 @@ object SnappyThinConnectorTableStatsProvider extends TableStatsProviderService {
   private var _url: String = null
 
   def initializeConnection(): Unit = {
+    val props = new Properties()
+    props.setProperty("driver", "io.snappydata.jdbc.ClientDriver")
     conn = JdbcUtils.createConnectionFactory(
-      _url + ";route-query=false;" , new Properties())()
+      _url + ";route-query=false;" , props)()
     getStatsStmt = conn.prepareCall("call sys.GET_SNAPPY_TABLE_STATS(?)")
     getStatsStmt.registerOutParameter(1, java.sql.Types.BLOB)
   }

--- a/core/src/main/scala/org/apache/spark/sql/SmartConnectorHelper.scala
+++ b/core/src/main/scala/org/apache/spark/sql/SmartConnectorHelper.scala
@@ -63,8 +63,10 @@ class SmartConnectorHelper(snappySession: SnappySession) extends Logging {
   }
 
   def initializeConnection(): Unit = {
+    val props = new Properties()
+    props.setProperty("driver", "io.snappydata.jdbc.ClientDriver")
     conn = JdbcUtils.createConnectionFactory(
-      connectionURL + ";route-query=false;" , new Properties())()
+      connectionURL + ";route-query=false;" , props)()
     createSnappyTblStmt =  conn.prepareCall(createSnappyTblString)
     dropSnappyTblStmt = conn.prepareCall(dropSnappyTblString)
     createSnappyIdxStmt = conn.prepareCall(createSnappyIdxString)


### PR DESCRIPTION
## Changes proposed in this pull request
Changes from @hbhanawat  and @sumwale.

Add client driver classname as a driver property when creating a connection factory. It avoids 'No suitable driver' issues when driver is not auto-loaded.

## Patch testing
Manual testing with Apache Spark. 
./bin/spark-shell  --master local[*] --conf spark.snappydata.connection=localhost:1527 --jars /latest/master/snappydata-core.jar

## ReleaseNotes.txt changes
NA

## Other PRs 
NA