### PR TITLE
SNAP-1794

### DIFF
--- a/core/src/main/scala/org/apache/spark/sql/catalyst/expressions/ParamLiteral.scala
+++ b/core/src/main/scala/org/apache/spark/sql/catalyst/expressions/ParamLiteral.scala
@@ -253,6 +253,9 @@ case class DynamicFoldableExpression(expr: Expression) extends Expression
     val newVar = ctx.freshName("paramLiteralExpr")
     val newVarIsNull = ctx.freshName("paramLiteralExprIsNull")
     val comment = ctx.registerComment(expr.toString)
+    // initialization for both variable and isNull is being done together
+    // due to dependence of latter on the variable and the two get
+    // separated due to Spark's splitExpressions -- SNAP-1794
     ctx.addMutableState(ctx.javaType(expr.dataType), newVar,
       s"$comment\n${eval.code}\n$newVar = ${eval.value};\n" +
         s"$newVarIsNull = ${eval.isNull};")

--- a/core/src/main/scala/org/apache/spark/sql/catalyst/expressions/ParamLiteral.scala
+++ b/core/src/main/scala/org/apache/spark/sql/catalyst/expressions/ParamLiteral.scala
@@ -254,9 +254,9 @@ case class DynamicFoldableExpression(expr: Expression) extends Expression
     val newVarIsNull = ctx.freshName("paramLiteralExprIsNull")
     val comment = ctx.registerComment(expr.toString)
     ctx.addMutableState(ctx.javaType(expr.dataType), newVar,
-      s"$comment\n${eval.code}\n$newVar = ${eval.value};")
-    ctx.addMutableState("boolean", newVarIsNull, s"$newVarIsNull = ${eval.isNull};")
-
+      s"$comment\n${eval.code}\n$newVar = ${eval.value};\n" +
+        s"$newVarIsNull = ${eval.isNull};")
+    ctx.addMutableState("boolean", newVarIsNull, "")
     ev.copy(code = "", value = newVar, isNull = newVarIsNull)
   }
 


### PR DESCRIPTION
## Changes proposed in this pull request

Modified code generation of DynamicFoldableExpression such that even the initMutableState splits into multiple init() functions, code will be generated properly.

## Patch testing

clean precheckin

## ReleaseNotes.txt changes

None

## Other PRs 

spark - https://github.com/SnappyDataInc/spark/pull/59