### PR TITLE
[SNAP-1760] Correct null bitset expansion and reduce copying in inserts

### DIFF
--- a/cluster/src/main/scala/io/snappydata/impl/LeadImpl.scala
+++ b/cluster/src/main/scala/io/snappydata/impl/LeadImpl.scala
@@ -27,7 +27,7 @@ import scala.collection.JavaConverters._
 import akka.actor.ActorSystem
 import com.gemstone.gemfire.distributed.internal.DistributionConfig
 import com.gemstone.gemfire.distributed.internal.locks.{DLockService, DistributedMemberLock}
-import com.gemstone.gemfire.internal.cache.{GemFireCacheImpl}
+import com.gemstone.gemfire.internal.cache.GemFireCacheImpl
 import com.pivotal.gemfirexd.FabricService.State
 import com.pivotal.gemfirexd.internal.engine.store.ServerGroupUtils
 import com.pivotal.gemfirexd.{FabricService, NetworkInterface}
@@ -110,7 +110,6 @@ class LeadImpl extends ServerImpl with Lead
           set("spark.scheduler.mode", "FAIR").
           setIfMissing("spark.memory.manager",
             ExecutorInitiator.SNAPPY_MEMORY_MANAGER)
-          .setIfMissing("spark.memory.storageMaxFraction", "0.95")
 
       Utils.setDefaultSerializerAndCodec(conf)
 
@@ -126,10 +125,7 @@ class LeadImpl extends ServerImpl with Lead
           } else {
             Constant.STORE_PROPERTY_PREFIX + k
           }
-        } 
-        else {
-          k
-        }
+        } else k
         conf.set(key, v)
       })
       // set spark ui port to 5050 that is snappy's default
@@ -168,7 +164,7 @@ class LeadImpl extends ServerImpl with Lead
       checkAndStartZeppelinInterpreter(bootProperties)
 
     } catch {
-      case ie: InterruptedException =>
+      case _: InterruptedException =>
         logInfo(s"Thread interrupted, aborting.")
       case e: Throwable =>
         logWarning("Exception while starting lead node", e)
@@ -298,8 +294,8 @@ class LeadImpl extends ServerImpl with Lead
           changeOrAppend(attr, value, overwrite, ignoreIfPresent,
             sparkPrefix = Constant.SPARK_PREFIX)
         } else conf.set(attr, value)
-        case v if ignoreIfPresent => // skip setting property
-        case v if overwrite => conf.set(attr, value)
+        case _ if ignoreIfPresent => // skip setting property
+        case _ if overwrite => conf.set(attr, value)
         case Some(x) => conf.set(attr, x ++ s""",$value""")
       }
     }

