### PR TITLE
[SNAP-1806] Changed the exception handling in SnappyConnector mode.

### DIFF
--- a/core/src/main/scala/org/apache/spark/sql/SnappySession.scala
+++ b/core/src/main/scala/org/apache/spark/sql/SnappySession.scala
@@ -186,14 +186,8 @@ class SnappySession(@transient private val sc: SparkContext,
         // object in SnappyStoreHiveCatalog.cachedDataSourceTables
         SnappyContext.getClusterMode(sparkContext) match {
           case ThinClientConnectorMode(_, _) =>
-            val plan = sessionState.sqlParser.parsePlan(sqlText)
-            var tables: Seq[TableIdentifier] = Seq()
-            plan.foreach {
-              case UnresolvedRelation(table, _) => tables = tables.+:(table)
-              case _ =>
-            }
-            tables.foreach(sessionCatalog.refreshTable)
-            Dataset.ofRows(snappyContext.sparkSession, plan)
+            sessionCatalog.invalidateAll()
+            throw e
           case _ =>
             throw e
         }

--- a/examples/src/main/python/AirlineDataPythonApp.py
+++ b/examples/src/main/python/AirlineDataPythonApp.py
@@ -12,78 +12,8 @@ import sys
 # connect to a Snappy cluster to fetch and query the tables
 # using Python APIs in a Spark App.
 
-from pyspark.sql.types import *
-from decimal import *
-import os
 
-
-# A Python example showing how create table in SnappyData and run queries
-# To run this example use following command:
-# bin/spark-submit <example>
-# For example:
-# bin/spark-submit quickstart/python/CreateTable.py
-
-def createpartitionedtableusingsql(snappy):
-    print("Creating partitioned table AIRLINE using SQL")
-    snappy.sql("DROP TABLE IF EXISTS AIRLINE")
-    # Create the table using SQL command
-    # "PARTITION_BY" attribute specifies partitioning key for PARTSUPP table(PS_PARTKEY),
-    # For complete list of table attributes refer the documentation
-    # http://snappydatainc.github.io/snappydata/rowAndColumnTables/
-    snappy.sql("CREATE TABLE AIRLINE(" +
-               "YearI             INTEGER NOT NULL," +
-               "MonthI            INTEGER NOT NULL,"
-               "DayOfMonth        INTEGER NOT NULL PRIMARY KEY," +
-               "DayOfWeek         INTEGER NOT NULL," +
-               "DepTime           INTEGER," +
-               "CRSDepTime        INTEGER," +
-               "ArrTime           INTEGER," +
-               "CRSArrTime        INTEGER," +
-               "UniqueCarrier     VARCHAR(20) NOT NULL,"
-               "FlightNum         INTEGER," +
-               "TailNum           VARCHAR(20)," +
-               "ActualElapsedTime INTEGER," +
-               "CRSElapsedTime    INTEGER," +
-               "AirTime           INTEGER," +
-               "ArrDelay          INTEGER," +
-               "DepDelay          INTEGER," +
-               "Origin            VARCHAR(20)," +
-               "Dest              VARCHAR(20)," +
-               "Distance          INTEGER," +
-               "TaxiIn            INTEGER," +
-               "TaxiOut           INTEGER," +
-               "Cancelled         INTEGER," +
-               "CancellationCode  VARCHAR(20)," +
-               "Diverted          INTEGER," +
-               "CarrierDelay      INTEGER," +
-               "WeatherDelay      INTEGER," +
-               "NASDelay          INTEGER," +
-               "SecurityDelay     INTEGER," +
-               "LateAircraftDelay INTEGER," +
-               "ArrDelaySlot      INTEGER)" +
-               "USING ROW OPTIONS (PARTITION_BY 'DayOfMonth')")
-    print
-    print("Inserting data in AIRLINE table using INSERT query")
-    snappy.sql("INSERT INTO AIRLINE VALUES(2017, 06, 20, 02, 0715, 0715,1000, 1000,"
-               " 'Delta', 0627, 'N123AA', 0245, 0245, 0245, 0, 0, 'PDX',"
-               " 'LAX', 963, 0, 0, 0, 'ABC', 0, 15, 0, 0, 0, 0, 0)")
-    print("Printing the contents of the AIRLINE table")
-    snappy.sql("SELECT * FROM AIRLINE").show()
-
-    snappy.sql("DROP TABLE IF EXISTS STAGING_AIRLINEREF")
-    snappy.sql("DROP TABLE IF EXISTS AIRLINEREF")
-
-    fullpath = os.path.abspath("quickstart/data/airportcodeParquetData")
-    snappy.sql("CREATE EXTERNAL TABLE STAGING_AIRLINEREF"
-               " USING parquet OPTIONS(path '{}')".format(fullpath))
-    print ("Done creating external table")
-    # ----- CREATE ROW TABLE -----
-
-    snappy.sql("CREATE TABLE AIRLINEREF USING ROW OPTIONS() AS (SELECT CODE, DESCRIPTION FROM STAGING_AIRLINEREF)")
-    print ("Done creating airlineref")
-
-
-# Constants
+## Constants
 APP_NAME = " Python Airline Data Application "
 COLUMN_TABLE_NAME = "airline"
 ROW_TABLE_NAME = "airlineref"
@@ -92,12 +22,12 @@ ROW_TABLE_NAME = "airlineref"
 def main(snappy):
     snappy.sql("set spark.sql.shuffle.partitions=6")
     # Get the tables that were created using sql scripts via snappy-sql
-    airlinedf = snappy.table(COLUMN_TABLE_NAME)
-    airlinecodedF = snappy.table(ROW_TABLE_NAME)
+    airlineDF = snappy.table(COLUMN_TABLE_NAME)
+    airlineCodeDF = snappy.table(ROW_TABLE_NAME)
 
     # Data Frame query :Which Airlines Arrive On Schedule? JOIN with reference table
-    colResult = airlinedf.alias('airlineDF') \
-        .join(airlinecodedF.alias('airlineCodeDF'), col('airlineDF.UniqueCarrier') == col('airlineCodeDF.CODE')) \
+    colResult = airlineDF.alias('airlineDF') \
+        .join(airlineCodeDF.alias('airlineCodeDF'), col('airlineDF.UniqueCarrier') == col('airlineCodeDF.CODE')) \
         .groupBy(col('airlineDF.UniqueCarrier'), col('airlineCodeDF.Description')) \
         .agg({"ArrDelay": "avg"}). \
         orderBy("avg(ArrDelay)")
@@ -107,23 +37,30 @@ def main(snappy):
     colResult.show()
     totalTimeCol = int(time.time() * 1000) - start
     print("Query time: %dms" % totalTimeCol)
+
     # Suppose a particular Airline company say 'Delta Air Lines Inc.'
     # re-brands itself as 'Delta America'.Update the row table.
     query = " CODE ='DL'"
     newColumnValues = ["Delta America Renewed"]
     snappy.update(ROW_TABLE_NAME, query, newColumnValues, ["DESCRIPTION"])
 
+    # Data Frame query :Which Airlines Arrive On Schedule? JOIN with reference table
+    colResultAftUpd = airlineDF.alias('airlineDF') \
+        .join(airlineCodeDF.alias('airlineCodeDF'), col('airlineDF.UniqueCarrier') == col('airlineCodeDF.CODE')) \
+        .groupBy(col('airlineDF.UniqueCarrier'), col('airlineCodeDF.Description')) \
+        .agg({"ArrDelay": "avg"}). \
+        orderBy("avg(ArrDelay)")
+
     print("Airline arrival schedule after Updated values:")
 
     startColUpd = int(time.time() * 1000)
+    colResultAftUpd.show()
     totalTimeColUpd = int(time.time() * 1000) - startColUpd
     print("Query time:%dms" % totalTimeColUpd)
 
-
 if __name__ == "__main__":
     # Configure Spark
-    conf = SparkConf().setAppName('Python Example').setMaster("local[*]")
+    conf = SparkConf().setAppName(APP_NAME)
     sc = SparkContext(conf=conf)
-    snappy = SnappySession(sc)
-    createpartitionedtableusingsql(snappy)
-    main(snappy)
+    snc = SnappySession(sc)
+    main(snc)

--- a/examples/src/main/python/AirlineDataPythonApp.py
+++ b/examples/src/main/python/AirlineDataPythonApp.py
@@ -12,8 +12,78 @@ import sys
 # connect to a Snappy cluster to fetch and query the tables
 # using Python APIs in a Spark App.
 
+from pyspark.sql.types import *
+from decimal import *
+import os
 
-## Constants
+
+# A Python example showing how create table in SnappyData and run queries
+# To run this example use following command:
+# bin/spark-submit <example>
+# For example:
+# bin/spark-submit quickstart/python/CreateTable.py
+
+def createpartitionedtableusingsql(snappy):
+    print("Creating partitioned table AIRLINE using SQL")
+    snappy.sql("DROP TABLE IF EXISTS AIRLINE")
+    # Create the table using SQL command
+    # "PARTITION_BY" attribute specifies partitioning key for PARTSUPP table(PS_PARTKEY),
+    # For complete list of table attributes refer the documentation
+    # http://snappydatainc.github.io/snappydata/rowAndColumnTables/
+    snappy.sql("CREATE TABLE AIRLINE(" +
+               "YearI             INTEGER NOT NULL," +
+               "MonthI            INTEGER NOT NULL,"
+               "DayOfMonth        INTEGER NOT NULL PRIMARY KEY," +
+               "DayOfWeek         INTEGER NOT NULL," +
+               "DepTime           INTEGER," +
+               "CRSDepTime        INTEGER," +
+               "ArrTime           INTEGER," +
+               "CRSArrTime        INTEGER," +
+               "UniqueCarrier     VARCHAR(20) NOT NULL,"
+               "FlightNum         INTEGER," +
+               "TailNum           VARCHAR(20)," +
+               "ActualElapsedTime INTEGER," +
+               "CRSElapsedTime    INTEGER," +
+               "AirTime           INTEGER," +
+               "ArrDelay          INTEGER," +
+               "DepDelay          INTEGER," +
+               "Origin            VARCHAR(20)," +
+               "Dest              VARCHAR(20)," +
+               "Distance          INTEGER," +
+               "TaxiIn            INTEGER," +
+               "TaxiOut           INTEGER," +
+               "Cancelled         INTEGER," +
+               "CancellationCode  VARCHAR(20)," +
+               "Diverted          INTEGER," +
+               "CarrierDelay      INTEGER," +
+               "WeatherDelay      INTEGER," +
+               "NASDelay          INTEGER," +
+               "SecurityDelay     INTEGER," +
+               "LateAircraftDelay INTEGER," +
+               "ArrDelaySlot      INTEGER)" +
+               "USING ROW OPTIONS (PARTITION_BY 'DayOfMonth')")
+    print
+    print("Inserting data in AIRLINE table using INSERT query")
+    snappy.sql("INSERT INTO AIRLINE VALUES(2017, 06, 20, 02, 0715, 0715,1000, 1000,"
+               " 'Delta', 0627, 'N123AA', 0245, 0245, 0245, 0, 0, 'PDX',"
+               " 'LAX', 963, 0, 0, 0, 'ABC', 0, 15, 0, 0, 0, 0, 0)")
+    print("Printing the contents of the AIRLINE table")
+    snappy.sql("SELECT * FROM AIRLINE").show()
+
+    snappy.sql("DROP TABLE IF EXISTS STAGING_AIRLINEREF")
+    snappy.sql("DROP TABLE IF EXISTS AIRLINEREF")
+
+    fullpath = os.path.abspath("quickstart/data/airportcodeParquetData")
+    snappy.sql("CREATE EXTERNAL TABLE STAGING_AIRLINEREF"
+               " USING parquet OPTIONS(path '{}')".format(fullpath))
+    print ("Done creating external table")
+    # ----- CREATE ROW TABLE -----
+
+    snappy.sql("CREATE TABLE AIRLINEREF USING ROW OPTIONS() AS (SELECT CODE, DESCRIPTION FROM STAGING_AIRLINEREF)")
+    print ("Done creating airlineref")
+
+
+# Constants
 APP_NAME = " Python Airline Data Application "
 COLUMN_TABLE_NAME = "airline"
 ROW_TABLE_NAME = "airlineref"
@@ -22,12 +92,12 @@ ROW_TABLE_NAME = "airlineref"
 def main(snappy):
     snappy.sql("set spark.sql.shuffle.partitions=6")
     # Get the tables that were created using sql scripts via snappy-sql
-    airlineDF = snappy.table(COLUMN_TABLE_NAME)
-    airlineCodeDF = snappy.table(ROW_TABLE_NAME)
+    airlinedf = snappy.table(COLUMN_TABLE_NAME)
+    airlinecodedF = snappy.table(ROW_TABLE_NAME)
 
     # Data Frame query :Which Airlines Arrive On Schedule? JOIN with reference table
-    colResult = airlineDF.alias('airlineDF') \
-        .join(airlineCodeDF.alias('airlineCodeDF'), col('airlineDF.UniqueCarrier') == col('airlineCodeDF.CODE')) \
+    colResult = airlinedf.alias('airlineDF') \
+        .join(airlinecodedF.alias('airlineCodeDF'), col('airlineDF.UniqueCarrier') == col('airlineCodeDF.CODE')) \
         .groupBy(col('airlineDF.UniqueCarrier'), col('airlineCodeDF.Description')) \
         .agg({"ArrDelay": "avg"}). \
         orderBy("avg(ArrDelay)")
@@ -37,30 +107,23 @@ def main(snappy):
     colResult.show()
     totalTimeCol = int(time.time() * 1000) - start
     print("Query time: %dms" % totalTimeCol)
-
     # Suppose a particular Airline company say 'Delta Air Lines Inc.'
     # re-brands itself as 'Delta America'.Update the row table.
     query = " CODE ='DL'"
     newColumnValues = ["Delta America Renewed"]
     snappy.update(ROW_TABLE_NAME, query, newColumnValues, ["DESCRIPTION"])
 
-    # Data Frame query :Which Airlines Arrive On Schedule? JOIN with reference table
-    colResultAftUpd = airlineDF.alias('airlineDF') \
-        .join(airlineCodeDF.alias('airlineCodeDF'), col('airlineDF.UniqueCarrier') == col('airlineCodeDF.CODE')) \
-        .groupBy(col('airlineDF.UniqueCarrier'), col('airlineCodeDF.Description')) \
-        .agg({"ArrDelay": "avg"}). \
-        orderBy("avg(ArrDelay)")
-
     print("Airline arrival schedule after Updated values:")
 
     startColUpd = int(time.time() * 1000)
-    colResultAftUpd.show()
     totalTimeColUpd = int(time.time() * 1000) - startColUpd
     print("Query time:%dms" % totalTimeColUpd)
 
+
 if __name__ == "__main__":
     # Configure Spark
-    conf = SparkConf().setAppName(APP_NAME)
+    conf = SparkConf().setAppName('Python Example').setMaster("local[*]")
     sc = SparkContext(conf=conf)
-    snc = SnappySession(sc)
-    main(snc)
+    snappy = SnappySession(sc)
+    createpartitionedtableusingsql(snappy)
+    main(snappy)


### PR DESCRIPTION
## Changes proposed in this pull request

Removed the code to selectively invalidate cache for failed analysis query in connector mode.
As any Analysis exception is caught and re-parsed. While parsing some of the RunnableCommand gets executed again and results in some weird error. 
e.g. A path not found exception became table already exists, as the command was retried.

Regarding issue [SNAP-1806] the doc needs to change to show another python app CreateTable.py. The airline example is too much dependent on old quick start and assumptions. 
e.g. We can not drop airline table if we don't drop airline_sample. The user would get confused.
 

## Patch testing

pre-checkin 

## ReleaseNotes.txt changes

NA

## Other PRs 

NA
