### PR TITLE
SNAP-1744: UI itself needs to consistently refer to itself as "SnappyData Pulse"

### DIFF
--- a/cluster/src/main/scala/org/apache/spark/ui/SnappyDashboardPage.scala
+++ b/cluster/src/main/scala/org/apache/spark/ui/SnappyDashboardPage.scala
@@ -148,7 +148,7 @@ private[ui] class SnappyDashboardPage (parent: SnappyDashboardTab)
     val pageContent = pageTitleNode ++ keyStatsSection ++ membersStatsDetails ++
                       sparkConnectorsStatsDetails ++ tablesStatsDetails ++ indexStatsDetails
 
-    UIUtils.simpleSparkPageWithTabs_2(pageHeaderText, pageContent, parent, Some(500))
+    UIUtils.simpleSparkPageWithTabs(pageHeaderText, pageContent, parent, Some(500))
 
   }
 

--- a/cluster/src/main/scala/org/apache/spark/ui/SnappyMemberDetailsPage.scala
+++ b/cluster/src/main/scala/org/apache/spark/ui/SnappyMemberDetailsPage.scala
@@ -361,7 +361,7 @@ private[ui] class SnappyMemberDetailsPage (parent: SnappyDashboardTab)
 
     PageContent = pageTitleNode ++ memberStats ++ memberLogTitle ++ content
 
-    UIUtils.simpleSparkPageWithTabs_2(pageHeaderText, PageContent, parent, Some(500))
+    UIUtils.simpleSparkPageWithTabs(pageHeaderText, PageContent, parent, Some(500))
   }
 
   def renderLog(request: HttpServletRequest): String = {


### PR DESCRIPTION
## Changes proposed in this pull request

- Changes related to spark side code refactoring and clean up.

## Patch testing

- Tested Manually

## ReleaseNotes.txt changes

- None

## Other PRs 

https://github.com/SnappyDataInc/spark/pull/64
