### PR TITLE
Changed warning message

### DIFF
--- a/core/src/main/scala/io/snappydata/SnappyThinConnectorTableStatsProvider.scala
+++ b/core/src/main/scala/io/snappydata/SnappyThinConnectorTableStatsProvider.scala
@@ -82,9 +82,8 @@ object SnappyThinConnectorTableStatsProvider extends TableStatsProviderService {
       executeStatsStmt()
     } catch {
       case e: Exception =>
-        logWarning("SnappyThinConnectorTableStatsProvider: exception while retrieving stats " +
-            "from Snappy embedded cluster. Check whether the embedded cluster is stopped. " +
-            "Exception: " + e.toString)
+        logWarning("Warning: unable to retrieve table stats " +
+            "from SnappyData cluster due to " + e.toString)
         logDebug("Exception stack trace: ", e)
         conn = null
         return (Seq.empty[SnappyRegionStats], Seq.empty[SnappyIndexStats])


### PR DESCRIPTION
## Changes proposed in this pull request
Changed warning message logged on connector side when embedded cluster's lead is down (by SnappyThinConnectorTableStatsProvider). 
Also changed exception when lead is down from NoDataStoreAvailableException to NoMemberFoundException

The message that will be warning displayed is:-

```
17/07/25 16:43:36 WARN SnappyThinConnectorTableStatsProvider: Warning: unable to retrieve table stats from SnappyData cluster due to java.sql.SQLException: (SQLState=38000 Severity=20000) (Server=localhost/127.0.0.1[1528] Thread=pool-3-thread-1) The exception 'com.gemstone.gemfire.cache.execute.NoMemberFoundException: SnappyData Lead node is not available' was thrown while evaluating an expression.
```

The earlier message was:-

```
17/07/10 15:15:48 WARN SnappyThinConnectorTableStatsProvider: SnappyThinConnectorTableStatsProvider: exception while retrieving stats from Snappy embedded cluster. Check whether the embedded cluster is stopped. Exception: java.sql.SQLException: (SQLState=38000 Severity=20000) (Server=localhost/127.0.0.1[1528] Thread=pool-3-thread-1) The exception 'com.gemstone.gemfire.internal.cache.NoDataStoreAvailableException: No Data Store found in the distributed system for: SnappyData Lead Node' was thrown while evaluating an expression.
```

## Patch testing
Will run precheckin prior to merge

## ReleaseNotes.txt changes
NA
## Other PRs 
https://github.com/SnappyDataInc/snappy-store/compare/snappy/master...connector_warn_msg_change