--- a/cluster/src/main/scala/org/apache/spark/memory/SnappyUnifiedMemoryManager.scala
+++ b/cluster/src/main/scala/org/apache/spark/memory/SnappyUnifiedMemoryManager.scala
@@ -61,7 +61,7 @@ class SnappyUnifiedMemoryManager private[memory](
   private val managerId = if (!tempManager) "RuntimeManager" else "BootTimeManager"
 
   private val maxOffHeapStorageSize = (maxOffHeapMemory *
-           conf.getDouble("spark.memory.storageMaxFraction", 0.9)).toLong
+      conf.getDouble("spark.memory.storageMaxFraction", 0.95)).toLong
 
   /**
    * An estimate of the maximum result size handled by a single partition.

--- a/core/src/main/scala/io/snappydata/collection/ByteBufferHashMap.scala
+++ b/core/src/main/scala/io/snappydata/collection/ByteBufferHashMap.scala
@@ -157,7 +157,9 @@ final class ByteBufferHashMap(initialCapacity: Int, val loadFactor: Double,
 
   def release(): Unit = {
     keyData.release(allocator)
+    keyData = null
     valueData.release(allocator)
+    valueData = null
   }
 
   private def newInsert(s: UTF8String): Int = {
@@ -166,7 +168,7 @@ final class ByteBufferHashMap(initialCapacity: Int, val loadFactor: Double,
     var position = valueDataPosition
     val dataSize = position - valueData.baseOffset
     if (position + numBytes + 4 > valueData.endPosition) {
-      valueData = valueData.resize(position, numBytes + 4, allocator)
+      valueData = valueData.resize(numBytes + 4, allocator)
       position = valueData.baseOffset + dataSize
     }
     valueDataPosition = ColumnEncoding.writeUTF8String(valueData.baseObject,
@@ -235,7 +237,7 @@ final class ByteBufferData private(val buffer: ByteBuffer,
     val baseObject: AnyRef, val baseOffset: Long, val endPosition: Long) {
 
   def this(buffer: ByteBuffer, baseObject: AnyRef, baseOffset: Long) = {
-    this(buffer, baseObject, baseOffset, baseOffset + buffer.capacity())
+    this(buffer, baseObject, baseOffset, baseOffset + buffer.limit())
   }
 
   def this(buffer: ByteBuffer, allocator: BufferAllocator) = {
@@ -262,8 +264,7 @@ final class ByteBufferData private(val buffer: ByteBuffer,
         .arrayEquals(baseObject, offset + 4, oBase, oBaseOffset, size)
   }
 
-  def resize(cursor: Long, required: Int,
-      allocator: BufferAllocator): ByteBufferData = {
+  def resize(required: Int, allocator: BufferAllocator): ByteBufferData = {
     val buffer = allocator.expand(this.buffer, required, "HASHMAP")
     val baseOffset = allocator.baseOffset(buffer)
     new ByteBufferData(buffer, allocator.baseObject(buffer), baseOffset,

--- a/core/src/main/scala/io/snappydata/collection/ByteBufferHashMap.scala
+++ b/core/src/main/scala/io/snappydata/collection/ByteBufferHashMap.scala
@@ -119,7 +119,7 @@ final class ByteBufferHashMap(initialCapacity: Int, val loadFactor: Double,
         // first compare the hash codes
         val mapKeyHash = mapKey.toInt
         // equalsSize will include check for 4 bytes of numBytes itself
-        if (hash == mapKeyHash && valueData.equalsSize((mapKey >>> 32).toInt - 4,
+        if (hash == mapKeyHash && valueData.equalsSize((mapKey >>> 32L).toInt - 4,
           key.getBaseObject, key.getBaseOffset, key.numBytes())) {
           return Platform.getInt(mapKeyObject, mapKeyOffset + 8)
         } else {

--- a/core/src/main/scala/io/snappydata/collection/ByteBufferHashMap.scala
+++ b/core/src/main/scala/io/snappydata/collection/ByteBufferHashMap.scala
@@ -144,7 +144,7 @@ final class ByteBufferHashMap(initialCapacity: Int, val loadFactor: Double,
 
   def duplicate(): ByteBufferHashMap = {
     new ByteBufferHashMap(_capacity - 1, loadFactor, keySize, valueSize,
-      allocator, keyData.duplicate(), valueData.duplicate(), valueDataPosition)
+      allocator, keyData.duplicate(), valueData.duplicate(), valueData.baseOffset)
   }
 
   def reset(): Unit = {
@@ -157,8 +157,8 @@ final class ByteBufferHashMap(initialCapacity: Int, val loadFactor: Double,
 
   def release(): Unit = {
     keyData.release(allocator)
-    keyData = null
     valueData.release(allocator)
+    keyData = null
     valueData = null
   }
 
@@ -282,7 +282,7 @@ final class ByteBufferData private(val buffer: ByteBuffer,
         // will be more efficient
         buffer.capacity(), 0)
     }
-    buffer.clear()
+    buffer.rewind()
   }
 
   def release(allocator: BufferAllocator): Unit = {

--- a/core/src/main/scala/org/apache/spark/sql/execution/columnar/ColumnBatch.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/columnar/ColumnBatch.scala
@@ -29,7 +29,7 @@ import com.gemstone.gemfire.internal.shared.unsafe.UnsafeHolder
 import io.snappydata.thrift.common.BufferedBlob
 import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap
 
-import org.apache.spark.sql.execution.columnar.impl.{ColumnFormatEntry, ColumnFormatKey, ColumnFormatValue}
+import org.apache.spark.sql.execution.columnar.impl.{ColumnFormatKey, ColumnFormatValue}
 import org.apache.spark.sql.execution.row.PRValuesIterator
 import org.apache.spark.{Logging, TaskContext}
 
@@ -135,10 +135,6 @@ final class ColumnBatchIterator(region: LocalRegion, val batch: ColumnBatch,
   if (region ne null) {
     assert(!region.getEnableOffHeapMemory,
       s"Unexpected buffer iterator call for off-heap $region")
-  } else {
-    // skip the serialization headers in the ByteBuffers
-    batch.buffers.foreach(buffer => buffer.position(buffer.position() +
-        ColumnFormatEntry.VALUE_HEADER_SIZE))
   }
 
   if (context ne null) {

--- a/core/src/main/scala/org/apache/spark/sql/execution/columnar/ColumnBatch.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/columnar/ColumnBatch.scala
@@ -29,7 +29,7 @@ import com.gemstone.gemfire.internal.shared.unsafe.UnsafeHolder
 import io.snappydata.thrift.common.BufferedBlob
 import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap
 
-import org.apache.spark.sql.execution.columnar.impl.{ColumnFormatKey, ColumnFormatValue}
+import org.apache.spark.sql.execution.columnar.impl.{ColumnFormatEntry, ColumnFormatKey, ColumnFormatValue}
 import org.apache.spark.sql.execution.row.PRValuesIterator
 import org.apache.spark.{Logging, TaskContext}
 
@@ -135,6 +135,10 @@ final class ColumnBatchIterator(region: LocalRegion, val batch: ColumnBatch,
   if (region ne null) {
     assert(!region.getEnableOffHeapMemory,
       s"Unexpected buffer iterator call for off-heap $region")
+  } else {
+    // skip the serialization headers in the ByteBuffers
+    batch.buffers.foreach(buffer => buffer.position(buffer.position() +
+        ColumnFormatEntry.VALUE_HEADER_SIZE))
   }
 
   if (context ne null) {

--- a/core/src/main/scala/org/apache/spark/sql/execution/columnar/ColumnInsertExec.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/columnar/ColumnInsertExec.scala
@@ -195,7 +195,7 @@ case class ColumnInsertExec(_child: SparkPlan, partitionColumns: Seq[String],
        |  $childProduce
        |}
        |if ($batchSizeTerm > 0) {
-       |  $storeColumnBatch(-1, $storeColumnBatchArgs);
+       |  $storeColumnBatch($columnMaxDeltaRows / 2, $storeColumnBatchArgs);
        |  $batchSizeTerm = 0;
        |}
        |${if (numInsertedRowsMetric eq null) ""

--- a/core/src/main/scala/org/apache/spark/sql/execution/columnar/ColumnInsertExec.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/columnar/ColumnInsertExec.scala
@@ -88,9 +88,46 @@ case class ColumnInsertExec(_child: SparkPlan, partitionColumns: Seq[String],
 
   def loop(code: String, numTimes: Int): String = {
     s"""
-      for(int i=0;i< $numTimes; i++){
+      for (int i = 0;i < $numTimes; i++) {
           $code
       }"""
+  }
+
+  /**
+   * Add a task listener to close encoders as part of defining
+   * "defaultBatchSizeTerm". Also return a string as a fallback check
+   * to be added at the end of doProduce code before returning in case
+   * this is generated on executor that has no TaskContext.
+   */
+  private def addBatchSizeAndCloseEncoders(ctx: CodegenContext,
+      closeEncoders: String): String = {
+    val closeEncodersFunction = ctx.freshName("closeEncoders")
+    ctx.addNewFunction(closeEncodersFunction,
+      s"""
+         |private void $closeEncodersFunction() {
+         |  $closeEncoders
+         |}
+      """.stripMargin)
+    // add a task completion listener to close the encoders
+    val contextClass = classOf[TaskContext].getName
+    val listenerClass = classOf[TaskCompletionListener].getName
+    val context = ctx.freshName("taskContext")
+    ctx.addMutableState("int", defaultBatchSizeTerm,
+      s"""
+         |final $contextClass $context = $contextClass.get();
+         |if ($context != null) {
+         |  $context.addTaskCompletionListener(new $listenerClass() {
+         |    @Override
+         |    public void onTaskCompletion($contextClass context) {
+         |      if ($numInsertions >= 0) $closeEncodersFunction();
+         |    }
+         |  });
+         |}
+      """.stripMargin)
+    s"""
+       |if ($numInsertions >= 0 && $contextClass.get() == null) {
+       |  $closeEncodersFunction();
+       |}""".stripMargin
   }
 
   /**
@@ -121,7 +158,6 @@ case class ColumnInsertExec(_child: SparkPlan, partitionColumns: Seq[String],
       s"int $batchSizeTerm = 0;"
     }
     defaultBatchSizeTerm = ctx.freshName("defaultBatchSize")
-    ctx.addMutableState("int", defaultBatchSizeTerm, "")
     val defaultRowSize = ctx.freshName("defaultRowSize")
     val childProduce = doChildProduce(ctx)
 
@@ -178,6 +214,10 @@ case class ColumnInsertExec(_child: SparkPlan, partitionColumns: Seq[String],
          |}
       """.stripMargin)
 
+    val closeEncoders = loop(
+      s"if ($encoderArrayTerm[i] != null) $encoderArrayTerm[i].close();",
+      relationSchema.length)
+    val closeForNoContext = addBatchSizeAndCloseEncoders(ctx, closeEncoders)
     s"""
        |$checkEnd; // already done
        |$batchSizeDeclaration
@@ -198,6 +238,7 @@ case class ColumnInsertExec(_child: SparkPlan, partitionColumns: Seq[String],
        |  $storeColumnBatch($columnMaxDeltaRows / 2, $storeColumnBatchArgs);
        |  $batchSizeTerm = 0;
        |}
+       |$closeForNoContext
        |${if (numInsertedRowsMetric eq null) ""
         else s"$numInsertedRowsMetric.${metricAdd(numInsertions)};"}
        |${consume(ctx, Seq(ExprCode("", "false", numInsertions)))}
@@ -277,29 +318,7 @@ case class ColumnInsertExec(_child: SparkPlan, partitionColumns: Seq[String],
          |  return false;
          |}
       """.stripMargin)
-    val closeEncodersFunction = ctx.freshName("closeEncoders")
-    ctx.addNewFunction(closeEncodersFunction,
-      s"""
-         |private void $closeEncodersFunction() {
-         |  $closeEncoders
-         |}
-      """.stripMargin)
-    // add a task completion listener to close the encoders
-    val contextClass = classOf[TaskContext].getName
-    val listenerClass = classOf[TaskCompletionListener].getName
-    val context = ctx.freshName("taskContext")
-    ctx.addMutableState("int", defaultBatchSizeTerm,
-      s"""
-         |final $contextClass $context = $contextClass.get();
-         |if ($context != null) {
-         |  $context.addTaskCompletionListener(new $listenerClass() {
-         |    @Override
-         |    public void onTaskCompletion($contextClass context) {
-         |      if ($numInsertions >= 0) $closeEncodersFunction();
-         |    }
-         |  });
-         |}
-      """.stripMargin)
+    val closeForNoContext = addBatchSizeAndCloseEncoders(ctx, closeEncoders.toString())
     s"""
        |$checkEnd; // already done
        |$batchSizeDeclaration
@@ -323,9 +342,7 @@ case class ColumnInsertExec(_child: SparkPlan, partitionColumns: Seq[String],
        |  $storeColumnBatch($columnMaxDeltaRows, $storeColumnBatchArgs);
        |  $batchSizeTerm = 0;
        |}
-       |if ($numInsertions >= 0 && $contextClass.get() == null) {
-       |  $closeEncodersFunction();
-       |}
+       |$closeForNoContext
        |${if (numInsertedRowsMetric eq null) ""
           else s"$numInsertedRowsMetric.${metricAdd(numInsertions)};"}
        |${consume(ctx, Seq(ExprCode("", "false", numInsertions)))}
@@ -392,13 +409,16 @@ case class ColumnInsertExec(_child: SparkPlan, partitionColumns: Seq[String],
   private def genMultipleStatsMethods(ctx: CodegenContext,
                                       methodName: String,
                                       statsCode: IndexedSeq[String],
-                                      schema : IndexedSeq[Seq[Attribute]],
+                                      schema: IndexedSeq[Seq[Attribute]],
+                                      statsAttrs: IndexedSeq[Attribute],
                                       exprs: IndexedSeq[Seq[ExprCode]]): (String, String) = {
 
 
     val statsRowTerm = ctx.freshName("statsRow")
-    ctx.addMutableState("MutableRow", statsRowTerm,
-      s"$statsRowTerm = new GenericMutableRow(${schema.flatten.length} + 1);")
+    val statsSchema = StructType.fromAttributes(statsAttrs)
+    val statsSchemaVar = ctx.addReferenceObj("statsSchema", statsSchema)
+    ctx.addMutableState("SpecificMutableRow", statsRowTerm,
+      s"$statsRowTerm = new SpecificMutableRow($statsSchemaVar);")
 
 
     val blocks = new ArrayBuffer[String]()
@@ -424,7 +444,7 @@ case class ColumnInsertExec(_child: SparkPlan, partitionColumns: Seq[String],
           if (${e._1.isNull}) {
              $statsRowTerm.setNullAt($ordinal);
           } else {
-             ${ctx.setColumn(statsRowTerm, e._2.dataType, ordinal, e._1.value)};
+             ${setColumn(ctx, statsRowTerm, e._2.dataType, ordinal, e._1.value)};
           }
          """.stripMargin
         blockBuilder.append(s"$writerCode\n")
@@ -451,6 +471,20 @@ case class ColumnInsertExec(_child: SparkPlan, partitionColumns: Seq[String],
 
   }
 
+  /**
+   * Returns the code to update a column in Row for a given DataType.
+   */
+  private def setColumn(ctx: CodegenContext, row: String, dataType: DataType,
+      ordinal: Int, value: String): String = {
+    val jt = ctx.javaType(dataType)
+    dataType match {
+      case _ if ctx.isPrimitiveType(jt) =>
+        s"$row.set${ctx.primitiveTypeName(jt)}($ordinal, $value)"
+      case t: DecimalType => s"$row.setDecimal($ordinal, $value, ${t.precision})"
+      case udt: UserDefinedType[_] => setColumn(ctx, row, udt.sqlType, ordinal, value)
+      case _ => s"$row.update($ordinal, $value)"
+    }
+  }
 
   private def doConsumeWideTables(ctx: CodegenContext, input: Seq[ExprCode],
                                   row: ExprCode): String = {
@@ -462,8 +496,8 @@ case class ColumnInsertExec(_child: SparkPlan, partitionColumns: Seq[String],
     cursorsArrayTerm = ctx.freshName("cursors")
 
     val mutableRow = ctx.freshName("mutableRow")
-    ctx.addMutableState("MutableRow", mutableRow,
-      s"$mutableRow = new GenericMutableRow(${relationSchema.length});")
+    ctx.addMutableState("SpecificMutableRow", mutableRow,
+      s"$mutableRow = new SpecificMutableRow($schemaTerm);")
 
     val rowWriteExprs = schema.indices.map { i =>
       val field = schema(i)
@@ -474,7 +508,7 @@ case class ColumnInsertExec(_child: SparkPlan, partitionColumns: Seq[String],
          if (${evaluationCode.isNull}) {
            $mutableRow.setNullAt($i);
          } else {
-           ${ctx.setColumn(mutableRow, dataType, i, evaluationCode.value)};
+           ${setColumn(ctx, mutableRow, dataType, i, evaluationCode.value)};
          }
       """
     }
@@ -523,8 +557,8 @@ case class ColumnInsertExec(_child: SparkPlan, partitionColumns: Seq[String],
       "java.lang.String")
     val (statsCode, statsSchema, stats) = columnStats.unzip3
     val statsVars = ExprCode("", "false", batchSizeTerm) +: stats.flatten
-    val statsExprs = (ColumnStatsSchema.COUNT_ATTRIBUTE +: statsSchema.flatten)
-        .zipWithIndex.map { case (a, i) =>
+    val statsAttrs = ColumnStatsSchema.COUNT_ATTRIBUTE +: statsSchema.flatten
+    val statsExprs = statsAttrs.zipWithIndex.map { case (a, i) =>
       a.dataType match {
         // some types will always be null so avoid unnecessary generated code
         case _ if statsVars(i).isNull == "true" => Literal(null, NullType)
@@ -536,8 +570,8 @@ case class ColumnInsertExec(_child: SparkPlan, partitionColumns: Seq[String],
       s"""$buffers[i] = $encoderArrayTerm[i].finish($cursorArrayTerm[i]);\n""".stripMargin
     val buffersCode = loop(bufferLoopCode, relationSchema.length)
 
-    val (statsSplitCode, statsRowTerm) =
-      genMultipleStatsMethods(ctx, "writeStats", statsCode, statsSchema, stats)
+    val (statsSplitCode, statsRowTerm) = genMultipleStatsMethods(ctx,
+      "writeStats", statsCode, statsSchema, statsAttrs, stats)
 
     ctx.INPUT_ROW = statsRowTerm
     ctx.currentVars = null

--- a/core/src/main/scala/org/apache/spark/sql/execution/columnar/ExternalStore.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/columnar/ExternalStore.scala
@@ -27,7 +27,7 @@ import org.apache.spark.sql.types.StructType
 
 trait ExternalStore extends Serializable {
 
-  final val columnPrefix = "Col_"
+  final val columnPrefix = "COL_"
 
   def storeColumnBatch(tableName: String, batch: ColumnBatch,
       partitionId: Int, batchId: Option[String], maxDeltaRows: Int): Unit

--- a/core/src/main/scala/org/apache/spark/sql/execution/columnar/encoding/ColumnEncoding.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/columnar/encoding/ColumnEncoding.scala
@@ -356,14 +356,14 @@ trait ColumnEncoder extends ColumnEncoding {
   protected final def setSource(buffer: ByteBuffer,
       releaseOld: Boolean): Unit = {
     if (buffer ne columnData) {
-      if ((columnData ne null) && releaseOld) {
+      if (releaseOld && (columnData ne null)) {
         allocator.release(columnData)
       }
       columnData = buffer
       columnBytes = allocator.baseObject(buffer)
       columnBeginPosition = allocator.baseOffset(buffer)
-      columnEndPosition = columnBeginPosition + buffer.limit()
     }
+    columnEndPosition = columnBeginPosition + buffer.limit()
   }
 
   protected final def clearSource(newSize: Int, releaseData: Boolean): Unit = {
@@ -387,7 +387,7 @@ trait ColumnEncoder extends ColumnEncoding {
     val limit = src.limit()
 
     if (position != srcOffset) src.position(srcOffset)
-    if (limit > endOffset) src.limit(endOffset)
+    if (limit != endOffset) src.limit(endOffset)
 
     dest.put(src)
 
@@ -713,7 +713,7 @@ trait ColumnEncoder extends ColumnEncoding {
       numWords: Int): Long
 
   protected final def releaseForReuse(newSize: Int): Unit = {
-    columnData.clear()
+    columnData.rewind()
     reuseUsedSize = newSize
   }
 }

--- a/core/src/main/scala/org/apache/spark/sql/execution/columnar/encoding/ColumnEncoding.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/columnar/encoding/ColumnEncoding.scala
@@ -31,7 +31,6 @@ import org.apache.spark.sql.catalyst.expressions.UnsafeRow.calculateBitSetWidthI
 import org.apache.spark.sql.catalyst.util.{ArrayData, MapData}
 import org.apache.spark.sql.collection.Utils
 import org.apache.spark.sql.execution.columnar.encoding.ColumnEncoding.checkBufferSize
-import org.apache.spark.sql.execution.columnar.impl.ColumnFormatEntry
 import org.apache.spark.sql.types._
 import org.apache.spark.unsafe.Platform
 import org.apache.spark.unsafe.bitset.BitSetMethods
@@ -42,16 +41,16 @@ import org.apache.spark.util.collection.BitSet
  * Base class for encoding and decoding in columnar form. Memory layout of
  * the bytes for a set of column values is:
  * {{{
- *    .----------------------- Serialization header (8 bytes)
- *   |    .------------------- Encoding scheme (4 bytes)
- *   |   | .------------------ Null bitset size as number of longs N (4 bytes)
- *   |   | | .---------------- Null bitset longs (8 x N bytes,
- *   |   | | |                                    empty if null count is zero)
- *   |   | | |     .---------- Encoded non-null elements
- *   V   V V V     V
- *   +---+-+-+-----+---------+
- *   |   | | | ... | ... ... |
- *   +---+-+-+-----+---------+
+ *    .----------------------- Encoding scheme (4 bytes)
+ *   |    .------------------- Null bitset size as number of longs N (4 bytes)
+ *   |   |
+ *   |   |   .---------------- Null bitset longs (8 x N bytes,
+ *   |   |   |                                    empty if null count is zero)
+ *   |   |   |     .---------- Encoded non-null elements
+ *   V   V   V     V
+ *   +---+---+-----+---------+
+ *   |   |   | ... | ... ... |
+ *   +---+---+-----+---------+
  *    \-----/ \-------------/
  *     header      body
  * }}}
@@ -308,8 +307,6 @@ trait ColumnEncoder extends ColumnEncoding {
 
     var baseSize: Long = numNullBytes
     if (withHeader) {
-      // add header size for serialized form to avoid a copy in Oplog layer
-      baseSize += ColumnFormatEntry.VALUE_HEADER_SIZE
       baseSize += 8L /* typeId + nullsSize */
     }
     if ((columnData eq null) || (columnData.limit() < (baseSize + defSize))) {
@@ -336,8 +333,7 @@ trait ColumnEncoder extends ColumnEncoding {
     }
     reuseUsedSize = 0
     if (withHeader) {
-      // skip serialization header which will be filled in by ColumnFormatValue
-      var cursor = columnBeginPosition + ColumnFormatEntry.VALUE_HEADER_SIZE
+      var cursor = columnBeginPosition
       // typeId followed by nulls bitset size and space for values
       ColumnEncoding.writeInt(columnBytes, cursor, typeId)
       cursor += 4
@@ -1139,9 +1135,8 @@ trait NullableEncoder extends NotNullEncoder {
     val maxWastedWords = 8
     // check if the number of words to be written matches the space that
     // was left at initialization; as an optimization allow for larger
-    // space left at initialization when one full data copy can be avoided;
-    // add serialization header which will be filled in by ColumnFormatValue
-    val baseOffset = columnBeginPosition + ColumnFormatEntry.VALUE_HEADER_SIZE
+    // space left at initialization when one full data copy can be avoided
+    val baseOffset = columnBeginPosition
     if (initialNumWords == numWords) {
       writeNulls(columnBytes, baseOffset + 8, numWords)
       super.finish(cursor)
@@ -1156,14 +1151,14 @@ trait NullableEncoder extends NotNullEncoder {
       // make space (or shrink) for writing nulls at the start
       val numNullBytes = numWords << 3
       val initialNullBytes = initialNumWords << 3
-      val oldSize = cursor - baseOffset + ColumnFormatEntry.VALUE_HEADER_SIZE
+      val oldSize = cursor - baseOffset
       val newSize = checkBufferSize(oldSize + numNullBytes - initialNullBytes)
       val storageAllocator = this.storageAllocator
       val newColumnData = storageAllocator.allocateForStorage(newSize)
 
       // first copy the rest of the bytes skipping header and nulls
-      val srcOffset = ColumnFormatEntry.VALUE_HEADER_SIZE + 8 + initialNullBytes
-      val destOffset = ColumnFormatEntry.VALUE_HEADER_SIZE + 8 + numNullBytes
+      val srcOffset = 8 + initialNullBytes
+      val destOffset = 8 + numNullBytes
       newColumnData.position(destOffset)
       copyTo(newColumnData, srcOffset, oldSize.toInt)
       newColumnData.rewind()
@@ -1179,8 +1174,6 @@ trait NullableEncoder extends NotNullEncoder {
       // now write the header including nulls
       val newColumnBytes = storageAllocator.baseObject(newColumnData)
       var position = storageAllocator.baseOffset(newColumnData)
-      // skip serialization header which will be filled in by ColumnFormatValue
-      position += ColumnFormatEntry.VALUE_HEADER_SIZE
       ColumnEncoding.writeInt(newColumnBytes, position, typeId)
       position += 4
       ColumnEncoding.writeInt(newColumnBytes, position, numWords)

--- a/core/src/main/scala/org/apache/spark/sql/execution/columnar/encoding/ColumnEncoding.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/columnar/encoding/ColumnEncoding.scala
@@ -31,6 +31,7 @@ import org.apache.spark.sql.catalyst.expressions.UnsafeRow.calculateBitSetWidthI
 import org.apache.spark.sql.catalyst.util.{ArrayData, MapData}
 import org.apache.spark.sql.collection.Utils
 import org.apache.spark.sql.execution.columnar.encoding.ColumnEncoding.checkBufferSize
+import org.apache.spark.sql.execution.columnar.impl.ColumnFormatEntry
 import org.apache.spark.sql.types._
 import org.apache.spark.unsafe.Platform
 import org.apache.spark.unsafe.bitset.BitSetMethods
@@ -41,16 +42,16 @@ import org.apache.spark.util.collection.BitSet
  * Base class for encoding and decoding in columnar form. Memory layout of
  * the bytes for a set of column values is:
  * {{{
- *    .----------------------- Encoding scheme (4 bytes)
- *   |    .------------------- Null bitset size as number of longs N (4 bytes)
- *   |   |
- *   |   |   .---------------- Null bitset longs (8 x N bytes,
- *   |   |   |                                    empty if null count is zero)
- *   |   |   |     .---------- Encoded non-null elements
- *   V   V   V     V
- *   +---+---+-----+---------+
- *   |   |   | ... | ... ... |
- *   +---+---+-----+---------+
+ *    .----------------------- Serialization header (8 bytes)
+ *   |    .------------------- Encoding scheme (4 bytes)
+ *   |   | .------------------ Null bitset size as number of longs N (4 bytes)
+ *   |   | | .---------------- Null bitset longs (8 x N bytes,
+ *   |   | | |                                    empty if null count is zero)
+ *   |   | | |     .---------- Encoded non-null elements
+ *   V   V V V     V
+ *   +---+-+-+-----+---------+
+ *   |   | | | ... | ... ... |
+ *   +---+-+-+-----+---------+
  *    \-----/ \-------------/
  *     header      body
  * }}}
@@ -307,6 +308,8 @@ trait ColumnEncoder extends ColumnEncoding {
 
     var baseSize: Long = numNullBytes
     if (withHeader) {
+      // add header size for serialized form to avoid a copy in Oplog layer
+      baseSize += ColumnFormatEntry.VALUE_HEADER_SIZE
       baseSize += 8L /* typeId + nullsSize */
     }
     if ((columnData eq null) || (columnData.limit() < (baseSize + defSize))) {
@@ -333,7 +336,8 @@ trait ColumnEncoder extends ColumnEncoding {
     }
     reuseUsedSize = 0
     if (withHeader) {
-      var cursor = columnBeginPosition
+      // skip serialization header which will be filled in by ColumnFormatValue
+      var cursor = columnBeginPosition + ColumnFormatEntry.VALUE_HEADER_SIZE
       // typeId followed by nulls bitset size and space for values
       ColumnEncoding.writeInt(columnBytes, cursor, typeId)
       cursor += 4
@@ -1136,8 +1140,9 @@ trait NullableEncoder extends NotNullEncoder {
     val maxWastedWords = 8
     // check if the number of words to be written matches the space that
     // was left at initialization; as an optimization allow for larger
-    // space left at initialization when one full data copy can be avoided
-    val baseOffset = columnBeginPosition
+    // space left at initialization when one full data copy can be avoided;
+    // add serialization header which will be filled in by ColumnFormatValue
+    val baseOffset = columnBeginPosition + ColumnFormatEntry.VALUE_HEADER_SIZE
     if (initialNumWords == numWords) {
       writeNulls(columnBytes, baseOffset + 8, numWords)
       super.finish(cursor)
@@ -1152,14 +1157,14 @@ trait NullableEncoder extends NotNullEncoder {
       // make space (or shrink) for writing nulls at the start
       val numNullBytes = numWords << 3
       val initialNullBytes = initialNumWords << 3
-      val oldSize = cursor - baseOffset
+      val oldSize = cursor - baseOffset + ColumnFormatEntry.VALUE_HEADER_SIZE
       val newSize = checkBufferSize(oldSize + numNullBytes - initialNullBytes)
       val storageAllocator = this.storageAllocator
       val newColumnData = storageAllocator.allocateForStorage(newSize)
 
       // first copy the rest of the bytes skipping header and nulls
-      val srcOffset = 8 + initialNullBytes
-      val destOffset = 8 + numNullBytes
+      val srcOffset = ColumnFormatEntry.VALUE_HEADER_SIZE + 8 + initialNullBytes
+      val destOffset = ColumnFormatEntry.VALUE_HEADER_SIZE + 8 + numNullBytes
       newColumnData.position(destOffset)
       copyTo(newColumnData, srcOffset, oldSize.toInt)
       newColumnData.rewind()
@@ -1175,6 +1180,8 @@ trait NullableEncoder extends NotNullEncoder {
       // now write the header including nulls
       val newColumnBytes = storageAllocator.baseObject(newColumnData)
       var position = storageAllocator.baseOffset(newColumnData)
+      // skip serialization header which will be filled in by ColumnFormatValue
+      position += ColumnFormatEntry.VALUE_HEADER_SIZE
       ColumnEncoding.writeInt(newColumnBytes, position, typeId)
       position += 4
       ColumnEncoding.writeInt(newColumnBytes, position, numWords)

--- a/core/src/main/scala/org/apache/spark/sql/execution/columnar/encoding/DictionaryEncoding.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/columnar/encoding/DictionaryEncoding.scala
@@ -416,7 +416,9 @@ trait DictionaryEncoderBase extends ColumnEncoder with DictionaryEncoding {
     columnData.position(position)
 
     // reuse this index data in next round if possible
-    releaseForReuse(numIndexBytes)
+    // releaseForReuse(numIndexBytes)
+    // SNAP-1760: clearing somehow fixes the issue
+    clearSource(numIndexBytes, releaseData = true)
 
     columnData
   }

--- a/core/src/main/scala/org/apache/spark/sql/execution/columnar/encoding/DictionaryEncoding.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/columnar/encoding/DictionaryEncoding.scala
@@ -23,6 +23,7 @@ import com.gemstone.gnu.trove.TLongArrayList
 import io.snappydata.collection.{ByteBufferHashMap, LongKey, ObjectHashSet}
 
 import org.apache.spark.sql.collection.Utils
+import org.apache.spark.sql.execution.columnar.impl.ColumnFormatEntry
 import org.apache.spark.sql.types._
 import org.apache.spark.unsafe.Platform
 import org.apache.spark.unsafe.types.UTF8String
@@ -361,12 +362,14 @@ trait DictionaryEncoderBase extends ColumnEncoder with DictionaryEncoding {
     val numNullWords = getNumNullWords
     val dataSize = 4L /* dictionary size */ + dictionarySize + numIndexBytes
     val storageAllocator = this.storageAllocator
+    // serialization header size + typeId + number of nulls
+    val headerSize = ColumnFormatEntry.VALUE_HEADER_SIZE + 8L
     val columnData = storageAllocator.allocateForStorage(ColumnEncoding
-        // typeId + number of nulls
-        .checkBufferSize(8L + (numNullWords << 3L) + dataSize))
+        .checkBufferSize(headerSize + (numNullWords << 3L) + dataSize))
     val columnBytes = storageAllocator.baseObject(columnData)
     val baseOffset = storageAllocator.baseOffset(columnData)
-    var cursor = baseOffset
+    // skip serialization header which will be filled in by ColumnFormatValue
+    var cursor = baseOffset + ColumnFormatEntry.VALUE_HEADER_SIZE
     // typeId
     ColumnEncoding.writeInt(columnBytes, cursor, typeId)
     cursor += 4
@@ -407,9 +410,10 @@ trait DictionaryEncoderBase extends ColumnEncoder with DictionaryEncoding {
       }
     }
     // lastly copy the index bytes
+    val position = columnData.position()
     columnData.position((cursor - baseOffset).toInt)
     copyTo(columnData, srcOffset = 0, numIndexBytes)
-    columnData.rewind()
+    columnData.position(position)
 
     // reuse this index data in next round if possible
     releaseForReuse(numIndexBytes)

--- a/core/src/main/scala/org/apache/spark/sql/execution/columnar/encoding/DictionaryEncoding.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/columnar/encoding/DictionaryEncoding.scala
@@ -23,7 +23,6 @@ import com.gemstone.gnu.trove.TLongArrayList
 import io.snappydata.collection.{ByteBufferHashMap, LongKey, ObjectHashSet}
 
 import org.apache.spark.sql.collection.Utils
-import org.apache.spark.sql.execution.columnar.impl.ColumnFormatEntry
 import org.apache.spark.sql.types._
 import org.apache.spark.unsafe.Platform
 import org.apache.spark.unsafe.types.UTF8String
@@ -362,14 +361,12 @@ trait DictionaryEncoderBase extends ColumnEncoder with DictionaryEncoding {
     val numNullWords = getNumNullWords
     val dataSize = 4L /* dictionary size */ + dictionarySize + numIndexBytes
     val storageAllocator = this.storageAllocator
-    // serialization header size + typeId + number of nulls
-    val headerSize = ColumnFormatEntry.VALUE_HEADER_SIZE + 8L
     val columnData = storageAllocator.allocateForStorage(ColumnEncoding
-        .checkBufferSize(headerSize + (numNullWords << 3L) + dataSize))
+        // typeId + number of nulls
+        .checkBufferSize(8L + (numNullWords << 3L) + dataSize))
     val columnBytes = storageAllocator.baseObject(columnData)
     val baseOffset = storageAllocator.baseOffset(columnData)
-    // skip serialization header which will be filled in by ColumnFormatValue
-    var cursor = baseOffset + ColumnFormatEntry.VALUE_HEADER_SIZE
+    var cursor = baseOffset
     // typeId
     ColumnEncoding.writeInt(columnBytes, cursor, typeId)
     cursor += 4
@@ -410,15 +407,12 @@ trait DictionaryEncoderBase extends ColumnEncoder with DictionaryEncoding {
       }
     }
     // lastly copy the index bytes
-    val position = columnData.position()
     columnData.position((cursor - baseOffset).toInt)
     copyTo(columnData, srcOffset = 0, numIndexBytes)
-    columnData.position(position)
+    columnData.rewind()
 
     // reuse this index data in next round if possible
-    // releaseForReuse(numIndexBytes)
-    // SNAP-1760: clearing somehow fixes the issue
-    clearSource(numIndexBytes, releaseData = true)
+    releaseForReuse(numIndexBytes)
 
     columnData
   }

--- a/core/src/main/scala/org/apache/spark/sql/execution/columnar/impl/ColumnFormatEntry.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/columnar/impl/ColumnFormatEntry.scala
@@ -66,7 +66,35 @@ object ColumnFormatEntry extends Logging {
     GfxdDataSerializable.registerSqlSerializable(classOf[ColumnFormatValue])
   }
 
+  /**
+   * Size of the serialization type/class IDs of [[ColumnFormatValue]].
+   */
+  private[columnar] val VALUE_HEADER_CLASSID_SIZE = 3
+
+  /**
+   * Size of the serialization header of [[ColumnFormatValue]] including the
+   * serialization type/class IDs (3 bytes), padding (1 byte), and size (4).
+   * Padding is added for 8 byte alignment.
+   */
+  private[columnar] val VALUE_HEADER_SIZE = VALUE_HEADER_CLASSID_SIZE + 1 + 4
+
+  private[columnar] val VALUE_EMPTY_BUFFER = {
+    val buffer = ByteBuffer.wrap(new Array[Byte](VALUE_HEADER_SIZE))
+    writeValueSerializationHeader(buffer, 0)
+    buffer
+  }
+
   private[columnar] def alignedSize(size: Int) = ((size + 7) >>> 3) << 3
+
+  private[columnar] def writeValueSerializationHeader(buffer: ByteBuffer,
+      size: Int): Unit = {
+    // write the typeId + classId and size
+    buffer.put(DSCODE.DS_FIXED_ID_BYTE)
+    buffer.put(DataSerializableFixedID.GFXD_TYPE)
+    buffer.put(GfxdSerializable.COLUMN_FORMAT_VALUE)
+    buffer.put(0.toByte) // padding
+    buffer.putInt(size) // assume big-endian buffer
+  }
 }
 
 /**
@@ -230,16 +258,16 @@ final class ColumnPartitionResolver(tableName: TableName)
  * well as efficiently serialize/deserialize them directly to Oplog/socket.
  *
  * This class extends [[SerializedDiskBuffer]] to avoid a copy when
- * reading/writing from Oplog. Consequently it writes the serialization header
- * itself (typeID + classID + size) into stream as would be written by
- * DataSerializer.writeObject. This helps it avoid additional byte writes when
- * transferring data to the channels.
+ * reading/writing from Oplog. Consequently it has a pre-serialized buffer
+ * that has the serialization header at the start (typeID + classID + size).
+ * This helps it avoid additional byte writes when transferring data to the
+ * channels as well as avoiding trimming of buffer when reading from it.
  */
 final class ColumnFormatValue
     extends SerializedDiskBuffer with GfxdSerializable with Sizeable {
 
   @volatile
-  @transient private var columnBuffer = DiskEntry.Helper.NULL_BUFFER
+  @transient private var columnBuffer = ColumnFormatEntry.VALUE_EMPTY_BUFFER
   @transient private var diskId: DiskId = _
   @transient private var diskRegion: DiskRegionView = _
 
@@ -249,12 +277,18 @@ final class ColumnFormatValue
   }
 
   def setBuffer(buffer: ByteBuffer,
-      changeOwnerToStorage: Boolean = true): Unit = synchronized {
+      changeOwnerToStorage: Boolean = true,
+      writeSerializationHeader: Boolean = true): Unit = synchronized {
     val columnBuffer = GemFireCacheImpl.getCurrentBufferAllocator
         .transfer(buffer, ManagedDirectBufferAllocator.DIRECT_STORE_OBJECT_OWNER)
     if (changeOwnerToStorage && columnBuffer.isDirect) {
       MemoryManagerCallback.memoryManager.changeOffHeapOwnerToStorage(
         columnBuffer, allowNonAllocator = true)
+    }
+    if (writeSerializationHeader) {
+      // write the serialization header and move ahead to start of data
+      ColumnFormatEntry.writeValueSerializationHeader(columnBuffer,
+        buffer.remaining() - ColumnFormatEntry.VALUE_HEADER_SIZE)
     }
     this.columnBuffer = columnBuffer
     // reference count is required to be 1 at this point
@@ -264,11 +298,6 @@ final class ColumnFormatValue
 
   def isDirect: Boolean = columnBuffer.isDirect
 
-  @inline private def duplicateBuffer(buffer: ByteBuffer): ByteBuffer = {
-    // slice buffer for non-zero position so callers don't have to deal with it
-    if (buffer.position() == 0) buffer.duplicate() else buffer.slice()
-  }
-
   /**
    * Callers of this method should have a corresponding release method
    * for eager release to work else off-heap object may keep around
@@ -276,19 +305,15 @@ final class ColumnFormatValue
    * whether to keep the [[release]] method in a finally block to ensure
    * its invocation, or do it only in normal paths because JVM reference
    * collector will eventually clean it in any case.
-   *
-   * Calls to this specific class are guaranteed to always return buffers
-   * which have position as zero so callers can make simplifying assumptions
-   * about the same.
    */
   override def getBufferRetain: ByteBuffer = {
     if (retain()) {
-      duplicateBuffer(columnBuffer)
+      columnBuffer.duplicate()
     } else synchronized {
       // check if already read from disk by another thread and still valid
       val buffer = this.columnBuffer
-      if ((buffer ne DiskEntry.Helper.NULL_BUFFER) && retain()) {
-        return duplicateBuffer(buffer)
+      if ((buffer ne ColumnFormatEntry.VALUE_EMPTY_BUFFER) && retain()) {
+        return buffer.duplicate()
       }
 
       // try to read using DiskId
@@ -305,7 +330,7 @@ final class ColumnFormatValue
                 val updatedRefCount = if (refCount <= 0) 1 else refCount + 1
                 if (SerializedDiskBuffer.refCountUpdate.compareAndSet(
                   this, refCount, updatedRefCount)) {
-                  return duplicateBuffer(columnBuffer)
+                  return columnBuffer.duplicate()
                 }
               }
             case null | _: Token => // return empty buffer
@@ -321,7 +346,7 @@ final class ColumnFormatValue
             // processors like gateway event processors will not expect it.
         }
       }
-      DiskEntry.Helper.NULL_BUFFER.duplicate()
+      ColumnFormatEntry.VALUE_EMPTY_BUFFER.duplicate()
     }
   }
 
@@ -332,7 +357,7 @@ final class ColumnFormatValue
     // done either using DiskId, or will return empty if no DiskId is available
     val buffer = this.columnBuffer
     if (buffer.isDirect) {
-      this.columnBuffer = DiskEntry.Helper.NULL_BUFFER
+      this.columnBuffer = ColumnFormatEntry.VALUE_EMPTY_BUFFER
       ManagedDirectBufferAllocator.instance().release(buffer)
     }
   }
@@ -354,24 +379,16 @@ final class ColumnFormatValue
     // write the pre-serialized buffer as is
     val buffer = getBufferRetain
     try {
-      // first write the serialization header
-      // write the typeId + classId and size
-      channel.write(DSCODE.DS_FIXED_ID_BYTE)
-      channel.write(DataSerializableFixedID.GFXD_TYPE)
-      channel.write(GfxdSerializable.COLUMN_FORMAT_VALUE)
-      channel.write(0.toByte) // padding
-      channel.writeInt(buffer.limit())
-
+      // rewind buffer to the start for the write;
       // no need to change position back since this is a duplicate ByteBuffer
+      buffer.rewind()
       write(channel, buffer)
     } finally {
       release()
     }
   }
 
-  override def channelSize(): Int = 8 /* header */ + columnBuffer.remaining()
-
-  override def size(): Int = columnBuffer.remaining()
+  override def size(): Int = columnBuffer.limit()
 
   override def getGfxdID: Byte = GfxdSerializable.COLUMN_FORMAT_VALUE
 
@@ -382,7 +399,7 @@ final class ColumnFormatValue
   override def toData(out: DataOutput): Unit = {
     val buffer = getBufferRetain
     try {
-      val numBytes = buffer.limit()
+      val numBytes = buffer.remaining()
       out.writeByte(0) // padding for 8-byte alignment
       out.writeInt(numBytes)
       if (numBytes > 0) {
@@ -424,7 +441,11 @@ final class ColumnFormatValue
 
         case channel: InputStreamChannel =>
           // order is BIG_ENDIAN by default
-          val buffer = allocator.allocateForStorage(numBytes)
+          val buffer = allocator.allocateForStorage(numBytes +
+              ColumnFormatEntry.VALUE_HEADER_SIZE)
+          ColumnFormatEntry.writeValueSerializationHeader(buffer,
+            numBytes)
+          val position = buffer.position()
           do {
             if (channel.read(buffer) == 0) {
               // wait for a bit before retrying
@@ -432,19 +453,22 @@ final class ColumnFormatValue
             }
           } while (buffer.hasRemaining)
           // move to the start of data
-          buffer.rewind()
+          buffer.position(position)
           columnBuffer = buffer
 
         case _ =>
           // order is BIG_ENDIAN by default
-          val bytes = new Array[Byte](numBytes)
-          in.readFully(bytes, 0, numBytes)
-          val buffer = allocator.fromBytesToStorage(bytes, 0, numBytes)
+          val bytes = new Array[Byte](numBytes +
+              ColumnFormatEntry.VALUE_HEADER_SIZE)
+          in.readFully(bytes, ColumnFormatEntry.VALUE_HEADER_SIZE, numBytes)
+          // extra copy of empty 8-byte header too
+          val buffer = allocator.fromBytesToStorage(bytes, 0,
+            numBytes + ColumnFormatEntry.VALUE_HEADER_SIZE)
           // owner is already marked for storage
           setBuffer(buffer, changeOwnerToStorage = false)
       }
     } else {
-      columnBuffer = DiskEntry.Helper.NULL_BUFFER
+      columnBuffer = ColumnFormatEntry.VALUE_EMPTY_BUFFER
     }
   }
 
@@ -504,7 +528,9 @@ final class ColumnFormatEncoder extends RowEncoder {
     row.setColumn(1, new SQLVarchar(batchKey.uuid))
     row.setColumn(2, new SQLInteger(batchKey.partitionId))
     row.setColumn(3, new SQLInteger(batchKey.columnIndex))
-    // set value reference which will be released after thrift write
+    // set value reference which will be released after thrift write;
+    // this written blob does not include the serialization header
+    // unlike in fromRow which does include it
     row.setColumn(4, new SQLBlob(new ClientBlob(batchValue)))
     row
   }
@@ -518,6 +544,9 @@ final class ColumnFormatEncoder extends RowEncoder {
       case blob: BufferedBlob => blob.getAsLastChunk.chunk
       case blob: Blob => ByteBuffer.wrap(blob.getBytes(1, blob.length().toInt))
     }
+    // the incoming blob includes the space for serialization header to avoid
+    // a copy when transferring to ColumnFormatValue, so just move to
+    // the start of data and write the serialization header
     columnBuffer.rewind()
     // set the buffer into ColumnFormatValue
     val batchValue = new ColumnFormatValue(columnBuffer)

--- a/core/src/main/scala/org/apache/spark/sql/execution/columnar/impl/ColumnFormatEntry.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/columnar/impl/ColumnFormatEntry.scala
@@ -66,35 +66,7 @@ object ColumnFormatEntry extends Logging {
     GfxdDataSerializable.registerSqlSerializable(classOf[ColumnFormatValue])
   }
 
-  /**
-   * Size of the serialization type/class IDs of [[ColumnFormatValue]].
-   */
-  private[columnar] val VALUE_HEADER_CLASSID_SIZE = 3
-
-  /**
-   * Size of the serialization header of [[ColumnFormatValue]] including the
-   * serialization type/class IDs (3 bytes), padding (1 byte), and size (4).
-   * Padding is added for 8 byte alignment.
-   */
-  private[columnar] val VALUE_HEADER_SIZE = VALUE_HEADER_CLASSID_SIZE + 1 + 4
-
-  private[columnar] val VALUE_EMPTY_BUFFER = {
-    val buffer = ByteBuffer.wrap(new Array[Byte](VALUE_HEADER_SIZE))
-    writeValueSerializationHeader(buffer, 0)
-    buffer
-  }
-
   private[columnar] def alignedSize(size: Int) = ((size + 7) >>> 3) << 3
-
-  private[columnar] def writeValueSerializationHeader(buffer: ByteBuffer,
-      size: Int): Unit = {
-    // write the typeId + classId and size
-    buffer.put(DSCODE.DS_FIXED_ID_BYTE)
-    buffer.put(DataSerializableFixedID.GFXD_TYPE)
-    buffer.put(GfxdSerializable.COLUMN_FORMAT_VALUE)
-    buffer.put(0.toByte) // padding
-    buffer.putInt(size) // assume big-endian buffer
-  }
 }
 
 /**
@@ -258,16 +230,16 @@ final class ColumnPartitionResolver(tableName: TableName)
  * well as efficiently serialize/deserialize them directly to Oplog/socket.
  *
  * This class extends [[SerializedDiskBuffer]] to avoid a copy when
- * reading/writing from Oplog. Consequently it has a pre-serialized buffer
- * that has the serialization header at the start (typeID + classID + size).
- * This helps it avoid additional byte writes when transferring data to the
- * channels as well as avoiding trimming of buffer when reading from it.
+ * reading/writing from Oplog. Consequently it writes the serialization header
+ * itself (typeID + classID + size) into stream as would be written by
+ * DataSerializer.writeObject. This helps it avoid additional byte writes when
+ * transferring data to the channels.
  */
 final class ColumnFormatValue
     extends SerializedDiskBuffer with GfxdSerializable with Sizeable {
 
   @volatile
-  @transient private var columnBuffer = ColumnFormatEntry.VALUE_EMPTY_BUFFER
+  @transient private var columnBuffer = DiskEntry.Helper.NULL_BUFFER
   @transient private var diskId: DiskId = _
   @transient private var diskRegion: DiskRegionView = _
 
@@ -277,18 +249,12 @@ final class ColumnFormatValue
   }
 
   def setBuffer(buffer: ByteBuffer,
-      changeOwnerToStorage: Boolean = true,
-      writeSerializationHeader: Boolean = true): Unit = synchronized {
+      changeOwnerToStorage: Boolean = true): Unit = synchronized {
     val columnBuffer = GemFireCacheImpl.getCurrentBufferAllocator
         .transfer(buffer, ManagedDirectBufferAllocator.DIRECT_STORE_OBJECT_OWNER)
     if (changeOwnerToStorage && columnBuffer.isDirect) {
       MemoryManagerCallback.memoryManager.changeOffHeapOwnerToStorage(
         columnBuffer, allowNonAllocator = true)
-    }
-    if (writeSerializationHeader) {
-      // write the serialization header and move ahead to start of data
-      ColumnFormatEntry.writeValueSerializationHeader(columnBuffer,
-        buffer.remaining() - ColumnFormatEntry.VALUE_HEADER_SIZE)
     }
     this.columnBuffer = columnBuffer
     // reference count is required to be 1 at this point
@@ -298,6 +264,11 @@ final class ColumnFormatValue
 
   def isDirect: Boolean = columnBuffer.isDirect
 
+  @inline private def duplicateBuffer(buffer: ByteBuffer): ByteBuffer = {
+    // slice buffer for non-zero position so callers don't have to deal with it
+    if (buffer.position() == 0) buffer.duplicate() else buffer.slice()
+  }
+
   /**
    * Callers of this method should have a corresponding release method
    * for eager release to work else off-heap object may keep around
@@ -305,15 +276,19 @@ final class ColumnFormatValue
    * whether to keep the [[release]] method in a finally block to ensure
    * its invocation, or do it only in normal paths because JVM reference
    * collector will eventually clean it in any case.
+   *
+   * Calls to this specific class are guaranteed to always return buffers
+   * which have position as zero so callers can make simplifying assumptions
+   * about the same.
    */
   override def getBufferRetain: ByteBuffer = {
     if (retain()) {
-      columnBuffer.duplicate()
+      duplicateBuffer(columnBuffer)
     } else synchronized {
       // check if already read from disk by another thread and still valid
       val buffer = this.columnBuffer
-      if ((buffer ne ColumnFormatEntry.VALUE_EMPTY_BUFFER) && retain()) {
-        return buffer.duplicate()
+      if ((buffer ne DiskEntry.Helper.NULL_BUFFER) && retain()) {
+        return duplicateBuffer(buffer)
       }
 
       // try to read using DiskId
@@ -330,7 +305,7 @@ final class ColumnFormatValue
                 val updatedRefCount = if (refCount <= 0) 1 else refCount + 1
                 if (SerializedDiskBuffer.refCountUpdate.compareAndSet(
                   this, refCount, updatedRefCount)) {
-                  return columnBuffer.duplicate()
+                  return duplicateBuffer(columnBuffer)
                 }
               }
             case null | _: Token => // return empty buffer
@@ -346,7 +321,7 @@ final class ColumnFormatValue
             // processors like gateway event processors will not expect it.
         }
       }
-      ColumnFormatEntry.VALUE_EMPTY_BUFFER.duplicate()
+      DiskEntry.Helper.NULL_BUFFER.duplicate()
     }
   }
 
@@ -357,7 +332,7 @@ final class ColumnFormatValue
     // done either using DiskId, or will return empty if no DiskId is available
     val buffer = this.columnBuffer
     if (buffer.isDirect) {
-      this.columnBuffer = ColumnFormatEntry.VALUE_EMPTY_BUFFER
+      this.columnBuffer = DiskEntry.Helper.NULL_BUFFER
       ManagedDirectBufferAllocator.instance().release(buffer)
     }
   }
@@ -379,16 +354,24 @@ final class ColumnFormatValue
     // write the pre-serialized buffer as is
     val buffer = getBufferRetain
     try {
-      // rewind buffer to the start for the write;
+      // first write the serialization header
+      // write the typeId + classId and size
+      channel.write(DSCODE.DS_FIXED_ID_BYTE)
+      channel.write(DataSerializableFixedID.GFXD_TYPE)
+      channel.write(GfxdSerializable.COLUMN_FORMAT_VALUE)
+      channel.write(0.toByte) // padding
+      channel.writeInt(buffer.limit())
+
       // no need to change position back since this is a duplicate ByteBuffer
-      buffer.rewind()
       write(channel, buffer)
     } finally {
       release()
     }
   }
 
-  override def size(): Int = columnBuffer.limit()
+  override def channelSize(): Int = 8 /* header */ + columnBuffer.remaining()
+
+  override def size(): Int = columnBuffer.remaining()
 
   override def getGfxdID: Byte = GfxdSerializable.COLUMN_FORMAT_VALUE
 
@@ -399,7 +382,7 @@ final class ColumnFormatValue
   override def toData(out: DataOutput): Unit = {
     val buffer = getBufferRetain
     try {
-      val numBytes = buffer.remaining()
+      val numBytes = buffer.limit()
       out.writeByte(0) // padding for 8-byte alignment
       out.writeInt(numBytes)
       if (numBytes > 0) {
@@ -441,11 +424,7 @@ final class ColumnFormatValue
 
         case channel: InputStreamChannel =>
           // order is BIG_ENDIAN by default
-          val buffer = allocator.allocateForStorage(numBytes +
-              ColumnFormatEntry.VALUE_HEADER_SIZE)
-          ColumnFormatEntry.writeValueSerializationHeader(buffer,
-            numBytes)
-          val position = buffer.position()
+          val buffer = allocator.allocateForStorage(numBytes)
           do {
             if (channel.read(buffer) == 0) {
               // wait for a bit before retrying
@@ -453,22 +432,19 @@ final class ColumnFormatValue
             }
           } while (buffer.hasRemaining)
           // move to the start of data
-          buffer.position(position)
+          buffer.rewind()
           columnBuffer = buffer
 
         case _ =>
           // order is BIG_ENDIAN by default
-          val bytes = new Array[Byte](numBytes +
-              ColumnFormatEntry.VALUE_HEADER_SIZE)
-          in.readFully(bytes, ColumnFormatEntry.VALUE_HEADER_SIZE, numBytes)
-          // extra copy of empty 8-byte header too
-          val buffer = allocator.fromBytesToStorage(bytes, 0,
-            numBytes + ColumnFormatEntry.VALUE_HEADER_SIZE)
+          val bytes = new Array[Byte](numBytes)
+          in.readFully(bytes, 0, numBytes)
+          val buffer = allocator.fromBytesToStorage(bytes, 0, numBytes)
           // owner is already marked for storage
           setBuffer(buffer, changeOwnerToStorage = false)
       }
     } else {
-      columnBuffer = ColumnFormatEntry.VALUE_EMPTY_BUFFER
+      columnBuffer = DiskEntry.Helper.NULL_BUFFER
     }
   }
 
@@ -513,7 +489,7 @@ final class ColumnFormatValue
 
   override def toString: String = {
     val buffer = columnBuffer.duplicate()
-    s"ColumnValue[size=${buffer.limit()} $buffer diskId=$diskId diskRegion=$diskRegion]"
+    s"ColumnValue[size=${buffer.remaining()} $buffer diskId=$diskId diskRegion=$diskRegion]"
   }
 }
 
@@ -528,9 +504,7 @@ final class ColumnFormatEncoder extends RowEncoder {
     row.setColumn(1, new SQLVarchar(batchKey.uuid))
     row.setColumn(2, new SQLInteger(batchKey.partitionId))
     row.setColumn(3, new SQLInteger(batchKey.columnIndex))
-    // set value reference which will be released after thrift write;
-    // this written blob does not include the serialization header
-    // unlike in fromRow which does include it
+    // set value reference which will be released after thrift write
     row.setColumn(4, new SQLBlob(new ClientBlob(batchValue)))
     row
   }
@@ -544,9 +518,6 @@ final class ColumnFormatEncoder extends RowEncoder {
       case blob: BufferedBlob => blob.getAsLastChunk.chunk
       case blob: Blob => ByteBuffer.wrap(blob.getBytes(1, blob.length().toInt))
     }
-    // the incoming blob includes the space for serialization header to avoid
-    // a copy when transferring to ColumnFormatValue, so just move to
-    // the start of data and write the serialization header
     columnBuffer.rewind()
     // set the buffer into ColumnFormatValue
     val batchValue = new ColumnFormatValue(columnBuffer)

--- a/core/src/main/scala/org/apache/spark/sql/execution/columnar/impl/JDBCSourceAsColumnarStore.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/columnar/impl/JDBCSourceAsColumnarStore.scala
@@ -75,14 +75,7 @@ class JDBCSourceAsColumnarStore(override val connProperties: ConnectionPropertie
 
   private def createStatsBuffer(statsData: Array[Byte],
       allocator: BufferAllocator): ByteBuffer = {
-    val statsLen = statsData.length
-    val statsBuffer = allocator.allocateForStorage(statsLen +
-        ColumnFormatEntry.VALUE_HEADER_SIZE)
-    statsBuffer.position(ColumnFormatEntry.VALUE_HEADER_SIZE)
-    statsBuffer.put(statsData, 0, statsLen)
-    // move to start for ColumnFormatValue to write the serialization header
-    statsBuffer.rewind()
-    statsBuffer
+    allocator.fromBytesToStorage(statsData, 0, statsData.length)
   }
 
   /**

--- a/core/src/main/scala/org/apache/spark/sql/execution/columnar/impl/JDBCSourceAsColumnarStore.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/columnar/impl/JDBCSourceAsColumnarStore.scala
@@ -75,7 +75,14 @@ class JDBCSourceAsColumnarStore(override val connProperties: ConnectionPropertie
 
   private def createStatsBuffer(statsData: Array[Byte],
       allocator: BufferAllocator): ByteBuffer = {
-    allocator.fromBytesToStorage(statsData, 0, statsData.length)
+    val statsLen = statsData.length
+    val statsBuffer = allocator.allocateForStorage(statsLen +
+        ColumnFormatEntry.VALUE_HEADER_SIZE)
+    statsBuffer.position(ColumnFormatEntry.VALUE_HEADER_SIZE)
+    statsBuffer.put(statsData, 0, statsLen)
+    // move to start for ColumnFormatValue to write the serialization header
+    statsBuffer.rewind()
+    statsBuffer
   }
 
   /**


### PR DESCRIPTION
## Changes proposed in this pull request

- ensure that the expanded bitset size is able to accomodate the incoming ordinal
- reduce byte copying and boxing for wide-table inserts:
  - use SpecificMutableRow instead of GenericMutableRow to avoid primitive boxing
  - use own setColumn method instead of CodegenContext.setColumn that avoids cloning
    of UTF8String which is not really required
- refactored encoder close in ColumnInsertExec to use for wide-table case too
  (else those remain dangling until collected by some GC cycle)
- use a maxDeltaRows for wide-schema case too in ColumnInsertExec
- use buffer.limit() instead of capacity in ByteBufferHashMap
- corrected some scalastyle/indentation

## Patch testing

precheckin, failing test cases

## ReleaseNotes.txt changes

NA

## Other PRs 

https://github.com/SnappyDataInc/spark/commit/5147b60ec4a627565a692dba59244bbd214cd3e4 reduces byte copying in Spark layer when reading from dictionary
Also see the store PR