### PR TITLE
Snap 1734

### DIFF
--- a/core/src/main/java/org/apache/spark/sql/hive/SnappySharedState.java
+++ b/core/src/main/java/org/apache/spark/sql/hive/SnappySharedState.java
@@ -54,6 +54,9 @@ public final class SnappySharedState extends SharedState {
 
   private static final String CATALOG_IMPLEMENTATION = "spark.sql.catalogImplementation";
 
+  /**
+   *  Create Snappy's SQL Listener instead of SQLListener
+   */
   private static SQLListener createListenerAndUI(SparkContext sc) {
     if (ExternalStoreUtils.getSQLListener().get() == null) {
       SnappySQLListener listener = new SnappySQLListener(sc.conf());

--- a/core/src/main/java/org/apache/spark/sql/hive/SnappySharedState.java
+++ b/core/src/main/java/org/apache/spark/sql/hive/SnappySharedState.java
@@ -58,7 +58,8 @@ public final class SnappySharedState extends SharedState {
    *  Create Snappy's SQL Listener instead of SQLListener
    */
   private static SQLListener createListenerAndUI(SparkContext sc) {
-    if (ExternalStoreUtils.getSQLListener().get() == null) {
+    SQLListener initListener = ExternalStoreUtils.getSQLListener().get();
+    if (initListener == null) {
       SnappySQLListener listener = new SnappySQLListener(sc.conf());
       if (ExternalStoreUtils.getSQLListener().compareAndSet(null, listener)) {
         sc.addSparkListener(listener);
@@ -67,8 +68,11 @@ public final class SnappySharedState extends SharedState {
           new SQLTab(listener, ui);
         }
       }
+      return ExternalStoreUtils.getSQLListener().get();
     }
-    return ExternalStoreUtils.getSQLListener().get();
+    else {
+      return initListener;
+    }
   }
 
   private SnappySharedState(SparkContext sparkContext) {

--- a/core/src/main/scala/org/apache/spark/sql/CachedDataFrame.scala
+++ b/core/src/main/scala/org/apache/spark/sql/CachedDataFrame.scala
@@ -572,9 +572,9 @@ object CachedDataFrame
    * Custom method to allow passing in cached SparkPlanInfo and queryExecution string.
    */
   def withNewExecutionId[T](sparkSession: SparkSession,
-    queryShortForm: String, queryLongForm: String, queryExecutionStr: String,
-    queryPlanInfo: SparkPlanInfo, currentExecutionId: Option[Long] = None,
-    planProcessingTime: Long = 0)(body: => T): T = {
+      queryShortForm: String, queryLongForm: String, queryExecutionStr: String,
+      queryPlanInfo: SparkPlanInfo, currentExecutionId: Option[Long] = None,
+      planProcessingTime: Long = 0)(body: => T): T = {
     val sc = sparkSession.sparkContext
     val oldExecutionId = sc.getLocalProperty(SQLExecution.EXECUTION_ID_KEY)
     if (oldExecutionId == null) {

--- a/core/src/main/scala/org/apache/spark/sql/execution/columnar/ExternalStoreUtils.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/columnar/ExternalStoreUtils.scala
@@ -18,6 +18,7 @@ package org.apache.spark.sql.execution.columnar
 
 import java.sql.{Connection, PreparedStatement}
 import java.util.Properties
+import java.util.concurrent.atomic.AtomicReference
 
 import scala.collection.JavaConverters._
 import scala.collection.mutable
@@ -37,6 +38,7 @@ import org.apache.spark.sql.catalyst.expressions.codegen.{CodeAndComment, CodeFo
 import org.apache.spark.sql.collection.Utils
 import org.apache.spark.sql.execution.columnar.impl.JDBCSourceAsColumnarStore
 import org.apache.spark.sql.execution.datasources.jdbc.{DriverRegistry, JdbcUtils}
+import org.apache.spark.sql.execution.ui.SQLListener
 import org.apache.spark.sql.execution.{BufferedRowIterator, CodegenSupport, CodegenSupportOnExecutor, ConnectionPool}
 import org.apache.spark.sql.hive.SnappyStoreHiveCatalog
 import org.apache.spark.sql.jdbc.{JdbcDialect, JdbcDialects}
@@ -669,6 +671,10 @@ object ExternalStoreUtils {
 
   def defaultCompressionCodec(session: SparkSession): String = {
     Property.CompressionCodec.get(session.sessionState.conf)
+  }
+
+  def getSQLListener(): AtomicReference[SQLListener] = {
+    SparkSession.sqlListener
   }
 }
 


### PR DESCRIPTION
## Changes proposed in this pull request

Snappy's execution happens in two phases. First phase the plan is executed to create a rdd which is then used to create a CachedDataFrame. In second phase, the CachedDataFrame is then used for further actions. For accumulating the metrics for first phase, SparkListenerSQLPlanExecutionStart is fired. This keeps the current executionID in _executionIdToData but does not add it to the active executions. This ensures that query is not shown in the UI but the new jobs that are run while the plan is being executed are tracked against this executionID. In the second phase, when the query is actually executed, SparkListenerSQLPlanExecutionStart adds the execution data to the active executions. SparkListenerSQLPlanExecutionEnd is then sent with the accumulated time of both the phases.

For consuming SparkListenerSQLPlanExecutionStart, Snappy's SQLListener has been added. 

Overridden withNewExecutionId in CachedDataFrame so that the above explained process also happens when the dataset APIs are used. 

## Patch testing

Precheckin- Manual for embedded and smart connector mode. 
