### PR TITLE
[SNAP-1878] Proper handling of path option while creation of external table using API

### DIFF
--- a/cluster/src/dunit/scala/io/snappydata/externalstore/ColumnTableDUnitTest.scala
+++ b/cluster/src/dunit/scala/io/snappydata/externalstore/ColumnTableDUnitTest.scala
@@ -663,6 +663,28 @@ class ColumnTableDUnitTest(s: String) extends ClusterManagerTestBase(s) {
     FileUtils.deleteDirectory(new File(tempPath))
   }
 
+
+
+  def testSNAP1878(): Unit = {
+    val snc = org.apache.spark.sql.SnappyContext(sc)
+
+    snc.sql(s"create table t1 (c1 integer,c2 string)")
+    snc.sql(s"insert into t1 values(1,'test1')")
+    snc.sql(s"insert into t1 values(2,'test2')")
+    snc.sql(s"insert into t1 values(3,'test3')")
+    val df=snc.sql("select * from t1")
+    df.show
+    val tempPath = "/tmp/" + System.currentTimeMillis()
+
+    assert(df.count()==3)
+    df.write.option("header","true").csv(tempPath)
+    snc.createExternalTable("TEST_EXTERNAL","csv",Map("path" -> tempPath,"header" -> "true"))
+    val dataDF=snc.sql("select * from TEST_EXTERNAL")
+    assert(dataDF.count==3)
+    FileUtils.deleteDirectory(new File(tempPath))
+  }
+
+
 }
 
 case class TData(Key1: Int, Value: Int)

--- a/cluster/src/dunit/scala/io/snappydata/externalstore/ColumnTableDUnitTest.scala
+++ b/cluster/src/dunit/scala/io/snappydata/externalstore/ColumnTableDUnitTest.scala
@@ -681,6 +681,7 @@ class ColumnTableDUnitTest(s: String) extends ClusterManagerTestBase(s) {
     snc.createExternalTable("TEST_EXTERNAL","csv",Map("path" -> tempPath,"header" -> "true"))
     val dataDF=snc.sql("select * from TEST_EXTERNAL")
     assert(dataDF.count==3)
+    snc.sql("drop table if exists TEST_EXTERNAL")
     FileUtils.deleteDirectory(new File(tempPath))
   }
 

--- a/core/src/main/scala/org/apache/spark/sql/sources/StoreStrategy.scala
+++ b/core/src/main/scala/org/apache/spark/sql/sources/StoreStrategy.scala
@@ -35,10 +35,13 @@ object StoreStrategy extends Strategy {
       val userSpecifiedSchema = SparkSession.getActiveSession.get
         .asInstanceOf[SnappySession].normalizeSchema(tableDesc.schema)
       val options = Map.empty[String, String] ++ tableDesc.storage.properties
+
+      val optionsWithPath: Map[String,String] = if(tableDesc.storage.locationUri.isDefined)
+        options +("path"-> tableDesc.storage.locationUri.get) else options
       val cmd =
         CreateMetastoreTableUsing(tableDesc.identifier, None, Some(userSpecifiedSchema),
           None, SnappyContext.getProvider(tableDesc.provider.get, onlyBuiltIn = false),
-          mode != SaveMode.ErrorIfExists, options, isBuiltIn = false)
+          mode != SaveMode.ErrorIfExists, optionsWithPath, isBuiltIn = false)
       ExecutedCommandExec(cmd) :: Nil
 
     case CreateTable(tableDesc, mode, Some(query)) =>

--- a/core/src/test/scala/org/apache/spark/sql/store/ColumnTableTest.scala
+++ b/core/src/test/scala/org/apache/spark/sql/store/ColumnTableTest.scala
@@ -19,6 +19,7 @@ package org.apache.spark.sql.store
 import java.sql.{DriverManager, SQLException}
 
 import com.pivotal.gemfirexd.TestUtil
+import org.apache.commons.io.FileUtils
 
 import scala.util.{Failure, Success, Try}
 import com.gemstone.gemfire.cache.{EvictionAction, EvictionAlgorithm}
@@ -1140,6 +1141,26 @@ class ColumnTableTest
     assert(rows(0) =="{\"NAME\":\"Yin\",\"CITY\":\"Columbus\",\"STATE\":\"Ohio\",\"DISTRICT\":\"Pune\"}")
     assert(rows(1) == "{\"NAME\":\"Michael\",\"STATE\":\"California\",\"LANE\":\"15\"}")
 
+  }
+
+  test("Test for SNAP-1878 create external table using api") {
+
+
+    snc.sql(s"create table t1 (c1 integer,c2 string)")
+    snc.sql(s"insert into t1 values(1,'test1')")
+    snc.sql(s"insert into t1 values(2,'test2')")
+    snc.sql(s"insert into t1 values(3,'test3')")
+    val df = snc.sql("select * from t1")
+    df.show
+    val tempPath = "/tmp/" + System.currentTimeMillis()
+
+    assert(df.count() == 3)
+    df.write.option("header", "true").csv(tempPath)
+    snc.createExternalTable("TEST_EXTERNAL", "csv", Map("path" -> tempPath, "header" -> "true"))
+    val dataDF = snc.sql("select * from TEST_EXTERNAL")
+    assert(dataDF.count == 3)
+    snc.sql("drop table if exists TEST_EXTERNAL")
+    FileUtils.deleteDirectory(new java.io.File(tempPath))
   }
 
 }


### PR DESCRIPTION
## Changes proposed in this pull request
* Changes to add path to the options map in StoreStartegy 

## Patch testing
* Added Unit test and executed it manually
* Precheckin in progress

## ReleaseNotes.txt changes
NA
## Other PRs 
NA