### PR TITLE
[SNAP-1714] correcting case-sensitivity handling for API calls

### DIFF
--- a/cluster/src/test/scala/io/snappydata/QueryTest.scala
+++ b/cluster/src/test/scala/io/snappydata/QueryTest.scala
@@ -127,9 +127,17 @@ class QueryTest extends SnappyFunSuite {
         "BUCKETS '1')")
     snc.sql("insert into ColumnTable(\"a/b\",col2,col3) values(1,2,3)")
     snc.sql("select col2,col3 from columnTable").show()
+    snc.sql("select col2, col3, `a/b` from columnTable").show()
+    snc.sql("select col2, col3, \"a/b\" from columnTable").show()
+    snc.sql("select col2, col3, \"A/B\" from columnTable").show()
+    snc.sql("select col2, col3, `A/B` from columnTable").show()
+
+    snc.sql("select col2,col3 from columnTable").show()
     snc.table("columnTable").select("col3", "col2", "a/b").show()
     snc.table("columnTable").select("col3", "Col2", "A/b").show()
     snc.table("columnTable").select("COL3", "Col2", "A/B").show()
+    snc.table("columnTable").select("COL3", "Col2", "`A/B`").show()
+    snc.table("columnTable").select("COL3", "Col2", "`a/b`").show()
 
     snc.setConf("spark.sql.caseSensitive", "true")
     try {
@@ -144,7 +152,21 @@ class QueryTest extends SnappyFunSuite {
     } catch {
       case _: AnalysisException => // expected
     }
+    try {
+      snc.sql("select col2, col3, \"A/B\" from columnTable").show()
+      fail("expected to fail for case-sensitive=true")
+    } catch {
+      case _: AnalysisException => // expected
+    }
+    try {
+      snc.sql("select COL2, COL3, `A/B` from columnTable").show()
+      fail("expected to fail for case-sensitive=true")
+    } catch {
+      case _: AnalysisException => // expected
+    }
     // hive meta-store is case-insensitive so column table names are not
+    snc.sql("select COL2, COL3, \"a/b\" from columnTable").show()
+    snc.sql("select COL2, COL3, `a/b` from ColumnTable").show()
     snc.table("columnTable").select("COL3", "COL2", "a/b").show()
     snc.table("COLUMNTABLE").select("COL3", "COL2", "a/b").show()
   }

--- a/core/src/main/scala/org/apache/spark/sql/SnappyBaseParser.scala
+++ b/core/src/main/scala/org/apache/spark/sql/SnappyBaseParser.scala
@@ -21,8 +21,8 @@ import scala.collection.mutable
 import io.snappydata.Constant
 import org.parboiled2._
 
-import org.apache.spark.sql.catalyst.{FunctionIdentifier, TableIdentifier}
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
+import org.apache.spark.sql.catalyst.{FunctionIdentifier, TableIdentifier}
 import org.apache.spark.sql.collection.Utils
 import org.apache.spark.sql.hive.SnappyStoreHiveCatalog
 import org.apache.spark.sql.types._
@@ -33,7 +33,7 @@ import org.apache.spark.sql.{SnappyParserConsts => Consts}
  */
 abstract class SnappyBaseParser(session: SnappySession) extends Parser {
 
-  val caseSensitive: Boolean = session.sessionState.conf.caseSensitiveAnalysis
+  protected var caseSensitive: Boolean = session.sessionState.conf.caseSensitiveAnalysis
 
   private[sql] final val queryHints = new mutable.HashMap[String, String]
 
@@ -130,12 +130,11 @@ abstract class SnappyBaseParser(session: SnappySession) extends Parser {
   }
 
   protected final def quotedIdentifier: Rule1[String] = rule {
-    atomic('"' ~ capture((noneOf("\"") | "\"\""). +) ~ '"') ~
-        ws ~> { (s: String) =>
-      if (s.indexOf("\"\"") >= 0) s.replace("\"\"", "\"") else s
-    } |
     atomic('`' ~ capture((noneOf("`") | "``"). +) ~ '`') ~ ws ~> { (s: String) =>
       if (s.indexOf("``") >= 0) s.replace("``", "`") else s
+    } |
+    atomic('"' ~ capture((noneOf("\"") | "\"\""). +) ~ '"') ~ ws ~> { (s: String) =>
+      if (s.indexOf("\"\"") >= 0) s.replace("\"\"", "\"") else s
     }
   }
 

--- a/core/src/main/scala/org/apache/spark/sql/SnappyParser.scala
+++ b/core/src/main/scala/org/apache/spark/sql/SnappyParser.scala
@@ -846,9 +846,10 @@ class SnappyParser(session: SnappySession)
         dmlOperation | ctes | ddl | set | cache | uncache | desc))
   }
 
