### PR TITLE
Snap 1698

### DIFF
--- a/cluster/src/main/scala/org/apache/spark/ui/SnappyDashboardPage.scala
+++ b/cluster/src/main/scala/org/apache/spark/ui/SnappyDashboardPage.scala
@@ -685,7 +685,9 @@ private[ui] class SnappyDashboardPage (parent: SnappyDashboardTab)
         <br/><strong>Process ID:</strong> {processId}
       </span>
     }
-    val memberDescDetailsHandler = "$('#" + shortDirName + "').toggle();";
+
+    val memberDescDetailsBtn = shortDirName + "-btn";
+    val memberDescDetailsHandler = "toggleCellDetails('" + shortDirName + "');";
 
     val memberType = {
       if(memberDetails.getOrElse("lead", false).toString.toBoolean){
@@ -726,7 +728,8 @@ private[ui] class SnappyDashboardPage (parent: SnappyDashboardTab)
     }
 
     val heapDetailsId = shortDirName + "-heap"
-    val heapDetailsHandler = "$('#" + heapDetailsId + "').toggle();";
+    val heapDetailsBtn = heapDetailsId + "-btn"
+    val heapDetailsHandler = "toggleCellDetails('" + heapDetailsId + "');";
     val heapUsageDetails = {
       if(memberType.toString.equalsIgnoreCase("LOCATOR")) {
         <span><strong>JVM Heap:</strong>
@@ -752,7 +755,8 @@ private[ui] class SnappyDashboardPage (parent: SnappyDashboardTab)
     }
 
     val offHeapDetailsId = shortDirName + "-offheap"
-    val offHeapDetailsHandler = "$('#" + offHeapDetailsId + "').toggle();";
+    val offHeapDetailsBtn = offHeapDetailsId + "-btn"
+    val offHeapDetailsHandler = "toggleCellDetails('" + offHeapDetailsId + "');";
     val offHeapUsageDetails = {
       if(memberType.toString.equalsIgnoreCase("LOCATOR")) {
         <span><strong>Storage Memory:</strong>
@@ -782,7 +786,9 @@ private[ui] class SnappyDashboardPage (parent: SnappyDashboardTab)
       <td>
         <div style="width: 80%; float: left; padding-left: 10px;">{memberDescription}</div>
         <div style="width: 10px; float: right; padding-right: 10px; cursor: pointer;"
-             onclick={memberDescDetailsHandler}> + </div>
+             onclick={memberDescDetailsHandler}>
+          <span class="caret-downward" id={memberDescDetailsBtn}></span>
+        </div>
         <div class="cellDetailsBox" id={shortDirName}>
           {memberDescriptionDetails}
         </div>
@@ -806,7 +812,9 @@ private[ui] class SnappyDashboardPage (parent: SnappyDashboardTab)
             }
           }</div>
         <div style="width: 5px; float: right; padding-right: 10px; cursor: pointer;"
-             onclick={heapDetailsHandler}> + </div>
+             onclick={heapDetailsHandler}>
+          <span class="caret-downward" id={heapDetailsBtn}></span>
+        </div>
         <div class="cellDetailsBox" id={heapDetailsId}
              style="width: 90%;">
           {heapUsageDetails}
@@ -822,7 +830,9 @@ private[ui] class SnappyDashboardPage (parent: SnappyDashboardTab)
             }
           }</div>
         <div style="width: 5px; float: right; padding-right: 10px; cursor: pointer;"
-             onclick={offHeapDetailsHandler}> + </div>
+             onclick={offHeapDetailsHandler}>
+          <span class="caret-downward" id={offHeapDetailsBtn}></span>
+        </div>
         <div class="cellDetailsBox" id={offHeapDetailsId}
              style="width: 90%;">
           {offHeapUsageDetails}

--- a/cluster/src/main/scala/org/apache/spark/ui/SnappyDashboardPage.scala
+++ b/cluster/src/main/scala/org/apache/spark/ui/SnappyDashboardPage.scala
@@ -720,16 +720,27 @@ private[ui] class SnappyDashboardPage (parent: SnappyDashboardTab)
     }
 
     val heapUsageDetails = {
-      <span><strong>JVM Heap:</strong>
-        <br/> { Utils.bytesToString(jvmHeapUsed).toString + " / " +
-          Utils.bytesToString(jvmHeapSize).toString }
-        <br/><strong>Storage Memory:</strong>
-        <br/> { Utils.bytesToString(storagePoolUsed).toString + " / " +
-          Utils.bytesToString(storagePoolSize).toString }
-        <br/><strong>Execution Memory:</strong>
-        <br/> { Utils.bytesToString(executionPoolUsed).toString + " / " +
-          Utils.bytesToString(executionPoolSize).toString }
-      </span>
+      if(memberType.toString.equalsIgnoreCase("LOCATOR")) {
+        <span><strong>JVM Heap:</strong>
+          <br/> { Utils.bytesToString(jvmHeapUsed).toString + " / " +
+            Utils.bytesToString(jvmHeapSize).toString }
+          <br/><strong>Storage Memory:</strong>
+          <br/> { SnappyDashboardPage.ValueNotApplicable }
+          <br/><strong>Execution Memory:</strong>
+          <br/> { SnappyDashboardPage.ValueNotApplicable }
+        </span>
+      } else {
+        <span><strong>JVM Heap:</strong>
+          <br/> { Utils.bytesToString(jvmHeapUsed).toString + " / " +
+            Utils.bytesToString(jvmHeapSize).toString }
+          <br/><strong>Storage Memory:</strong>
+          <br/> { Utils.bytesToString(storagePoolUsed).toString + " / " +
+            Utils.bytesToString(storagePoolSize).toString }
+          <br/><strong>Execution Memory:</strong>
+          <br/> { Utils.bytesToString(executionPoolUsed).toString + " / " +
+            Utils.bytesToString(executionPoolSize).toString }
+        </span>
+      }
     }
     val heapDetailsId = shortDirName + "-heap"
     val heapDetailsHandler = "$('#" + heapDetailsId + "').toggle();";
@@ -761,8 +772,12 @@ private[ui] class SnappyDashboardPage (parent: SnappyDashboardTab)
       </td>
       <td>
         <div style="width: 80%; float: left; padding-right:10px; text-align:right;">{
-            Utils.bytesToString(heapMemoryUsed).toString + " / " +
-                Utils.bytesToString(heapMemorySize).toString
+            if(memberType.toString.equalsIgnoreCase("LOCATOR")) {
+              SnappyDashboardPage.ValueNotApplicable
+            } else {
+              Utils.bytesToString(heapMemoryUsed).toString + " / " +
+                  Utils.bytesToString(heapMemorySize).toString
+            }
           }</div>
         <div style="width: 5px; float: right; padding-right: 10px; cursor: pointer;"
              onclick={heapDetailsHandler}> + </div>
