### PR TITLE
[Snap 1871] Remove custom built-in jdbc provider and instead use spark's JDBC provider

### DIFF
--- a/cluster/src/dunit/scala/io/snappydata/cluster/ClusterMgrDUnitTest.scala
+++ b/cluster/src/dunit/scala/io/snappydata/cluster/ClusterMgrDUnitTest.scala
@@ -118,22 +118,23 @@ object ClusterMgrDUnitTest {
         "DepTime INT," +
         "ArrTime INT," +
         "UniqueCarrier CHAR(6) NOT NULL"
-
+    snContext.sql("drop table if exists airline")
+    snContext.sql(s"create table airline ($ddlStr)")
     if (new Random().nextBoolean()) {
-      snContext.sql("drop table if exists airline")
-      snContext.sql(s"create table airline ($ddlStr) " +
+
+      snContext.sql(s"create external table airline1 " +
           s" using jdbc options (URL '$externalUrl'," +
-          "  Driver 'io.snappydata.jdbc.EmbeddedDriver')").collect()
+          "  Driver 'io.snappydata.jdbc.EmbeddedDriver', dbtable 'APP.AIRLINE')").collect()
     } else {
-      snContext.sql(s"create table if not exists airline ($ddlStr) " +
+      snContext.sql(s"create external table if not exists airline1 " +
           s" using jdbc options (URL '$externalUrl'," +
-          "  Driver 'com.pivotal.gemfirexd.jdbc.EmbeddedDriver')").collect()
+          "  Driver 'com.pivotal.gemfirexd.jdbc.EmbeddedDriver',dbtable 'APP.AIRLINE')").collect()
     }
 
     snContext.sql("insert into airline values(2015, 2, 15, 1002, 1803, 'AA')")
     snContext.sql("insert into airline values(2014, 4, 15, 1324, 1500, 'UT')")
 
-    val result = snContext.sql("select * from airline")
+    val result = snContext.sql("select * from airline1")
     val expected = Set[Row](Row(2015, 2, 15, 1002, 1803, "AA    "),
         Row(2014, 4, 15, 1324, 1500, "UT    "))
     val returnedRows = result.collect()
@@ -144,6 +145,7 @@ object ClusterMgrDUnitTest {
     assert(returnedRows.toSet == expected)
 
     snContext.sql("drop table if exists airline")
+    snContext.sql("drop table if exists airline1")
   }
 
   def startExternalSparkApp(locatorPort: Int): Unit = {

--- a/core/src/main/scala/org/apache/spark/sql/SnappyContext.scala
+++ b/core/src/main/scala/org/apache/spark/sql/SnappyContext.scala
@@ -826,7 +826,6 @@ object SnappyContext extends Logging {
     "org.apache.spark.sql.sampling.DefaultSource"
   )
   private val builtinSources = new CaseInsensitiveMap(Map(
-    "jdbc" -> classOf[row.DefaultSource].getCanonicalName,
     COLUMN_SOURCE -> classOf[execution.columnar.impl.DefaultSource].getCanonicalName,
     ROW_SOURCE -> classOf[execution.row.DefaultSource].getCanonicalName,
     SAMPLE_SOURCE -> "org.apache.spark.sql.sampling.DefaultSource",

--- a/core/src/test/scala/org/apache/spark/jdbc/ConnectionConfTest.scala
+++ b/core/src/test/scala/org/apache/spark/jdbc/ConnectionConfTest.scala
@@ -172,23 +172,26 @@ class ConnectionConfTest extends SnappyFunSuite with Logging with BeforeAndAfter
     )
 
     // Start the database
-    DriverManager.getConnection(s"jdbc:derby:$path;create=true")
+    val conn = DriverManager.getConnection(s"jdbc:derby:$path;create=true")
+    conn.createStatement().execute("create table TEST_JDBC_TABLE_1(COL1 INTEGER,COL2 INTEGER,COL3 INTEGER)")
 
     snc.sql("DROP TABLE IF EXISTS TEST_JDBC_TABLE_1")
-    snc.sql("CREATE TABLE TEST_JDBC_TABLE_1(COL1 INTEGER,COL2 INTEGER,COL3 INTEGER)")
+    snc.sql(s"CREATE external TABLE TEST_JDBC_TABLE_1  " +
+      s"USING jdbc " +
+      s"options(url 'jdbc:derby:$path',driver 'org.apache.derby.jdbc.EmbeddedDriver',poolImpl " +
+      s"'tomcat',user 'app',password 'app')")
 
     val data = Seq(Seq(1, 2, 3), Seq(7, 8, 9), Seq(9, 2, 3), Seq(4, 2, 3), Seq(5, 6, 7))
     val rdd = sc.parallelize(data, data.length).map(s => Data(s.head, s(1), s(2)))
     val dataDF = snc.createDataFrame(rdd)
     dataDF.write.format("jdbc").mode(SaveMode.Overwrite).options(props)
-        .insertInto("TEST_JDBC_TABLE_1")
+      .insertInto("TEST_JDBC_TABLE_1")
     val connConf = new ConnectionConfBuilder(snc.snappySession)
     props.map(entry => connConf.setConf(entry._1, entry._2))
     val conf = connConf.build()
 
     try {
-      // Update will not work
-      /*rdd.foreachPartition(d => {
+      rdd.foreachPartition(d => {
         val conn = ConnectionUtil.getPooledConnection("testDerby", conf)
         TaskContext.get().addTaskCompletionListener(_ => {
           conn.commit()
@@ -196,7 +199,7 @@ class ConnectionConfTest extends SnappyFunSuite with Logging with BeforeAndAfter
         })
         val stmt = conn.prepareStatement("update TEST_JDBC_TABLE_1 set col1 = 9")
         stmt.executeUpdate()
-      })*/
+      })
 
       val result = snc.sql("SELECT col1 from TEST_JDBC_TABLE_1")
       result.show()

--- a/core/src/test/scala/org/apache/spark/sql/store/JDBCMutableRelationAPISuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/store/JDBCMutableRelationAPISuite.scala
@@ -65,12 +65,13 @@ class JDBCMutableRelationAPISuite
       "password" -> "app"
     )
     snc.sql("DROP TABLE IF EXISTS TEST_JDBC_TABLE_1")
+    snc.sql("CREATE TABLE TEST_JDBC_TABLE_1(COL1 INTEGER,COL2 INTEGER,COL3 INTEGER)")
 
     val data = Seq(Seq(1, 2, 3), Seq(7, 8, 9), Seq(9, 2, 3), Seq(4, 2, 3), Seq(5, 6, 7))
     val rdd = sc.parallelize(data, data.length).map(s => Data(s.head, s(1), s(2)))
     val dataDF = snc.createDataFrame(rdd)
     dataDF.write.format("jdbc").mode(SaveMode.Overwrite)
-        .options(props).saveAsTable("TEST_JDBC_TABLE_1")
+        .options(props).insertInto("TEST_JDBC_TABLE_1")
     val count = dataDF.count()
     assert(count === data.length)
   }


### PR DESCRIPTION
## Changes proposed in this pull request
* Removed mapping of custom built-in jdbc provider and instead use spark's JDBC provider
* Modified tests to use spark jdbc provider

## Patch testing
* Precheckin

## ReleaseNotes.txt changes
Needs some changes in documentation if we have documented it will do it with help of shyja
## Other PRs 
NA