-  def parse[T](sqlText: String, parseRule: => Try[T]): T = session.synchronized {
+  final def parse[T](sqlText: String, parseRule: => Try[T]): T = session.synchronized {
     session.clearQueryData()
     session.sessionState.clearExecutionData()
+    caseSensitive = session.sessionState.conf.caseSensitiveAnalysis
     parseSQL(sqlText, parseRule)
   }
 

--- a/core/src/main/scala/org/apache/spark/sql/execution/ExistingPlans.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/ExistingPlans.scala
@@ -24,9 +24,10 @@ import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.errors.attachTree
 import org.apache.spark.sql.catalyst.expressions.codegen.{CodegenContext, ExprCode}
 import org.apache.spark.sql.catalyst.expressions.{Attribute, Expression, _}
+import org.apache.spark.sql.catalyst.plans.logical.LocalRelation
 import org.apache.spark.sql.catalyst.plans.physical.{ClusteredDistribution, Distribution, HashPartitioning, Partitioning, SinglePartition}
 import org.apache.spark.sql.catalyst.util.{ArrayData, MapData}
-import org.apache.spark.sql.catalyst.{InternalRow, TableIdentifier}
+import org.apache.spark.sql.catalyst.{InternalRow, TableIdentifier, analysis}
 import org.apache.spark.sql.collection.{ToolsCallbackInit, Utils}
 import org.apache.spark.sql.execution.columnar.impl.{BaseColumnFormatRelation, IndexColumnFormatRelation}
 import org.apache.spark.sql.execution.columnar.{ColumnTableScan, ConnectionType}
@@ -75,6 +76,19 @@ private[sql] abstract class PartitionedPhysicalScan(
     dataRDD.getNumPartitions
   } else {
     -1
+  }
+
+  def caseSensitive: Boolean
+
+  protected def fieldIndex(relationOutput: Seq[Attribute], columnName: String): Int = {
+    // lookup as per case-sensitivity (SNAP-1714)
+    val resolver = if (caseSensitive) analysis.caseSensitiveResolution
+    else analysis.caseInsensitiveResolution
+    LocalRelation(relationOutput).resolveQuoted(columnName, resolver) match {
+      case Some(a) => relationOutput.indexWhere(_.semanticEquals(a))
+      case None => throw new IllegalArgumentException(
+        s"""Field "$columnName" does not exist in "$relationOutput".""")
+    }
   }
 
   @transient val (metricAdd, metricValue): (String => String, String => String) =
@@ -135,9 +149,10 @@ private[sql] object PartitionedPhysicalScan {
       scanBuilderArgs: => (Seq[AttributeReference], Seq[Filter])): SparkPlan =
     relation match {
       case i: IndexColumnFormatRelation =>
+        val caseSensitive = i.sqlContext.conf.caseSensitiveAnalysis
         val columnScan = ColumnTableScan(output, rdd, otherRDDs, numBuckets,
           partitionColumns, partitionColumnAliases, relation, relation.schema,
-          allFilters, schemaAttributes)
+          allFilters, schemaAttributes, caseSensitive)
         val table = i.getBaseTableRelation
         val (a, f) = scanBuilderArgs
         val baseTableRDD = table.buildRowBufferRDD(() => Array.empty,
@@ -147,7 +162,7 @@ private[sql] object PartitionedPhysicalScan {
           columnScan.sqlContext.sessionState.analyzer.resolver(left.name, right.name)
 
         val rowBufferScan = RowTableScan(output, StructType.fromAttributes(
-          output), baseTableRDD, numBuckets, Seq.empty, Seq.empty, table)
+          output), baseTableRDD, numBuckets, Seq.empty, Seq.empty, table, caseSensitive)
         val otherPartKeys = partitionColumns.map(_.transform {
           case a: AttributeReference => rowBufferScan.output.find(resolveCol(_, a)).getOrElse {
             throw new AnalysisException(s"RowBuffer output column $a not found in " +
@@ -158,23 +173,25 @@ private[sql] object PartitionedPhysicalScan {
           ClusteredDistribution(columnScan.partitionColumns)))
         ZipPartitionScan(columnScan, columnScan.partitionColumns,
           rowBufferScan, otherPartKeys)
-      case _: BaseColumnFormatRelation =>
+      case c: BaseColumnFormatRelation =>
         ColumnTableScan(output, rdd, otherRDDs, numBuckets,
           partitionColumns, partitionColumnAliases, relation, relation.schema,
-          allFilters, schemaAttributes)
+          allFilters, schemaAttributes, c.sqlContext.conf.caseSensitiveAnalysis)
       case r: SamplingRelation =>
         if (r.isReservoirAsRegion) {
           ColumnTableScan(output, rdd, Nil, numBuckets, partitionColumns,
             partitionColumnAliases, relation, relation.schema, allFilters,
-            schemaAttributes, isForSampleReservoirAsRegion = true)
+            schemaAttributes, r.sqlContext.conf.caseSensitiveAnalysis,
+            isForSampleReservoirAsRegion = true)
         } else {
           ColumnTableScan(output, rdd, otherRDDs, numBuckets,
             partitionColumns, partitionColumnAliases, relation, relation.schema,
-            allFilters, schemaAttributes)
+            allFilters, schemaAttributes, r.sqlContext.conf.caseSensitiveAnalysis)
         }
-      case _: RowFormatRelation =>
+      case r: RowFormatRelation =>
         RowTableScan(output, StructType.fromAttributes(output), rdd, numBuckets,
-          partitionColumns, partitionColumnAliases, relation)
+          partitionColumns, partitionColumnAliases, relation,
+          r.sqlContext.conf.caseSensitiveAnalysis)
     }
 
   def getSparkPlanInfo(plan: SparkPlan): SparkPlanInfo =

