### PR TITLE
[SNAP-1688] Use execution memory for serialized result.

### DIFF
--- a/cluster/src/dunit/scala/org/apache/spark/memory/SnappyUnifiedMemoryManagerDUnitTest.scala
+++ b/cluster/src/dunit/scala/org/apache/spark/memory/SnappyUnifiedMemoryManagerDUnitTest.scala
@@ -196,7 +196,7 @@ class SnappyUnifiedMemoryManagerDUnitTest(s: String) extends ClusterManagerTestB
     dataDF.write.insertInto(col_table)
     vm1.invoke(restartServer(props))
 
-    val waitAssert = new WaitAssert(10, getClass)
+    val waitAssert = new WaitAssert(20, getClass)
     // Setting ignore bytecount as VM doing GII does have a valid value, hence key is kept as null
     // This decreases the size of entry overhead. @TODO find out why only column table needs this ?
     ClusterManagerTestBase.waitForCriterion(waitAssert.assertStorageUsed(vm1, vm2),
@@ -232,7 +232,7 @@ class SnappyUnifiedMemoryManagerDUnitTest(s: String) extends ClusterManagerTestB
     dataDF.write.insertInto(rr_table)
     vm1.invoke(restartServer(props))
 
-    val waitAssert = new WaitAssert(2, getClass)
+    val waitAssert = new WaitAssert(10, getClass)
     ClusterManagerTestBase.waitForCriterion(waitAssert.assertStorageUsed(vm1, vm2),
       waitAssert.exceptionString(),
       20000, 5000, true)
@@ -269,7 +269,7 @@ class SnappyUnifiedMemoryManagerDUnitTest(s: String) extends ClusterManagerTestB
     dataDF.write.insertInto(rr_table)
     vm1.invoke(restartServer(props))
 
-    val waitAssert = new WaitAssert(2, getClass)
+    val waitAssert = new WaitAssert(10, getClass)
     ClusterManagerTestBase.waitForCriterion(waitAssert.assertStorageUsed(vm1, vm2),
       waitAssert.exceptionString(),
       20000, 5000, true)
@@ -314,7 +314,7 @@ class SnappyUnifiedMemoryManagerDUnitTest(s: String) extends ClusterManagerTestB
 
     vm1.invoke(restartServer(props))
 
-    val waitAssert = new WaitAssert(5, getClass)
+    val waitAssert = new WaitAssert(10, getClass)
     // The delete operation takes time to propagate
     ClusterManagerTestBase.waitForCriterion(waitAssert.assertStorageUsed(vm1, vm2),
       waitAssert.exceptionString(),

--- a/cluster/src/dunit/scala/org/apache/spark/memory/SnappyUnifiedMemoryManagerDUnitTest.scala
+++ b/cluster/src/dunit/scala/org/apache/spark/memory/SnappyUnifiedMemoryManagerDUnitTest.scala
@@ -81,6 +81,9 @@ class SnappyUnifiedMemoryManagerDUnitTest(s: String) extends ClusterManagerTestB
   }
 
   override def tearDown2(): Unit = {
+    val snc = SnappyContext(sc).newSession()
+    snc.dropTable(col_table, ifExists = true)
+    snc.dropTable(rr_table, ifExists = true)
     resetMemoryManagers()
     super.tearDown2()
   }

--- a/cluster/src/main/scala/org/apache/spark/memory/SnappyUnifiedMemoryManager.scala
+++ b/cluster/src/main/scala/org/apache/spark/memory/SnappyUnifiedMemoryManager.scala
@@ -361,13 +361,11 @@ class SnappyUnifiedMemoryManager private[memory](
           return
         }
 
-        // Stop execution pool to grow beyond eviction percentage of heap.
-        if (memoryMode eq MemoryMode.ON_HEAP) {
-          if (executionPool.memoryUsed + extraMemoryNeeded > maxHeapExecutionSize) {
-            logWarning(s"MemoryManager can't allocate $numBytes bytes as it " +
-                s"would exceed maxHeapExecutionSize = $maxHeapExecutionSize")
-            return
-          }
+        // Stop execution pool to grow beyond storage fraction.
+        if (executionPool.memoryUsed + extraMemoryNeeded > storageRegionSize) {
+          logWarning(s"MemoryManager can't allocate $numBytes bytes as it " +
+              s"would exceed storageRegionSize = $storageRegionSize")
+          return
         }
 
         // There is not enough free memory in the execution pool, so try to reclaim memory from

--- a/cluster/src/main/scala/org/apache/spark/memory/SnappyUnifiedMemoryManager.scala
+++ b/cluster/src/main/scala/org/apache/spark/memory/SnappyUnifiedMemoryManager.scala
@@ -479,8 +479,11 @@ class SnappyUnifiedMemoryManager private[memory](
       // TODO use something like "(spark.driver.maxResultSize / numPartitions) * 2"
       val doEvict = if (shouldEvict &&
           objectName.endsWith(BufferAllocator.STORE_DATA_FRAME_OUTPUT)) {
-        // don't use more than 30% of pool size for one partition result
-        numBytes < math.min(0.3 * storagePool.poolSize,
+        // don't use more than 10% of pool size for one partition result
+        // 30% of storagePool size is still large. WIth retries it virtually evicts all data.
+        // Hence taking 30% of initial storage pool size. Once retry of LowMemoryException is
+        // stopped it would be much cleaner.
+        numBytes < math.min(0.3 * maxStorageSize,
           math.max(maxPartResultSize, storagePool.memoryFree))
       } else shouldEvict
 

--- a/cluster/src/test/scala/org/apache/spark/memory/MemoryFunSuite.scala
+++ b/cluster/src/test/scala/org/apache/spark/memory/MemoryFunSuite.scala
@@ -72,6 +72,7 @@ class MemoryFunSuite extends SparkFunSuite with BeforeAndAfter with BeforeAndAft
       .config("spark.testing.memory", sparkMemory)
       .config("spark.testing.reservedMemory", "0")
       .config("snappydata.store.critical-heap-percentage", "90")
+      .config("spark.testing.maxStorageFraction", "0.9")
       .config("spark.memory.manager", "org.apache.spark.memory.SnappyUnifiedMemoryManager")
       .config("spark.storage.unrollMemoryThreshold", 500)
       .getOrCreate

--- a/cluster/src/test/scala/org/apache/spark/memory/SnappyMemoryAccountingSuite.scala
+++ b/cluster/src/test/scala/org/apache/spark/memory/SnappyMemoryAccountingSuite.scala
@@ -255,6 +255,8 @@ class SnappyMemoryAccountingSuite extends MemoryFunSuite {
         assert(totalEvictedBytes > 0)
     }
     // scalastyle:on
+    SparkEnv.get.memoryManager.
+        asInstanceOf[SnappyUnifiedMemoryManager].dropAllObjects(memoryMode)
     val count = snSession.sql("select * from t1").count()
     assert(count >= rows)
     snSession.dropTable("t1")

--- a/cluster/src/test/scala/org/apache/spark/memory/SnappyStorageEvictorSuite.scala
+++ b/cluster/src/test/scala/org/apache/spark/memory/SnappyStorageEvictorSuite.scala
@@ -125,6 +125,7 @@ class SnappyStorageEvictorSuite extends MemoryFunSuite {
       }
     }
     snappyMemoryManager.dropAllObjects(memoryMode)
+    SparkEnv.get.memoryManager.releaseExecutionMemory(500L, taskAttemptId, memoryMode)
     val count = snSession.sql("select * from t1").count()
     assert(count == rows)
     snSession.dropTable("t1")

--- a/core/src/main/scala/org/apache/spark/sql/CachedDataFrame.scala
+++ b/core/src/main/scala/org/apache/spark/sql/CachedDataFrame.scala
@@ -477,11 +477,10 @@ object CachedDataFrame
             s" result data. Please check -XX:MaxDirectMemorySize while starting the server",
           java.util.Collections.emptySet())
     } finally {
-      // Not handling DirectByteBuffer case which gives a OOM exception.
-      // Assumption is most of the big workload will use off-heap
       bufferOutput.clear()
       // one additional release for the explicit getBufferRetain
       if (output ne null) {
+        output.release()
         output.release()
       }
     }

--- a/core/src/main/scala/org/apache/spark/sql/CachedDataFrame.scala
+++ b/core/src/main/scala/org/apache/spark/sql/CachedDataFrame.scala
@@ -410,12 +410,12 @@ object CachedDataFrame
       iter: Iterator[InternalRow]): PartitionResult = {
     var count = 0
     val buffer = new Array[Byte](4 << 10)
-    // 4K
+
     // final output is written to this buffer
     var output: ByteBufferDataOutput = null
     // holds intermediate bytes which are compressed and flushed to output
     val maxOutputBufferSize = 64 << 10
-    // 64K
+
     // can't enforce maxOutputBufferSize due to a row larger than that limit
     val bufferOutput = new Output(4 << 10, -1)
     var outputRetained = false

--- a/core/src/main/scala/org/apache/spark/sql/CachedDataFrame.scala
+++ b/core/src/main/scala/org/apache/spark/sql/CachedDataFrame.scala
@@ -484,7 +484,6 @@ object CachedDataFrame
       if (output ne null) {
         output.release()
       }
-      output.release()
     }
   }
 


### PR DESCRIPTION
We have safeguarded the result serialization memory consumption from each partition. These safeguards are put in CachedDataFrame. Before copying the result iterator to heap we ask UMM for memory availability. If sufficient memory is not available the partition of result task fails. 

When accounting in UMM we take memory from the storage pool. This leads to code complexity and unused execution pool space. Also, it unnecessarily evicts some table data which otherwise could have fitted in memory

## Changes proposed in this pull request
Use execution memory instead of storage memory for CachedDataFrame serialized memory.
For this, we create a memory consumer which acts on behalf of ResultTask and asks for execution memory. 

Also added a guard in execution pool to stop growing the pool beyond a storage fraction. 

Couple of test changes.

## Patch testing

pre-checkin, manual tests

## ReleaseNotes.txt changes

NA

## Other PRs 
NA
