### PR TITLE
Fix for SNAP-1892 caused due to empty UserSpecifiedSchema instead of …

### DIFF
--- a/core/src/test/scala/org/apache/spark/sql/store/ColumnTableTest.scala
+++ b/core/src/test/scala/org/apache/spark/sql/store/ColumnTableTest.scala
@@ -1156,11 +1156,19 @@ class ColumnTableTest
 
     assert(df.count() == 3)
     df.write.option("header", "true").csv(tempPath)
-    snc.createExternalTable("TEST_EXTERNAL", "csv", Map("path" -> tempPath, "header" -> "true"))
-    val dataDF = snc.sql("select * from TEST_EXTERNAL")
+    snc.createExternalTable("TEST_EXTERNAL", "csv",
+      Map("path" -> tempPath, "header" -> "true", "inferSchema"-> "true"))
+    val dataDF = snc.sql("select * from TEST_EXTERNAL order by c1")
+
+    snc.sql("select * from TEST_EXTERNAL").show
+
     assert(dataDF.count == 3)
+
+    val rows=dataDF.collect()
+
+    for(i<- 0 to 2) assert(rows(i)(0)==i+1)
+
     snc.sql("drop table if exists TEST_EXTERNAL")
     FileUtils.deleteDirectory(new java.io.File(tempPath))
   }
-
 }


### PR DESCRIPTION
…None

## Changes proposed in this pull request
* While creating external table after spark-2.1 merge UserSpecifiedSchema was passed as empty instead of None when user has not specified schema which was causing this issue.

## Patch testing
* Modified and tested exsiting tests .Also added assertion for individual rows
* precheckin in progress

## ReleaseNotes.txt changes
NA
## Other PRs 
NA