### PR TITLE
Snap-1422

### DIFF
--- a/core/src/main/scala/org/apache/spark/sql/execution/CodegenSparkFallback.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/CodegenSparkFallback.scala
@@ -91,7 +91,7 @@ case class CodegenSparkFallback(var child: SparkPlan) extends UnaryExecNode {
     } finally {
       // SNAP-1422
       val cacheMetaDataForConnector =
-        java.lang.Boolean.getBoolean("SMART_CONNECTOR_CACHE_METEADATA")
+        java.lang.Boolean.getBoolean("SMART_CONNECTOR_CACHE_METADATA")
       lazy val session = sqlContext.sparkSession.asInstanceOf[SnappySession]
       if (!cacheMetaDataForConnector &&
         ExternalStoreUtils.isSmartConnectorMode(session.sparkContext)) {

--- a/core/src/main/scala/org/apache/spark/sql/execution/CodegenSparkFallback.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/CodegenSparkFallback.scala
@@ -89,6 +89,7 @@ case class CodegenSparkFallback(var child: SparkPlan) extends UnaryExecNode {
           case None => throw t
         }
     } finally {
+      // SNAP-1422
       val cacheMetaDataForConnector =
         java.lang.Boolean.getBoolean("SMART_CONNECTOR_CACHE_METEADATA")
       lazy val session = sqlContext.sparkSession.asInstanceOf[SnappySession]

--- a/core/src/main/scala/org/apache/spark/sql/execution/CodegenSparkFallback.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/CodegenSparkFallback.scala
@@ -23,6 +23,7 @@ import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.SnappySession
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.Attribute
+import org.apache.spark.sql.execution.columnar.ExternalStoreUtils
 import org.apache.spark.sql.internal.CodeGenerationException
 
 /**
@@ -87,6 +88,11 @@ case class CodegenSparkFallback(var child: SparkPlan) extends UnaryExecNode {
             }
           case None => throw t
         }
+    } finally {
+      val session = sqlContext.sparkSession.asInstanceOf[SnappySession]
+      if (ExternalStoreUtils.isSmartConnectorMode(session.sparkContext)) {
+        session.sessionCatalog.invalidateAll()
+      }
     }
   }
 

--- a/core/src/main/scala/org/apache/spark/sql/execution/CodegenSparkFallback.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/CodegenSparkFallback.scala
@@ -89,8 +89,11 @@ case class CodegenSparkFallback(var child: SparkPlan) extends UnaryExecNode {
           case None => throw t
         }
     } finally {
-      val session = sqlContext.sparkSession.asInstanceOf[SnappySession]
-      if (ExternalStoreUtils.isSmartConnectorMode(session.sparkContext)) {
+      val cacheMetaDataForConnector =
+        java.lang.Boolean.getBoolean("SMART_CONNECTOR_CACHE_METEADATA")
+      lazy val session = sqlContext.sparkSession.asInstanceOf[SnappySession]
+      if (!cacheMetaDataForConnector &&
+        ExternalStoreUtils.isSmartConnectorMode(session.sparkContext)) {
         session.sessionCatalog.invalidateAll()
       }
     }

--- a/core/src/main/scala/org/apache/spark/sql/execution/columnar/ExternalStoreUtils.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/columnar/ExternalStoreUtils.scala
@@ -198,6 +198,13 @@ object ExternalStoreUtils extends Logging {
     }
   }
 
+  def isSmartConnectorMode(sparkContext: SparkContext): Boolean = {
+    SnappyContext.getClusterMode(sparkContext) match {
+      case ThinClientConnectorMode(_, _) => true
+      case _ => false
+    }
+  }
+
   def validateAndGetAllProps(session: Option[SparkSession],
       parameters: mutable.Map[String, String]): ConnectionProperties = {
 


### PR DESCRIPTION
## Changes proposed in this pull request
Clearing the connector catalog cache after every query execution in CodegenSparkFallback to avoid issues as reported in SNAP-1422.  Adding this fix as this is a usability issue. However provided a system property just in case we do not want to clear the catalog after every query.

## Patch testing
Test case as described in the bug
precheckin

## ReleaseNotes.txt changes
NA
## Other PRs 
Fixed one more issue discovered in testing for this
https://github.com/SnappyDataInc/snappy-store/pull/245