### PR TITLE
[SNAP-1752] Use ManagedByteBuffer in CachedDataFrame

### DIFF
--- a/cluster/src/dunit/scala/org/apache/spark/memory/SnappyUnifiedMemoryManagerDUnitTest.scala
+++ b/cluster/src/dunit/scala/org/apache/spark/memory/SnappyUnifiedMemoryManagerDUnitTest.scala
@@ -81,6 +81,9 @@ class SnappyUnifiedMemoryManagerDUnitTest(s: String) extends ClusterManagerTestB
   }
 
   override def tearDown2(): Unit = {
+    val snc = SnappyContext(sc).newSession()
+    snc.dropTable(col_table, ifExists = true)
+    snc.dropTable(rr_table, ifExists = true)
     resetMemoryManagers()
     super.tearDown2()
   }
@@ -144,7 +147,7 @@ class SnappyUnifiedMemoryManagerDUnitTest(s: String) extends ClusterManagerTestB
     assertApproximate(vm1_memoryUsed, vm2_memoryUsed)
   }
 
-  def testMemoryUsedInBucketRegions_ColumntTables(): Unit = {
+  def testMemoryUsedInBucketRegions_ColumnTables(): Unit = {
     val snc = newContext()
     val data = for (i <- 1 to 500) yield (Seq(i, (i + 1), (i + 2)))
     val rdd = snc.sparkContext.parallelize(data.toSeq, 2).map(s =>

--- a/core/src/main/scala/org/apache/spark/sql/CachedDataFrame.scala
+++ b/core/src/main/scala/org/apache/spark/sql/CachedDataFrame.scala
@@ -412,7 +412,6 @@ object CachedDataFrame
     val buffer = new Array[Byte](4 << 10) // 4K
     // final output is written to this buffer
     val output = new ByteBufferDataOutput(4 << 10,
-      DirectBufferAllocator.instance(),
       null,
       ManagedDirectBufferAllocator.DIRECT_STORE_DATA_FRAME_OUTPUT)
     // holds intermediate bytes which are compressed and flushed to output


### PR DESCRIPTION


## Changes proposed in this pull request
Changed the ByteBufferAllocator to use ManagedByteBuffer 
for heap as well as off-heap cases.
## Patch testing

pre-checkin

## ReleaseNotes.txt changes

NA

## Other PRs 


