### PR TITLE
SNAP-1787 - Handling Array[Decimal] in both embedded and split mode

### DIFF
--- a/cluster/src/test/scala/org/apache/spark/sql/execution/benchmark/TAQTest.scala
+++ b/cluster/src/test/scala/org/apache/spark/sql/execution/benchmark/TAQTest.scala
@@ -80,7 +80,7 @@ class TAQTest extends SnappyFunSuite {
       tradeSize, numDays, queryNumber = 3, numIters, doInit = false)
   }
 
-  test("SNAP-1787"){
+  test("SNAP-1787") {
     val tableName = "complexTypeTable"
     val arr1 = Array(Decimal("4.92"), Decimal("51.98"))
     val arr2 = Array(4.92f, 51.98f)

--- a/cluster/src/test/scala/org/apache/spark/sql/execution/benchmark/TAQTest.scala
+++ b/cluster/src/test/scala/org/apache/spark/sql/execution/benchmark/TAQTest.scala
@@ -80,23 +80,6 @@ class TAQTest extends SnappyFunSuite {
       tradeSize, numDays, queryNumber = 3, numIters, doInit = false)
   }
 
-  test("SNAP-1787") {
-    val tableName = "complexTypeTable"
-    val arr1 = Array(Decimal("4.92"), Decimal("51.98"))
-    val arr2 = Array(4.92f, 51.98f)
-    val arr3 = Array(4921212121L, 5198121212L)
-    val arr4 = Array(true, false)
-    val arr5 = Array(4.92, 51.98)
-    val data = scala.collection.mutable.ArrayBuffer[ComplexTypeData]()
-    data +=  new ComplexTypeData(arr1, arr2, arr3, arr4, arr5)
-    val rdd = snc.sparkContext.parallelize(data, 8)
-    val dataDF = snc.createDataFrame(rdd)
-    snc.createTable(s"$tableName", "column", dataDF.schema, Map.empty[String, String])
-    dataDF.write.insertInto(s"$tableName")
-    assert(snc.sql(s"select * from $tableName").count() == 1)
-    snc.dropTable(s"$tableName", true)
-  }
-
   ignore("basic query performance with JDBC") {
     val numRuns = 1000
     val numIters = 1000
@@ -553,6 +536,3 @@ object TAQTest extends Logging with Assertions {
     benchmark.run()
   }
 }
-
-case class ComplexTypeData (arr1: Array[Decimal], arr2: Array[Float],
-  arr3: Array[Long], arr4: Array[Boolean], arr5: Array[Double])

--- a/cluster/src/test/scala/org/apache/spark/sql/execution/benchmark/TAQTest.scala
+++ b/cluster/src/test/scala/org/apache/spark/sql/execution/benchmark/TAQTest.scala
@@ -21,16 +21,17 @@ import java.time.{ZoneId, ZonedDateTime}
 
 import com.typesafe.config.Config
 import io.snappydata.SnappyFunSuite
+import org.scalatest.Assertions
+
 import org.apache.spark.memory.SnappyUnifiedMemoryManager
 import org.apache.spark.sql._
 import org.apache.spark.sql.execution.benchmark.TAQTest.CreateOp
 import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.types._
+import org.apache.spark.sql.types.{Decimal, DecimalType, StringType, StructField, StructType}
 import org.apache.spark.unsafe.types.UTF8String
 import org.apache.spark.util.Benchmark
 import org.apache.spark.util.random.XORShiftRandom
 import org.apache.spark.{Logging, SparkConf, SparkContext}
-import org.scalatest.Assertions
 
 class TAQTest extends SnappyFunSuite {
 

--- a/core/src/dunit/scala/io/snappydata/cluster/SplitClusterDUnitSecurityTest.scala
+++ b/core/src/dunit/scala/io/snappydata/cluster/SplitClusterDUnitSecurityTest.scala
@@ -186,6 +186,8 @@ class SplitClusterDUnitSecurityTest(s: String)
 
   override def testTableFormChanges(): Unit = {}
 
+  override def testComplexTypesForColumnTables_SNAP643(): Unit = {}
+
   // Test to make sure that stock spark-shell works with SnappyData core jar
   def testSparkShell(): Unit = {
     // perform some operation thru spark-shell

--- a/core/src/dunit/scala/io/snappydata/cluster/SplitClusterDUnitTest.scala
+++ b/core/src/dunit/scala/io/snappydata/cluster/SplitClusterDUnitTest.scala
@@ -303,8 +303,6 @@ object SplitClusterDUnitTest extends SplitClusterDUnitTestObject {
     val keys = new OpenHashSet[Int](1005)
     val dec1 = Array(Decimal("4.92"), Decimal("51.98"))
     val dec2 = Array(Decimal("95.27"), Decimal("17.25"), Decimal("7583.2956"))
-    val dbl1 = Array(4.92, 51.98)
-    val dbl2 = Array(95.27, 17.25, 7583.2956)
     val time = System.currentTimeMillis()
     val ts = Array(new Timestamp(time), new Timestamp(time + 123456L),
       new Timestamp(0L), new Timestamp(time - 12246L), new Timestamp(-1L))
@@ -317,17 +315,17 @@ object SplitClusterDUnitTest extends SplitClusterDUnitTestObject {
       ts(0) -> Data(7, "5", Decimal("7.6")),
       ts(4) -> Data(4, "8", Decimal("8.9")))
     val data = ArrayBuffer[ComplexData]()
-    data += ComplexData(1, dbl1, "3", m2, 7.56, Data(2, "8", Decimal("3.8")),
+    data += ComplexData(1, dec1, "3", m2, 7.56, Data(2, "8", Decimal("3.8")),
       dec1(0), ts(0))
-    data += ComplexData(7, dbl1, "8", m1, 8.45, Data(7, "4", Decimal("9")),
+    data += ComplexData(7, dec1, "8", m1, 8.45, Data(7, "4", Decimal("9")),
       dec2(0), ts(1))
-    data += ComplexData(9, dbl2, "2", m2, 12.33, Data(3, "1", Decimal("7.3")),
+    data += ComplexData(9, dec2, "2", m2, 12.33, Data(3, "1", Decimal("7.3")),
       dec1(1), ts(2))
-    data += ComplexData(4, dbl2, "2", m1, 92.85, Data(9, "3", Decimal("4.3")),
+    data += ComplexData(4, dec2, "2", m1, 92.85, Data(9, "3", Decimal("4.3")),
       dec2(1), ts(3))
-    data += ComplexData(5, dbl2, "7", m1, 5.28, Data(4, "8", Decimal("1.0")),
+    data += ComplexData(5, dec2, "7", m1, 5.28, Data(4, "8", Decimal("1.0")),
       dec2(2), ts(4))
-    for (i <- 1 to 1000) {
+    for (_ <- 1 to 1000) {
       var rnd: Long = 0L
       var rnd1 = 0
       do {
@@ -340,9 +338,8 @@ object SplitClusterDUnitTest extends SplitClusterDUnitTestObject {
       val drnd1 = drnd & 0xff
       val drnd2 = (drnd >>> 8) & 0xff
       val dec = if ((rnd1 % 2) == 0) dec1 else dec2
-      val dbl = if ((rnd1 % 2) == 0) dbl1 else dbl2
       val map = if ((rnd2 % 2) == 0) m1 else m2
-      data += ComplexData(rnd1, dbl, rnd2.toString, map, Random.nextDouble(),
+      data += ComplexData(rnd1, dec, rnd2.toString, map, Random.nextDouble(),
         Data(rnd1, Integer.toString(rnd2), Decimal(drnd1.toString + '.' +
             drnd2.toString)), dec(1), ts(math.abs(rnd1) % 5))
     }
@@ -350,7 +347,7 @@ object SplitClusterDUnitTest extends SplitClusterDUnitTestObject {
       s"""
         CREATE TABLE $tableName (
           col1 Int,
-          col2 Array<Double>,
+          col2 Array<Decimal>,
           col3 String,
           col4 Map<Timestamp, Struct<col1: Int, col2: String, col3: Decimal(10,5)>>,
           col5 Double,
@@ -366,7 +363,7 @@ object SplitClusterDUnitTest extends SplitClusterDUnitTestObject {
     val serializer3 = ComplexTypeSerializer.create(tableName, "col6", conn)
 
     // check failures with incompatible serialization first
-    checkSerializationMetadata(ts, dec1, dbl1, m2,
+    checkSerializationMetadata(ts, dec1, m2,
       Array(serializer1, serializer2, serializer3))
 
     // proper inserts
@@ -399,19 +396,19 @@ object SplitClusterDUnitTest extends SplitClusterDUnitTestObject {
   }
 
   private def checkSerializationMetadata(ts: Array[Timestamp],
-      dec1: Array[Decimal], dbl1: Array[Double], m2: Map[Timestamp, Data],
+      dec1: Array[Decimal], m2: Map[Timestamp, Data],
       serializers: Array[ComplexTypeSerializer]): Unit = {
     val m3 = Map(
       ts(3) -> Data3(8, 3, Decimal("8.1")),
       ts(0) -> Data3(7, 5, Decimal("5.7")),
       ts(4) -> Data3(4, 8, Decimal("9.4")))
-    val data2 = ComplexData2(1, dbl1, "3", m3, 7.56,
+    val data2 = ComplexData2(1, dec1, "3", m3, 7.56,
       Data(2, "8", Decimal("23.82")), dec1(0), ts(0))
-    val data3 = ComplexData3(1, dbl1, "3", m2, 7.56, Data2(2, "8", "3"),
+    val data3 = ComplexData3(1, dec1, "3", m2, 7.56, Data2(2, "8", "3"),
       dec1(0), ts(0))
 
     val dec3 = Array(Decimal("4.92"), "51.98")
-    val dec4 = Array(4.92, "51.98")
+    val dec4 = Array("4.92", "51.98")
     try {
       serializers(0).serialize(dec3)
       Assert.fail("Expected an IllegalArgumentException")
@@ -440,12 +437,12 @@ object SplitClusterDUnitTest extends SplitClusterDUnitTestObject {
     // check validateAll and clearing of "validated" flag and reset for failures
 
     // for ARRAY serializers(0)
-    serializers(0).serialize(dbl1)
+    serializers(0).serialize(dec1)
     try {
-      serializers(0).serialize(dec4) // String cannot be casted to Double
-      Assert.fail("Expected an ClassCastException")
+      serializers(0).serialize(dec4)
+      Assert.fail("Expected an IllegalArgumentException")
     } catch {
-      case _: ClassCastException => // expected
+      case _: IllegalArgumentException => // expected
     }
     try {
       serializers(0).serialize(dec4, true)
@@ -660,10 +657,10 @@ case class Data2(col1: Int, col2: String, col3: String)
 
 case class Data3(col1: Int, col2: Int, col3: Decimal)
 
-case class ComplexData2(col1: Int, col2: Array[Double], col3: String,
+case class ComplexData2(col1: Int, col2: Array[Decimal], col3: String,
     col4: Map[Timestamp, Data3], col5: Double, col6: Data, col7: Decimal,
     col8: Timestamp)
 
-case class ComplexData3(col1: Int, col2: Array[Double], col3: String,
+case class ComplexData3(col1: Int, col2: Array[Decimal], col3: String,
     col4: Map[Timestamp, Data], col5: Double, col6: Data2, col7: Decimal,
     col8: Timestamp)

--- a/core/src/dunit/scala/io/snappydata/cluster/SplitClusterDUnitTestBase.scala
+++ b/core/src/dunit/scala/io/snappydata/cluster/SplitClusterDUnitTestBase.scala
@@ -378,7 +378,7 @@ trait SplitClusterDUnitTestObject extends Logging {
             drnd2)), dec(1), ts(math.abs(rnd1) % 5))
     }
     val rdd = context.parallelize(data, 8)
-    val dataDF = snc.createDataFrame(rdd)
+    val dataDF = snc.createDataFrameFromRDD(rdd)
 
     snc.createTable(tableName, tableType, dataDF.schema, props)
     dataDF.write.insertInto(tableName)

--- a/core/src/dunit/scala/io/snappydata/cluster/SplitClusterDUnitTestBase.scala
+++ b/core/src/dunit/scala/io/snappydata/cluster/SplitClusterDUnitTestBase.scala
@@ -378,7 +378,7 @@ trait SplitClusterDUnitTestObject extends Logging {
             drnd2)), dec(1), ts(math.abs(rnd1) % 5))
     }
     val rdd = context.parallelize(data, 8)
-    val dataDF = snc.createDataFrameFromRDD(rdd)
+    val dataDF = snc.createDataFrameUsingRDD(rdd)
 
     snc.createTable(tableName, tableType, dataDF.schema, props)
     dataDF.write.insertInto(tableName)

--- a/core/src/dunit/scala/io/snappydata/cluster/SplitClusterDUnitTestBase.scala
+++ b/core/src/dunit/scala/io/snappydata/cluster/SplitClusterDUnitTestBase.scala
@@ -150,7 +150,7 @@ trait SplitClusterDUnitTestBase extends Logging {
     doTestRowTableCreation()
   }
 
-  def _testComplexTypesForColumnTables_SNAP643(): Unit = {
+  def testComplexTypesForColumnTables_SNAP643(): Unit = {
     doTestComplexTypesForColumnTables_SNAP643()
   }
 
@@ -337,6 +337,8 @@ trait SplitClusterDUnitTestObject extends Logging {
     val context = snc.sparkContext
     val dec1 = Array(Decimal("4.92"), Decimal("51.98"))
     val dec2 = Array(Decimal("95.27"), Decimal("17.25"), Decimal("7583.2956"))
+    val dbl1 = Array(4.92, 51.98)
+    val dbl2 = Array(95.27, 17.25, 7583.2956)
     val time = System.currentTimeMillis()
     val ts = Array(new Timestamp(time), new Timestamp(time + 123456L),
       new Timestamp(0L), new Timestamp(time - 12246L), new Timestamp(-1L))
@@ -349,15 +351,15 @@ trait SplitClusterDUnitTestObject extends Logging {
       ts(0) -> Data(7, "5", Decimal("7.5")),
       ts(4) -> Data(4, "8", Decimal("4.9")))
     val data = ArrayBuffer[ComplexData]()
-    data += ComplexData(1, dec1, "3", m2, 7.56, Data(2, "8", Decimal("3.2")),
+    data += ComplexData(1, dbl1, "3", m2, 7.56, Data(2, "8", Decimal("3.2")),
       dec1(0), ts(0))
-    data += ComplexData(7, dec1, "8", m1, 8.45, Data(7, "4", Decimal("4.9")),
+    data += ComplexData(7, dbl2, "8", m1, 8.45, Data(7, "4", Decimal("4.9")),
       dec2(0), ts(1))
-    data += ComplexData(9, dec2, "2", m2, 12.33, Data(3, "1", Decimal("1.7")),
+    data += ComplexData(9, dbl2, "2", m2, 12.33, Data(3, "1", Decimal("1.7")),
       dec1(1), ts(2))
-    data += ComplexData(4, dec2, "2", m1, 92.85, Data(9, "3", Decimal("9.4")),
+    data += ComplexData(4, dbl2, "2", m1, 92.85, Data(9, "3", Decimal("9.4")),
       dec2(1), ts(3))
-    data += ComplexData(5, dec2, "7", m1, 5.28, Data(4, "8", Decimal("1.8")),
+    data += ComplexData(5, dbl2, "7", m1, 5.28, Data(4, "8", Decimal("1.8")),
       dec2(2), ts(4))
     for (_ <- 1 to 1000) {
       var rnd: Long = 0L
@@ -372,8 +374,9 @@ trait SplitClusterDUnitTestObject extends Logging {
       val drnd1 = drnd & 0xff
       val drnd2 = (drnd >>> 8) & 0xff
       val dec = if ((rnd1 % 2) == 0) dec1 else dec2
+      val dbl = if ((rnd1 % 2) == 0) dbl1 else dbl2
       val map = if ((rnd2 % 2) == 0) m1 else m2
-      data += ComplexData(rnd1, dec, rnd2.toString, map, Random.nextDouble(),
+      data += ComplexData(rnd1, dbl, rnd2.toString, map, Random.nextDouble(),
         Data(rnd1, Integer.toString(rnd2), Decimal(drnd1.toString + '.' +
             drnd2)), dec(1), ts(math.abs(rnd1) % 5))
     }
@@ -399,6 +402,6 @@ case class IndexData(col1: Int, col2: Int, col3: Decimal)
 
 case class Data(col1: Int, col2: String, col3: Decimal)
 
-case class ComplexData(col1: Int, col2: Array[Decimal], col3: String,
+case class ComplexData(col1: Int, col2: Array[Double], col3: String,
     col4: Map[Timestamp, Data], col5: Double, col6: Data, col7: Decimal,
     col8: Timestamp)

--- a/core/src/dunit/scala/io/snappydata/cluster/SplitClusterDUnitTestBase.scala
+++ b/core/src/dunit/scala/io/snappydata/cluster/SplitClusterDUnitTestBase.scala
@@ -337,8 +337,6 @@ trait SplitClusterDUnitTestObject extends Logging {
     val context = snc.sparkContext
     val dec1 = Array(Decimal("4.92"), Decimal("51.98"))
     val dec2 = Array(Decimal("95.27"), Decimal("17.25"), Decimal("7583.2956"))
-    val dbl1 = Array(4.92, 51.98)
-    val dbl2 = Array(95.27, 17.25, 7583.2956)
     val time = System.currentTimeMillis()
     val ts = Array(new Timestamp(time), new Timestamp(time + 123456L),
       new Timestamp(0L), new Timestamp(time - 12246L), new Timestamp(-1L))
@@ -351,15 +349,15 @@ trait SplitClusterDUnitTestObject extends Logging {
       ts(0) -> Data(7, "5", Decimal("7.5")),
       ts(4) -> Data(4, "8", Decimal("4.9")))
     val data = ArrayBuffer[ComplexData]()
-    data += ComplexData(1, dbl1, "3", m2, 7.56, Data(2, "8", Decimal("3.2")),
+    data += ComplexData(1, dec1, "3", m2, 7.56, Data(2, "8", Decimal("3.2")),
       dec1(0), ts(0))
-    data += ComplexData(7, dbl2, "8", m1, 8.45, Data(7, "4", Decimal("4.9")),
+    data += ComplexData(7, dec1, "8", m1, 8.45, Data(7, "4", Decimal("4.9")),
       dec2(0), ts(1))
-    data += ComplexData(9, dbl2, "2", m2, 12.33, Data(3, "1", Decimal("1.7")),
+    data += ComplexData(9, dec2, "2", m2, 12.33, Data(3, "1", Decimal("1.7")),
       dec1(1), ts(2))
-    data += ComplexData(4, dbl2, "2", m1, 92.85, Data(9, "3", Decimal("9.4")),
+    data += ComplexData(4, dec2, "2", m1, 92.85, Data(9, "3", Decimal("9.4")),
       dec2(1), ts(3))
-    data += ComplexData(5, dbl2, "7", m1, 5.28, Data(4, "8", Decimal("1.8")),
+    data += ComplexData(5, dec2, "7", m1, 5.28, Data(4, "8", Decimal("1.8")),
       dec2(2), ts(4))
     for (_ <- 1 to 1000) {
       var rnd: Long = 0L
@@ -374,9 +372,8 @@ trait SplitClusterDUnitTestObject extends Logging {
       val drnd1 = drnd & 0xff
       val drnd2 = (drnd >>> 8) & 0xff
       val dec = if ((rnd1 % 2) == 0) dec1 else dec2
-      val dbl = if ((rnd1 % 2) == 0) dbl1 else dbl2
       val map = if ((rnd2 % 2) == 0) m1 else m2
-      data += ComplexData(rnd1, dbl, rnd2.toString, map, Random.nextDouble(),
+      data += ComplexData(rnd1, dec, rnd2.toString, map, Random.nextDouble(),
         Data(rnd1, Integer.toString(rnd2), Decimal(drnd1.toString + '.' +
             drnd2)), dec(1), ts(math.abs(rnd1) % 5))
     }
@@ -402,6 +399,6 @@ case class IndexData(col1: Int, col2: Int, col3: Decimal)
 
 case class Data(col1: Int, col2: String, col3: Decimal)
 
-case class ComplexData(col1: Int, col2: Array[Double], col3: String,
+case class ComplexData(col1: Int, col2: Array[Decimal], col3: String,
     col4: Map[Timestamp, Data], col5: Double, col6: Data, col7: Decimal,
     col8: Timestamp)

--- a/core/src/main/scala/org/apache/spark/sql/SnappyContext.scala
+++ b/core/src/main/scala/org/apache/spark/sql/SnappyContext.scala
@@ -46,6 +46,7 @@ import org.apache.spark.sql.types.StructField
 import scala.collection.JavaConverters._
 import scala.collection.concurrent.TrieMap
 import scala.language.implicitConversions
+import scala.reflect.runtime.universe.TypeTag
 import scala.reflect.runtime.{universe => u}
 // import org.apache.spark.sql.execution.datasources.CaseInsensitiveMap
 import org.apache.spark.sql.catalyst.util.CaseInsensitiveMap
@@ -338,6 +339,14 @@ class SnappyContext protected[spark](val snappySession: SnappySession)
     createApproxTSTopK(topKName, Option(baseTable), keyColumnName,
       topkOptions.asScala.toMap, allowExisting)
   }
+
+   /**
+    * :: Experimental ::
+    * Creates a [[DataFrame]] from an RDD of Product (e.g. case classes, tuples).
+    */
+   def createDataFrameFromRDD[A <: Product : TypeTag](rdd: RDD[A]): DataFrame = {
+     snappySession.createDataFrameFromRDD(rdd)
+   }
 
   /**
    * Creates a SnappyData managed table. Any relation providers

--- a/core/src/main/scala/org/apache/spark/sql/SnappyContext.scala
+++ b/core/src/main/scala/org/apache/spark/sql/SnappyContext.scala
@@ -343,9 +343,10 @@ class SnappyContext protected[spark](val snappySession: SnappySession)
    /**
     * :: Experimental ::
     * Creates a [[DataFrame]] from an RDD of Product (e.g. case classes, tuples).
+    * This method handles generic array datatype like Array[Decimal]
     */
-   def createDataFrameFromRDD[A <: Product : TypeTag](rdd: RDD[A]): DataFrame = {
-     snappySession.createDataFrameFromRDD(rdd)
+   def createDataFrameUsingRDD[A <: Product : TypeTag](rdd: RDD[A]): DataFrame = {
+     snappySession.createDataFrameUsingRDD(rdd)
    }
 
   /**

--- a/core/src/main/scala/org/apache/spark/sql/SnappySession.scala
+++ b/core/src/main/scala/org/apache/spark/sql/SnappySession.scala
@@ -14,7 +14,7 @@
  * permissions and limitations under the License. See accompanying
  * LICENSE file.
  */
-  package org.apache.spark.sql
+package org.apache.spark.sql
 
 import java.sql.SQLException
 import java.util.concurrent.atomic.AtomicInteger
@@ -163,7 +163,11 @@ class SnappySession(@transient private val sc: SparkContext,
     new SnappySession(sparkContext, Some(sharedState))
   }
 
-  override def createDataFrame[A <: Product : TypeTag](rdd: RDD[A]): DataFrame = {
+ /**
+  * :: Experimental ::
+  * Creates a [[DataFrame]] from an RDD of Product (e.g. case classes, tuples).
+  */
+  def createDataFrameFromRDD[A <: Product : TypeTag](rdd: RDD[A]): DataFrame = {
     SparkSession.setActiveSession(this)
     val schema = ScalaReflection.schemaFor[A].dataType.asInstanceOf[StructType]
     val attributeSeq = schema.toAttributes

--- a/core/src/main/scala/org/apache/spark/sql/SnappySession.scala
+++ b/core/src/main/scala/org/apache/spark/sql/SnappySession.scala
@@ -166,8 +166,9 @@ class SnappySession(@transient private val sc: SparkContext,
  /**
   * :: Experimental ::
   * Creates a [[DataFrame]] from an RDD of Product (e.g. case classes, tuples).
+  * This method handles generic array datatype like Array[Decimal]
   */
-  def createDataFrameFromRDD[A <: Product : TypeTag](rdd: RDD[A]): DataFrame = {
+  def createDataFrameUsingRDD[A <: Product : TypeTag](rdd: RDD[A]): DataFrame = {
     SparkSession.setActiveSession(this)
     val schema = ScalaReflection.schemaFor[A].dataType.asInstanceOf[StructType]
     val attributeSeq = schema.toAttributes

--- a/core/src/main/scala/org/apache/spark/sql/SnappySession.scala
+++ b/core/src/main/scala/org/apache/spark/sql/SnappySession.scala
@@ -23,9 +23,9 @@ import scala.collection.JavaConverters._
 import scala.collection.mutable
 import scala.collection.mutable.ArrayBuffer
 import scala.language.implicitConversions
+import scala.reflect.runtime.universe.TypeTag
 import scala.reflect.runtime.{universe => u}
 import scala.util.control.NonFatal
-
 import com.gemstone.gemfire.cache.EntryExistsException
 import com.gemstone.gemfire.distributed.internal.DistributionAdvisor.Profile
 import com.gemstone.gemfire.distributed.internal.ProfileListener
@@ -36,7 +36,6 @@ import com.google.common.util.concurrent.UncheckedExecutionException
 import com.pivotal.gemfirexd.internal.iapi.sql.ParameterValueSet
 import com.pivotal.gemfirexd.internal.shared.common.StoredFormatIds
 import io.snappydata.{Constant, Property, SnappyTableStatsProviderService, functions => snappydataFunctions}
-
 import org.apache.spark.annotation.{DeveloperApi, Experimental}
 import org.apache.spark.rdd.RDD
 import org.apache.spark.scheduler.{SparkListener, SparkListenerApplicationEnd}
@@ -47,7 +46,7 @@ import org.apache.spark.sql.catalyst.expressions.codegen.CodegenContext
 import org.apache.spark.sql.catalyst.expressions.{Alias, Ascending, AttributeReference, Descending, Exists, ExprId, Expression, GenericRow, ListQuery, LiteralValue, ParamLiteral, PredicateSubquery, ScalarSubquery, SortDirection}
 import org.apache.spark.sql.catalyst.plans.QueryPlan
 import org.apache.spark.sql.catalyst.plans.logical.{Filter, LogicalPlan, Union}
-import org.apache.spark.sql.catalyst.{DefinedByConstructorParams, InternalRow, TableIdentifier}
+import org.apache.spark.sql.catalyst.{DefinedByConstructorParams, InternalRow, ScalaReflection, TableIdentifier}
 import org.apache.spark.sql.collection.{Utils, WrappedInternalRow}
 import org.apache.spark.sql.execution._
 import org.apache.spark.sql.execution.aggregate.CollectAggregateExec
@@ -162,6 +161,14 @@ class SnappySession(@transient private val sc: SparkContext,
    */
   override def newSession(): SnappySession = {
     new SnappySession(sparkContext, Some(sharedState))
+  }
+
+  override def createDataFrame[A <: Product : TypeTag](rdd: RDD[A]): DataFrame = {
+    SparkSession.setActiveSession(this)
+    val schema = ScalaReflection.schemaFor[A].dataType.asInstanceOf[StructType]
+    val attributeSeq = schema.toAttributes
+    val rowRDD = RDDConversions.productToRowRdd(rdd, schema.map(_.dataType))
+    Dataset.ofRows(self, LogicalRDD(attributeSeq, rowRDD)(self))
   }
 
   override def sql(sqlText: String): CachedDataFrame =


### PR DESCRIPTION

## Changes proposed in this pull request
- Spark 2.1 Encoders only handle Array of primitives through ScalaReflection and not generic array like Array[DecimalType]
- Overridden createDataFrame in SnappySession to avoid the Encoders route, which fixes the problem for both embedded and split mode.
- Enabled complexTypeTest

## Patch testing

precheckin 

## ReleaseNotes.txt changes

None

## Other PRs 

https://github.com/SnappyDataInc/spark/pull/66