### PR TITLE
Now each pooled datasources is keyed against both table-name and user-name

### DIFF
--- a/core/src/main/scala/org/apache/spark/sql/execution/ConnectionPool.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/ConnectionPool.scala
@@ -23,9 +23,10 @@ import javax.sql.DataSource
 import scala.collection.JavaConverters._
 import scala.collection.mutable
 
+import com.pivotal.gemfirexd.Attribute
 import com.zaxxer.hikari.util.PropertyElf
 import com.zaxxer.hikari.{HikariConfig, HikariDataSource => HDataSource}
-import org.apache.tomcat.jdbc.pool.{DataSource => TDataSource, PoolProperties}
+import org.apache.tomcat.jdbc.pool.{PoolProperties, DataSource => TDataSource}
 
 import org.apache.spark.sql.jdbc.JdbcDialect
 import org.apache.spark.sql.row.{GemFireXDClientDialect, GemFireXDDialect}
@@ -50,7 +51,7 @@ object ConnectionPool {
    * only lock-free reads so keeping it at minimum.
    */
   private[this] val idToPoolMap = new java.util.concurrent.ConcurrentHashMap[
-      String, (DataSource, PoolKey)](8, 0.75f, 1)
+      (String, String), (DataSource, PoolKey)](8, 0.75f, 1)
 
   /**
    * Reference counted pools which will share a pool across IDs
@@ -80,12 +81,12 @@ object ConnectionPool {
   def getPoolDataSource(id: String, props: Map[String, String],
       connectionProps: Properties, hikariCP: Boolean): DataSource = {
     // fast lock-free path first (the usual case)
-    val dsKey = idToPoolMap.get(id)
+    val dsKey = idToPoolMap.get((id, props.getOrElse(Attribute.USERNAME_ALT_ATTR.toLowerCase, "")))
     if (dsKey != null) {
       dsKey._1
     } else pools.synchronized {
       // double check after the global lock
-      val dsKey = idToPoolMap.get(id)
+      val dsKey = idToPoolMap.get((id, props.getOrElse(Attribute.USERNAME_ALT_ATTR.toLowerCase, "")))
       if (dsKey != null) {
         dsKey._1
       } else {
@@ -96,7 +97,8 @@ object ConnectionPool {
         pools.get(poolKey) match {
           case Some((newDS, ids)) =>
             ids += id
-            val err = idToPoolMap.putIfAbsent(id, (newDS, poolKey))
+            val err = idToPoolMap.putIfAbsent((id,
+                props.getOrElse(Attribute.USERNAME_ALT_ATTR.toLowerCase, "")), (newDS, poolKey))
             require(err == null, s"unexpected existing pool for $id: $err")
             newDS
           case None =>
@@ -116,7 +118,8 @@ object ConnectionPool {
               new TDataSource(tconf)
             }
             pools(poolKey) = (newDS, mutable.Set(id))
-            val err = idToPoolMap.putIfAbsent(id, (newDS, poolKey))
+            val err = idToPoolMap.putIfAbsent((id,
+                props.getOrElse(Attribute.USERNAME_ALT_ATTR.toLowerCase, "")), (newDS, poolKey))
             require(err == null, s"unexpected existing pool for $id: $err")
             newDS
         }
@@ -169,8 +172,8 @@ object ConnectionPool {
    * @return true if this was the last reference and entire pool was removed
    *         and false otherwise
    */