--- a/core/src/main/scala/org/apache/spark/sql/execution/columnar/ColumnBatchCreator.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/columnar/ColumnBatchCreator.scala
@@ -83,7 +83,7 @@ final class ColumnBatchCreator(
         val gen = CodeGeneration.compileCode("COLUMN_TABLE.BATCH", schema.fields, () => {
           val tableScan = RowTableScan(schema.toAttributes, schema,
             dataRDD = null, numBuckets = -1, partitionColumns = Seq.empty,
-            partitionColumnAliases = Seq.empty, baseRelation = null)
+            partitionColumnAliases = Seq.empty, baseRelation = null, caseSensitive = true)
           // sending negative values for batch size and delta rows will create
           // only one column batch that will not be checked for size again
           val insertPlan = ColumnInsertExec(tableScan, Seq.empty, Seq.empty,

--- a/core/src/main/scala/org/apache/spark/sql/execution/columnar/ColumnTableScan.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/columnar/ColumnTableScan.scala
@@ -74,6 +74,7 @@ private[sql] final case class ColumnTableScan(
     relationSchema: StructType,
     allFilters: Seq[Expression],
     schemaAttributes: Seq[AttributeReference],
+    caseSensitive: Boolean,
     isForSampleReservoirAsRegion: Boolean = false)
     extends PartitionedPhysicalScan(output, dataRDD, numBuckets,
       partitionColumns, partitionColumnAliases,
@@ -459,7 +460,7 @@ private[sql] final case class ColumnTableScan(
         ctx.addMutableState("Object", bufferVar, s"$bufferVar = null;")
       }
       // projections are not pushed in embedded mode for optimized access
-      val baseIndex = relationSchema.fieldIndex(attr.name)
+      val baseIndex = fieldIndex(schemaAttributes, attr.name)
       val bufferPosition = if (isEmbedded) baseIndex + 1 else index + 1
       val rsPosition = bufferPosition
 

--- a/core/src/main/scala/org/apache/spark/sql/execution/columnar/ExternalStoreUtils.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/columnar/ExternalStoreUtils.scala
@@ -388,21 +388,6 @@ object ExternalStoreUtils extends Logging {
     })
   }
 
-  def columnIndicesAndDataTypes(requestedSchema: StructType,
-      schema: StructType): Seq[(Int, StructField)] = {
-    if (requestedSchema.isEmpty) {
-      val (narrowestOrdinal, narrowestField) =
-        schema.fields.zipWithIndex.map(f => f._2 -> f._1).minBy { f =>
-          ColumnType(f._2.dataType).defaultSize
-        }
-      Seq(narrowestOrdinal -> narrowestField)
-    } else {
-      requestedSchema.map { a =>
-        schema.fieldIndex(Utils.fieldName(a)) -> a
-      }
-    }
-  }
-
   def setStatementParameters(stmt: PreparedStatement,
       row: mutable.ArrayBuffer[Any]): Unit = {
     var col = 1

--- a/core/src/main/scala/org/apache/spark/sql/execution/columnar/impl/JDBCSourceAsColumnarStore.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/columnar/impl/JDBCSourceAsColumnarStore.scala
@@ -317,7 +317,8 @@ class JDBCSourceAsColumnarStore(override val connProperties: ConnectionPropertie
             val tableScan = ColumnTableScan(schemaAttrs, dataRDD = null,
               otherRDDs = Seq.empty, numBuckets = -1,
               partitionColumns = Seq.empty, partitionColumnAliases = Seq.empty,
-              baseRelation = null, schema, allFilters = Seq.empty, schemaAttrs)
+              baseRelation = null, schema, allFilters = Seq.empty, schemaAttrs,
+              caseSensitive = true)
             val insertPlan = RowDMLExec(tableScan, putInto = true, delete = false,
               Seq.empty, Seq.empty, -1, schema, None, onExecutor = true,
               resolvedName = null, connProperties)

--- a/core/src/main/scala/org/apache/spark/sql/execution/row/RowFormatRelation.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/row/RowFormatRelation.scala
@@ -23,12 +23,11 @@ import com.gemstone.gemfire.internal.cache.{LocalRegion, PartitionedRegion}
 import com.pivotal.gemfirexd.internal.engine.Misc
 import com.pivotal.gemfirexd.internal.engine.ddl.catalog.GfxdSystemProcedures
 import com.pivotal.gemfirexd.internal.engine.ddl.resolver.GfxdPartitionByExpressionResolver
-import com.pivotal.gemfirexd.internal.engine.store.GemFireContainer
 
 import org.apache.spark.Partition
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql._
-import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.{InternalRow, analysis}
 import org.apache.spark.sql.catalyst.expressions.{Ascending, Descending, SortDirection}
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.apache.spark.sql.execution.columnar.ExternalStoreUtils.CaseInsensitiveMutableHashMap
@@ -163,7 +162,7 @@ class RowFormatRelation(
           handledFilters,
           _partEval = () => relInfo.partitions,
           relInfo.embdClusterRelDestroyVersion,
-          _commitTx=true
+          _commitTx = true
         )
     }
     (rdd, Nil)
@@ -197,8 +196,10 @@ class RowFormatRelation(
 
   override def getInsertPlan(relation: LogicalRelation,
       child: SparkPlan): SparkPlan = {
+    // use case-insensitive resolution since partitioning columns during
+    // creation could be using the same as opposed to during insert
     val partitionExpressions = partitionColumns.map(colName =>
-      relation.resolveQuoted(colName, sqlContext.sessionState.analyzer.resolver)
+      relation.resolveQuoted(colName, analysis.caseInsensitiveResolution)
           .getOrElse(throw new AnalysisException(
             s"""Cannot resolve column "$colName" among (${relation.output})""")))
     RowDMLExec(child, putInto = false, delete = false, partitionColumns,
@@ -208,8 +209,10 @@ class RowFormatRelation(
 
   override def getPutPlan(relation: LogicalRelation,
       child: SparkPlan): SparkPlan = {
+    // use case-insensitive resolution since partitioning columns during
+    // creation could be using the same as opposed to during put
     val partitionExpressions = partitionColumns.map(colName =>
-      relation.resolveQuoted(colName, sqlContext.sessionState.analyzer.resolver)
+      relation.resolveQuoted(colName, analysis.caseInsensitiveResolution)
           .getOrElse(throw new AnalysisException(
             s"""Cannot resolve column "$colName" among (${relation.output})""")))
     RowDMLExec(child, putInto = true, delete = false, partitionColumns,
@@ -219,8 +222,10 @@ class RowFormatRelation(
 
   override def getDeletePlan(relation: LogicalRelation,
       child: SparkPlan): SparkPlan = {
+    // use case-insensitive resolution since partitioning columns during
+    // creation could be using the same as opposed to during delete
     val partitionExpressions = partitionColumns.map(colName =>
-      relation.resolveQuoted(colName, sqlContext.sessionState.analyzer.resolver)
+      relation.resolveQuoted(colName, analysis.caseInsensitiveResolution)
           .getOrElse(throw new AnalysisException(
             s"""Cannot resolve column "$colName" among (${relation.output})""")))
     RowDMLExec(child, putInto = false, delete = true, partitionColumns,

--- a/core/src/main/scala/org/apache/spark/sql/execution/row/RowTableScan.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/row/RowTableScan.scala
@@ -43,7 +43,8 @@ private[sql] final case class RowTableScan(
     numBuckets: Int,
     partitionColumns: Seq[Expression],
     partitionColumnAliases: Seq[Seq[Attribute]],
-    @transient baseRelation: PartitionedDataSourceScan)
+    @transient baseRelation: PartitionedDataSourceScan,
+    caseSensitive: Boolean)
     extends PartitionedPhysicalScan(output, dataRDD, numBuckets,
       partitionColumns, partitionColumnAliases,
       baseRelation.asInstanceOf[BaseRelation]) {
@@ -86,8 +87,9 @@ private[sql] final case class RowTableScan(
     val holder = ctx.freshName("nullHolder")
     val holderClass = classOf[ResultSetNullHolder].getName
     val compactRowClass = classOf[AbstractCompactExecRow].getName
+    val baseSchemaOutput = baseSchema.toAttributes
     val columnsRowInput = output.map(a => genCodeCompactRowColumn(ctx,
-      row, holder, baseSchema.fieldIndex(a.name), a.dataType, a.nullable))
+      row, holder, fieldIndex(baseSchemaOutput, a.name), a.dataType, a.nullable))
     s"""
        |final scala.collection.Iterator $iterator = $input;
        |final $holderClass $holder = new $holderClass();

--- a/core/src/main/scala/org/apache/spark/sql/store/StoreUtils.scala
+++ b/core/src/main/scala/org/apache/spark/sql/store/StoreUtils.scala
@@ -294,13 +294,9 @@ object StoreUtils {
                 .normalizeSchema(schema)
             val schemaFields = Utils.schemaFields(normalizedSchema)
             val cols = v.split(",") map (_.trim)
-            val normalizedCols = cols map { c =>
-              if (context.conf.caseSensitiveAnalysis) {
-                c
-              } else {
-                if (Utils.hasLowerCase(c)) Utils.toUpperCase(c) else c
-              }
-            }
+            // always use case-insensitive analysis for partitioning columns
+            // since table creation can use case-insensitive in creation
+            val normalizedCols = cols.map(Utils.toUpperCase)
             val prunedSchema = ExternalStoreUtils.pruneSchema(schemaFields,
               normalizedCols)
 


### PR DESCRIPTION
## Changes proposed in this pull request

- pass through "caseSensitive" flag to ColumnTableScan and RowTableScan to
  do resolution as per case-sensitivity settings (in base PartitionedPhysicalPlan.fieldIndex);
  the method uses a temporary LocalRelation to invoke resolveQuoted
- always use case-insensitive resolution for partitioned column resolution since
  it may be case-insensitive during CREATE TABLE (and we are not storing that
      flag in the DDL itself); this means that users can't have two columns
  that just differ in case-sensitivity esp for partitioning which is a reasonable
  restriction
- SnappyBaseParser now has caseSensitive flag as a var which is updated on each
  top-level parse() call since the flag in SQLConf may have changed
- added a test in QueryTest as per the failure scenario mentioned in SNAP-1714
  with different case checks including for caseSensitiveAnalysis=false or true
  apart from quoted names
- some scalaStyle corrections

## Patch testing

precheckin

## ReleaseNotes.txt changes

Cannot have column names in the table that differ only in case-sensitivity especially
the partitioning columns.

## Other PRs 

NA