### PR TITLE
SNAP-1808 Create cachedbatch tables in user's schema instead of SNAPPYSYS_INTERNAL

### DIFF
--- a/cluster/src/dunit/scala/io/snappydata/cluster/QueryRoutingDUnitTest.scala
+++ b/cluster/src/dunit/scala/io/snappydata/cluster/QueryRoutingDUnitTest.scala
@@ -21,7 +21,6 @@ import java.io.File
 import java.sql.{Connection, DatabaseMetaData, DriverManager, ResultSet, SQLException, Statement}
 
 import scala.collection.mutable
-
 import com.pivotal.gemfirexd.internal.engine.Misc
 import com.pivotal.gemfirexd.internal.engine.distributed.utils.GemFireXDUtils
 import io.snappydata.Constant._
@@ -29,12 +28,12 @@ import io.snappydata.test.dunit.{AvailablePortHelper, SerializableRunnable}
 import junit.framework.TestCase
 import org.apache.commons.io.FileUtils
 import org.junit.Assert
-
 import org.apache.spark.Logging
 import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.analysis.UnresolvedRelation
 import org.apache.spark.sql.catalyst.expressions.SubqueryExpression
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
+import org.apache.spark.sql.execution.columnar.impl.ColumnFormatRelation
 import org.apache.spark.sql.types.Decimal
 import org.apache.spark.sql.{IndexTest, SaveMode, SingleNodeTest, SnappyContext, TPCHUtils}
 import org.apache.spark.util.Benchmark
@@ -476,7 +475,7 @@ class QueryRoutingDUnitTest(val s: String)
         results += tableMd.getString(2) + '.' + tableMd.getString(3)
       }
       // 2 for column table and 1 for parquet external table
-      assert(results.size == 3, s"Got size = ${results.size} but expected 3")
+      assert(results.size == 3, s"Got size = ${results.size} [$results] but expected 3.")
       assert(results.contains(s"APP.$colTable"))
       assert(results.contains(s"APP_PARQUET.$parquetTable"))
       results.clear()
@@ -563,13 +562,13 @@ class QueryRoutingDUnitTest(val s: String)
     }
     assert(foundTable)
 
