### PR TITLE
SNAP-1326 ALTER TABLE Support

### DIFF
--- a/cluster/src/dunit/scala/io/snappydata/cluster/DDLRoutingDUnitTest.scala
+++ b/cluster/src/dunit/scala/io/snappydata/cluster/DDLRoutingDUnitTest.scala
@@ -177,11 +177,39 @@ class DDLRoutingDUnitTest(val s: String) extends ClusterManagerTestBase(s) {
     s.execute(s"ALTER TABLE $tableName DROP COLUMN Col3")
     verifyResultAndSchema(snc, tableName, 3)
 
-    // execute at store level
-    s.execute(s"ALTER TABLE $tableName SET GATEWAYSENDER ()")
-    s.execute(s"ALTER TABLE $tableName add constraint emp_uk unique (Col1)")
+    s.execute(s"ALTER TABLE $tableName DROP COLUMN Col4")
+    verifyResultAndSchema(snc, tableName, 2)
 
-    verifyResultAndSchema(snc, tableName, 3)
+    // execute at store level
+    s.execute(s"insert into $tableName values (1,1)")
+    s.execute(s"insert into $tableName values (1,1)")
+    s.execute(s"ALTER TABLE $tableName add constraint emp_uk unique (Col1)")
+    try {
+    s.execute(s"insert into $tableName values (1,1)")
+    } catch {
+      case sqle: SQLException =>
+        if (sqle.getSQLState != "23505" ||
+          !sqle.getMessage.contains("duplicate key value in a unique or" +
+            " primary key constraint or unique index")) {
+          throw sqle
+        }
+    }
+    // Commented due to SNAP-1818
+//    s.execute(s"ALTER TABLE $tableName SET GATEWAYSENDER ()")
+//    s.execute("CREATE ASYNCEVENTLISTENER myListener (" +
+//      " listenerclass 'com.pivotal.gemfirexd.callbacks.DBSynchronizer'" +
+//      " initparams 'org.apache.derby.jdbc.EmbeddedDriver,jdbc:derby:newDB;create=true')")
+//
+//    s.execute(s"ALTER TABLE $tableName SET ASYNCEVENTLISTENER (myListener) ")
+//    var rs = s.executeQuery(s"select * from SYS.SYSTABLES where tablename='$tableName'")
+//    while (rs.next) {
+//      assert("MYLISTENER".equalsIgnoreCase(rs.getString(17)))
+//    }
+//    s.execute(s"ALTER TABLE $tableName SET ASYNCEVENTLISTENER () ")
+//    rs = s.executeQuery("select * from SYS.SYSTABLES where tablename='TESTTABLE'")
+//    while (rs.next) {
+//      assert(rs.getString(17) == null)
+//    }
 
     dropTableXD(conn, tableName)
   }
