### PR TITLE
[SNAP-1735] use single batch count in stats row

### DIFF
--- a/core/src/main/scala/org/apache/spark/sql/execution/ExistingPlans.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/ExistingPlans.scala
@@ -30,8 +30,8 @@ import org.apache.spark.sql.catalyst.{InternalRow, TableIdentifier}
 import org.apache.spark.sql.collection.{ToolsCallbackInit, Utils}
 import org.apache.spark.sql.execution.columnar.impl.{BaseColumnFormatRelation, IndexColumnFormatRelation}
 import org.apache.spark.sql.execution.columnar.{ColumnTableScan, ConnectionType}
-import org.apache.spark.sql.execution.exchange.ShuffleExchange
-import org.apache.spark.sql.execution.metric.{SQLMetric, SQLMetrics}
+import org.apache.spark.sql.execution.exchange.{ReusedExchangeExec, ShuffleExchange}
+import org.apache.spark.sql.execution.metric.{SQLMetric, SQLMetricInfo, SQLMetrics}
 import org.apache.spark.sql.execution.row.{RowFormatRelation, RowTableScan}
 import org.apache.spark.sql.sources.{BaseRelation, Filter, PrunedUnsafeFilteredScan, SamplingRelation}
 import org.apache.spark.sql.types._
@@ -177,8 +177,24 @@ private[sql] object PartitionedPhysicalScan {
           partitionColumns, partitionColumnAliases, relation)
     }
 
-  def getSparkPlanInfo(plan: SparkPlan): SparkPlanInfo =
-    SparkPlanInfo.fromSparkPlan(plan)
+  def getSparkPlanInfo(fullPlan: SparkPlan): SparkPlanInfo = {
+    val plan = fullPlan match {
+      case CodegenSparkFallback(CachedPlanHelperExec(child)) => child
+      case CodegenSparkFallback(child) => child
+      case CachedPlanHelperExec(child) => child
+      case _ => fullPlan
+    }
+    val children = plan match {
+      case ReusedExchangeExec(_, child) => child :: Nil
+      case _ => plan.children ++ plan.subqueries
+    }
+    val metrics = plan.metrics.toSeq.map { case (key, metric) =>
+      new SQLMetricInfo(metric.name.getOrElse(key), metric.id, metric.metricType)
+    }
+
+    new SparkPlanInfo(plan.nodeName, plan.simpleString,
+      children.map(getSparkPlanInfo), plan.metadata, metrics)
+  }
 }
 
 /**
@@ -195,7 +211,7 @@ case class ExecutePlan(child: SparkPlan, preAction: () => Unit = () => ())
     val callSite = sqlContext.sparkContext.getCallSite()
     CachedDataFrame.withNewExecutionId(sqlContext.sparkSession,
       callSite.shortForm, callSite.longForm,
-      child.treeString(verbose = true), SparkPlanInfo.fromSparkPlan(child)) {
+      child.treeString(verbose = true), PartitionedPhysicalScan.getSparkPlanInfo(child)) {
       child.executeCollect()
     }
   }

--- a/core/src/main/scala/org/apache/spark/sql/execution/columnar/encoding/DictionaryEncoding.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/columnar/encoding/DictionaryEncoding.scala
@@ -316,7 +316,6 @@ trait DictionaryEncoderBase extends ColumnEncoder with DictionaryEncoding {
           (numUsedIndexes << 2) / 3)
       }
     }
-    updateCount()
     // write the index
     writeIndex(position, index)
   }

--- a/core/src/main/scala/org/apache/spark/sql/execution/columnar/encoding/Uncompressed.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/columnar/encoding/Uncompressed.scala
@@ -354,7 +354,6 @@ trait UncompressedEncoderBase extends ColumnEncoder with Uncompressed {
       position = expand(position, size + 4)
     }
     updateStringStats(value)
-    updateCount()
     ColumnEncoding.writeUTF8String(columnBytes, position,
       value.getBaseObject, value.getBaseOffset, size)
   }

--- a/core/src/main/scala/org/apache/spark/sql/execution/columnar/impl/ColumnFormatEntry.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/columnar/impl/ColumnFormatEntry.scala
@@ -124,12 +124,14 @@ final class ColumnFormatKey(private[columnar] var partitionId: Int,
           .asInstanceOf[ColumnFormatValue]
       if (value ne null) {
         val buffer = value.getBufferRetain
-        if (buffer.remaining() > 0) {
-          val unsafeRow = Utils.toUnsafeRow(buffer, numColumns)
-          val n = unsafeRow.getInt(ColumnStatsSchema.COUNT_INDEX_IN_SCHEMA)
+        try {
+          if (buffer.remaining() > 0) {
+            val unsafeRow = Utils.toUnsafeRow(buffer, numColumns)
+            unsafeRow.getInt(ColumnStatsSchema.COUNT_INDEX_IN_SCHEMA)
+          } else 0
+        } finally {
           value.release()
-          n
-        } else 0
+        }
       } else 0
     } else 0
   }

--- a/core/src/main/scala/org/apache/spark/sql/execution/columnar/impl/ColumnFormatEntry.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/columnar/impl/ColumnFormatEntry.scala
@@ -116,7 +116,7 @@ final class ColumnFormatKey(private[columnar] var partitionId: Int,
 
   override def getColumnBatchRowCount(itr: PREntriesIterator[_],
       re: AbstractRegionEntry, numColumnsInTable: Int): Int = {
-    val numColumns = numColumnsInTable * ColumnStatsSchema.NUM_STATS_PER_COLUMN
+    val numColumns = numColumnsInTable * ColumnStatsSchema.NUM_STATS_PER_COLUMN + 1
     val currentBucketRegion = itr.getHostedBucketRegion
     if (columnIndex == ColumnBatchIterator.STATROW_COL_INDEX &&
         !re.isDestroyedOrRemoved) {


### PR DESCRIPTION
## Changes proposed in this pull request

- now using a single common batch count column (first one) in the stats row removing
  the separate count per column
- removed updateCount() from ColumnEncoders
- added test for normal and wide schema with this scenario in ColumnCacheBenchmark

## Patch testing

precheckin

## ReleaseNotes.txt changes

NA

## Other PRs 

NA