### PR TITLE
[SNAP-1710] separate plan to fallback to Spark

### DIFF
--- a/cluster/src/dunit/scala/io/snappydata/cluster/DDLRoutingDUnitTest.scala
+++ b/cluster/src/dunit/scala/io/snappydata/cluster/DDLRoutingDUnitTest.scala
@@ -143,14 +143,16 @@ class DDLRoutingDUnitTest(val s: String) extends ClusterManagerTestBase(s) {
 
     dropTableXD(conn, tableName)
 
-    // check offheap
+    // offheap has been removed
     options = "OPTIONS(OFFHEAP 'true')"
     try {
       s.execute(s"CREATE TABLE $tableName (Col1 INT, Col2 INT, Col3 INT) " +
           s"USING column $options")
     } catch {
       case sqle: SQLException => if (sqle.getSQLState != "38000" ||
-          !sqle.getMessage.contains("No off-heap memory")) throw sqle
+          !sqle.getMessage.contains("Unknown option")) {
+        throw sqle
+      }
     }
 
     s.execute("DROP DISKSTORE d1")

--- a/cluster/src/test/scala/org/apache/spark/sql/execution/benchmark/ColumnCacheBenchmark.scala
+++ b/cluster/src/test/scala/org/apache/spark/sql/execution/benchmark/ColumnCacheBenchmark.scala
@@ -197,7 +197,7 @@ class ColumnCacheBenchmark extends SnappyFunSuite {
   private def createAndTestBigTable(): Unit = {
     snappySession.sql("drop table if exists wide_table")
 
-    val size = 1
+    val size = 100
     val num_col = 300
     val str = (1 to num_col).map(i => s" '$i' as C$i")
     val testDF = snappySession.range(size).select(str.map { expr =>
@@ -212,10 +212,21 @@ class ColumnCacheBenchmark extends SnappyFunSuite {
     testDF.write.insertInto("wide_table")
     testDF.write.insertInto("wide_table1")
 
+    val uniqDf = snappySession.table("wide_table").dropDuplicates(Array("C1"))
+    uniqDf.count()
+    // check fallback plans being invoked via API
+    uniqDf.show()
+    // and also via SQL
+    val s = (2 to num_col).map(i => s"last(C$i)").mkString(",")
+    snappySession.sql(s"select C1, $s from wide_table group by C1").show()
 
     val df = snappySession.sql("select *" +
       " from wide_table a , wide_table1 b where a.c1 = b.c1 and a.c1 = '1'")
     df.collect()
+
+    val df0 = snappySession.sql(s"select * from wide_table")
+    df0.collect()
+    df0.show()
 
     val avgProjections = (1 to num_col).map(i => s"AVG(C$i)").mkString(",")
     val df1 = snappySession.sql(s"select $avgProjections from wide_table")

--- a/core/src/main/scala/org/apache/spark/sql/CachedDataFrame.scala
+++ b/core/src/main/scala/org/apache/spark/sql/CachedDataFrame.scala
@@ -19,12 +19,20 @@ package org.apache.spark.sql
 import java.nio.ByteBuffer
 import java.sql.SQLException
 
+import scala.annotation.tailrec
+import scala.collection.mutable
+import scala.collection.mutable.ArrayBuffer
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.duration.Duration
+import scala.concurrent.{Await, Future}
+import scala.reflect.ClassTag
+
 import com.esotericsoftware.kryo.io.{Input, Output}
 import com.esotericsoftware.kryo.{Kryo, KryoSerializable}
 import com.gemstone.gemfire.cache.LowMemoryException
 import com.gemstone.gemfire.internal.cache.store.ManagedDirectBufferAllocator
-import com.gemstone.gemfire.internal.shared.{BufferAllocator, ClientSharedUtils}
 import com.gemstone.gemfire.internal.shared.unsafe.{DirectBufferAllocator, UnsafeHolder}
+import com.gemstone.gemfire.internal.shared.{BufferAllocator, ClientSharedUtils}
 import com.gemstone.gemfire.internal.{ByteArrayDataInput, ByteBufferDataOutput}
 import com.pivotal.gemfirexd.internal.shared.common.reference.SQLState
 
@@ -46,13 +54,6 @@ import org.apache.spark.sql.types.StructType
 import org.apache.spark.storage.{BlockManager, RDDBlockId, StorageLevel}
 import org.apache.spark.unsafe.Platform
 import org.apache.spark.util.CallSite
-import scala.annotation.tailrec
-import scala.collection.mutable
-import scala.collection.mutable.ArrayBuffer
-import scala.concurrent.ExecutionContext.Implicits.global
-import scala.concurrent.{Await, Future}
-import scala.reflect.ClassTag
-import scala.concurrent.duration.Duration
 
 class CachedDataFrame(df: Dataset[Row], var queryString: String,
     cachedRDD: RDD[InternalRow], shuffleDependencies: Array[Int],

--- a/core/src/main/scala/org/apache/spark/sql/CachedDataFrame.scala
+++ b/core/src/main/scala/org/apache/spark/sql/CachedDataFrame.scala
@@ -249,6 +249,8 @@ class CachedDataFrame(df: Dataset[Row], var queryString: String,
     def execute(): Iterator[R] = CachedDataFrame.withNewExecutionId(
       sparkSession, queryShortForm, queryString, queryExecutionString, queryPlanInfo) {
       val executedPlan = queryExecution.executedPlan match {
+        case CodegenSparkFallback(WholeStageCodegenExec(CachedPlanHelperExec(plan))) => plan
+        case CodegenSparkFallback(plan) => plan
         case WholeStageCodegenExec(CachedPlanHelperExec(plan)) => plan
         case plan => plan
       }

--- a/core/src/main/scala/org/apache/spark/sql/SnappySession.scala
+++ b/core/src/main/scala/org/apache/spark/sql/SnappySession.scala
@@ -25,6 +25,7 @@ import scala.collection.mutable.ArrayBuffer
 import scala.language.implicitConversions
 import scala.reflect.runtime.{universe => u}
 import scala.util.control.NonFatal
+
 import com.gemstone.gemfire.cache.EntryExistsException
 import com.gemstone.gemfire.distributed.internal.DistributionAdvisor.Profile
 import com.gemstone.gemfire.distributed.internal.ProfileListener
@@ -35,6 +36,7 @@ import com.google.common.util.concurrent.UncheckedExecutionException
 import com.pivotal.gemfirexd.internal.iapi.sql.ParameterValueSet
 import com.pivotal.gemfirexd.internal.shared.common.StoredFormatIds
 import io.snappydata.{Constant, SnappyTableStatsProviderService}
+
 import org.apache.spark.annotation.{DeveloperApi, Experimental}
 import org.apache.spark.rdd.RDD
 import org.apache.spark.scheduler.{SparkListener, SparkListenerApplicationEnd}
@@ -43,8 +45,8 @@ import org.apache.spark.sql.catalyst.analysis.{EliminateSubqueryAliases, Unresol
 import org.apache.spark.sql.catalyst.encoders.{RowEncoder, _}
 import org.apache.spark.sql.catalyst.expressions.aggregate.AggregateExpression
 import org.apache.spark.sql.catalyst.expressions.codegen.CodegenContext
-import org.apache.spark.sql.catalyst.plans.QueryPlan
 import org.apache.spark.sql.catalyst.expressions.{Alias, Ascending, AttributeReference, Descending, Exists, ExprId, Expression, GenericRow, ListQuery, LiteralValue, ParamLiteral, PredicateSubquery, ScalarSubquery, SortDirection}
+import org.apache.spark.sql.catalyst.plans.QueryPlan
 import org.apache.spark.sql.catalyst.plans.logical.{Filter, LogicalPlan, Union}
 import org.apache.spark.sql.catalyst.{DefinedByConstructorParams, InternalRow, TableIdentifier}
 import org.apache.spark.sql.collection.{Utils, WrappedInternalRow}
@@ -57,7 +59,7 @@ import org.apache.spark.sql.execution.datasources.jdbc.JdbcUtils
 import org.apache.spark.sql.execution.datasources.{DataSource, LogicalRelation}
 import org.apache.spark.sql.execution.joins.BroadcastHashJoinExec
 import org.apache.spark.sql.hive.{ConnectorCatalog, QualifiedTableName, SnappyStoreHiveCatalog}
-import org.apache.spark.sql.internal.{CodeGenerationException, PreprocessTableInsertOrPut, SnappySessionState, SnappySharedState}
+import org.apache.spark.sql.internal.{PreprocessTableInsertOrPut, SnappySessionState, SnappySharedState}
 import org.apache.spark.sql.row.GemFireXDDialect
 import org.apache.spark.sql.sources._
 import org.apache.spark.sql.store.{CodeGeneration, StoreUtils}
@@ -1709,9 +1711,9 @@ object SnappySession extends Logging {
     }
 
     if (key ne null) {
-      val nocaching = session.getContextObject[Boolean](
+      val noCaching = session.getContextObject[Boolean](
         CachedPlanHelperExec.NOCACHING_KEY).getOrElse(false)
-      if (nocaching) {
+      if (noCaching) {
         key.invalidatePlan()
       }
       else {
@@ -1722,11 +1724,9 @@ object SnappySession extends Logging {
       }
     }
     // keep the broadcast hash join plans and their references as well
-    val allbroadcastplans = session.getContextObject[mutable.Map[BroadcastHashJoinExec,
+    val allBroadcastPlans = session.getContextObject[mutable.Map[BroadcastHashJoinExec,
         ArrayBuffer[Any]]](CachedPlanHelperExec.BROADCASTS_KEY).getOrElse(
       mutable.Map.empty[BroadcastHashJoinExec, ArrayBuffer[Any]])
-
-    // logDebug(s"all bc plans = ${allbroadcastplans} ... size = ${allbroadcastplans.size}")
 
     val (cachedRDD, shuffleDeps, rddId, localCollect) = executedPlan match {
       case _: ExecutedCommandExec | _: ExecutedCommand | _: ExecutePlan =>
@@ -1760,9 +1760,11 @@ object SnappySession extends Logging {
         (rdd, findShuffleDependencies(rdd).toArray, rdd.id, false)
     }
 
-    val allallbroadcastplans = session.getContextObject[mutable.Map[BroadcastHashJoinExec,
+    /*
+    val allAllBroadcastPlans = session.getContextObject[mutable.Map[BroadcastHashJoinExec,
         ArrayBuffer[Any]]](CachedPlanHelperExec.BROADCASTS_KEY).getOrElse(
       mutable.Map.empty[BroadcastHashJoinExec, ArrayBuffer[Any]])
+    */
 
     // keep references as well
     // filter unvisited literals. If the query is on a view for example the
@@ -1814,7 +1816,7 @@ object SnappySession extends Logging {
       logDebug(s"Plan caching will be used for sql ${key.sqlText}")
     }
     val cdf = new CachedDataFrame(df, sqlText, cachedRDD, shuffleDeps, rddId,
-      localCollect, allLiterals, allbroadcastplans)
+      localCollect, allLiterals, allBroadcastPlans)
 
     // Now check if optimization plans have been applied such that
     val queryHints = session.synchronized {
@@ -1831,7 +1833,6 @@ object SnappySession extends Logging {
       override def load(key: CachedKey): (CachedDataFrame,
           Map[String, String]) = {
         val session = key.session
-        session.sessionState.disableStoreOptimizations = false
         val df = session.executeSQL(key.sqlText)
         val plan = df.queryExecution.executedPlan
         // if this has in-memory caching then don't cache the first time
@@ -1839,16 +1840,7 @@ object SnappySession extends Logging {
         if (plan.find(_.isInstanceOf[InMemoryTableScanExec]).isDefined) {
           (null, null)
         } else {
-          try {
-            evaluatePlan(df, session, key.sqlText, key)
-          } catch {
-            case e: CodeGenerationException => {
-              session.sessionState.disableStoreOptimizations = true
-              logInfo("Snappy Code generation failed. Falling back to Spark plans ")
-              val df = session.executeSQL(key.sqlText)
-              evaluatePlan(df, session, key.sqlText, key)
-            }
-          }
+          evaluatePlan(df, session, key.sqlText, key)
         }
       }
     }
@@ -1975,7 +1967,7 @@ object SnappySession extends Logging {
       if (key.valid) {
         // logDebug(s"calling reprepare broadcast with new constants ${currentWrappedConstants}")
         // cachedDF.reprepareBroadcast(lp, currentWrappedConstants)
-        logDebug(s"calling replace constants with new constants ${currentWrappedConstants}" +
+        logDebug(s"calling replace constants with new constants $currentWrappedConstants" +
             s" in Literal values = ${cachedDF.allLiterals.toSet}")
         CachedPlanHelperExec.replaceConstants(cachedDF.allLiterals, lp, currentWrappedConstants)
       }

--- a/core/src/main/scala/org/apache/spark/sql/SnappySession.scala
+++ b/core/src/main/scala/org/apache/spark/sql/SnappySession.scala
@@ -1706,6 +1706,8 @@ object SnappySession extends Logging {
       session: SnappySession, sqlText: String,
       key: CachedKey = null): (CachedDataFrame, Map[String, String]) = {
     val executedPlan = df.queryExecution.executedPlan match {
+      case CodegenSparkFallback(WholeStageCodegenExec(CachedPlanHelperExec(plan))) => plan
+      case CodegenSparkFallback(plan) => plan
       case WholeStageCodegenExec(CachedPlanHelperExec(plan)) => plan
       case plan => plan
     }

--- a/core/src/main/scala/org/apache/spark/sql/SnappyStrategies.scala
+++ b/core/src/main/scala/org/apache/spark/sql/SnappyStrategies.scala
@@ -19,7 +19,6 @@ package org.apache.spark.sql
 import io.snappydata.Property
 
 import org.apache.spark.sql.JoinStrategy._
-import org.apache.spark.sql.backwardcomp.ExecutedCommand
 import org.apache.spark.sql.catalyst.expressions.aggregate.{AggregateExpression, AggregateFunction, Complete, Final, ImperativeAggregate, Partial, PartialMerge}
 import org.apache.spark.sql.catalyst.expressions.{Alias, Expression, NamedExpression, RowOrdering}
 import org.apache.spark.sql.catalyst.planning.{ExtractEquiJoinKeys, PhysicalAggregation, PhysicalOperation}
@@ -30,7 +29,6 @@ import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.collection.Utils
 import org.apache.spark.sql.execution._
 import org.apache.spark.sql.execution.aggregate.{AggUtils, CollectAggregateExec, SnappyHashAggregateExec}
-import org.apache.spark.sql.execution.command.ExecutedCommandExec
 import org.apache.spark.sql.execution.datasources.LogicalRelation
 import org.apache.spark.sql.execution.exchange.{EnsureRequirements, Exchange, ShuffleExchange}
 import org.apache.spark.sql.execution.joins.{BuildLeft, BuildRight}
@@ -682,10 +680,8 @@ case class InsertCachedPlanHelper(session: SnappySession, topLevel: Boolean)
     if (!topLevel || session.sessionState.disableStoreOptimizations) plan
     else plan match {
       // TODO: disabled for StreamPlans due to issues but can it require fallback?
-      case _: ExecutedCommandExec | _: ExecutedCommand |
-           _: ExecutePlan | _: LocalTableScanExec | _: StreamPlan => plan
+      case _: StreamPlan => plan
       case _ => CodegenSparkFallback(plan)
-
     }
   }
 

--- a/core/src/main/scala/org/apache/spark/sql/collection/MultiColumnOpenHashSet.scala
+++ b/core/src/main/scala/org/apache/spark/sql/collection/MultiColumnOpenHashSet.scala
@@ -22,16 +22,13 @@ import scala.collection.mutable.ArrayBuffer
 import scala.collection.{IterableLike, mutable}
 import scala.util.hashing.MurmurHash3
 
-import org.apache.spark.Partition
-import org.apache.spark.rdd.{MapPartitionsRDD, RDD}
-import org.apache.spark.sql.catalyst.expressions.codegen.{GeneratedClass, CodeGenerator, CodeAndComment}
-import org.apache.spark.sql.{SnappyContext, Row}
+import org.apache.spark.sql.Row
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions._
+import org.apache.spark.sql.catalyst.expressions.codegen.{CodeAndComment, CodeGenerator, GeneratedClass}
 import org.apache.spark.sql.collection.MultiColumnOpenHashSet.ColumnHandler
-import org.apache.spark.sql.execution.{BufferedRowIterator, WholeStageCodegenExec, SparkPlan}
+import org.apache.spark.sql.execution.BufferedRowIterator
 import org.apache.spark.sql.types._
-import org.apache.spark.unsafe.types.UTF8String
 import org.apache.spark.util.collection.BitSet
 
 /**

--- a/core/src/main/scala/org/apache/spark/sql/execution/CodegenSparkFallback.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/CodegenSparkFallback.scala
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2017 SnappyData, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License. You
+ * may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License. See accompanying
+ * LICENSE file.
+ */
+
+package org.apache.spark.sql.execution
+
+import com.gemstone.gemfire.SystemFailure
+
+import org.apache.spark.rdd.RDD
+import org.apache.spark.sql.SnappySession
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.expressions.Attribute
+
+/**
+ * Catch exceptions in code generation of SnappyData plans and fallback
+ * to Spark plans as last resort (including non-code generated paths).
+ */
+case class CodegenSparkFallback(child: SparkPlan) extends UnaryExecNode {
+
+  override def output: Seq[Attribute] = child.output
+
+  private def executeWithFallback[T](f: SparkPlan => T): T = {
+    try {
+      f(child)
+    } catch {
+      case t: Throwable =>
+        t match {
+          case e: Error =>
+            if (SystemFailure.isJVMFailureError(e)) {
+              SystemFailure.initiateFailure(e)
+              // If this ever returns, rethrow the error. We're poisoned
+              // now, so don't let this thread continue.
+              throw e
+            }
+          case _ =>
+        }
+        // Whenever you catch Error or Throwable, you must also
+        // check for fatal JVM error (see above).  However, there is
+        // _still_ a possibility that you are dealing with a cascading
+        // error condition, so you also need to check to see if the JVM
+        // is still usable:
+        SystemFailure.checkFailure()
+
+        // fallback to Spark plan
+        val session = sqlContext.sparkSession.asInstanceOf[SnappySession]
+        session.getContextObject[() => QueryExecution]("EXECUTION") match {
+          case Some(exec) =>
+            logInfo("SnappyData code generation failed. Falling back to Spark plans.")
+            session.sessionState.disableStoreOptimizations = true
+            try {
+              f(exec().executedPlan)
+            } finally {
+              session.sessionState.disableStoreOptimizations = false
+            }
+          case None => throw t
+        }
+    }
+  }
+
+  override protected def doExecute(): RDD[InternalRow] =
+    executeWithFallback(child => child.execute())
+
+  override def executeCollect(): Array[InternalRow] =
+    executeWithFallback(child => child.executeCollect())
+
+  override def executeToIterator(): Iterator[InternalRow] =
+    executeWithFallback(child => child.executeToIterator())
+
+  override def executeTake(n: Int): Array[InternalRow] =
+    executeWithFallback(child => child.executeTake(n))
+
+  override def generateTreeString(depth: Int, lastChildren: Seq[Boolean],
+      builder: StringBuilder, verbose: Boolean, prefix: String): StringBuilder =
+    child.generateTreeString(depth, lastChildren, builder, verbose)
+
+  override def children: Seq[SparkPlan] = child.children
+
+  override private[sql] def metrics = child.metrics
+
+  override private[sql] def metadata = child.metadata
+
+  override def subqueries: Seq[SparkPlan] = child.subqueries
+
+  override def nodeName: String = child.nodeName
+
+  override def simpleString: String = child.simpleString
+}

--- a/core/src/main/scala/org/apache/spark/sql/execution/CodegenSparkFallback.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/CodegenSparkFallback.scala
@@ -84,7 +84,7 @@ case class CodegenSparkFallback(child: SparkPlan) extends UnaryExecNode {
 
   override def generateTreeString(depth: Int, lastChildren: Seq[Boolean],
       builder: StringBuilder, verbose: Boolean, prefix: String): StringBuilder =
-    child.generateTreeString(depth, lastChildren, builder, verbose)
+    child.generateTreeString(depth, lastChildren, builder, verbose, prefix)
 
   override def children: Seq[SparkPlan] = child.children
 

--- a/core/src/main/scala/org/apache/spark/sql/execution/CodegenSparkFallback.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/CodegenSparkFallback.scala
@@ -47,7 +47,7 @@ case class CodegenSparkFallback(child: SparkPlan) extends UnaryExecNode {
               // now, so don't let this thread continue.
               throw e
             }
-            // assume all other errors will be some assert failures
+            // assume all other errors will be some stack/assertion failures
             // or similar compilation issues in janino for very large code
             useFallback = true
           case _ =>

--- a/core/src/main/scala/org/apache/spark/sql/execution/ExistingPlans.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/ExistingPlans.scala
@@ -298,7 +298,7 @@ private[sql] final case class ZipPartitionScan(basePlan: CodegenSupport,
   }
 
   override protected def doExecute(): RDD[InternalRow] = attachTree(this, "execute") {
-    WholeStageCodegenExec(this).execute()
+    WholeStageCodegenExec(CachedPlanHelperExec(this)).execute()
   }
 
   override def output: Seq[Attribute] = basePlan.output

--- a/core/src/main/scala/org/apache/spark/sql/execution/aggregate/SnappyHashAggregateExec.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/aggregate/SnappyHashAggregateExec.scala
@@ -227,7 +227,7 @@ case class SnappyHashAggregateExec(
 
 
   override protected def doProduce(ctx: CodegenContext): String = {
-    startProducing
+    startProducing()
     if (groupingExpressions.isEmpty) {
       doProduceWithoutKeys(ctx)
     } else {

--- a/core/src/main/scala/org/apache/spark/sql/execution/columnar/impl/JDBCSourceAsColumnarStore.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/columnar/impl/JDBCSourceAsColumnarStore.scala
@@ -42,7 +42,7 @@ import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.{DynamicReplacableConstant, ParamLiteral}
 import org.apache.spark.sql.collection._
 import org.apache.spark.sql.execution.columnar._
-import org.apache.spark.sql.execution.row.{ResultSetTraversal, RowFormatScanRDD, RowDMLExec}
+import org.apache.spark.sql.execution.row.{ResultSetTraversal, RowDMLExec, RowFormatScanRDD}
 import org.apache.spark.sql.execution.{BufferedRowIterator, ConnectionPool, RDDKryo, WholeStageCodegenExec}
 import org.apache.spark.sql.hive.ConnectorCatalog
 import org.apache.spark.sql.sources.{ConnectionProperties, Filter, JdbcExtendedUtils}
@@ -535,14 +535,14 @@ final class SmartConnectorColumnRDD(
       context.addTaskCompletionListener { _ =>
         logDebug(s"The txid going to be committed is $txId " + tableName)
 
-        //if ((txId ne null) && !txId.equals("null")) {
+        // if ((txId ne null) && !txId.equals("null")) {
           val ps = conn.prepareStatement(s"call sys.COMMIT_SNAPSHOT_TXID(?)")
           ps.setString(1, if (txId == null) "null" else txId)
           ps.executeUpdate()
           logDebug(s"The txid being committed is $txId")
           ps.close()
           SparkShellRDDHelper.snapshotTxId.set(null)
-        //}
+        // }
       }
     }
     itr
@@ -596,20 +596,20 @@ class SmartConnectorRowRDD(_session: SnappySession,
     _filters, _partEval, _commitTx) {
 
 
-  override def commitTxBeforeTaskCompletion(conn: Option[Connection], context: TaskContext) = {
+  override def commitTxBeforeTaskCompletion(conn: Option[Connection],
+      context: TaskContext): Unit = {
     Option(TaskContext.get()).foreach(_.addTaskCompletionListener(_ => {
-      val txId =  SparkShellRDDHelper.snapshotTxId.get
+      val txId = SparkShellRDDHelper.snapshotTxId.get
       logDebug(s"The txid going to be committed is $txId " + tableName)
-      //if ((txId ne null) && !txId.equals("null")) {
+      // if ((txId ne null) && !txId.equals("null")) {
         val ps = conn.get.prepareStatement(s"call sys.COMMIT_SNAPSHOT_TXID(?)")
         ps.setString(1, if (txId == null) "null" else txId)
         ps.executeUpdate()
         logDebug(s"The txid being committed is $txId")
         ps.close()
         SparkShellRDDHelper.snapshotTxId.set(null)
-      //}
-    }
-    ))
+      // }
+    }))
   }
 
   override def computeResultSet(
@@ -664,9 +664,9 @@ class SmartConnectorRowRDD(_session: SnappySession,
       val txid: String = getSnapshotTXId.getString(1)
       getSnapshotTXId.close()
       SparkShellRDDHelper.snapshotTxId.set(txid)
-      logDebug(s"The snapshot tx id is ${txid} and tablename is ${tableName}")
+      logDebug(s"The snapshot tx id is $txid and tablename is $tableName")
     }
-    logDebug(s"The previous snapshot tx id is ${txId} and tablename is ${tableName}")
+    logDebug(s"The previous snapshot tx id is $txId and tablename is $tableName")
     (conn, stmt, rs)
   }
 

--- a/core/src/main/scala/org/apache/spark/sql/execution/joins/HashJoinExec.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/joins/HashJoinExec.scala
@@ -60,7 +60,7 @@ case class HashJoinExec(leftKeys: Seq[Expression],
     leftSizeInBytes: BigInt,
     rightSizeInBytes: BigInt,
     replicatedTableJoin: Boolean)
-    extends BinaryExecNode with HashJoin with BatchConsumer with NonRecursivePlans{
+    extends BinaryExecNode with HashJoin with BatchConsumer with NonRecursivePlans {
 
   override def nodeName: String = "SnappyHashJoin"
 
@@ -232,7 +232,7 @@ case class HashJoinExec(leftKeys: Seq[Expression],
   override def inputRDDs(): Seq[RDD[InternalRow]] = streamSideRDDs
 
   override def doProduce(ctx: CodegenContext): String = {
-    startProducing
+    startProducing()
     val initMap = ctx.freshName("initMap")
     ctx.addMutableState("boolean", initMap, s"$initMap = false;")
 

--- a/core/src/main/scala/org/apache/spark/sql/execution/row/RowFormatScanRDD.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/row/RowFormatScanRDD.scala
@@ -36,7 +36,7 @@ import com.zaxxer.hikari.pool.ProxyResultSet
 
 import org.apache.spark.serializer.ConnectionPropertiesSerializer
 import org.apache.spark.sql.SnappySession
-import org.apache.spark.sql.catalyst.expressions.{DynamicReplacableConstant, ParamLiteral}
+import org.apache.spark.sql.catalyst.expressions.DynamicReplacableConstant
 import org.apache.spark.sql.collection.MultiBucketExecutorPartition
 import org.apache.spark.sql.execution.columnar.{ExternalStoreUtils, ResultSetIterator}
 import org.apache.spark.sql.execution.{ConnectionPool, RDDKryo}
@@ -214,16 +214,17 @@ class RowFormatScanRDD(@transient val session: SnappySession,
   }
 
 
-  def commitTxBeforeTaskCompletion(conn: Option[Connection], context: TaskContext) = {
+  def commitTxBeforeTaskCompletion(conn: Option[Connection], context: TaskContext): Unit = {
     Option(TaskContext.get()).foreach(_.addTaskCompletionListener(_ => {
       val tx = TXManagerImpl.snapshotTxState.get()
-      if (tx != null /*&& !(tx.asInstanceOf[TXStateProxy]).isClosed()*/) {
-        GemFireCacheImpl.getInstance().getCacheTransactionManager.masqueradeAs(tx)
-        GemFireCacheImpl.getInstance().getCacheTransactionManager.commit()
+      if (tx != null /* && !(tx.asInstanceOf[TXStateProxy]).isClosed() */ ) {
+        val txMgr = tx.getTxMgr
+        txMgr.masqueradeAs(tx)
+        txMgr.commit()
       }
-    }
-    ))
+    }))
   }
+
   /**
    * Runs the SQL query against the JDBC driver.
    */
@@ -390,7 +391,7 @@ abstract class PRValuesIterator[T](container: GemFireContainer,
   protected final var hasNextValue = true
   protected final var doMove = true
   // transaction started by row buffer scan should be used here
-  val tx = TXManagerImpl.snapshotTxState.get()
+  private val tx = TXManagerImpl.snapshotTxState.get()
   private[execution] final val itr = if (container ne null) {
     container.getEntrySetIteratorForBucketSet(
       bucketIds.asInstanceOf[java.util.Set[Integer]], null, tx, 0,

--- a/core/src/main/scala/org/apache/spark/sql/internal/SnappySessionState.scala
+++ b/core/src/main/scala/org/apache/spark/sql/internal/SnappySessionState.scala
@@ -253,26 +253,34 @@ class SnappySessionState(snappySession: SnappySession)
   override def planner: SparkPlanner = new DefaultPlanner(snappySession, conf,
     experimentalMethods.extraStrategies)
 
-  protected[sql] def queryPreparations: Seq[Rule[SparkPlan]] = Seq(
+  protected[sql] def queryPreparations(topLevel: Boolean): Seq[Rule[SparkPlan]] = Seq(
     python.ExtractPythonUDFs,
     PlanSubqueries(snappySession),
     EnsureRequirements(snappySession.sessionState.conf),
     CollapseCollocatedPlans(snappySession),
     CollapseCodegenStages(snappySession.sessionState.conf),
-    InsertCachedPlanHelper(snappySession),
+    InsertCachedPlanHelper(snappySession, topLevel),
     ReuseExchange(snappySession.sessionState.conf))
 
-  override def executePlan(plan: LogicalPlan): QueryExecution = {
-    clearExecutionData()
+  protected def newQueryExecution(plan: LogicalPlan): QueryExecution = {
     new QueryExecution(snappySession, plan) {
+
+      snappySession.addContextObject("EXECUTION", () => newQueryExecution(plan))
+
       override protected def preparations: Seq[Rule[SparkPlan]] =
-        queryPreparations
+        queryPreparations(topLevel = true)
     }
   }
 
-  private[spark] def prepareExecution(plan: SparkPlan): SparkPlan = {
+  override def executePlan(plan: LogicalPlan): QueryExecution = {
     clearExecutionData()
-    queryPreparations.foldLeft(plan) { case (sp, rule) => rule.apply(sp) }
+    newQueryExecution(plan)
+  }
+
+  private[spark] def prepareExecution(plan: SparkPlan): SparkPlan = {
+    queryPreparations(topLevel = false).foldLeft(plan) {
+      case (sp, rule) => rule.apply(sp)
+    }
   }
 
   private[spark] def clearExecutionData(): Unit = {

--- a/core/src/main/scala/org/apache/spark/sql/store/StoreUtils.scala
+++ b/core/src/main/scala/org/apache/spark/sql/store/StoreUtils.scala
@@ -48,7 +48,6 @@ object StoreUtils {
   val PERSISTENT = "PERSISTENT"
   val DISKSTORE = "DISKSTORE"
   val SERVER_GROUPS = "SERVER_GROUPS"
-  val OFFHEAP = "OFFHEAP"
   val EXPIRE = "EXPIRE"
   val OVERFLOW = "OVERFLOW"
 
@@ -63,7 +62,6 @@ object StoreUtils {
   val GEM_EVICTION_BY = "EVICTION BY"
   val GEM_PERSISTENT = "PERSISTENT"
   val GEM_SERVER_GROUPS = "SERVER GROUPS"
-  val GEM_OFFHEAP = "OFFHEAP"
   val GEM_EXPIRE = "EXPIRE"
   val GEM_OVERFLOW = "EVICTACTION OVERFLOW"
   val GEM_HEAPPERCENT = "EVICTION BY LRUHEAPPERCENT "
@@ -91,7 +89,7 @@ object StoreUtils {
 
   val ddlOptions: Seq[String] = Seq(PARTITION_BY, REPLICATE, BUCKETS, PARTITIONER,
     COLOCATE_WITH, REDUNDANCY, RECOVERYDELAY, MAXPARTSIZE, EVICTION_BY,
-    PERSISTENCE, PERSISTENT, SERVER_GROUPS, OFFHEAP, EXPIRE, OVERFLOW,
+    PERSISTENCE, PERSISTENT, SERVER_GROUPS, EXPIRE, OVERFLOW,
     GEM_INDEXED_TABLE) ++ ExternalStoreUtils.ddlOptions
 
   val EMPTY_STRING = ""
@@ -427,9 +425,6 @@ object StoreUtils {
     }
     sb.append(parameters.remove(SERVER_GROUPS)
         .map(v => s"$GEM_SERVER_GROUPS ($v) ")
-        .getOrElse(EMPTY_STRING))
-    sb.append(parameters.remove(OFFHEAP).map(v =>
-      if (v.equalsIgnoreCase("true")) s"$GEM_OFFHEAP " else EMPTY_STRING)
         .getOrElse(EMPTY_STRING))
 
     sb.append(parameters.remove(EXPIRE).map(v => {


### PR DESCRIPTION
## Changes proposed in this pull request

- CodegenSparkFallback plan added at the very top to catch code generation failures and
  fallback to Spark plans. This plan is completely transparent and delegates everything
  to child (including "children" itself) so will never be visible in SparkPlanInfo or anywhere else.
- Switch the "disableStoreOptimizations" flag in its execute* overrides to fallback to Spark plans.
- Removed the old handling in SnappySession.load that only works for sql() API while
  above works for all cases.
- Added testcase in ColumnCacheBenchmark
- Removed OFFHEAP option from StoreUtils which refers to Gem/GemXD option and is not supported.
- Some scalastyle corrections.

## Patch testing

precheckin

## ReleaseNotes.txt changes

NA

## Other PRs 

Some AQP changes