### PR TITLE
SNAP-1876 Grant/revoke on column table may not work after restart

### DIFF
--- a/core/src/dunit/scala/io/snappydata/cluster/SplitClusterDUnitSecurityTest.scala
+++ b/core/src/dunit/scala/io/snappydata/cluster/SplitClusterDUnitSecurityTest.scala
@@ -470,11 +470,11 @@ class SplitClusterDUnitSecurityTest(s: String)
     user2Conn = getConn(jdbcUser2, true)
     user2Stmt = user2Conn.createStatement()
     assertFailure(() => {executeSQL(user2Stmt, sqls(0))}, sqls(0)) // select on embeddedColTab1
-    assertFailure(() => {snc.sql(sqls(0))}, sqls(0)) // select on embeddedColTab1
+    assertFailure(() => {snc.sql(sqls(0)).collect()}, sqls(0)) // select on embeddedColTab1
     executeSQL(user2Stmt, sqls(3)) // insert into embeddedRowTab1
-    snc.sql(sqls(3)) // insert into embeddedRowTab1
+    snc.sql(sqls(3)).collect() // insert into embeddedRowTab1
     assertFailure(() => {executeSQL(user2Stmt, sqls(5))}, sqls(5)) // delete on embeddedRowTab1
-    assertFailure(() => {snc.sql(sqls(5))}, sqls(5)) // delete on embeddedRowTab1
+    assertFailure(() => {snc.sql(sqls(5)).collect()}, sqls(5)) // delete on embeddedRowTab1
   }
 
   /**


### PR DESCRIPTION
## Changes proposed in this pull request
* Add a testcase for SNAP-1876: Restart the cluster and verify grant/revoke permissions are retained.

## Patch testing
precheckin pending

## ReleaseNotes.txt changes
NA

## Other PRs 
https://github.com/SnappyDataInc/snappy-store/pull/264