### PR TITLE
Support for default snapshot isolation in write op

### DIFF
--- a/cluster/src/dunit/scala/io/snappydata/cluster/ClusterManagerTestBase.scala
+++ b/cluster/src/dunit/scala/io/snappydata/cluster/ClusterManagerTestBase.scala
@@ -47,10 +47,10 @@ abstract class ClusterManagerTestBase(s: String)
 
   val bootProps: Properties = new Properties()
   bootProps.setProperty("log-file", "snappyStore.log")
-  bootProps.setProperty("log-level", "config")
+  bootProps.setProperty("log-level", "fine")
   // Easier to switch ON traces. thats why added this.
-  // bootProps.setProperty("gemfirexd.debug.true",
-  //   "QueryDistribution,TraceExecution,TraceActivation,TraceTran")
+  bootProps.setProperty("gemfirexd.debug.true",
+     "QueryDistribution,TraceExecution,TraceActivation,TraceTran")
   bootProps.setProperty("statistic-archive-file", "snappyStore.gfs")
   bootProps.setProperty("spark.executor.cores",
     TestUtils.defaultCores.toString)
@@ -120,10 +120,7 @@ abstract class ClusterManagerTestBase(s: String)
       }
     }
 
-    vm0.invoke(startNode)
-    vm1.invoke(startNode)
-    vm2.invoke(startNode)
-
+    Array(vm0, vm1, vm2).foreach(_.invoke(startNode))
     // start lead node in this VM
     val sc = SnappyContext.globalSparkContext
     if (sc == null || sc.isStopped) {

--- a/cluster/src/dunit/scala/io/snappydata/cluster/ValidateMVCCDUnitTest.scala
+++ b/cluster/src/dunit/scala/io/snappydata/cluster/ValidateMVCCDUnitTest.scala
@@ -29,7 +29,7 @@ import io.snappydata.{Locator, ServiceManager}
 import org.slf4j.LoggerFactory
 
 import org.apache.spark.Logging
-import org.apache.spark.sql.SnappyContext
+import org.apache.spark.sql.{SaveMode, SnappyContext}
 import org.apache.spark.sql.collection.Utils
 import org.apache.spark.sql.execution.columnar.impl.ColumnFormatRelation
 
@@ -115,7 +115,67 @@ class ValidateMVCCDUnitTest(val s: String) extends ClusterManagerTestBase(s) wit
     GemFireXDUtils.DML_MAX_CHUNK_SIZE = size
   }
 