@@ -773,8 +788,12 @@ private[ui] class SnappyDashboardPage (parent: SnappyDashboardTab)
       </td>
       <td>
         <div style="text-align:right; padding-right:15px;">{
-            Utils.bytesToString(offHeapMemoryUsed).toString + " / " +
-                Utils.bytesToString(offHeapMemorySize).toString
+            if(memberType.toString.equalsIgnoreCase("LOCATOR")) {
+              SnappyDashboardPage.ValueNotApplicable
+            } else {
+              Utils.bytesToString(offHeapMemoryUsed).toString + " / " +
+                  Utils.bytesToString(offHeapMemorySize).toString
+            }
           }</div>
       </td>
     </tr>
@@ -905,6 +924,8 @@ object SnappyDashboardPage{
     val error = "Error"
     val severe = "Severe"
   }
+
+  val ValueNotApplicable = "N/A"
 
   val clusterStatsTitle = "Cluster"
   val clusterStatsTitleTooltip = "SnappyData Clusters Summary"

--- a/cluster/src/main/scala/org/apache/spark/ui/SnappyDashboardPage.scala
+++ b/cluster/src/main/scala/org/apache/spark/ui/SnappyDashboardPage.scala
@@ -702,10 +702,16 @@ private[ui] class SnappyDashboardPage (parent: SnappyDashboardTab)
       }
     }
 
-    val storagePoolUsed = memberDetails.getOrElse("storagePoolUsed", 0).asInstanceOf[Long]
-    val storagePoolSize = memberDetails.getOrElse("storagePoolSize", 0).asInstanceOf[Long]
-    val executionPoolSize = memberDetails.getOrElse("executionPoolSize", 0).asInstanceOf[Long]
-    val executionPoolUsed = memberDetails.getOrElse("executionPoolUsed", 0).asInstanceOf[Long]
+    val heapStoragePoolUsed = memberDetails.getOrElse("heapStoragePoolUsed", 0).asInstanceOf[Long]
+    val heapStoragePoolSize = memberDetails.getOrElse("heapStoragePoolSize", 0).asInstanceOf[Long]
+    val heapExecutionPoolUsed = memberDetails.getOrElse("heapExecutionPoolUsed", 0).asInstanceOf[Long]
+    val heapExecutionPoolSize = memberDetails.getOrElse("heapExecutionPoolSize", 0).asInstanceOf[Long]
+
+    val offHeapStoragePoolUsed = memberDetails.getOrElse("offHeapStoragePoolUsed", 0).asInstanceOf[Long]
+    val offHeapStoragePoolSize = memberDetails.getOrElse("offHeapStoragePoolSize", 0).asInstanceOf[Long]
+    val offHeapExecutionPoolUsed = memberDetails.getOrElse("offHeapExecutionPoolUsed", 0).asInstanceOf[Long]
+    val offHeapExecutionPoolSize = memberDetails.getOrElse("offHeapExecutionPoolSize", 0).asInstanceOf[Long]
+
     val heapMemorySize = memberDetails.getOrElse("heapMemorySize", 0).asInstanceOf[Long]
     val heapMemoryUsed = memberDetails.getOrElse("heapMemoryUsed", 0).asInstanceOf[Long]
     val offHeapMemorySize = memberDetails.getOrElse("offHeapMemorySize", 0).asInstanceOf[Long]
@@ -719,6 +725,8 @@ private[ui] class SnappyDashboardPage (parent: SnappyDashboardTab)
           (heapMemorySize + offHeapMemorySize)
     }
 
+    val heapDetailsId = shortDirName + "-heap"
+    val heapDetailsHandler = "$('#" + heapDetailsId + "').toggle();";
     val heapUsageDetails = {
       if(memberType.toString.equalsIgnoreCase("LOCATOR")) {
         <span><strong>JVM Heap:</strong>
@@ -734,16 +742,34 @@ private[ui] class SnappyDashboardPage (parent: SnappyDashboardTab)
           <br/> { Utils.bytesToString(jvmHeapUsed).toString + " / " +
             Utils.bytesToString(jvmHeapSize).toString }
           <br/><strong>Storage Memory:</strong>
-          <br/> { Utils.bytesToString(storagePoolUsed).toString + " / " +
-            Utils.bytesToString(storagePoolSize).toString }
+          <br/> { Utils.bytesToString(heapStoragePoolUsed).toString + " / " +
+            Utils.bytesToString(heapStoragePoolSize).toString }
           <br/><strong>Execution Memory:</strong>
-          <br/> { Utils.bytesToString(executionPoolUsed).toString + " / " +
-            Utils.bytesToString(executionPoolSize).toString }
+          <br/> { Utils.bytesToString(heapExecutionPoolUsed).toString + " / " +
+            Utils.bytesToString(heapExecutionPoolSize).toString }
         </span>
       }
     }
-    val heapDetailsId = shortDirName + "-heap"
-    val heapDetailsHandler = "$('#" + heapDetailsId + "').toggle();";
+
+    val offHeapDetailsId = shortDirName + "-offheap"
+    val offHeapDetailsHandler = "$('#" + offHeapDetailsId + "').toggle();";
+    val offHeapUsageDetails = {
+      if(memberType.toString.equalsIgnoreCase("LOCATOR")) {
+        <span><strong>Storage Memory:</strong>
+          <br/> { SnappyDashboardPage.ValueNotApplicable }
+          <br/><strong>Execution Memory:</strong>
+          <br/> { SnappyDashboardPage.ValueNotApplicable }
+        </span>
+      } else {
+        <span><strong>Storage Memory:</strong>
+          <br/> { Utils.bytesToString(offHeapStoragePoolUsed).toString + " / " +
+            Utils.bytesToString(offHeapStoragePoolSize).toString }
+          <br/><strong>Execution Memory:</strong>
+          <br/> { Utils.bytesToString(offHeapExecutionPoolUsed).toString + " / " +
+            Utils.bytesToString(offHeapExecutionPoolSize).toString }
+        </span>
+      }
+    }
 
     <tr>
       <td>
@@ -787,7 +813,7 @@ private[ui] class SnappyDashboardPage (parent: SnappyDashboardTab)
         </div>
       </td>
       <td>
-        <div style="text-align:right; padding-right:15px;">{
+        <div style="width: 80%; float: left; padding-right:10px; text-align:right;">{
             if(memberType.toString.equalsIgnoreCase("LOCATOR")) {
               SnappyDashboardPage.ValueNotApplicable
             } else {
@@ -795,6 +821,12 @@ private[ui] class SnappyDashboardPage (parent: SnappyDashboardTab)
                   Utils.bytesToString(offHeapMemorySize).toString
             }
           }</div>
+        <div style="width: 5px; float: right; padding-right: 10px; cursor: pointer;"
+             onclick={offHeapDetailsHandler}> + </div>
+        <div class="cellDetailsBox" id={offHeapDetailsId}
+             style="width: 90%;">
+          {offHeapUsageDetails}
+        </div>
       </td>
     </tr>
   }

