### PR TITLE
Fix for SNAP-1805 caused because function to withNewExecutionId was e…

### DIFF
--- a/core/src/main/scala/org/apache/spark/sql/CachedDataFrame.scala
+++ b/core/src/main/scala/org/apache/spark/sql/CachedDataFrame.scala
@@ -242,7 +242,7 @@ class CachedDataFrame(df: Dataset[Row], var queryString: String,
       case plan => plan
     }
 
-    def withNewExecutionId[T](body: T): T = executedPlan match {
+    def withNewExecutionId[T](body: => T): T = executedPlan match {
       // don't create a new executionId for ExecutePlan since it has already done so
       case _: ExecutePlan => body
       case _ => CachedDataFrame.withNewExecutionId(


### PR DESCRIPTION
…xecuted before it was passed as argument

## Changes proposed in this pull request
* Proper passing of function as argument to withNewExecutionId method
* As UI data is stored based on the execution id and because of this issue job was executed before creation of new execution id data was not displayed on UI

## Patch testing
* Manually tested
* precheckin in progress

## ReleaseNotes.txt changes
NA
## Other PRs 
NA