-  def testMVCCForColumnTable(): Unit = {
+  def _testSnapshotInsertionForColumnTable(): Unit = {
+    errorInThread = null
+    val netPort1 = AvailablePortHelper.getRandomAvailableTCPPort
+    vm0.invoke(classOf[ClusterManagerTestBase], "startNetServer", netPort1)
+
+    val snc = SnappyContext(sc)
+    val tableName: String = "TESTTABLE"
+
+    snc.sql(s"create table $tableName(col1 integer, col2 String, col3 integer) using column " +
+        s"OPTIONS (PARTITION_BY 'col1', buckets '1',MAXPARTSIZE '200'," +
+        s"COLUMN_MAX_DELTA_ROWS '10',COLUMN_BATCH_SIZE " +
+        s"'5000')")
+
+    val df = for(i <- 1 to 100) yield Seq(i, i+1, i+2)
+
+    for (i <- 1 to 10) {
+      snc.sql(s"insert into $tableName values($i,'${i + 1}',${i + 2})")
+      println(s"Inserting $i")
+    }
+
+    val cnt = snc.sql(s"select * from $tableName").count()
+    vm0.invoke(classOf[ValidateMVCCDUnitTest], "printRegionSize")
+    assert(cnt == 10, s"Expected row count is 10 while actual row count is $cnt")
+    snc.sql(s"drop table $tableName")
+
+    // scalastyle:off
+    println("Successful")
+    // scalastyle:on
+  }
+
+  def testSnapshotInsertionForColumnTableDFInsert(): Unit = {
+    errorInThread = null
+    val netPort1 = AvailablePortHelper.getRandomAvailableTCPPort
+    vm0.invoke(classOf[ClusterManagerTestBase], "startNetServer", netPort1)
+
+    val snc = SnappyContext(sc)
+    val tableName: String = "TESTTABLE"
+
+    snc.sql(s"create table $tableName(col1 integer, col2 String, col3 integer) using column " +
+        s"OPTIONS (PARTITION_BY 'col1', buckets '1',MAXPARTSIZE '200'," +
+        s"COLUMN_MAX_DELTA_ROWS '10',COLUMN_BATCH_SIZE " +
+        s"'5000')")
+
+    val df = for(i <- 1 to 100) yield Seq(i, i+1, i+2)
+    val rdd = sc.parallelize(df, df.length).map(
+      s => new Data2(s(0), s(1).toString, s(2).toString))
+
+    val dataDF = snc.createDataFrame(rdd)
+    dataDF.write.mode(SaveMode.Append).saveAsTable(tableName)
+
+    val cnt = snc.sql(s"select * from $tableName").count()
+    vm0.invoke(classOf[ValidateMVCCDUnitTest], "printRegionSize")
+    assert(cnt == 100, s"Expected row count is 10 while actual row count is $cnt")
+    snc.sql(s"drop table $tableName")
+
+    // scalastyle:off
+    println("Successful")
+    // scalastyle:on
+  }
+
+  def _testMVCCForColumnTable(): Unit = {
     errorInThread = null
     val netPort1 = AvailablePortHelper.getRandomAvailableTCPPort
     vm0.invoke(classOf[ClusterManagerTestBase], "startNetServer", netPort1)
@@ -176,7 +236,7 @@ class ValidateMVCCDUnitTest(val s: String) extends ClusterManagerTestBase(s) wit
   }
 
 
-  def testMVCCForColumnTableWithRollback(): Unit = {
+  def _testMVCCForColumnTableWithRollback(): Unit = {
     errorInThread = null
     val netPort1 = AvailablePortHelper.getRandomAvailableTCPPort
     vm0.invoke(classOf[ClusterManagerTestBase], "startNetServer", netPort1)
@@ -225,7 +285,7 @@ class ValidateMVCCDUnitTest(val s: String) extends ClusterManagerTestBase(s) wit
   }
 
 
-  def testMixOperationsOnRowTables(): Unit = {
+  def _testMixOperationsOnRowTables(): Unit = {
     errorInThread = null
     val netPort1 = AvailablePortHelper.getRandomAvailableTCPPort
     vm0.invoke(classOf[ClusterManagerTestBase], "startNetServer", netPort1)
@@ -249,7 +309,7 @@ class ValidateMVCCDUnitTest(val s: String) extends ClusterManagerTestBase(s) wit
   }
 
 
-  def testBatchInsertUsingPreparedStatement(): Unit = {
+  def _testBatchInsertUsingPreparedStatement(): Unit = {
     errorInThread = null
     val netPort1 = AvailablePortHelper.getRandomAvailableTCPPort
     vm0.invoke(classOf[ClusterManagerTestBase], "startNetServer", netPort1)

--- a/cluster/src/test/resources/log4j.properties
+++ b/cluster/src/test/resources/log4j.properties
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-log4j.rootCategory=INFO, file
+log4j.rootCategory=DEBUG, file
 
 # RollingFile appender
 log4j.appender.file=org.apache.log4j.RollingFileAppender
@@ -75,6 +75,6 @@ log4j.logger.org.apache.spark.scheduler.cluster.CoarseGrainedSchedulerBackend$Dr
 log4j.logger.org.apache.spark.storage.BlockManagerInfo=WARN
 log4j.logger.org.apache.spark.executor.SnappyExecutor=WARN
 
-# log4j.logger.org.apache.spark.sql.execution.WholeStageCodegenExec=DEBUG
-# log4j.logger.org.apache.spark.sql.catalyst.expressions.codegen.CodeGenerator=DEBUG
-# log4j.logger.org.apache.spark.sql.store.CodeGeneration=DEBUG
+log4j.logger.org.apache.spark.sql.execution.WholeStageCodegenExec=DEBUG
+log4j.logger.org.apache.spark.sql.catalyst.expressions.codegen.CodeGenerator=DEBUG
+log4j.logger.org.apache.spark.sql.store.CodeGeneration=DEBUG

--- a/core/src/main/scala/org/apache/spark/sql/execution/columnar/ExternalStore.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/columnar/ExternalStore.scala
@@ -42,9 +42,8 @@ trait ExternalStore extends Serializable {
 
   def connProperties: ConnectionProperties
 
-  def tryExecute[T: ClassTag](tableName: String,
-      f: Connection => T,
-      closeOnSuccess: Boolean = true, onExecutor: Boolean = false)
+  def tryExecute[T: ClassTag](tableName: String, closeOnSuccess: Boolean = true, onExecutor: Boolean = false)
+      (f: Connection => T)
       (implicit c: Option[Connection] = None): T = {
     var isClosed = false
     val conn = c.getOrElse(getConnection(tableName, onExecutor))
@@ -84,13 +83,13 @@ trait ConnectedExternalStore extends ExternalStore {
   }
 
   override def tryExecute[T: ClassTag](tableName: String,
-      f: Connection => T,
       closeOnSuccess: Boolean = true, onExecutor: Boolean = false)
+      (f: Connection => T)
       (implicit c: Option[Connection]): T = {
     assert(!connectedInstance.isClosed)
-    val ret = super.tryExecute(tableName, f,
+    val ret = super.tryExecute(tableName,
       closeOnSuccess = false /* responsibility of the user to close later */ ,
-      onExecutor)(
+      onExecutor)(f)(
       implicitly, Some(connectedInstance))
 
     if (dependentAction.isDefined) {

--- a/core/src/main/scala/org/apache/spark/sql/execution/columnar/JDBCAppendableRelation.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/columnar/JDBCAppendableRelation.scala
@@ -67,9 +67,9 @@ abstract case class JDBCAppendableRelation(
   protected final val connFactory: () => Connection = JdbcUtils
       .createConnectionFactory(connProperties.url, connProperties.connProps)
 
-  val resolvedName: String = externalStore.tryExecute(table, conn => {
+  val resolvedName: String = externalStore.tryExecute(table) { conn =>
     ExternalStoreUtils.lookupName(table, conn.getSchema)
-  })
+  }
 
   def numBuckets: Int = -1
 
@@ -160,9 +160,9 @@ abstract case class JDBCAppendableRelation(
 
   // truncate both actual and shadow table
   def truncate(): Unit = writeLock {
-    externalStore.tryExecute(table, conn => {
+    externalStore.tryExecute(table) { conn =>
       JdbcExtendedUtils.truncateTable(conn, table, dialect)
-    })
+    }
   }
 
   def createTable(mode: SaveMode): Unit = {
@@ -213,8 +213,8 @@ abstract case class JDBCAppendableRelation(
   def createTable(externalStore: ExternalStore, tableStr: String,
       tableName: String, dropIfExists: Boolean): Unit = {
 
-    externalStore.tryExecute(tableName,
-      conn => {
+    externalStore.tryExecute(tableName)
+      { conn =>
         if (dropIfExists) {
           JdbcExtendedUtils.dropTable(conn, tableName, dialect, sqlContext,
             ifExists = true)
@@ -231,7 +231,7 @@ abstract case class JDBCAppendableRelation(
             case _ => // do nothing
           }
         }
-      })
+      }
   }
 
   /**

--- a/core/src/main/scala/org/apache/spark/sql/execution/columnar/impl/ColumnFormatRelation.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/columnar/impl/ColumnFormatRelation.scala
@@ -278,13 +278,13 @@ abstract class BaseColumnFormatRelation(
   // truncate both actual and shadow table
   override def truncate(): Unit = writeLock {
     try {
-      externalStore.tryExecute(externalColumnTableName, conn => {
+      externalStore.tryExecute(externalColumnTableName) { conn =>
         JdbcExtendedUtils.truncateTable(conn, externalColumnTableName, dialect)
-      })
+      }
     } finally {
-      externalStore.tryExecute(table, conn => {
+      externalStore.tryExecute(table) { conn =>
         JdbcExtendedUtils.truncateTable(conn, table, dialect)
-      })
+      }
     }
   }
 

--- a/core/src/main/scala/org/apache/spark/sql/execution/columnar/impl/JDBCSourceAsColumnarStore.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/columnar/impl/JDBCSourceAsColumnarStore.scala
@@ -29,7 +29,7 @@ import scala.util.control.NonFatal
 
 import com.esotericsoftware.kryo.io.{Input, Output}
 import com.esotericsoftware.kryo.{Kryo, KryoSerializable}
-import com.gemstone.gemfire.internal.cache.{GemFireCacheImpl, LocalRegion, PartitionedRegion, TXManagerImpl}
+import com.gemstone.gemfire.internal.cache.{TXStateInterface, GemFireCacheImpl, LocalRegion, PartitionedRegion, TXManagerImpl}
 import com.gemstone.gemfire.internal.shared.BufferAllocator
 import com.gemstone.gemfire.internal.shared.unsafe.UnsafeHolder
 import com.pivotal.gemfirexd.internal.engine.{GfxdConstants, Misc}
@@ -68,10 +68,78 @@ class JDBCSourceAsColumnarStore(override val connProperties: ConnectionPropertie
   override def storeColumnBatch(tableName: String, batch: ColumnBatch,
       partitionId: Int, batchId: Option[String], maxDeltaRows: Int): Unit = {
     // noinspection RedundantDefaultArgument
-    tryExecute(tableName, doInsert(tableName, batch, batchId,
-      getPartitionID(tableName, partitionId), maxDeltaRows),
-      closeOnSuccess = true, onExecutor = true)
+    tryExecute(tableName, closeOnSuccess = true, onExecutor = true)(doInsert(tableName, batch, batchId,
+      getPartitionID(tableName, partitionId), maxDeltaRows))
+
   }
+
+  def beginTx(): Boolean = {
+    tryExecute(tableName, closeOnSuccess = true, onExecutor = true) {
+      (conn: Connection) => {
+        connectionType match {
+          case ConnectionType.Embedded =>
+            if (Misc.getGemFireCache().getCacheTransactionManager().getTXState() == null) {
+              Misc.getGemFireCache().getCacheTransactionManager()
+                  .begin(com.gemstone.gemfire.cache.IsolationLevel.SNAPSHOT, null)
+              true
+            } else {
+              false
+            }
+          case _ =>
+            if (SparkShellRDDHelper.snapshotTxId == null) {
+              val startAndGetSnapshotTXId = conn.prepareCall(s"call sys.START_SNAPSHOT_TXID (?)")
+              startAndGetSnapshotTXId.registerOutParameter(1, java.sql.Types.VARCHAR)
+              startAndGetSnapshotTXId.execute()
+              val txid: String = startAndGetSnapshotTXId.getString(1)
+              startAndGetSnapshotTXId.close()
+              SparkShellRDDHelper.snapshotTxId.set(txid)
+              //logDebug(s"The snapshot tx id is ${txid} and tablename is ${tableName}")
+              true
+            } else {
+              false
+            }
+        }
+      }
+    }
+  }
+
+  def commitTx(txId: String): Unit = {
+    tryExecute(tableName, closeOnSuccess = true, onExecutor = true) {
+      (conn: Connection) => {
+        connectionType match {
+          case ConnectionType.Embedded =>
+            Misc.getGemFireCache().getCacheTransactionManager().commit()
+          case _ =>
+            val ps = conn.prepareStatement(s"call sys.COMMIT_SNAPSHOT_TXID(?)")
+            ps.setString(1, if (txId == null) "null" else txId)
+            ps.executeUpdate()
+            //logDebug(s"The txid being committed is $txId")
+            ps.close()
+            SparkShellRDDHelper.snapshotTxId.set(null)
+        }
+      }
+    }
+  }
+
+
+  def rollbackTx(txId: String): Unit = {
+    tryExecute(tableName, closeOnSuccess = true, onExecutor = true) {
+      (conn: Connection) => {
+        connectionType match {
+          case ConnectionType.Embedded =>
+            Misc.getGemFireCache().getCacheTransactionManager().rollback()
+          case _ =>
+            val ps = conn.prepareStatement(s"call sys.ROLLBACK_SNAPSHOT_TXID(?)")
+            ps.setString(1, if (txId == null) "null" else txId)
+            ps.executeUpdate()
+            //logDebug(s"The txid being committed is $txId")
+            ps.close()
+            SparkShellRDDHelper.snapshotTxId.set(null)
+        }
+      }
+    }
+  }
+
 
   private def createStatsBuffer(statsData: Array[Byte],
       allocator: BufferAllocator): ByteBuffer = {
@@ -119,6 +187,7 @@ class JDBCSourceAsColumnarStore(override val connProperties: ConnectionPropertie
       region.putAll(keyValues)
     } catch {
       // TODO: test this code
+      // should be rolled back. so no need to delete.
       case NonFatal(e) =>
         // delete the base entry first
         val key = new ColumnFormatKey(partitionId,
@@ -152,6 +221,19 @@ class JDBCSourceAsColumnarStore(override val connProperties: ConnectionPropertie
       maxDeltaRows: Int): (Connection => Any) = {
     {
       (connection: Connection) => {
+        // we should use a txId to start a tx if not started already
+        // then for subsequent use use the same txid for each connection
+        // the tx will be committed at the end.
+        val txId = SparkShellRDDHelper.snapshotTxId.get
+        // it should always be not null.
+        if (txId != null) {
+          if (!txId.equals("null")) {
+            val statement = connection.createStatement()
+            statement.execute(
+              s"call sys.USE_SNAPSHOT_TXID('$txId')")
+          }
+        }
+
         val rowInsertStr = getRowInsertStr(tableName, batch.buffers.length)
         val stmt = connection.prepareStatement(rowInsertStr)
         var columnIndex = 1
@@ -182,6 +264,9 @@ class JDBCSourceAsColumnarStore(override val connProperties: ConnectionPropertie
           stmt.close()
         } catch {
           // TODO: test this code
+          // Need to rollback.
+          // we can't do this for only this cachedbatch
+          // all the inserts in this partitionId will be rolled back.
           case NonFatal(e) =>
             val deletestmt = connection.prepareStatement(
               s"delete from $tableName where partitionId = $partitionId " +
@@ -217,6 +302,13 @@ class JDBCSourceAsColumnarStore(override val connProperties: ConnectionPropertie
               }
             }
           }
+          val getSnapshotTXId = connection.prepareCall(s"call sys.GET_SNAPSHOT_TXID (?)")
+          getSnapshotTXId.registerOutParameter(1, java.sql.Types.VARCHAR)
+          getSnapshotTXId.execute()
+          val txid: String = getSnapshotTXId.getString(1)
+          getSnapshotTXId.close()
+          //SparkShellRDDHelper.snapshotTxId.set(txid)
+          //logDebug(s"The snapshot tx id is ${txid} and tablename is ${tableName}")
         }
       }
     }
@@ -306,8 +398,13 @@ class JDBCSourceAsColumnarStore(override val connProperties: ConnectionPropertie
       maxDeltaRows: Int): (Connection => Any) = {
     (connection: Connection) => {
       // split the batch and put into row buffer if it is small
+
       if (maxDeltaRows > 0 && batch.numRows < math.max(maxDeltaRows / 10,
         GfxdConstants.SNAPPY_MIN_COLUMN_DELTA_ROWS)) {
+        // better to start snapshot tx here if not already started.
+        // if onexecutor then tx will be started already? check
+        //
+
         // the lookup key depends only on schema and not on the table
         // name since the prepared statement specific to the table is
         // passed in separately through the references object
@@ -422,7 +519,7 @@ final class ColumnarStorePartitionedRDD(
 
   private[this] var allPartitions: Array[Partition] = _
   private val evaluatePartitions: () => Array[Partition] = () => {
-    store.tryExecute(tableName, conn => {
+    store.tryExecute(tableName) { conn =>
       val resolvedName = ExternalStoreUtils.lookupName(tableName,
         conn.getSchema)
       val region = Misc.getRegionForTable(resolvedName, true)
@@ -450,7 +547,7 @@ final class ColumnarStorePartitionedRDD(
               pr.getTotalNumberOfBuckets, prefNodes.toSeq))
           }
       }
-    })
+    }
   }
 
   override def compute(part: Partition, context: TaskContext): Iterator[Any] = {
@@ -557,7 +654,7 @@ final class SmartConnectorColumnRDD(
     if (parts != null && parts.length > 0) {
       return parts
     }
-    store.tryExecute(tableName, SparkShellRDDHelper.getPartitions(tableName, _))
+    store.tryExecute(tableName)(SparkShellRDDHelper.getPartitions(tableName, _))
   }
 
   override def write(kryo: Kryo, output: Output): Unit = {
@@ -597,6 +694,10 @@ class SmartConnectorRowRDD(_session: SnappySession,
 
 
   override def commitTxBeforeTaskCompletion(conn: Option[Connection], context: TaskContext) = {
+    TaskContext.get.addTaskCompletionListener(context => {
+
+    })
+
     Option(TaskContext.get()).foreach(_.addTaskCompletionListener(_ => {
       val txId =  SparkShellRDDHelper.snapshotTxId.get
       logDebug(s"The txid going to be committed is $txId " + tableName)

--- a/core/src/test/resources/log4j.properties
+++ b/core/src/test/resources/log4j.properties
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-log4j.rootCategory=INFO, file
+log4j.rootCategory=DEBUG, file
 
 # RollingFile appender
 log4j.appender.file=org.apache.log4j.RollingFileAppender
@@ -75,6 +75,6 @@ log4j.logger.org.apache.spark.scheduler.cluster.CoarseGrainedSchedulerBackend$Dr
 log4j.logger.org.apache.spark.storage.BlockManagerInfo=WARN
 log4j.logger.org.apache.spark.executor.SnappyExecutor=WARN
 
-# log4j.logger.org.apache.spark.sql.execution.WholeStageCodegenExec=DEBUG
-# log4j.logger.org.apache.spark.sql.catalyst.expressions.codegen.CodeGenerator=DEBUG
-# log4j.logger.org.apache.spark.sql.store.CodeGeneration=DEBUG
+ log4j.logger.org.apache.spark.sql.execution.WholeStageCodegenExec=DEBUG
+ log4j.logger.org.apache.spark.sql.catalyst.expressions.codegen.CodeGenerator=DEBUG
+ log4j.logger.org.apache.spark.sql.store.CodeGeneration=DEBUG


### PR DESCRIPTION
    For column table writes, start an snapshot isolation
    If any exception then rollback
    Added tests for the same

## Changes proposed in this pull request

(Fill in the changes here)

## Patch testing

(Fill in the details about how this patch was tested)

## ReleaseNotes.txt changes

(Does this change require an entry in ReleaseNotes.txt? If yes, has it been added to it?)

## Other PRs 

(Does this change require changes in other projects- store, spark, spark-jobserver, aqp? Add the links of PR of the other subprojects that are related to this change)