--- a/cluster/src/main/scala/org/apache/spark/ui/SnappyDashboardPage.scala
+++ b/cluster/src/main/scala/org/apache/spark/ui/SnappyDashboardPage.scala
@@ -77,7 +77,8 @@ private[ui] class SnappyDashboardPage (parent: SnappyDashboardTab)
     // Generate Pages HTML
     val pageTitleNode = createPageTitleNode(pageHeaderText)
 
-    val clustersStatsTitle = createTitleNode(SnappyDashboardPage.clusterStatsTitle, SnappyDashboardPage.clusterStatsTitleTooltip)
+    val clustersStatsTitle = createTitleNode(SnappyDashboardPage.clusterStatsTitle,
+                                SnappyDashboardPage.clusterStatsTitleTooltip)
 
     val clusterDetails = clusterStats(clusterStatsMap)
 
@@ -85,18 +86,28 @@ private[ui] class SnappyDashboardPage (parent: SnappyDashboardTab)
 
     val membersStatsDetails = {
       val countsList:Array[mutable.Map[String, Any]] = new Array(3)
-      countsList(0) = mutable.Map("value" -> clusterStatsMap.getOrElse("numLocators",0).toString.toInt, "displayText" -> "Locators")
-      countsList(1) = mutable.Map("value" -> clusterStatsMap.getOrElse("numLeads",0).toString.toInt, "displayText" -> "Leads")
-      countsList(2) = mutable.Map("value" -> clusterStatsMap.getOrElse("numDataServers",0).toString.toInt, "displayText" -> "Data Servers")
+      countsList(0) = mutable.Map(
+                           "value" -> clusterStatsMap.getOrElse("numLocators",0).toString.toInt,
+                           "displayText" -> "Locators")
+      countsList(1) = mutable.Map(
+                           "value" -> clusterStatsMap.getOrElse("numLeads",0).toString.toInt,
+                           "displayText" -> "Leads")
+      countsList(2) = mutable.Map(
+                           "value" -> clusterStatsMap.getOrElse("numDataServers",0).toString.toInt,
+                           "displayText" -> "Data Servers")
 
-      val membersStatsTitle = createTitleNode(SnappyDashboardPage.membersStatsTitle, SnappyDashboardPage.membersStatsTitleTooltip, countsList)
+      val membersStatsTitle = createTitleNode(SnappyDashboardPage.membersStatsTitle,
+                                SnappyDashboardPage.membersStatsTitleTooltip,
+                                countsList)
       val membersStatsTable = memberStats(clusterMembers)
 
       membersStatsTitle ++ membersStatsTable
     }
 
     val sparkConnectorsStatsDetails = {
-      val sparkConnectorsStatsTitle = createTitleNode(SnappyDashboardPage.sparkConnectorsStatsTitle, SnappyDashboardPage.sparkConnectorsStatsTitleTooltip, sparkConnectors.size)
+      val sparkConnectorsStatsTitle = createTitleNode(SnappyDashboardPage.sparkConnectorsStatsTitle,
+                                SnappyDashboardPage.sparkConnectorsStatsTitleTooltip,
+                                sparkConnectors.size)
       val sparkConnectorsStatsTable = connectorStats(sparkConnectors)
 
       if(sparkConnectors.size > 0)
@@ -107,17 +118,25 @@ private[ui] class SnappyDashboardPage (parent: SnappyDashboardTab)
 
     val tablesStatsDetails = {
       val countsList:Array[mutable.Map[String, Any]] = new Array(2)
-      countsList(0) = mutable.Map("value" -> clusterStatsMap.getOrElse("numColumnTables",0).toString.toInt, "displayText" -> "Column Tables")
-      countsList(1) = mutable.Map("value" -> clusterStatsMap.getOrElse("numRowTables",0).toString.toInt, "displayText" -> "Row Tables")
+      countsList(0) = mutable.Map(
+                           "value" -> clusterStatsMap.getOrElse("numColumnTables",0).toString.toInt,
+                           "displayText" -> "Column Tables")
+      countsList(1) = mutable.Map(
+                           "value" -> clusterStatsMap.getOrElse("numRowTables",0).toString.toInt,
+                           "displayText" -> "Row Tables")
 
-      val tablesStatsTitle = createTitleNode(SnappyDashboardPage.tablesStatsTitle, SnappyDashboardPage.tablesStatsTitleTooltip, countsList)
+      val tablesStatsTitle = createTitleNode(SnappyDashboardPage.tablesStatsTitle,
+                                SnappyDashboardPage.tablesStatsTitleTooltip,
+                                countsList)
       val tablesStatsTable = tableStats(tableBuff)
 
       tablesStatsTitle ++ tablesStatsTable
     }
 
     val indexStatsDetails = {
-      val indexStatsTitle = createTitleNode(SnappyDashboardPage.indexStatsTitle, SnappyDashboardPage.indexStatsTitleTooltip, indexBuff.size)
+      val indexStatsTitle = createTitleNode(SnappyDashboardPage.indexStatsTitle,
+                               SnappyDashboardPage.indexStatsTitleTooltip,
+                               indexBuff.size)
       val indexStatsTable = indexStats(indexBuff)
 
       if(indexBuff.size > 0)
@@ -126,7 +145,8 @@ private[ui] class SnappyDashboardPage (parent: SnappyDashboardTab)
         mutable.Seq.empty[Node]
     }
 
-    val pageContent = pageTitleNode ++ keyStatsSection ++ membersStatsDetails ++ sparkConnectorsStatsDetails ++ tablesStatsDetails ++ indexStatsDetails
+    val pageContent = pageTitleNode ++ keyStatsSection ++ membersStatsDetails ++
+                      sparkConnectorsStatsDetails ++ tablesStatsDetails ++ indexStatsDetails
 
     UIUtils.simpleSparkPageWithTabs_2(pageHeaderText, pageContent, parent, Some(500))
 
@@ -147,16 +167,24 @@ private[ui] class SnappyDashboardPage (parent: SnappyDashboardTab)
     var numClientsToDataServers = 0
     var numColumnTables = 0
     var numRowTables = 0
-    var avgMemoryUsage:Long = 0;
-    var avgHeapUsage:Long = 0;
-    var avgOffHeapUsage:Long = 0;
-    var avgJvmHeapUsage:Long = 0;
+    var cpuUsage:Double = 0
+    var memoryUsage:Double = 0;
+    var heapUsage:Double = 0;
+    var offHeapUsage:Double = 0;
+    var jvmHeapUsage:Double = 0;
 
-    // Todo : remove hard coding
+    var totalCPUSize:Int = 0;
+    var totalCPUUsage:Int = 0;
+    var totalMemorySize:Long = 0;
     var totalMemoryUsage:Long = 0;
+    var totalHeapSize:Long = 0;
     var totalHeapUsage:Long = 0;
+    var totalOffHeapSize:Long = 0;
     var totalOffHeapUsage:Long = 0;
+    var totalJvmHeapSize:Long = 0;
     var totalJvmHeapUsage:Long = 0;
+
+    val hostsList:mutable.Set[String] = mutable.Set.empty[String]
 
     membersBuf.foreach(mb => {
       val m = mb._2
@@ -181,30 +209,39 @@ private[ui] class SnappyDashboardPage (parent: SnappyDashboardTab)
 
       numClients += m("clients").toString.toInt
 
-      if(m("heapMemorySize").asInstanceOf[Long] > 0){
-        totalHeapUsage = totalHeapUsage +
-            (m("heapMemoryUsed").asInstanceOf[Long] * 100 / m("heapMemorySize").asInstanceOf[Long])
-      }
+      totalHeapSize = totalHeapSize + m("heapMemorySize").asInstanceOf[Long]
+      totalHeapUsage = totalHeapUsage + m("heapMemoryUsed").asInstanceOf[Long]
 
-      if(m("offHeapMemorySize").asInstanceOf[Long] > 0){
-        totalOffHeapUsage = totalOffHeapUsage +
-            (m("offHeapMemoryUsed").asInstanceOf[Long] * 100 / m("offHeapMemorySize").asInstanceOf[Long])
-      }
+      totalOffHeapSize = totalOffHeapSize + m("offHeapMemorySize").asInstanceOf[Long]
+      totalOffHeapUsage = totalOffHeapUsage + m("offHeapMemoryUsed").asInstanceOf[Long]
 
-      if(m("totalMemory").asInstanceOf[Long] > 0){
-        totalJvmHeapUsage = totalJvmHeapUsage +
-            (m("usedMemory").asInstanceOf[Long] * 100 / m("totalMemory").asInstanceOf[Long])
+      totalJvmHeapSize = totalJvmHeapSize + m("totalMemory").asInstanceOf[Long]
+      totalJvmHeapUsage = totalJvmHeapUsage + m("usedMemory").asInstanceOf[Long]
+
+      // CPU
+      if(!hostsList.contains(m("host").toString)
+          && !m("locator").toString.toBoolean ){
+        hostsList.add(m("host").toString)
+        totalCPUUsage = totalCPUUsage + m("cpuActive").asInstanceOf[Int]
+        totalCPUSize += 1
       }
 
     })
 
     if(membersBuf.size > 0){
+      totalMemorySize = totalHeapSize + totalOffHeapSize
       totalMemoryUsage = totalHeapUsage + totalOffHeapUsage
 
-      avgMemoryUsage = totalMemoryUsage / numMembers
-      avgHeapUsage = totalHeapUsage / numMembers
-      avgOffHeapUsage = totalOffHeapUsage / numMembers
-      avgJvmHeapUsage = totalJvmHeapUsage / numMembers
+      if(totalMemorySize > 0)
+        memoryUsage = totalMemoryUsage * 100 / totalMemorySize
+      if(totalHeapSize > 0)
+        heapUsage = totalHeapUsage * 100 / totalHeapSize
+      if(totalOffHeapSize > 0)
+        offHeapUsage = totalOffHeapUsage * 100 / totalOffHeapSize
+      if(totalJvmHeapSize > 0)
+        jvmHeapUsage = totalJvmHeapUsage * 100 / totalJvmHeapSize
+
+      cpuUsage = totalCPUUsage / totalCPUSize
     }
 
     numClientsToDataServers = numClients - numClientsToLocator
@@ -229,10 +266,15 @@ private[ui] class SnappyDashboardPage (parent: SnappyDashboardTab)
     clusterStatsMap += ("numClientsToDataServers" -> numClientsToDataServers)
     clusterStatsMap += ("numColumnTables" -> numColumnTables)
     clusterStatsMap += ("numRowTables" -> numRowTables)
-    clusterStatsMap += ("avgMemoryUsage" -> avgMemoryUsage)
-    clusterStatsMap += ("avgHeapUsage" -> avgHeapUsage)
-    clusterStatsMap += ("avgOffHeapUsage" -> avgOffHeapUsage)
-    clusterStatsMap += ("avgJvmHeapUsage" -> avgJvmHeapUsage)
+    clusterStatsMap += ("cpuUsage" -> cpuUsage)
+    clusterStatsMap += ("memoryUsage" -> memoryUsage)
+    clusterStatsMap += ("totalMemoryUsage" -> totalMemoryUsage)
+    clusterStatsMap += ("heapUsage" -> heapUsage)
+    clusterStatsMap += ("totalHeapUsage" -> totalHeapUsage)
+    clusterStatsMap += ("offHeapUsage" -> offHeapUsage)
+    clusterStatsMap += ("totalOffHeapUsage" -> totalOffHeapUsage)
+    clusterStatsMap += ("jvmHeapUsage" -> jvmHeapUsage)
+    clusterStatsMap += ("totalJvmHeapUsage" -> totalJvmHeapUsage)
 
   }
 
@@ -247,7 +289,9 @@ private[ui] class SnappyDashboardPage (parent: SnappyDashboardTab)
           {title}
         </h3>
         <span style="float:right; font-size: 12px;" data-toggle="tooltip" title=""
-              data-original-title="Reload page to refresh Dashboard." >Last updated on {lastUpdatedOn}</span>
+              data-original-title="Reload page to refresh Dashboard." >Last updated on {
+            lastUpdatedOn
+          }</span>
       </div>
     </div>
   }
