### PR TITLE
[SNAP-1798] Explicitly removed MemoryConcumer memory.

### DIFF
--- a/core/src/main/scala/org/apache/spark/sql/CachedDataFrame.scala
+++ b/core/src/main/scala/org/apache/spark/sql/CachedDataFrame.scala
@@ -454,6 +454,9 @@ object CachedDataFrame
           // TODO Remove the 4 times check once SNAP-1759 is fixed
           val required = 4L * memSize
           val granted = memoryConsumer.acquireMemory(4L * memSize)
+          context.addTaskCompletionListener(context => {
+            memoryConsumer.freeMemory(granted)
+          })
           if (granted < required) {
             throw new LowMemoryException(s"Could not obtain ${memoryConsumer.getMode} " +
                 s"memory of size $required ",


### PR DESCRIPTION
## Changes proposed in this pull request
Added a task context listener to explicitly remove the obtained memory.
This will remove warning messages at executor level.

## Patch testing

precheckin (Pending)

## ReleaseNotes.txt changes
NA

## Other PRs 

NA
