### PR TITLE
[SNAP-1777] increasing default member-timeout for SnappyData

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -315,16 +315,16 @@ subprojects {
                '-XX:CMSInitiatingOccupancyFraction=50',
                '-XX:+CMSClassUnloadingEnabled', '-ea']
 
-    def dunitTests = fileTree(dir: testClassesDir, include: '**/*DUnitTest.class')
-    FileTree includeTestFiles = dunitTests
     def single = rootProject.hasProperty('dunit.single') ?
         rootProject.property('dunit.single') : null
-    int dunitFrom = rootProject.hasProperty('dunit.from') ?
+    if (single == null || single.length() == 0) {
+      def dunitTests = fileTree(dir: testClassesDir, include: '**/*DUnitTest.class')
+      FileTree includeTestFiles = dunitTests
+      int dunitFrom = rootProject.hasProperty('dunit.from') ?
           getLast(includeTestFiles, rootProject.property('dunit.from')) : 0
-    int dunitTo = rootProject.hasProperty('dunit.to') ?
+      int dunitTo = rootProject.hasProperty('dunit.to') ?
           getLast(includeTestFiles, rootProject.property('dunit.to')) : includeTestFiles.size()
 
-    if (single == null || single.length() == 0) {
       int begin = dunitFrom != -1 ? dunitFrom : 0
       int end = dunitTo != -1 ? dunitTo : includeTestFiles.size()
       def filteredSet = includeTestFiles.drop(begin).take(end-begin+1).collect {f -> "**/" + f.name}

--- a/core/src/main/scala/io/snappydata/impl/ServerImpl.scala
+++ b/core/src/main/scala/io/snappydata/impl/ServerImpl.scala
@@ -21,7 +21,9 @@ import java.util.Properties
 
 import com.pivotal.gemfirexd.internal.engine.GfxdConstants
 import com.pivotal.gemfirexd.internal.engine.fabricservice.FabricServerImpl
+import io.snappydata.util.ServiceUtils
 import io.snappydata.{ProtocolOverrides, Server}
+
 import org.apache.spark.sql.row.GemFireXDDialect
 
 /**
@@ -38,11 +40,7 @@ class ServerImpl extends FabricServerImpl with Server with ProtocolOverrides {
 
   @throws[SQLException]
   override def start(bootProps: Properties, ignoreIfStarted: Boolean): Unit = {
-    if (!bootProps.containsKey(GfxdConstants.DEFAULT_STARTUP_RECOVERY_DELAY_PROP)) {
-      // set default startup-recovery-delay to be 2mins (SNAP-1541)
-      bootProps.setProperty(GfxdConstants.DEFAULT_STARTUP_RECOVERY_DELAY_PROP, "120000")
-    }
-    super.start(bootProps, ignoreIfStarted)
+    super.start(ServiceUtils.setCommonBootDefaults(bootProps), ignoreIfStarted)
   }
 
   override def isServer: Boolean = true

--- a/core/src/main/scala/org/apache/spark/sql/execution/columnar/ExternalStoreUtils.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/columnar/ExternalStoreUtils.scala
@@ -104,7 +104,6 @@ object ExternalStoreUtils extends Logging {
       props = addProperty(props, "maxActive", defaultMaxPoolSize)
       props = addProperty(props, "maxIdle", defaultMaxPoolSize)
       props = addProperty(props, "initialSize", "4")
-      props = addProperty(props, "minEvictableIdleTimeMillis", "120000")
     }
     props
   }


### PR DESCRIPTION
## Changes proposed in this pull request

- increasing the default member-timeout to 30s
- refactored methods a bit to do all SnappyData specific default boot setup in one place
- removed explicit pool minEvictableIdleTimeMillis added previously and let it be default

## Patch testing

precheckin

## ReleaseNotes.txt changes

Mention in best practices guide that default for member-timeout is 30s and needs to be increased further only if trouble is still seen.

## Other PRs 

NA