-  def removePoolReference(id: String): Boolean = {
-    val dsKey = idToPoolMap.remove(id)
+  def removePoolReference(id: String, userName: String): Boolean = {
+    val dsKey = idToPoolMap.remove((id, userName))
     if (dsKey != null) pools.synchronized {
       removePoolKey(id, dsKey)
     } else false
@@ -179,7 +182,7 @@ object ConnectionPool {
   /** To be invoked only on SparkContext stop or from tests. */
   def clear(): Unit = pools.synchronized {
     idToPoolMap.asScala.foreach {
-      case (id, dsKey) => removePoolKey(id, dsKey)
+      case (id, dsKey) => removePoolKey(id._1, dsKey)
     }
     pools.clear()
     idToPoolMap.clear()

--- a/core/src/main/scala/org/apache/spark/sql/execution/columnar/ExternalStoreUtils.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/columnar/ExternalStoreUtils.scala
@@ -499,21 +499,21 @@ object ExternalStoreUtils extends Logging {
 
   }
 
-  def removeCachedObjects(sqlContext: SQLContext, table: String,
+  def removeCachedObjects(sqlContext: SQLContext, table: String, userName: String,
       registerDestroy: Boolean = false): Unit = {
     // clean up the connection pool and caches on executors first
     Utils.mapExecutors(sqlContext,
-      removeCachedObjects(table)
+      removeCachedObjects(table, userName)
     ).count()
     // then on the driver
-    removeCachedObjects(table)()
+    removeCachedObjects(table, userName)()
     if (registerDestroy) {
       SnappyStoreHiveCatalog.registerRelationDestroy()
     }
   }
 
-  def removeCachedObjects(table: String): () => Iterator[Unit] = () => {
-    ConnectionPool.removePoolReference(table)
+  def removeCachedObjects(table: String, userName: String): () => Iterator[Unit] = () => {
+    ConnectionPool.removePoolReference(table, userName)
     CodeGeneration.removeCache(table)
     Iterator.empty
   }

--- a/core/src/main/scala/org/apache/spark/sql/execution/columnar/impl/ColumnFormatRelation.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/columnar/impl/ColumnFormatRelation.scala
@@ -19,9 +19,12 @@ package org.apache.spark.sql.execution.columnar.impl
 import java.sql.{Connection, PreparedStatement}
 
 import scala.util.control.NonFatal
+
 import com.gemstone.gemfire.internal.cache.{ExternalTableMetaData, PartitionedRegion}
+import com.pivotal.gemfirexd.Attribute
 import com.pivotal.gemfirexd.internal.engine.Misc
 import io.snappydata.Constant
+
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql._
 import org.apache.spark.sql.catalyst.{InternalRow, analysis}
@@ -294,7 +297,8 @@ abstract class BaseColumnFormatRelation(
     val conn = connFactory()
     try {
       // clean up the connection pool and caches
-      StoreUtils.removeCachedObjects(sqlContext, table)
+      StoreUtils.removeCachedObjects(sqlContext, table,
+        connProperties.poolProps.getOrElse(Attribute.USERNAME_ALT_ATTR.toLowerCase, ""))
     } finally {
       try {
         try {

--- a/core/src/main/scala/org/apache/spark/sql/row/JDBCMutableRelation.scala
+++ b/core/src/main/scala/org/apache/spark/sql/row/JDBCMutableRelation.scala
@@ -18,6 +18,7 @@ package org.apache.spark.sql.row
 
 import java.sql.Connection
 
+import com.pivotal.gemfirexd.Attribute
 import io.snappydata.SnappyTableStatsProviderService
 
 import org.apache.spark.rdd.RDD
@@ -300,7 +301,8 @@ case class JDBCMutableRelation(
     val conn = connFactory()
     try {
       // clean up the connection pool and caches
-      ExternalStoreUtils.removeCachedObjects(sqlContext, table)
+      ExternalStoreUtils.removeCachedObjects(sqlContext, table,
+        connProperties.poolProps.getOrElse(Attribute.USERNAME_ALT_ATTR.toLowerCase, ""))
     } finally {
       try {
         JdbcExtendedUtils.dropTable(conn, table, dialect, sqlContext, ifExists)

--- a/core/src/main/scala/org/apache/spark/sql/store/StoreUtils.scala
+++ b/core/src/main/scala/org/apache/spark/sql/store/StoreUtils.scala
@@ -265,9 +265,9 @@ object StoreUtils {
     partitions
   }
 
-  def removeCachedObjects(sqlContext: SQLContext, table: String,
+  def removeCachedObjects(sqlContext: SQLContext, table: String, userName: String,
       registerDestroy: Boolean = false): Unit = {
-    ExternalStoreUtils.removeCachedObjects(sqlContext, table, registerDestroy)
+    ExternalStoreUtils.removeCachedObjects(sqlContext, table, userName, registerDestroy)
   }
 
   def appendClause(sb: mutable.StringBuilder,


### PR DESCRIPTION
## Changes proposed in this pull request
Now each pooled datasources is keyed against both table-name and user-name.

Also removed redundant connection to XD from JDBCAppendableRelation.scala

## Patch testing
Manual testing of scenario. 
Dunit tests for security.
Precheckin pending.

## ReleaseNotes.txt changes
No

## Other PRs 
No