### PR TITLE
[SNAP-1885] Semijoin incorrect result

### DIFF
--- a/cluster/src/test/scala/org/apache/spark/sql/SnappySQLQuerySuite.scala
+++ b/cluster/src/test/scala/org/apache/spark/sql/SnappySQLQuerySuite.scala
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2016 SnappyData, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License. You
+ * may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License. See accompanying
+ * LICENSE file.
+ */
+package org.apache.spark.sql
+
+import io.snappydata.SnappyFunSuite
+
+import org.apache.spark.sql.catalyst.util.stackTraceToString
+import org.apache.spark.sql.test.SQLTestData.TestData2
+
+
+class SnappySQLQuerySuite extends SnappyFunSuite {
+
+  // Ported test from Spark
+  test("SNAP-1885 : left semi greater than predicate and equal operator") {
+    val df = snc.createDataFrame(snc.sparkContext.parallelize(
+          TestData2(1, 1) ::
+          TestData2(1, 2) ::
+          TestData2(2, 1) ::
+          TestData2(2, 2) ::
+          TestData2(3, 1) ::
+          TestData2(3, 2) :: Nil, 2))
+    df.write.format("row").saveAsTable("testData2")
+
+    checkAnswer(
+      snc.sql("SELECT * FROM testData2 x LEFT SEMI JOIN testData2 y " +
+          "ON x.b = y.b and x.a >= y.a + 2"),
+      Seq(Row(3, 1), Row(3, 2))
+    )
+
+    checkAnswer(
+      snc.sql("SELECT * FROM testData2 x LEFT SEMI JOIN testData2 y " +
+          "ON x.b = y.a and x.a >= y.b + 1"),
+      Seq(Row(2, 1), Row(2, 2), Row(3, 1), Row(3, 2))
+    )
+  }
+
+  protected def checkAnswer(df: => DataFrame, expectedAnswer: Seq[Row]): Unit = {
+    val analyzedDF = try df catch {
+      case ae: AnalysisException =>
+        if (ae.plan.isDefined) {
+          fail(
+            s"""
+               |Failed to analyze query: $ae
+               |${ae.plan.get}
+               |
+               |${stackTraceToString(ae)}
+               |""".stripMargin)
+        } else {
+          throw ae
+        }
+    }
+
+    assertEmptyMissingInput(analyzedDF)
+
+    QueryTest.checkAnswer(analyzedDF, expectedAnswer) match {
+      case Some(errorMessage) => fail(errorMessage)
+      case None =>
+    }
+  }
+
+  /**
+    * Asserts that a given [[Dataset]] does not have missing inputs in all the analyzed plans.
+    */
+  def assertEmptyMissingInput(query: Dataset[_]): Unit = {
+    assert(query.queryExecution.analyzed.missingInput.isEmpty,
+      s"The analyzed logical plan has missing inputs:\n${query.queryExecution.analyzed}")
+    assert(query.queryExecution.optimizedPlan.missingInput.isEmpty,
+      s"The optimized logical plan has missing inputs:\n${query.queryExecution.optimizedPlan}")
+    assert(query.queryExecution.executedPlan.missingInput.isEmpty,
+      s"The physical plan has missing inputs:\n${query.queryExecution.executedPlan}")
+  }
+
+}

--- a/core/src/main/scala/org/apache/spark/sql/execution/ObjectHashMapAccessor.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/ObjectHashMapAccessor.scala
@@ -1147,9 +1147,9 @@ case class ObjectHashMapAccessor(@transient session: SnappySession,
         $declareLocalVars
 
         $mapKeyCodes
-        $inputCodes
         $breakLoop: while (true) {
           do { // single iteration loop meant for breaking out with "continue"
+            $inputCodes
             ${ev.code}
             // consume only one result
             if (!${ev.isNull} && ${ev.value}) {


### PR DESCRIPTION
## Changes proposed in this pull request
The code to evaluate join condition is incorrect. Semijoin should traverse through all the values against a key which the code was doing.
However, the value field was not re-initialized afetr taking the next map entry against a key.

## Patch testing

precheckin

## ReleaseNotes.txt changes

NA

## Other PRs 
NA