@@ -190,6 +218,38 @@ class DDLRoutingDUnitTest(val s: String) extends ClusterManagerTestBase(s) {
     val dataDF = snc.sql("Select * from " + tableName)
     assert(dataDF.count() == 5)
     assert(dataDF.schema.fields.length == expectedColumns)
+  }
+
+  def testAlterRowTableFromXD_DifferentConnections(): Unit = {
+    val tableName: String = "RowTableQR"
+
+    val netPort1 = AvailablePortHelper.getRandomAvailableTCPPort
+    vm2.invoke(classOf[ClusterManagerTestBase], "startNetServer", netPort1)
+    val conn1 = getANetConnection(netPort1)
+    val conn2 = getANetConnection(netPort1)
+
+    conn1.createStatement().execute(s"CREATE TABLE $tableName (Col1 INT, Col2 INT, Col3 STRING)")
+    insertDataXD(conn1, tableName)
+    conn2.createStatement().execute(s"ALTER TABLE $tableName ADD COLUMN Col4 INT")
+
+    val rs = conn1.createStatement().executeQuery(s"select Col1, Col4 from $tableName")
+    var cnt = 0
+    while (rs.next()) {
+      cnt += 1
+      rs.getInt(1); rs.getInt(2);
+    }
+    assert(cnt == 5, cnt)
+
+    conn1.createStatement().execute(s"ALTER TABLE $tableName DROP COLUMN Col3")
+    val rs2 = conn2.createStatement().executeQuery(s"select Col1, Col2, Col4 from $tableName")
+    cnt = 0
+    while (rs2.next()) {
+      cnt += 1
+      rs2.getInt(1); rs2.getInt(2); rs2.getInt(3);
+    }
+    assert(cnt == 5, cnt)
+
+    dropTableXD(conn2, tableName)
   }
 
   def testAlterRowTableFromSnappy(): Unit = {

--- a/core/src/main/scala/org/apache/spark/sql/SnappyBaseParser.scala
+++ b/core/src/main/scala/org/apache/spark/sql/SnappyBaseParser.scala
@@ -436,6 +436,9 @@ object SnappyParserConsts {
   final val USING = nonReservedKeyword("using")
   final val RETURNS = nonReservedKeyword("returns")
   final val FN = nonReservedKeyword("fn")
+  final val ALTER = nonReservedKeyword("alter")
+  final val ADD = nonReservedKeyword("add")
+  final val COLUMN = nonReservedKeyword("column")
 
   // Window analytical functions are non-reserved
   final val DURATION = nonReservedKeyword("duration")

--- a/core/src/main/scala/org/apache/spark/sql/SnappyContext.scala
+++ b/core/src/main/scala/org/apache/spark/sql/SnappyContext.scala
@@ -20,15 +20,9 @@ import java.io.{Externalizable, ObjectInput, ObjectOutput}
 import java.lang.reflect.Method
 import java.util.concurrent.atomic.AtomicInteger
 
-import scala.collection.JavaConverters._
-import scala.collection.concurrent.TrieMap
-import scala.language.implicitConversions
-import scala.reflect.runtime.{universe => u}
-
 import com.pivotal.gemfirexd.internal.engine.Misc
 import io.snappydata.util.ServiceUtils
-import io.snappydata.{SnappyThinConnectorTableStatsProvider, Constant, Property, SnappyTableStatsProviderService}
-
+import io.snappydata.{Constant, Property, SnappyTableStatsProviderService}
 import org.apache.spark.annotation.{DeveloperApi, Experimental}
 import org.apache.spark.api.java.JavaSparkContext
 import org.apache.spark.memory.MemoryManagerCallback
@@ -38,6 +32,12 @@ import org.apache.spark.sql.catalyst.expressions.SortDirection
 import org.apache.spark.sql.collection.{ToolsCallbackInit, Utils}
 import org.apache.spark.sql.execution.ConnectionPool
 import org.apache.spark.sql.execution.columnar.ExternalStoreUtils
+import org.apache.spark.sql.types.StructField
+
+import scala.collection.JavaConverters._
+import scala.collection.concurrent.TrieMap
+import scala.language.implicitConversions
+import scala.reflect.runtime.{universe => u}
 // import org.apache.spark.sql.execution.datasources.CaseInsensitiveMap
 import org.apache.spark.sql.catalyst.util.CaseInsensitiveMap
 import org.apache.spark.sql.execution.datasources.csv.CSVFileFormat
@@ -49,7 +49,7 @@ import org.apache.spark.sql.streaming._
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.storage.{BlockManagerId, StorageLevel}
 import org.apache.spark.streaming.dstream.DStream
-import org.apache.spark.{Logging, SparkConf, SparkContext, SparkEnv, SparkException}
+import org.apache.spark._
 
 /**
  * Main entry point for SnappyData extensions to Spark. A SnappyContext
@@ -128,6 +128,30 @@ class SnappyContext protected[spark](val snappySession: SnappySession)
   def appendToTempTableCache(df: DataFrame, table: String,
       storageLevel: StorageLevel = StorageLevel.MEMORY_AND_DISK): Unit = {
     snappySession.appendToTempTableCache(df, table, storageLevel)
+  }
+
+  /**
+    * alter table adds/drops provided column, only supprted for row tables.
+    * For adding a column isAddColumn should be true, else it will be drop column
+    * @param tableName
+    * @param isAddColumn
+    * @param column
+    */
+  def alterTable(tableName: String, isAddColumn: Boolean,
+                 column: StructField): Unit = {
+    snappySession.alterTable(tableName, isAddColumn, column)
+  }
+
+  /**
+    * alter table adds/drops provided column, only supprted for row tables.
+    * For adding a column isAddColumn should be true, else it will be drop column
+    * @param tableIdent
+    * @param isAddColumn
+    * @param column
+    */
+  private[sql] def alterTable(tableIdent: QualifiedTableName, isAddColumn: Boolean,
+                              column: StructField): Unit = {
+    snappySession.alterTable(tableIdent, isAddColumn, column)
   }
 
   /**

--- a/core/src/main/scala/org/apache/spark/sql/SnappySession.scala
+++ b/core/src/main/scala/org/apache/spark/sql/SnappySession.scala
@@ -19,13 +19,6 @@
 import java.sql.SQLException
 import java.util.concurrent.atomic.AtomicInteger
 
-import scala.collection.JavaConverters._
-import scala.collection.mutable
-import scala.collection.mutable.ArrayBuffer
-import scala.language.implicitConversions
-import scala.reflect.runtime.{universe => u}
-import scala.util.control.NonFatal
-
 import com.gemstone.gemfire.cache.EntryExistsException
 import com.gemstone.gemfire.distributed.internal.DistributionAdvisor.Profile
 import com.gemstone.gemfire.distributed.internal.ProfileListener
@@ -36,7 +29,6 @@ import com.google.common.util.concurrent.UncheckedExecutionException
 import com.pivotal.gemfirexd.internal.iapi.sql.ParameterValueSet
 import com.pivotal.gemfirexd.internal.shared.common.StoredFormatIds
 import io.snappydata.{Constant, SnappyTableStatsProviderService}
-
 import org.apache.spark.annotation.{DeveloperApi, Experimental}
 import org.apache.spark.rdd.RDD
 import org.apache.spark.scheduler.{SparkListener, SparkListenerApplicationEnd}
@@ -63,11 +55,18 @@ import org.apache.spark.sql.internal.{PreprocessTableInsertOrPut, SnappySessionS
 import org.apache.spark.sql.row.GemFireXDDialect
 import org.apache.spark.sql.sources._
 import org.apache.spark.sql.store.{CodeGeneration, StoreUtils}
-import org.apache.spark.sql.types._
+import org.apache.spark.sql.types.{StructType, _}
 import org.apache.spark.storage.StorageLevel
 import org.apache.spark.streaming.Time
 import org.apache.spark.streaming.dstream.DStream
 import org.apache.spark.{Logging, ShuffleDependency, SparkContext}
+
+import scala.collection.JavaConverters._
+import scala.collection.mutable
+import scala.collection.mutable.ArrayBuffer
+import scala.language.implicitConversions
+import scala.reflect.runtime.{universe => u}
+import scala.util.control.NonFatal
 
 
 class SnappySession(@transient private val sc: SparkContext,
@@ -977,7 +976,6 @@ class SnappySession(@transient private val sc: SparkContext,
       mode: SaveMode,
       options: Map[String, String],
       isBuiltIn: Boolean): LogicalPlan = {
-
     SnappyContext.getClusterMode(sc) match {
       case ThinClientConnectorMode(_, _) =>
         return sessionCatalog.asInstanceOf[ConnectorCatalog].connectorHelper.createTable(tableIdent,
@@ -1004,7 +1002,6 @@ class SnappySession(@transient private val sc: SparkContext,
     else {
       options + (dbtableProp -> tableIdent.toString)
     }
-
     val source = if (isBuiltIn) SnappyContext.getProvider(provider,
       onlyBuiltIn = true) else provider
 
@@ -1267,6 +1264,50 @@ class SnappySession(@transient private val sc: SparkContext,
       case _ => // This is a temp table with no relation as source
         Dataset.ofRows(this, plan).unpersist(blocking = true)
         sessionCatalog.unregisterTable(tableIdent)
+    }
+  }
+
+  def invalidateAll(): Unit = {
+    sessionCatalog.invalidateAll()
+  }
+
+  private[sql] def alterTable(tableName: String, isAddColumn: Boolean,
+                 column: StructField): Unit = {
+    alterTable(sessionCatalog.newQualifiedTableName(tableName), isAddColumn, column)
+  }
+
+  private[sql]  def alterTable(tableIdent: QualifiedTableName, isAddColumn: Boolean,
+                              column: StructField): Unit = {
+    val plan = try {
+      sessionCatalog.lookupRelation(tableIdent)
+    } catch {
+      case tnfe: TableNotFoundException =>
+        throw tnfe
+    }
+    plan match {
+      case LogicalRelation(c: ColumnFormatRelation, _, _) =>
+        throw new AnalysisException("alter table not supported for column tables")
+      case _ =>
+    }
+
+    SnappyContext.getClusterMode(sc) match {
+      case ThinClientConnectorMode(_, _) =>
+        val isTempTable = sessionCatalog.isTemporaryTable(tableIdent)
+        if (!isTempTable) {
+          sessionCatalog.invalidateTable(tableIdent)
+          sessionCatalog.asInstanceOf[ConnectorCatalog].connectorHelper
+            .alterTable(tableIdent, isAddColumn, column)
+          return
+        }
+      case _ =>
+    }
+
+    plan match {
+      case LogicalRelation(ar: AlterableRelation, _, _) =>
+        sessionCatalog.invalidateTable(tableIdent)
+        ar.alterTable(tableIdent, isAddColumn, column)
+        SnappyStoreHiveCatalog.registerRelationDestroy()
+        SnappySession.clearAllCache()
     }
   }
 

--- a/core/src/main/scala/org/apache/spark/sql/sources/interfaces.scala
+++ b/core/src/main/scala/org/apache/spark/sql/sources/interfaces.scala
@@ -25,6 +25,7 @@ import org.apache.spark.sql.execution.SparkPlan
 import org.apache.spark.sql.execution.columnar.impl.BaseColumnFormatRelation
 import org.apache.spark.sql.execution.datasources.LogicalRelation
 import org.apache.spark.sql.hive.{QualifiedTableName, SnappyStoreHiveCatalog}
+import org.apache.spark.sql.types.StructField
 import org.apache.spark.sql.{Row, SQLContext, SaveMode}
 
 @DeveloperApi
@@ -254,6 +255,18 @@ trait IndexableRelation {
       tableIdent: QualifiedTableName,
       ifExists: Boolean): Unit
 
+}
+
+@DeveloperApi
+trait AlterableRelation {
+  /**
+    * Alter's table schema by adding or dropping a provided column
+    * @param tableIdent
+    * @param isAddColumn
+    * @param column
+    */
+  def alterTable(tableIdent: QualifiedTableName,
+                 isAddColumn: Boolean, column: StructField): Unit
 }
 
 /**

--- a/core/src/test/scala/org/apache/spark/sql/store/ColumnTableTest.scala
+++ b/core/src/test/scala/org/apache/spark/sql/store/ColumnTableTest.scala
@@ -19,18 +19,17 @@ package org.apache.spark.sql.store
 import java.sql.{DriverManager, SQLException}
 
 import com.pivotal.gemfirexd.TestUtil
-import scala.util.{Failure, Success, Try}
 
+import scala.util.{Failure, Success, Try}
 import com.gemstone.gemfire.cache.{EvictionAction, EvictionAlgorithm}
 import com.gemstone.gemfire.internal.cache.PartitionedRegion
 import com.pivotal.gemfirexd.internal.engine.Misc
-import com.pivotal.gemfirexd.internal.impl.jdbc.EmbedConnection
+import com.pivotal.gemfirexd.internal.impl.jdbc.{EmbedConnection, EmbedSQLException}
 import com.pivotal.gemfirexd.internal.impl.sql.compile.ParserImpl
 import io.snappydata.core.{Data, TestData, TestData2}
 import io.snappydata.{Property, SnappyEmbeddedTableStatsProviderService, SnappyFunSuite, SnappyTableStatsProviderService}
 import org.apache.hadoop.hive.ql.parse.ParseDriver
 import org.scalatest.{BeforeAndAfter, BeforeAndAfterAll}
-
 import org.apache.spark.Logging
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.apache.spark.sql.execution.columnar.impl.ColumnFormatRelation
@@ -413,6 +412,40 @@ class ColumnTableTest
 
     snc.dropTable(tableName2)
     logInfo("Successful")
+  }
+
+  test("Test alter table SQL not supported for column tables") {
+    snc.sql("drop table if exists employee")
+    snc.sql("create table employee(name string, surname string) using column options()")
+    assert (snc.sql("select * from employee").schema.fields.length == 2)
+    intercept[AnalysisException] { // not supported
+      snc.sql("alter table employee add column age int")
+    }
+    assert (snc.sql("select * from employee").schema.fields.length == 2)
+    intercept[AnalysisException] { // not supported
+      snc.sql("alter table employee drop column surname")
+    }
+    assert (snc.sql("select * from employee").schema.fields.length == 2)
+    intercept[TableNotFoundException] {
+      snc.sql("alter table non_employee add column age int")
+    }
+  }
+
+  test("Test alter table API not supported for column tables") {
+    val data = Seq(Seq(1, 2, 3), Seq(7, 8, 9), Seq(9, 2, 3), Seq(4, 2, 3), Seq(5, 6, 7))
+    val rdd = sc.parallelize(data, data.length).map(s => new Data(s(0), s(1), s(2)))
+    val dataDF = snc.createDataFrame(rdd)
+    snc.createTable(tableName, "column", dataDF.schema, props)
+    dataDF.write.format("column").mode(SaveMode.Append).options(props).saveAsTable(tableName)
+
+    intercept[AnalysisException] {
+      snc.alterTable(tableName, true, StructField("col4", IntegerType, true))
+    }
+    assert(snc.sql("SELECT * FROM " + tableName).schema.fields.length == 3)
+    intercept[AnalysisException] {
+      snc.alterTable(tableName, false, StructField("col3", IntegerType, true))
+    }
+    assert(snc.sql("SELECT * FROM " + tableName).schema.fields.length == 3)
   }
 
   test("Test the truncate syntax SQL and SnappyContext") {


### PR DESCRIPTION
## Changes proposed in this pull request

(Fill in the changes here)

- SnappyParser changes to support ALTER TABLE ADD/DROP COLUMN DDLs
- Added alterTable APIs in SnappyContext
- Added trait AlterableRelation
- Smart connector - alter table execution handling
- Added DDL routing dunits for Alter table
- scalaTests for alter table column and row tables

## Patch testing

clean precheckin, manual testing

## ReleaseNotes.txt changes

Yes

## Other PRs 