-    val rSet2 = dbmd.getTables(null, SHADOW_SCHEMA_NAME, null,
+    val rSet2 = dbmd.getTables(null, "APP", null,
       Array[String]("TABLE", "SYSTEM TABLE", "COLUMN TABLE",
         "EXTERNAL TABLE", "STREAM TABLE"))
 
     foundTable = false
     while (rSet2.next()) {
-      if (s"APP____${t + SHADOW_TABLE_SUFFIX}".
+      if (ColumnFormatRelation.columnBatchTableName(t).
           equalsIgnoreCase(rSet2.getString("TABLE_NAME"))) {
         foundTable = true
         assert(rSet2.getString("TABLE_TYPE").equalsIgnoreCase("TABLE"))
@@ -655,6 +654,7 @@ class QueryRoutingDUnitTest(val s: String)
           throw sqe
         }
     }
+    s.execute("DROP TABLE T1")
 
   }
 

--- a/cluster/src/dunit/scala/io/snappydata/cluster/ValidateMVCCDUnitTest.scala
+++ b/cluster/src/dunit/scala/io/snappydata/cluster/ValidateMVCCDUnitTest.scala
@@ -315,9 +315,9 @@ object ValidateMVCCDUnitTest {
 
   def printRegionSize(): Unit = {
     val cache = GemFireCacheImpl.getInstance()
-    println("APP.TESTTABLE Region size : "+cache.getRegion("/APP/TESTTABLE").size())
-    println("SNAPPYSYS_INTERNAL.APP____TESTTABLE_COLUMN_STORE_  Region size : "+cache.getRegion
-    ("/SNAPPYSYS_INTERNAL/APP____TESTTABLE_COLUMN_STORE_").size())
+    val cbName = ColumnFormatRelation.columnBatchTableName("APP.TESTTABLE")
+    println("APP.TESTTABLE Region size : " + cache.getRegion("/APP/TESTTABLE").size())
+    println(s"APP.$cbName  Region size : " + Misc.getRegionForTable(cbName, true).size())
   }
 
 

--- a/cluster/src/dunit/scala/io/snappydata/externalstore/ColumnTableDUnitTest.scala
+++ b/cluster/src/dunit/scala/io/snappydata/externalstore/ColumnTableDUnitTest.scala
@@ -117,7 +117,7 @@ class ColumnTableDUnitTest(s: String) extends ClusterManagerTestBase(s) {
         columnBatchTableName(tableName).toUpperCase
     val getPRMessageCount = new SerializableCallable[AnyRef] {
       override def call(): AnyRef = {
-        Int.box(Misc.getRegionForTable(columnTableRegionName, true).
+        Int.box(Misc.getRegionForTable("APP." + columnTableRegionName, true).
             asInstanceOf[PartitionedRegion].getPrStats.getPartitionMessagesSent)
       }
     }
@@ -167,7 +167,7 @@ class ColumnTableDUnitTest(s: String) extends ClusterManagerTestBase(s) {
     // we don't expect any increase in put distribution stats
     val getPRMessageCount = new SerializableCallable[AnyRef] {
       override def call(): AnyRef = {
-        Int.box(Misc.getRegionForTable(columnTableRegionName, true).
+        Int.box(Misc.getRegionForTable("APP." + columnTableRegionName, true).
             asInstanceOf[PartitionedRegion].getPrStats.getPartitionMessagesSent)
       }
     }
@@ -209,7 +209,7 @@ class ColumnTableDUnitTest(s: String) extends ClusterManagerTestBase(s) {
     val getTotalEntriesCount = new SerializableCallable[AnyRef] {
       override def call(): AnyRef = {
         val pr: PartitionedRegion =
-          Misc.getRegionForTable(tName, true).asInstanceOf[PartitionedRegion]
+          Misc.getRegionForTable("APP." + tName, true).asInstanceOf[PartitionedRegion]
         var buckets = Set.empty[Integer]
         0 to (pr.getTotalNumberOfBuckets - 1) foreach { x =>
           buckets = buckets + x
@@ -229,7 +229,7 @@ class ColumnTableDUnitTest(s: String) extends ClusterManagerTestBase(s) {
     val getLocalEntriesCount = new SerializableCallable[AnyRef] {
       override def call(): AnyRef = {
         val pr: PartitionedRegion =
-          Misc.getRegionForTable(tName, true).asInstanceOf[PartitionedRegion]
+          Misc.getRegionForTable("APP." + tName, true).asInstanceOf[PartitionedRegion]
         val iter = pr.getAppropriateLocalEntriesIterator(
           pr.getDataStore.getAllLocalBucketIds, false, false, true, pr, false)
         var count = 0
@@ -315,7 +315,7 @@ class ColumnTableDUnitTest(s: String) extends ClusterManagerTestBase(s) {
 
     val region = Misc.getRegionForTable(s"APP.${tableName.toUpperCase()}",
       true).asInstanceOf[PartitionedRegion]
-    val shadowRegion = Misc.getRegionForTable(ColumnFormatRelation.
+    val shadowRegion = Misc.getRegionForTable("APP." + ColumnFormatRelation.
         columnBatchTableName(tableName).toUpperCase(),
       true).asInstanceOf[PartitionedRegion]
 
@@ -359,6 +359,7 @@ class ColumnTableDUnitTest(s: String) extends ClusterManagerTestBase(s) {
     val region = Misc.getRegionForTable(s"APP.${tableNameWithPartition.toUpperCase()}",
       true).asInstanceOf[PartitionedRegion]
     val shadowRegion = Misc.getRegionForTable(
+      "APP." +
       ColumnFormatRelation.columnBatchTableName(tableNameWithPartition).toUpperCase(),
       true).asInstanceOf[PartitionedRegion]
 
@@ -412,6 +413,7 @@ class ColumnTableDUnitTest(s: String) extends ClusterManagerTestBase(s) {
     val region = Misc.getRegionForTable(s"APP.${tableNameWithPartition.toUpperCase()}",
       true).asInstanceOf[PartitionedRegion]
     val shadowRegion = Misc.getRegionForTable(
+      "APP." +
       ColumnFormatRelation.columnBatchTableName(tableNameWithPartition).toUpperCase(),
       true).asInstanceOf[PartitionedRegion]
 
@@ -461,6 +463,7 @@ class ColumnTableDUnitTest(s: String) extends ClusterManagerTestBase(s) {
     val region = Misc.getRegionForTable(s"APP.${tableNameWithPartition.toUpperCase()}",
       true).asInstanceOf[PartitionedRegion]
     val shadowRegion = Misc.getRegionForTable(
+      "APP." +
       ColumnFormatRelation.columnBatchTableName(tableNameWithPartition).toUpperCase(),
       true).asInstanceOf[PartitionedRegion]
 
@@ -514,6 +517,7 @@ class ColumnTableDUnitTest(s: String) extends ClusterManagerTestBase(s) {
     val region = Misc.getRegionForTable("APP.COLUMNTABLE4", true).
         asInstanceOf[PartitionedRegion]
     val shadowRegion = Misc.getRegionForTable(
+      "APP." +
       ColumnFormatRelation.columnBatchTableName("COLUMNTABLE4").toUpperCase(),
       true).asInstanceOf[PartitionedRegion]
 
@@ -573,7 +577,7 @@ class ColumnTableDUnitTest(s: String) extends ClusterManagerTestBase(s) {
 
     val region = Misc.getRegionForTable("APP.COLUMNTABLE4", true).
         asInstanceOf[PartitionedRegion]
-    val shadowRegion = Misc.getRegionForTable(ColumnFormatRelation.
+    val shadowRegion = Misc.getRegionForTable("APP." + ColumnFormatRelation.
         columnBatchTableName("COLUMNTABLE4").toUpperCase(),
       true).asInstanceOf[PartitionedRegion]
 

--- a/core/src/main/scala/io/snappydata/Literals.scala
+++ b/core/src/main/scala/io/snappydata/Literals.scala
@@ -85,6 +85,10 @@ object Constant {
 
   final val SHADOW_SCHEMA_SEPARATOR = StoreCallbacks.SHADOW_SCHEMA_SEPARATOR
 
+  final val SHADOW_SCHEMA_NAME_WITH_PREFIX = "." + SHADOW_SCHEMA_NAME
+
+  final val SHADOW_SCHEMA_NAME_WITH_SEPARATOR = SHADOW_SCHEMA_NAME + SHADOW_SCHEMA_SEPARATOR
+
   // Property to Specify whether zeppelin interpreter should be started
   // with leadnode
   val ENABLE_ZEPPELIN_INTERPRETER = "zeppelin.interpreter.enable"

--- a/core/src/main/scala/org/apache/spark/sql/SnappySession.scala
+++ b/core/src/main/scala/org/apache/spark/sql/SnappySession.scala
@@ -1369,7 +1369,8 @@ class SnappySession(@transient private val sc: SparkContext,
   private[sql] def getIndexTable(
       indexIdent: QualifiedTableName): QualifiedTableName = {
     // TODO: SW: proper schema handling required here
-    new QualifiedTableName(Constant.SHADOW_SCHEMA_NAME, indexIdent.table)
+    new QualifiedTableName(indexIdent.schemaName, Constant.SHADOW_SCHEMA_NAME_WITH_SEPARATOR +
+      indexIdent.table)
   }
 
   private def constructDropSQL(indexName: String,

--- a/core/src/main/scala/org/apache/spark/sql/execution/columnar/impl/ColumnFormatRelation.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/columnar/impl/ColumnFormatRelation.scala
@@ -671,24 +671,23 @@ object ColumnFormatRelation extends Logging with StoreCallback {
   }
 
   final def columnBatchTableName(table: String): String = {
-    val tableName = if (table.indexOf('.') > 0) {
-      table.replace(".", Constant.SHADOW_SCHEMA_SEPARATOR)
+    val schemaDot = table.indexOf('.')
+    if (schemaDot > 0) {
+      table.substring(0, schemaDot + 1) + Constant.SHADOW_SCHEMA_NAME_WITH_SEPARATOR +
+          table.substring(schemaDot + 1) + Constant.SHADOW_TABLE_SUFFIX
     } else {
-      Constant.DEFAULT_SCHEMA + Constant.SHADOW_SCHEMA_SEPARATOR + table
+      Constant.SHADOW_SCHEMA_NAME_WITH_SEPARATOR + table + Constant.SHADOW_TABLE_SUFFIX
     }
-    Constant.SHADOW_SCHEMA_NAME + "." + tableName + Constant.SHADOW_TABLE_SUFFIX
   }
 
   final def getTableName(columnBatchTableName: String): String = {
-    columnBatchTableName.substring(Constant.SHADOW_SCHEMA_NAME.length + 1,
-      columnBatchTableName.indexOf(Constant.SHADOW_TABLE_SUFFIX)).
-        replaceFirst(Constant.SHADOW_SCHEMA_SEPARATOR, ".")
+    val tableName = columnBatchTableName.replace(Constant.SHADOW_SCHEMA_NAME_WITH_SEPARATOR, "")
+    tableName.substring(0, tableName.length - Constant.SHADOW_TABLE_SUFFIX.length)
   }
 
   final def isColumnTable(tableName: String): Boolean = {
-    val r = tableName.startsWith(Constant.SHADOW_SCHEMA_NAME) &&
+    tableName.contains(Constant.SHADOW_SCHEMA_NAME_WITH_PREFIX) &&
         tableName.endsWith(Constant.SHADOW_TABLE_SUFFIX)
-    r
   }
 
   def getIndexUpdateStruct(indexEntry: ExternalTableMetaData,

--- a/core/src/main/scala/org/apache/spark/sql/execution/columnar/impl/StoreCallbacksImpl.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/columnar/impl/StoreCallbacksImpl.scala
@@ -16,7 +16,6 @@
  */
 package org.apache.spark.sql.execution.columnar.impl
 
-import java.lang
 import java.util.{Collections, UUID}
 
 import com.gemstone.gemfire.internal.cache.{BucketRegion, ExternalTableMetaData, TXManagerImpl, TXStateInterface}
@@ -30,18 +29,18 @@ import com.pivotal.gemfirexd.internal.iapi.sql.conn.LanguageConnectionContext
 import com.pivotal.gemfirexd.internal.iapi.store.access.TransactionController
 import com.pivotal.gemfirexd.internal.impl.jdbc.EmbedConnection
 import com.pivotal.gemfirexd.internal.snappy.LeadNodeSmartConnectorOpContext
-import io.snappydata.{Constant, SnappyTableStatsProviderService}
+import io.snappydata.SnappyTableStatsProviderService
 import org.apache.spark.memory.{MemoryManagerCallback, MemoryMode}
 import org.apache.spark.sql._
 import org.apache.spark.sql.catalyst.FunctionIdentifier
 import org.apache.spark.sql.catalyst.catalog.{CatalogFunction, FunctionResource, JarResource}
 import org.apache.spark.sql.catalyst.expressions.SortDirection
 import org.apache.spark.sql.collection.Utils
-import org.apache.spark.sql.execution.columnar.{ColumnBatchCreator, ExternalStore, ExternalStoreUtils}
+import org.apache.spark.sql.execution.columnar.{ColumnBatchCreator, ExternalStore}
 import org.apache.spark.sql.hive.{ExternalTableType, SnappyStoreHiveCatalog}
-import org.apache.spark.sql.store.{StoreHashFunction, StoreUtils}
+import org.apache.spark.sql.store.StoreHashFunction
 import org.apache.spark.sql.types._
-import org.apache.spark.{Logging, SparkContext, SparkException}
+import org.apache.spark.{Logging, SparkContext}
 
 import scala.collection.JavaConverters._
 
@@ -130,11 +129,13 @@ object StoreCallbacksImpl extends StoreCallbacks with Logging with Serializable 
   }
 
   def getInternalTableSchemas: java.util.List[String] = {
-    val schemas = new java.util.ArrayList[String](2)
+    val schemas = new java.util.ArrayList[String](1)
     schemas.add(SnappyStoreHiveCatalog.HIVE_METASTORE)
-    schemas.add(Constant.SHADOW_SCHEMA_NAME)
     schemas
   }
+
+  override def isColumnTable(qualifiedName: String): Boolean =
+    ColumnFormatRelation.isColumnTable(qualifiedName)
 
   override def getHashCodeSnappy(dvd: scala.Any, numPartitions: Int): Int = {
     partitioner.computeHash(dvd, numPartitions)
@@ -147,10 +148,6 @@ object StoreCallbacksImpl extends StoreCallbacks with Logging with Serializable 
 
   override def columnBatchTableName(table: String): String = {
     ColumnFormatRelation.columnBatchTableName(table)
-  }
-
-  override def snappyInternalSchemaName(): String = {
-    io.snappydata.Constant.SHADOW_SCHEMA_NAME
   }
 
   override def registerRelationDestroyForHiveStore(): Unit = {

--- a/core/src/test/scala/org/apache/spark/sql/store/ColumnTableInternalValidationTest.scala
+++ b/core/src/test/scala/org/apache/spark/sql/store/ColumnTableInternalValidationTest.scala
@@ -112,7 +112,7 @@ class ColumnTableInternalValidationTest extends SnappyFunSuite
     val region = Misc.getRegionForTable("APP.COLUMNTABLE7", true).
         asInstanceOf[PartitionedRegion]
 
-    val shadowRegion = Misc.getRegionForTable(ColumnFormatRelation.
+    val shadowRegion = Misc.getRegionForTable("APP." + ColumnFormatRelation.
         columnBatchTableName("COLUMNTABLE7").toUpperCase,
       true).asInstanceOf[PartitionedRegion]
 
@@ -157,7 +157,7 @@ class ColumnTableInternalValidationTest extends SnappyFunSuite
     val region = Misc.getRegionForTable("APP.COLUMNTABLE7", true).
         asInstanceOf[PartitionedRegion]
 
-    val shadowRegion = Misc.getRegionForTable(ColumnFormatRelation.
+    val shadowRegion = Misc.getRegionForTable("APP." + ColumnFormatRelation.
         columnBatchTableName("COLUMNTABLE7").toUpperCase,
       true).asInstanceOf[PartitionedRegion]
 
@@ -207,7 +207,7 @@ class ColumnTableInternalValidationTest extends SnappyFunSuite
 
     val region = Misc.getRegionForTable("APP.COLUMNTABLE7", true).
         asInstanceOf[PartitionedRegion]
-    val shadowRegion = Misc.getRegionForTable(ColumnFormatRelation.
+    val shadowRegion = Misc.getRegionForTable("APP." + ColumnFormatRelation.
         columnBatchTableName("COLUMNTABLE7").toUpperCase()
       , true).asInstanceOf[PartitionedRegion]
 

--- a/core/src/test/scala/org/apache/spark/sql/store/ColumnTableTest.scala
+++ b/core/src/test/scala/org/apache/spark/sql/store/ColumnTableTest.scala
@@ -946,7 +946,7 @@ class ColumnTableTest
     val rowBufferCount = rowBuffer.asInstanceOf[PartitionedRegion].getPrStats
         .getDataStoreEntryCount
 
-    val region = Misc.getRegionForTable(
+    val region = Misc.getRegionForTable("APP." +
       ColumnFormatRelation.columnBatchTableName(tableName).toUpperCase, true)
     SnappyEmbeddedTableStatsProviderService.publishColumnTableRowCountStats()
     val entries = region.asInstanceOf[PartitionedRegion].getPrStats


### PR DESCRIPTION
## Changes proposed in this pull request
* Changes from Sumedh @sumwale to create the CachedBatch tables inside user's schema
  instead of in the earlier common schema named SNAPPYSYS_INTERNAL
* Fix the Catalog consistency part with the above changes.

Old PR https://github.com/SnappyDataInc/snappydata/pull/707

## Patch testing
Clean precheckin

## ReleaseNotes.txt changes
NA

## Other PRs 
https://github.com/SnappyDataInc/snappy-store/pull/242
SnappyDataInc/snappy-aqp#153