@@ -263,28 +307,32 @@ private[ui] class SnappyDashboardPage (parent: SnappyDashboardTab)
     </div>
   }
 
-  private def createTitleNode(title:String, tooltip:String, count:Integer): Seq[Node] = {
+  private def createTitleNode(title:String, tooltip:String,
+      count:Integer): Seq[Node] = {
     <div class="row-fluid">
       <div class="span12">
         <h4 style="vertical-align: bottom; display: inline-block;"
             data-toggle="tooltip" data-placement="top" title={tooltip}>
           {title}
         </h4>
-        <div style="font-weight: bold; display: inline-block; line-height: 20px; margin: 10px 0; font-size: 17.5px;">( {count} )</div>
+        <div class="titleNodeCount" >( {count} )</div>
       </div>
     </div>
   }
 
-  private def createTitleNode(title:String, tooltip:String, countList:Array[mutable.Map[String, Any]]): Seq[Node] = {
+  private def createTitleNode(title:String, tooltip:String,
+      countList:Array[mutable.Map[String, Any]]): Seq[Node] = {
     var total = 0;
     var tooltipDetails = "";
     for(i <- 0 until countList.length){
       val ele = countList(i)
       total = total + ele.getOrElse("value", 0).toString.toInt
       if(tooltipDetails.isEmpty)
-        tooltipDetails += ele.getOrElse("displayText", 0).toString + ": " + ele.getOrElse("value", 0).toString.toInt
+        tooltipDetails += ele.getOrElse("displayText", 0).toString + ": " +
+            ele.getOrElse("value", 0).toString.toInt
       else
-        tooltipDetails += " | " + ele.getOrElse("displayText", 0).toString + ": " + ele.getOrElse("value", 0).toString.toInt
+        tooltipDetails += " | " + ele.getOrElse("displayText", 0).toString + ": " +
+            ele.getOrElse("value", 0).toString.toInt
     }
 
     <div class="row-fluid">
@@ -293,7 +341,7 @@ private[ui] class SnappyDashboardPage (parent: SnappyDashboardTab)
             data-toggle="tooltip" data-placement="top" title={tooltip}>
           {title}
         </h4>
-        <div style="font-weight: bold; display: inline-block; line-height: 20px; margin: 10px 0; font-size: 17.5px;">({
+        <div class="titleNodeCount2">({
           <a data-toggle="tooltip" data-placement="top" title={tooltipDetails}>{total}</a>
           })</div>
       </div>
@@ -310,51 +358,52 @@ private[ui] class SnappyDashboardPage (parent: SnappyDashboardTab)
       "/static/snappydata/warning-status-icon-70x68.png"
     }
 
-    val avgMemoryUsage = clusterDetails.getOrElse("avgMemoryUsage", 0.0).asInstanceOf[Long];
-    val avgHeapUsage = clusterDetails.getOrElse("avgHeapUsage", 0.0).asInstanceOf[Long];
-    val avgOffHeapUsage = clusterDetails.getOrElse("avgOffHeapUsage", 0.0).asInstanceOf[Long];
-    val avgJvmHeapUsage = clusterDetails.getOrElse("avgJvmHeapUsage", 0.0).asInstanceOf[Long];
+    val cpuUsage = clusterDetails.getOrElse("cpuUsage", 0.0).asInstanceOf[Double];
+    val memoryUsage = clusterDetails.getOrElse("memoryUsage", 0.0).asInstanceOf[Double];
+    // val heapUsage = clusterDetails.getOrElse("heapUsage", 0.0).asInstanceOf[Double];
+    // val offHeapUsage = clusterDetails.getOrElse("offHeapUsage", 0.0).asInstanceOf[Double];
+    val jvmHeapUsage = clusterDetails.getOrElse("jvmHeapUsage", 0.0).asInstanceOf[Double];
 
     <div class="row-fluid">
       <div class="keyStates">
         <div class="keyStatsValue"
              style="width:50%; margin: auto;" data-toggle="tooltip" title=""
-             data-original-title={SnappyDashboardPage.clusterStats("status").toString + ": " + status.toString} >
+             data-original-title={
+               SnappyDashboardPage.clusterStats("status").toString + ": " + status.toString
+             } >
           <img style="padding-top: 15px;" src={statusImgUri} />
         </div>
         <div class="keyStatesText">{SnappyDashboardPage.clusterStats("status")}</div>
       </div>
       <div class="keyStates">
-        <div class="keyStatsValue" id="avgMemoryUsage" data-value={avgMemoryUsage.toString}
+        <div class="keyStatsValue" id="cpuUsage" data-value={cpuUsage.toString}
              data-toggle="tooltip" title=""
-             data-original-title={SnappyDashboardPage.clusterStats("avgMemoryUsageTooltip").toString}>
+             data-original-title={
+               SnappyDashboardPage.clusterStats("cpuUsageTooltip").toString
+             }>
+          <svg id="cpuUsageGauge" width="100%" height="100%" ></svg>
+        </div>
+        <div class="keyStatesText">{SnappyDashboardPage.clusterStats("cpuUsage")}</div>
+      </div>
+      <div class="keyStates">
+        <div class="keyStatsValue" id="memoryUsage" data-value={memoryUsage.toString}
+             data-toggle="tooltip" title=""
+             data-original-title={
+             SnappyDashboardPage.clusterStats("memoryUsageTooltip").toString
+             }>
           <svg id="memoryUsageGauge" width="100%" height="100%" ></svg>
         </div>
-        <div class="keyStatesText">{SnappyDashboardPage.clusterStats("avgMemoryUsage")}</div>
+        <div class="keyStatesText">{SnappyDashboardPage.clusterStats("memoryUsage")}</div>
       </div>
       <div class="keyStates">
-        <div class="keyStatsValue" id="avgHeapUsage" data-value={avgHeapUsage.toString}
+        <div class="keyStatsValue" id="jvmHeapUsage" data-value={jvmHeapUsage.toString}
              data-toggle="tooltip" title=""
-             data-original-title={SnappyDashboardPage.clusterStats("avgHeapUsageTooltip").toString}>
-          <svg id="heapUsageGauge" width="100%" height="100%" ></svg>
-        </div>
-        <div class="keyStatesText">{SnappyDashboardPage.clusterStats("avgHeapUsage")}</div>
-      </div>
-      <div class="keyStates">
-        <div class="keyStatsValue" id="avgOffHeapUsage" data-value={avgOffHeapUsage.toString}
-             data-toggle="tooltip" title=""
-             data-original-title={SnappyDashboardPage.clusterStats("avgOffHeapUsageTooltip").toString}>
-          <svg id="offHeapUsageGauge" width="100%" height="100%" ></svg>
-        </div>
-        <div class="keyStatesText">{SnappyDashboardPage.clusterStats("avgOffHeapUsage")}</div>
-      </div>
-      <div class="keyStates">
-        <div class="keyStatsValue" id="avgJvmHeapUsage" data-value={avgJvmHeapUsage.toString}
-             data-toggle="tooltip" title=""
-             data-original-title={SnappyDashboardPage.clusterStats("avgJvmHeapUsageTooltip").toString}>
+             data-original-title={
+               SnappyDashboardPage.clusterStats("jvmHeapUsageTooltip").toString
+             }>
           <svg id="jvmHeapUsageGauge" width="100%" height="100%" ></svg>
         </div>
-        <div class="keyStatesText">{SnappyDashboardPage.clusterStats("avgJvmHeapUsage")}</div>
+        <div class="keyStatesText">{SnappyDashboardPage.clusterStats("jvmHeapUsage")}</div>
       </div>
     </div>
   }
@@ -366,67 +415,67 @@ private[ui] class SnappyDashboardPage (parent: SnappyDashboardTab)
           <tr>
             <th style="text-align:center; width: 150px; vertical-align: middle;">
               <span data-toggle="tooltip" title=""
-                    data-original-title={SnappyDashboardPage.memberStatsColumn("statusTooltip")}
+                    data-original-title={
+                      SnappyDashboardPage.memberStatsColumn("statusTooltip")
+                    }
                     style="font-size: 17px;">
                 {SnappyDashboardPage.memberStatsColumn("status")}
               </span>
             </th>
             <th style="text-align:center; vertical-align: middle;">
               <span data-toggle="tooltip" title=""
-                    data-original-title={SnappyDashboardPage.memberStatsColumn("descriptionTooltip")}
+                    data-original-title={
+                      SnappyDashboardPage.memberStatsColumn("descriptionTooltip")
+                    }
                     style="font-size: 17px;">
                 {SnappyDashboardPage.memberStatsColumn("description")}
               </span>
             </th>
             <th style="text-align:center; vertical-align: middle; min-width: 100px;">
               <span data-toggle="tooltip" title=""
-                    data-original-title={SnappyDashboardPage.memberStatsColumn("memberTypeTooltip")}
+                    data-original-title={
+                      SnappyDashboardPage.memberStatsColumn("memberTypeTooltip")
+                    }
                     style="font-size: 17px;">
                 {SnappyDashboardPage.memberStatsColumn("memberType")}
               </span>
             </th>
             <th style="text-align:center; width: 250px; vertical-align: middle;">
               <span data-toggle="tooltip" title=""
-                    data-original-title={SnappyDashboardPage.memberStatsColumn("cpuUsageTooltip")}
+                    data-original-title={
+                      SnappyDashboardPage.memberStatsColumn("cpuUsageTooltip")
+                    }
                     style="font-size: 17px;">
                 {SnappyDashboardPage.memberStatsColumn("cpuUsage")}
               </span>
             </th>
             <th style="text-align:center; width: 250px; vertical-align: middle;">
               <span data-toggle="tooltip" title=""
-                    data-original-title={SnappyDashboardPage.memberStatsColumn("memoryUsageTooltip")}
+                    data-original-title={
+                      SnappyDashboardPage.memberStatsColumn("memoryUsageTooltip")
+                    }
                     style="font-size: 17px;">
                 {SnappyDashboardPage.memberStatsColumn("memoryUsage")}
               </span>
             </th>
-            <th style="text-align:center; width: 150px; vertical-align: middle;">
+            <th style="text-align:center; width: 250px; vertical-align: middle;">
               <span data-toggle="tooltip" title=""
-                    data-original-title={SnappyDashboardPage.memberStatsColumn("heapMemoryTooltip")}
+                    data-original-title={
+                      SnappyDashboardPage.memberStatsColumn("heapMemoryTooltip")
+                    }
                     style="font-size: 17px;">
                 {SnappyDashboardPage.memberStatsColumn("heapMemory")}
               </span>
             </th>
-            <th style="text-align:center; width: 150px; vertical-align: middle;">
+            <th style="text-align:center; width: 250px; vertical-align: middle;">
               <span data-toggle="tooltip" title=""
-                    data-original-title={SnappyDashboardPage.memberStatsColumn("offHeapMemoryTooltip")}
+                    data-original-title={
+                      SnappyDashboardPage.memberStatsColumn("offHeapMemoryTooltip")
+                    }
                     style="font-size: 17px;">
                 {SnappyDashboardPage.memberStatsColumn("offHeapMemory")}
               </span>
             </th>
-            <th style="text-align:center; width: 150px; vertical-align: middle;">
-              <span data-toggle="tooltip" title=""
-                    data-original-title={SnappyDashboardPage.memberStatsColumn("jvmHeapMemoryTooltip")}
-                    style="font-size: 17px;">
-                {SnappyDashboardPage.memberStatsColumn("jvmHeapMemory")}
-              </span>
-            </th>
-            <!-- <th style="text-align:center; width: 100px; vertical-align: middle;">
-              <span data-toggle="tooltip" title=""
-                    data-original-title={SnappyDashboardPage.memberStatsColumn("clientsTooltip")}
-                    style="font-size: 17px;">
-                {SnappyDashboardPage.memberStatsColumn("clients")}
-              </span>
-            </th> -->
           </tr>
         </thead>
         <tbody>
@@ -444,35 +493,45 @@ private[ui] class SnappyDashboardPage (parent: SnappyDashboardTab)
           <tr>
             <th style="text-align:center; vertical-align: middle;">
               <span data-toggle="tooltip" title=""
-                    data-original-title={SnappyDashboardPage.sparkConnectorsStatsColumn("nameOrIdTooltip")}
+                    data-original-title={
+                      SnappyDashboardPage.sparkConnectorsStatsColumn("nameOrIdTooltip")
+                    }
                     style="font-size: 17px;">
                 {SnappyDashboardPage.sparkConnectorsStatsColumn("nameOrId")}
               </span>
             </th>
             <th style="text-align:center; width: 250px; vertical-align: middle;">
               <span data-toggle="tooltip" title=""
-                    data-original-title={SnappyDashboardPage.sparkConnectorsStatsColumn("cpuUsageTooltip")}
+                    data-original-title={
+                      SnappyDashboardPage.sparkConnectorsStatsColumn("cpuUsageTooltip")
+                    }
                     style="font-size: 17px;">
                 {SnappyDashboardPage.sparkConnectorsStatsColumn("cpuUsage")}
               </span>
             </th>
             <th style="text-align:center; width: 250px; vertical-align: middle;">
               <span data-toggle="tooltip" title=""
-                    data-original-title={SnappyDashboardPage.sparkConnectorsStatsColumn("memoryUsageTooltip")}
+                    data-original-title={
+                      SnappyDashboardPage.sparkConnectorsStatsColumn("memoryUsageTooltip")
+                    }
                     style="font-size: 17px;">
                 {SnappyDashboardPage.sparkConnectorsStatsColumn("memoryUsage")}
               </span>
             </th>
             <th style="text-align:center; width: 150px; vertical-align: middle;">
               <span data-toggle="tooltip" title=""
-                    data-original-title={SnappyDashboardPage.sparkConnectorsStatsColumn("usedMemoryTooltip")}
+                    data-original-title={
+                      SnappyDashboardPage.sparkConnectorsStatsColumn("usedMemoryTooltip")
+                    }
                     style="font-size: 17px;">
                 {SnappyDashboardPage.sparkConnectorsStatsColumn("usedMemory")}
               </span>
             </th>
             <th style="text-align:center; width: 150px; vertical-align: middle;">
               <span data-toggle="tooltip" title=""
-                    data-original-title={SnappyDashboardPage.sparkConnectorsStatsColumn("totalMemoryTooltip")}
+                    data-original-title={
+                      SnappyDashboardPage.sparkConnectorsStatsColumn("totalMemoryTooltip")
+                    }
                     style="font-size: 17px;">
                 {SnappyDashboardPage.sparkConnectorsStatsColumn("totalMemory")}
               </span>
@@ -494,42 +553,54 @@ private[ui] class SnappyDashboardPage (parent: SnappyDashboardTab)
           <tr>
             <th style="text-align:center; vertical-align: middle;">
               <span data-toggle="tooltip" title=""
-                    data-original-title={SnappyDashboardPage.tableStatsColumn("nameTooltip")}
+                    data-original-title={
+                      SnappyDashboardPage.tableStatsColumn("nameTooltip")
+                    }
                     style="font-size: 17px;">
                 {SnappyDashboardPage.tableStatsColumn("name")}
               </span>
             </th>
             <th style="text-align:center; vertical-align: middle;">
               <span data-toggle="tooltip" title=""
-                    data-original-title={SnappyDashboardPage.tableStatsColumn("storageModelTooltip")}
+                    data-original-title={
+                      SnappyDashboardPage.tableStatsColumn("storageModelTooltip")
+                    }
                     style="font-size: 17px;">
                 {SnappyDashboardPage.tableStatsColumn("storageModel")}
               </span>
             </th>
             <th style="text-align:center; vertical-align: middle;">
               <span data-toggle="tooltip" title=""
-                    data-original-title={SnappyDashboardPage.tableStatsColumn("distributionTypeTooltip")}
+                    data-original-title={
+                      SnappyDashboardPage.tableStatsColumn("distributionTypeTooltip")
+                    }
                     style="font-size: 17px;">
                 {SnappyDashboardPage.tableStatsColumn("distributionType")}
               </span>
             </th>
             <th style="text-align:center; width: 250px; vertical-align: middle;">
               <span data-toggle="tooltip" title=""
-                    data-original-title={SnappyDashboardPage.tableStatsColumn("rowCountTooltip")}
+                    data-original-title={
+                      SnappyDashboardPage.tableStatsColumn("rowCountTooltip")
+                    }
                     style="font-size: 17px;">
                 {SnappyDashboardPage.tableStatsColumn("rowCount")}
               </span>
             </th>
             <th style="text-align:center; width: 250px; vertical-align: middle;">
               <span data-toggle="tooltip" title=""
-                    data-original-title={SnappyDashboardPage.tableStatsColumn("sizeInMemoryTooltip")}
+                    data-original-title={
+                      SnappyDashboardPage.tableStatsColumn("sizeInMemoryTooltip")
+                    }
                     style="font-size: 17px;">
                 {SnappyDashboardPage.tableStatsColumn("sizeInMemory")}
               </span>
             </th>
             <th style="text-align:center; width: 250px; vertical-align: middle;">
               <span data-toggle="tooltip" title=""
-                    data-original-title={SnappyDashboardPage.tableStatsColumn("totalSizeTooltip")}
+                    data-original-title={
+                      SnappyDashboardPage.tableStatsColumn("totalSizeTooltip")
+                    }
                     style="font-size: 17px;">
                 {SnappyDashboardPage.tableStatsColumn("totalSize")}
               </span>
@@ -599,7 +670,8 @@ private[ui] class SnappyDashboardPage (parent: SnappyDashboardTab)
 
     val host = memberDetails.getOrElse("host", "").toString
     val fullDirName = memberDetails.getOrElse("userDir", "").toString
-    val shortDirName = fullDirName.substring(fullDirName.lastIndexOf(System.getProperty("file.separator")) + 1)
+    val shortDirName = fullDirName.substring(
+                         fullDirName.lastIndexOf(System.getProperty("file.separator")) + 1)
     val processId = memberDetails.getOrElse("processId","").toString
 
     val memberDescription = {
@@ -607,13 +679,13 @@ private[ui] class SnappyDashboardPage (parent: SnappyDashboardTab)
           " | " + shortDirName +
           " | " + processId
     }
-    val memberDescriptionTooltip = {
-      <span>Host: {host}
-        <br/>Directory: {fullDirName}
-        <br/>Process ID: {processId}
+    val memberDescriptionDetails = {
+      <span><strong>Host:</strong> {host}
+        <br/><strong>Directory:</strong> {fullDirName}
+        <br/><strong>Process ID:</strong> {processId}
       </span>
     }
-    val tooltipHandler = "$('#" + shortDirName + "').toggle();";
+    val memberDescDetailsHandler = "$('#" + shortDirName + "').toggle();";
 
     val memberType = {
       if(memberDetails.getOrElse("lead", false).toString.toBoolean){
@@ -630,6 +702,10 @@ private[ui] class SnappyDashboardPage (parent: SnappyDashboardTab)
       }
     }
 
+    val storagePoolUsed = memberDetails.getOrElse("storagePoolUsed", 0).asInstanceOf[Long]
+    val storagePoolSize = memberDetails.getOrElse("storagePoolSize", 0).asInstanceOf[Long]
+    val executionPoolSize = memberDetails.getOrElse("executionPoolSize", 0).asInstanceOf[Long]
+    val executionPoolUsed = memberDetails.getOrElse("executionPoolUsed", 0).asInstanceOf[Long]
     val heapMemorySize = memberDetails.getOrElse("heapMemorySize", 0).asInstanceOf[Long]
     val heapMemoryUsed = memberDetails.getOrElse("heapMemoryUsed", 0).asInstanceOf[Long]
     val offHeapMemorySize = memberDetails.getOrElse("offHeapMemorySize", 0).asInstanceOf[Long]
@@ -639,8 +715,24 @@ private[ui] class SnappyDashboardPage (parent: SnappyDashboardTab)
 
     var memoryUsage:Long = 0
     if((heapMemorySize + offHeapMemorySize) > 0) {
-      memoryUsage = (heapMemoryUsed + offHeapMemoryUsed) * 100 / (heapMemorySize + offHeapMemorySize)
+      memoryUsage = (heapMemoryUsed + offHeapMemoryUsed) * 100 /
+          (heapMemorySize + offHeapMemorySize)
     }
+
+    val heapUsageDetails = {
+      <span><strong>JVM Heap:</strong>
+        <br/> { Utils.bytesToString(jvmHeapUsed).toString + " / " +
+          Utils.bytesToString(jvmHeapSize).toString }
+        <br/><strong>Storage Memory:</strong>
+        <br/> { Utils.bytesToString(storagePoolUsed).toString + " / " +
+          Utils.bytesToString(storagePoolSize).toString }
+        <br/><strong>Execution Memory:</strong>
+        <br/> { Utils.bytesToString(executionPoolUsed).toString + " / " +
+          Utils.bytesToString(executionPoolSize).toString }
+      </span>
+    }
+    val heapDetailsId = shortDirName + "-heap"
+    val heapDetailsHandler = "$('#" + heapDetailsId + "').toggle();";
 
     <tr>
       <td>
@@ -653,10 +745,9 @@ private[ui] class SnappyDashboardPage (parent: SnappyDashboardTab)
       <td>
         <div style="width: 80%; float: left; padding-left: 10px;">{memberDescription}</div>
         <div style="width: 10px; float: right; padding-right: 10px; cursor: pointer;"
-             onclick={tooltipHandler}> + </div>
-        <div id={shortDirName}
-             style="float: left; padding: 0px 10px; display: none; border: 1px solid #dbd9cf; margin: 5px auto 2px;">
-          {memberDescriptionTooltip}
+             onclick={memberDescDetailsHandler}> + </div>
+        <div class="cellDetailsBox" id={shortDirName}>
+          {memberDescriptionDetails}
         </div>
       </td>
       <td>
@@ -669,23 +760,23 @@ private[ui] class SnappyDashboardPage (parent: SnappyDashboardTab)
         {makeProgressBar(memoryUsage)}
       </td>
       <td>
-        <div style="text-align:right; padding-right:15px;">{
-          Utils.bytesToString(heapMemoryUsed).toString + " / " + Utils.bytesToString(heapMemorySize).toString
+        <div style="width: 80%; float: left; padding-right:10px; text-align:right;">{
+            Utils.bytesToString(heapMemoryUsed).toString + " / " +
+                Utils.bytesToString(heapMemorySize).toString
           }</div>
+        <div style="width: 5px; float: right; padding-right: 10px; cursor: pointer;"
+             onclick={heapDetailsHandler}> + </div>
+        <div class="cellDetailsBox" id={heapDetailsId}
+             style="width: 90%;">
+          {heapUsageDetails}
+        </div>
       </td>
       <td>
         <div style="text-align:right; padding-right:15px;">{
-          Utils.bytesToString(offHeapMemoryUsed).toString + " / " + Utils.bytesToString(offHeapMemorySize).toString
+            Utils.bytesToString(offHeapMemoryUsed).toString + " / " +
+                Utils.bytesToString(offHeapMemorySize).toString
           }</div>
       </td>
-      <td>
-        <div style="text-align:right; padding-right:15px;">{
-          Utils.bytesToString(jvmHeapUsed).toString + " / " + Utils.bytesToString(jvmHeapSize).toString
-          }</div>
-      </td>
-      <!-- <td>
-        <div style="text-align:right; padding-right:15px;">{memberDetails.getOrElse("clients","NA")}</div>
-      </td> -->
     </tr>
   }
 
@@ -715,10 +806,14 @@ private[ui] class SnappyDashboardPage (parent: SnappyDashboardTab)
         {makeProgressBar(memoryUsage)}
       </td>
       <td>
-        <div style="text-align:right; padding-right:15px;">{Utils.bytesToString(usedMemory)}</div>
+        <div style="text-align:right; padding-right:15px;">{
+            Utils.bytesToString(usedMemory)
+          }</div>
       </td>
       <td>
-        <div style="text-align:right; padding-right:15px;">{Utils.bytesToString(totalMemory).toString}</div>
+        <div style="text-align:right; padding-right:15px;">{
+            Utils.bytesToString(totalMemory).toString
+          }</div>
       </td>
     </tr>
   }
@@ -821,14 +916,16 @@ object SnappyDashboardPage{
   clusterStats += ("locators" -> "Locators")
   clusterStats += ("clients" -> "Connections")
   clusterStats += ("tables" -> "Tables")
-  clusterStats += ("avgMemoryUsage" -> "Avg. Memory Usage")
-  clusterStats += ("avgMemoryUsageTooltip" -> "Members Average Memory Usage")
-  clusterStats += ("avgHeapUsage" -> "Avg. Heap Usage")
-  clusterStats += ("avgHeapUsageTooltip" -> "Members Average Heap Usage")
-  clusterStats += ("avgOffHeapUsage" -> "Avg. Off-Heap Usage")
-  clusterStats += ("avgOffHeapUsageTooltip" -> "Members Average Off-Heap Usage")
-  clusterStats += ("avgJvmHeapUsage" -> "Avg. JVM Heap Usage")
-  clusterStats += ("avgJvmHeapUsageTooltip" -> "Members Average JVM Heap Usage")
+  clusterStats += ("cpuUsage" -> "CPU Usage")
+  clusterStats += ("cpuUsageTooltip" -> "Clusters CPU Usage")
+  clusterStats += ("memoryUsage" -> "Memory Usage")
+  clusterStats += ("memoryUsageTooltip" -> "Clusters Total Memory Usage")
+  clusterStats += ("heapUsage" -> "Heap Usage")
+  clusterStats += ("heapUsageTooltip" -> "Clusters Total Heap Usage")
+  clusterStats += ("offHeapUsage" -> "Off-Heap Usage")
+  clusterStats += ("offHeapUsageTooltip" -> "Clusters Total Off-Heap Usage")
+  clusterStats += ("jvmHeapUsage" -> "JVM Heap Usage")
+  clusterStats += ("jvmHeapUsageTooltip" -> "Clusters Total JVM Heap Usage")
 
   val membersStatsTitle = "Members"
   val membersStatsTitleTooltip = "SnappyData Members Summary"
@@ -846,7 +943,7 @@ object SnappyDashboardPage{
   memberStatsColumn += ("host" -> "Host")
   memberStatsColumn += ("hostTooltip" -> "Physical machine on which member is running")
   memberStatsColumn += ("cpuUsage" -> "CPU Usage")
-  memberStatsColumn += ("cpuUsageTooltip" -> "CPU used by Member")
+  memberStatsColumn += ("cpuUsageTooltip" -> "CPU used by Member Host")
   memberStatsColumn += ("memoryUsage" -> "Memory Usage")
   memberStatsColumn += ("memoryUsageTooltip" -> "Memory(Heap + Off-Heap) used by Member")
   memberStatsColumn += ("usedMemory" -> "Used Memory")


### PR DESCRIPTION
## Changes proposed in this pull request

  1. Add CPU Usage Widget in cluster level stats section. 
  2. Remove Avg. Heap Usage and Avg. Off-Heap Usage Widgets from cluster level stats section.
  3. Instead of Average statistics on the cluster level, display total statistics with headings like "CPU Usage", "Memory Usage", "JVM Heap Usage".
  4. In members list, under Heap Usage column provide details of heap distribution details listed below.
      - JVM Heap Used and Total
      - Storage Memory Used and Total
      - Execution Memory Used and Total
  5. Display value as N/A under Heap and Off-Heap columns if member is Locator.
  6. Remove JVM Heap column from members list.

## Patch testing

Manually tested.

## ReleaseNotes.txt changes

(Does this change require an entry in ReleaseNotes.txt? If yes, has it been added to it?)

## Other PRs 

Spark: https://github.com/SnappyDataInc/spark/pull/55
