### PR TITLE
SNAP-1268: Code changes to start SnappyTableStatsProviderService service only once.

### DIFF
--- a/core/src/main/scala/io/snappydata/SnappyTableStatsProviderService.scala
+++ b/core/src/main/scala/io/snappydata/SnappyTableStatsProviderService.scala
@@ -93,36 +93,38 @@ object SnappyTableStatsProviderService {
 object SnappyEmbeddedTableStatsProviderService extends TableStatsProviderService {
 
   def start(sc: SparkContext): Unit = {
-    this.synchronized {
-      if (!doRun) {
-        val delay = sc.getConf.getLong(Constant.SPARK_SNAPPY_PREFIX +
-            "calcTableSizeInterval", DEFAULT_CALC_TABLE_SIZE_SERVICE_INTERVAL)
-        doRun = true
-        Misc.getGemFireCache.getCCPTimer.schedule(
-          new SystemTimer.SystemTimerTask {
-            private val logger: LogWriterI18n = Misc.getGemFireCache.getLoggerI18n
+    if (!doRun) {
+      this.synchronized {
+        if (!doRun) {
+          val delay = sc.getConf.getLong(Constant.SPARK_SNAPPY_PREFIX +
+              "calcTableSizeInterval", DEFAULT_CALC_TABLE_SIZE_SERVICE_INTERVAL)
+          doRun = true
+          Misc.getGemFireCache.getCCPTimer.schedule(
+            new SystemTimer.SystemTimerTask {
+              private val logger: LogWriterI18n = Misc.getGemFireCache.getLoggerI18n
 
-            override def run2(): Unit = {
-              try {
-                if (doRun) {
-                  aggregateStats()
-                }
-              } catch {
-                case _: CancelException => // ignore
-                case e: Exception => if (!e.getMessage.contains(
-                  "com.gemstone.gemfire.cache.CacheClosedException")) {
-                  logger.warning(e)
-                } else {
-                  logger.error(e)
+              override def run2(): Unit = {
+                try {
+                  if (doRun) {
+                    aggregateStats()
+                  }
+                } catch {
+                  case _: CancelException => // ignore
+                  case e: Exception => if (!e.getMessage.contains(
+                    "com.gemstone.gemfire.cache.CacheClosedException")) {
+                    logger.warning(e)
+                  } else {
+                    logger.error(e)
+                  }
                 }
               }
-            }
 
-            override def getLoggerI18n: LogWriterI18n = {
-              logger
-            }
-          },
-          delay, delay)
+              override def getLoggerI18n: LogWriterI18n = {
+                logger
+              }
+            },
+            delay, delay)
+        }
       }
     }
   }

--- a/core/src/main/scala/io/snappydata/SnappyThinConnectorTableStatsProvider.scala
+++ b/core/src/main/scala/io/snappydata/SnappyThinConnectorTableStatsProvider.scala
@@ -51,26 +51,28 @@ object SnappyThinConnectorTableStatsProvider extends TableStatsProviderService {
   }
 
   def start(sc: SparkContext, url: String): Unit = {
-    this.synchronized {
-      if (!doRun) {
-        _url = url
-        initializeConnection()
-        val delay = sc.getConf.getLong(Constant.SPARK_SNAPPY_PREFIX +
-            "calcTableSizeInterval", DEFAULT_CALC_TABLE_SIZE_SERVICE_INTERVAL)
-        doRun = true
-        new Timer("SnappyThinConnectorTableStatsProvider", true).schedule(
-          new TimerTask {
-            override def run(): Unit = {
-              try {
-                if (doRun) {
-                  aggregateStats()
+    if (!doRun) {
+      this.synchronized {
+        if (!doRun) {
+          _url = url
+          initializeConnection()
+          val delay = sc.getConf.getLong(Constant.SPARK_SNAPPY_PREFIX +
+              "calcTableSizeInterval", DEFAULT_CALC_TABLE_SIZE_SERVICE_INTERVAL)
+          doRun = true
+          new Timer("SnappyThinConnectorTableStatsProvider", true).schedule(
+            new TimerTask {
+              override def run(): Unit = {
+                try {
+                  if (doRun) {
+                    aggregateStats()
+                  }
+                } catch {
+                  case _: CancelException => // ignore
+                  case e: Exception => logError("SnappyThinConnectorTableStatsProvider", e)
                 }
-              } catch {
-                case _: CancelException => // ignore
-                case e: Exception => logError("SnappyThinConnectorTableStatsProvider", e)
               }
-            }
-          }, delay, delay)
+            }, delay, delay)
+        }
       }
     }
   }

--- a/core/src/main/scala/io/snappydata/SnappyThinConnectorTableStatsProvider.scala
+++ b/core/src/main/scala/io/snappydata/SnappyThinConnectorTableStatsProvider.scala
@@ -51,24 +51,28 @@ object SnappyThinConnectorTableStatsProvider extends TableStatsProviderService {
   }
 
   def start(sc: SparkContext, url: String): Unit = {
-    _url = url
-    initializeConnection()
-    val delay = sc.getConf.getLong(Constant.SPARK_SNAPPY_PREFIX +
-        "calcTableSizeInterval", DEFAULT_CALC_TABLE_SIZE_SERVICE_INTERVAL)
-    doRun = true
-    new Timer("SnappyThinConnectorTableStatsProvider", true).schedule(
-      new TimerTask {
-        override def run(): Unit = {
-          try {
-            if (doRun) {
-              aggregateStats()
+    this.synchronized {
+      if (!doRun) {
+        _url = url
+        initializeConnection()
+        val delay = sc.getConf.getLong(Constant.SPARK_SNAPPY_PREFIX +
+            "calcTableSizeInterval", DEFAULT_CALC_TABLE_SIZE_SERVICE_INTERVAL)
+        doRun = true
+        new Timer("SnappyThinConnectorTableStatsProvider", true).schedule(
+          new TimerTask {
+            override def run(): Unit = {
+              try {
+                if (doRun) {
+                  aggregateStats()
+                }
+              } catch {
+                case _: CancelException => // ignore
+                case e: Exception => logError("SnappyThinConnectorTableStatsProvider", e)
+              }
             }
-          } catch {
-            case _: CancelException => // ignore
-            case e: Exception => logError("SnappyThinConnectorTableStatsProvider", e)
-          }
-        }
-      }, delay, delay)
+          }, delay, delay)
+      }
+    }
   }
 
   def executeStatsStmt(): Unit = {


### PR DESCRIPTION
## Changes proposed in this pull request

 - SnappyTableStatsProviderService service should be started only once.

## Patch testing

Manually Tested

## ReleaseNotes.txt changes

NA

## Other PRs 

(Does this change require changes in other projects- store, spark, spark-jobserver, aqp? Add the links of PR of the other subprojects that are related to this change)
