### PR TITLE
SNAP-1694

### DIFF
--- a/cluster/src/dunit/scala/io/snappydata/cluster/QueryRoutingDUnitTest.scala
+++ b/cluster/src/dunit/scala/io/snappydata/cluster/QueryRoutingDUnitTest.scala
@@ -570,7 +570,7 @@ class QueryRoutingDUnitTest(val s: String)
 
     foundTable = false
     while (rSet2.next()) {
-      if (s"APP__${t + SHADOW_TABLE_SUFFIX}".
+      if (s"APP____${t + SHADOW_TABLE_SUFFIX}".
           equalsIgnoreCase(rSet2.getString("TABLE_NAME"))) {
         foundTable = true
         assert(rSet2.getString("TABLE_TYPE").equalsIgnoreCase("TABLE"))

--- a/cluster/src/dunit/scala/io/snappydata/cluster/ValidateMVCCDUnitTest.scala
+++ b/cluster/src/dunit/scala/io/snappydata/cluster/ValidateMVCCDUnitTest.scala
@@ -31,6 +31,7 @@ import org.slf4j.LoggerFactory
 import org.apache.spark.Logging
 import org.apache.spark.sql.SnappyContext
 import org.apache.spark.sql.collection.Utils
+import org.apache.spark.sql.execution.columnar.impl.ColumnFormatRelation
 
 class ValidateMVCCDUnitTest(val s: String) extends ClusterManagerTestBase(s) with Logging {
 
@@ -315,8 +316,8 @@ object ValidateMVCCDUnitTest {
   def printRegionSize(): Unit = {
     val cache = GemFireCacheImpl.getInstance()
     println("APP.TESTTABLE Region size : "+cache.getRegion("/APP/TESTTABLE").size())
-    println("SNAPPYSYS_INTERNAL.APP__TESTTABLE_COLUMN_STORE_  Region size : "+cache.getRegion
-    ("/SNAPPYSYS_INTERNAL/APP__TESTTABLE_COLUMN_STORE_").size())
+    println("SNAPPYSYS_INTERNAL.APP____TESTTABLE_COLUMN_STORE_  Region size : "+cache.getRegion
+    ("/SNAPPYSYS_INTERNAL/APP____TESTTABLE_COLUMN_STORE_").size())
   }
 
 

--- a/cluster/src/dunit/scala/io/snappydata/cluster/ValidateMVCCDUnitTest.scala
+++ b/cluster/src/dunit/scala/io/snappydata/cluster/ValidateMVCCDUnitTest.scala
@@ -373,9 +373,10 @@ object ValidateMVCCDUnitTest {
     // scalastyle:on
     assert(cnt1 == 10, s"Expected row count is 10 while actual row count is $cnt1")
 
-    var cnt2 = 0;
-    s.execute(s"select * from SNAPPYSYS_INTERNAL.APP__TESTTABLE_COLUMN_STORE_ -- " +
-        s"GEMFIREXD-PROPERTIES executionEngine=Store\n")
+    var cnt2 = 0
+    s.execute(s"select * from " +
+        ColumnFormatRelation.columnBatchTableName("APP.TESTTABLE") +
+        s" -- GEMFIREXD-PROPERTIES executionEngine=Store\n")
     val rs2 = s.getResultSet
     while (rs2.next) {
       cnt2 = cnt2 + 1
@@ -408,9 +409,10 @@ object ValidateMVCCDUnitTest {
     cache.setRvvSnapshotTestHook(null)
 
 
-    var cnt4 = 0;
-    s.execute(s"select * from SNAPPYSYS_INTERNAL.APP__TESTTABLE_COLUMN_STORE_ -- " +
-        s"GEMFIREXD-PROPERTIES executionEngine=Store\n")
+    var cnt4 = 0
+    s.execute(s"select * from " +
+        ColumnFormatRelation.columnBatchTableName("APP.TESTTABLE") +
+        s" -- GEMFIREXD-PROPERTIES executionEngine=Store\n")
     val rs4 = s.getResultSet
     while (rs4.next) {
       cnt4 = cnt4 + 1
@@ -498,9 +500,10 @@ object ValidateMVCCDUnitTest {
     println("Row count before creating the cachebatch in row buffer: " + cnt1)
     assert(cnt1 == 10, s"Expected row count is 10 while actual row count is $cnt1")
 
-    var cnt2 = 0;
-    s.execute(s"select * from SNAPPYSYS_INTERNAL.APP__TESTTABLE_COLUMN_STORE_ -- " +
-        s"GEMFIREXD-PROPERTIES executionEngine=Store\n")
+    var cnt2 = 0
+    s.execute(s"select * from " +
+        ColumnFormatRelation.columnBatchTableName("APP.TESTTABLE") +
+        s" -- GEMFIREXD-PROPERTIES executionEngine=Store\n")
     val rs2 = s.getResultSet
     while (rs2.next) {
       cnt2 = cnt2 + 1
@@ -525,9 +528,10 @@ object ValidateMVCCDUnitTest {
     assert(cnt3 == 10, s"Expected row count is 10 while actual row count is $cnt3")
 
 
-    var cnt4 = 0;
-    s.execute(s"select * from SNAPPYSYS_INTERNAL.APP__TESTTABLE_COLUMN_STORE_ -- " +
-        s"GEMFIREXD-PROPERTIES executionEngine=Store\n")
+    var cnt4 = 0
+    s.execute(s"select * from " +
+        ColumnFormatRelation.columnBatchTableName("APP.TESTTABLE") +
+        s" -- GEMFIREXD-PROPERTIES executionEngine=Store\n")
     val rs4 = s.getResultSet
     while (rs4.next) {
       cnt4 = cnt4 + 1

--- a/core/src/main/scala/io/snappydata/Literals.scala
+++ b/core/src/main/scala/io/snappydata/Literals.scala
@@ -83,6 +83,8 @@ object Constant {
   // Internal Column table store suffix
   final val SHADOW_TABLE_SUFFIX = StoreCallbacks.SHADOW_TABLE_SUFFIX
 
+  final val SHADOW_SCHEMA_SEPARATOR = StoreCallbacks.SHADOW_SCHEMA_SEPARATOR
+
   // Property to Specify whether zeppelin interpreter should be started
   // with leadnode
   val ENABLE_ZEPPELIN_INTERPRETER = "zeppelin.interpreter.enable"

--- a/core/src/main/scala/org/apache/spark/sql/execution/columnar/impl/ColumnFormatRelation.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/columnar/impl/ColumnFormatRelation.scala
@@ -675,16 +675,17 @@ object ColumnFormatRelation extends Logging with StoreCallback {
 
   final def columnBatchTableName(table: String): String = {
     val tableName = if (table.indexOf('.') > 0) {
-      table.replace(".", "__")
+      table.replace(".", "____")
     } else {
-      Constant.DEFAULT_SCHEMA + "__" + table
+      Constant.DEFAULT_SCHEMA + "____" + table
     }
     Constant.SHADOW_SCHEMA_NAME + "." + tableName + Constant.SHADOW_TABLE_SUFFIX
   }
 
   final def getTableName(columnBatchTableName: String): String = {
     columnBatchTableName.substring(Constant.SHADOW_SCHEMA_NAME.length + 1,
-      columnBatchTableName.indexOf(Constant.SHADOW_TABLE_SUFFIX)).replace("__", ".")
+      columnBatchTableName.indexOf(Constant.SHADOW_TABLE_SUFFIX)).
+        replaceFirst("____", ".")
   }
 
   final def isColumnTable(tableName: String): Boolean = {

--- a/core/src/main/scala/org/apache/spark/sql/execution/columnar/impl/ColumnFormatRelation.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/columnar/impl/ColumnFormatRelation.scala
@@ -675,9 +675,9 @@ object ColumnFormatRelation extends Logging with StoreCallback {
 
   final def columnBatchTableName(table: String): String = {
     val tableName = if (table.indexOf('.') > 0) {
-      table.replace(".", "____")
+      table.replace(".", Constant.SHADOW_SCHEMA_SEPARATOR)
     } else {
-      Constant.DEFAULT_SCHEMA + "____" + table
+      Constant.DEFAULT_SCHEMA + Constant.SHADOW_SCHEMA_SEPARATOR + table
     }
     Constant.SHADOW_SCHEMA_NAME + "." + tableName + Constant.SHADOW_TABLE_SUFFIX
   }
@@ -685,7 +685,7 @@ object ColumnFormatRelation extends Logging with StoreCallback {
   final def getTableName(columnBatchTableName: String): String = {
     columnBatchTableName.substring(Constant.SHADOW_SCHEMA_NAME.length + 1,
       columnBatchTableName.indexOf(Constant.SHADOW_TABLE_SUFFIX)).
-        replaceFirst("____", ".")
+        replaceFirst(Constant.SHADOW_SCHEMA_SEPARATOR, ".")
   }
 
   final def isColumnTable(tableName: String): Boolean = {


### PR DESCRIPTION
The issue is that ColumnFormatRelation#getTableName replaces all "__"  (2 consecutive _ chars) with '.' to derive row buffer table name from column table name. If the user tablename itself has 2 consecutive _ chars, then table name  returned is incorrect. This caused the stats generation code to fail with following stack trace at startup as table container was not found

```
17/06/05 08:22:41.370 PDT serverConnector<tid=0x1a> WARN snappystore: got throwable: None.get calling shut down
java.util.NoSuchElementException: None.get
at scala.None$.get(Option.scala:347)
at scala.None$.get(Option.scala:345)
at org.apache.spark.sql.execution.columnar.impl.ColumnFormatKey.getNumColumnsInTable(ColumnFormatEntry.scala:114)
at io.snappydata.SnappyEmbeddedTableStatsProviderService$$anonfun$publishColumnTableRowCountStats$2.apply(SnappyTableStatsProviderService.scala:207)
at io.snappydata.SnappyEmbeddedTableStatsProviderService$$anonfun$publishColumnTableRowCountStats$2.apply(SnappyTableStatsProviderService.scala:187)
at scala.collection.TraversableLike$WithFilter$$anonfun$foreach$1.apply(TraversableLike.scala:733)
at scala.collection.Iterator$class.foreach(Iterator.scala:893)
at scala.collection.AbstractIterator.foreach(Iterator.scala:1336)
at scala.collection.IterableLike$class.foreach(IterableLike.scala:72)
at scala.collection.AbstractIterable.foreach(Iterable.scala:54)
at scala.collection.TraversableLike$WithFilter.foreach(TraversableLike.scala:732)
at io.snappydata.SnappyEmbeddedTableStatsProviderService$.publishColumnTableRowCountStats(SnappyTableStatsProviderService.scala:187)
at io.snappydata.gemxd.ClusterCallbacksImpl$.publishColumnTableStats(ClusterCallbacksImpl.scala:119)
at com.pivotal.gemfirexd.internal.engine.db.FabricDatabase.postCreate(FabricDatabase.java:555)
```

As a fix using 4 consecutive '_' chars in internal column table and also using replaceFirst instead of replace in it. This reduces the possibility due to such a failure. Let me know if there exists a better way to handle this. 

## Patch testing
Running precheckin. 
Checked manually by creating a table with '__' chars.

## ReleaseNotes.txt changes
## Other PRs 
