### PR TITLE
Snap 1890 : Snappy Pulse UI suggestions for 1.0

### DIFF
--- a/ReleaseNotes.txt
+++ b/ReleaseNotes.txt
@@ -13,6 +13,9 @@ Release 1.0
 
   [Snap-1792] Snappy Monitoring UI now also displays Member Details View which shows member specific information,
   various statistics (like Status, CPU, Memory, Heap & Off-Heap Usages, etc) and members logs in incremental way.
+  
+  [Snap-1890] Snappy Monitoring UI displays new Pulse logo. Also product and it's build details are shown under version 
+  in pop up window.
 
 
 Release 0.9

--- a/cluster/src/main/scala/io/snappydata/gemxd/SnappyDataVersion.scala
+++ b/cluster/src/main/scala/io/snappydata/gemxd/SnappyDataVersion.scala
@@ -18,6 +18,8 @@ package io.snappydata.gemxd
 
 import java.io.{InputStream, PrintWriter, PrintStream}
 
+import scala.collection.mutable.HashMap
+
 import com.gemstone.gemfire.internal.{ClassPathLoader, SharedLibrary, GemFireVersion}
 import com.gemstone.gemfire.internal.cache.GemFireCacheImpl
 import com.gemstone.gemfire.internal.shared.NativeCalls
@@ -120,8 +122,17 @@ object SnappyDataVersion {
     GemFireVersion.createVersionFile
   }
 
-  def getSnappyDataProductVersion: String ={
+  def getSnappyDataProductVersion: HashMap[String, String] = {
     GemFireVersion.getInstance(classOf[SnappyDataVersion], SNAPPYDATA_VERSION_PROPERTIES)
-    GemFireVersion.getProductVersion
+    val versionDetails = HashMap.empty[String, String]
+    versionDetails.put("productName", GemFireVersion.getProductName)
+    versionDetails.put("productVersion", GemFireVersion.getProductVersion)
+    versionDetails.put("buildId", GemFireVersion.getBuildId)
+    versionDetails.put("buildDate", GemFireVersion.getBuildDate)
+    versionDetails.put("buildPlatform", GemFireVersion.getBuildPlatform)
+    versionDetails.put("nativeCodeVersion", GemFireVersion.getNativeCodeVersion)
+    versionDetails.put("sourceRevision", GemFireVersion.getSourceRevision)
+
+    versionDetails
   }
 }

--- a/cluster/src/main/scala/org/apache/spark/ui/SnappyDashboardPage.scala
+++ b/cluster/src/main/scala/org/apache/spark/ui/SnappyDashboardPage.scala
@@ -436,7 +436,7 @@ private[ui] class SnappyDashboardPage (parent: SnappyDashboardTab)
       <table class="table table-bordered table-condensed table-striped">
         <thead>
           <tr>
-            <th style="text-align:center; width: 150px; vertical-align: middle;">
+            <th style="text-align:center; width: 60px; vertical-align: middle;">
               <span data-toggle="tooltip" title=""
                     data-original-title={
                       SnappyDashboardPage.memberStatsColumn("statusTooltip")
@@ -454,7 +454,7 @@ private[ui] class SnappyDashboardPage (parent: SnappyDashboardTab)
                 {SnappyDashboardPage.memberStatsColumn("description")}
               </span>
             </th>
-            <th style="text-align:center; vertical-align: middle; min-width: 100px;">
+            <th style="text-align:center; vertical-align: middle; width: 100px;">
               <span data-toggle="tooltip" title=""
                     data-original-title={
                       SnappyDashboardPage.memberStatsColumn("memberTypeTooltip")
@@ -463,7 +463,7 @@ private[ui] class SnappyDashboardPage (parent: SnappyDashboardTab)
                 {SnappyDashboardPage.memberStatsColumn("memberType")}
               </span>
             </th>
-            <th style="text-align:center; width: 250px; vertical-align: middle;">
+            <th style="text-align:center; width: 200px; vertical-align: middle;">
               <span data-toggle="tooltip" title=""
                     data-original-title={
                       SnappyDashboardPage.memberStatsColumn("cpuUsageTooltip")
@@ -472,7 +472,7 @@ private[ui] class SnappyDashboardPage (parent: SnappyDashboardTab)
                 {SnappyDashboardPage.memberStatsColumn("cpuUsage")}
               </span>
             </th>
-            <th style="text-align:center; width: 250px; vertical-align: middle;">
+            <th style="text-align:center; width: 200px; vertical-align: middle;">
               <span data-toggle="tooltip" title=""
                     data-original-title={
                       SnappyDashboardPage.memberStatsColumn("memoryUsageTooltip")
@@ -481,30 +481,30 @@ private[ui] class SnappyDashboardPage (parent: SnappyDashboardTab)
                 {SnappyDashboardPage.memberStatsColumn("memoryUsage")}
               </span>
             </th>
-            <th style="text-align:center; width: 250px; vertical-align: middle;">
+            <th style="text-align:center; width: 200px; vertical-align: middle;">
               <span data-toggle="tooltip" title=""
                     data-original-title={
                       SnappyDashboardPage.memberStatsColumn("heapMemoryTooltip")
                     }
                     style="font-size: 17px;">
-                {SnappyDashboardPage.memberStatsColumn("heapMemory")}
+                Heap Memory<br/>(Used / Total)
               </span>
             </th>
-            <th style="text-align:center; width: 250px; vertical-align: middle;">
+            <th style="text-align:center; width: 200px; vertical-align: middle;">
               <span data-toggle="tooltip" title=""
                     data-original-title={
                       SnappyDashboardPage.memberStatsColumn("offHeapMemoryTooltip")
                     }
                     style="font-size: 17px;">
-                {SnappyDashboardPage.memberStatsColumn("offHeapMemory")}
+                Off-Heap Memory<br/>(Used / Total)
               </span>
             </th>
           </tr>
         </thead>
         <tbody>
-          {locators.map(mb => memberRow(mb._2))}
-          {leads.map(mb => memberRow(mb._2))}
           {dataServers.map(mb => memberRow(mb._2))}
+          {leads.map(mb => memberRow(mb._2))}
+          {locators.map(mb => memberRow(mb._2))}
         </tbody>
       </table>
     </div>
@@ -802,11 +802,10 @@ private[ui] class SnappyDashboardPage (parent: SnappyDashboardTab)
 
     <tr>
       <td>
-        <div style="float: left; border-right: thin inset; height: 24px; padding: 0 5px;">
-          <img src={statusImgUri} />
-        </div><div style="float: left; height: 24px; padding-left: 15px; "><b>{
-          memberDetails.getOrElse("status","NA")
-        }</b></div>
+        <div style="float: left; height: 24px; padding: 0 20px;" >
+          <img src={statusImgUri} data-toggle="tooltip" title=""
+               data-original-title={status.toString} />
+        </div>
       </td>
       <td>
         <div style="width: 80%; float: left; padding-left: 10px; font-weight: bold;">
@@ -979,7 +978,7 @@ private[ui] class SnappyDashboardPage (parent: SnappyDashboardTab)
     val completeWidth = "width: %s%%".format(completed)
 
     <div style="width:100%;">
-      <div style="float: left; width: 80%;">
+      <div style="float: left; width: 78%;">
         <div class="progressBar">
           <div class="completedProgress" style={completeWidth}>&nbsp;</div>
         </div>

--- a/cluster/src/main/scala/org/apache/spark/ui/SnappyDashboardPage.scala
+++ b/cluster/src/main/scala/org/apache/spark/ui/SnappyDashboardPage.scala
@@ -409,6 +409,29 @@ private[ui] class SnappyDashboardPage (parent: SnappyDashboardTab)
   }
 
   private def memberStats(membersBuf: mutable.Map[String, mutable.Map[String, Any]]): Seq[Node] = {
+
+    val locators = mutable.Map.empty[String, mutable.Map[String, Any]]
+    val leads = mutable.Map.empty[String, mutable.Map[String, Any]]
+    val dataServers = mutable.Map.empty[String, mutable.Map[String, Any]]
+
+    membersBuf.foreach(mb => {
+      val m = mb._2
+
+      if(m("lead").toString.toBoolean || m("activeLead").toString.toBoolean){
+        leads.put(mb._1, mb._2)
+      }
+      if(m("locator").toString.toBoolean){
+        locators.put(mb._1, mb._2)
+      }
+      if(m("dataServer").toString.toBoolean
+          && !m("activeLead").toString.toBoolean
+          && !m("lead").toString.toBoolean
+          && !m("locator").toString.toBoolean){
+        dataServers.put(mb._1, mb._2)
+      }
+
+    })
+
     <div>
       <table class="table table-bordered table-condensed table-striped">
         <thead>
@@ -479,7 +502,9 @@ private[ui] class SnappyDashboardPage (parent: SnappyDashboardTab)
           </tr>
         </thead>
         <tbody>
-          {membersBuf.map(mb => memberRow(mb._2))}
+          {locators.map(mb => memberRow(mb._2))}
+          {leads.map(mb => memberRow(mb._2))}
+          {dataServers.map(mb => memberRow(mb._2))}
         </tbody>
       </table>
     </div>

--- a/cluster/src/main/scala/org/apache/spark/ui/SnappyDashboardPage.scala
+++ b/cluster/src/main/scala/org/apache/spark/ui/SnappyDashboardPage.scala
@@ -978,7 +978,7 @@ private[ui] class SnappyDashboardPage (parent: SnappyDashboardTab)
     val completeWidth = "width: %s%%".format(completed)
 
     <div style="width:100%;">
-      <div style="float: left; width: 78%;">
+      <div style="float: left; width: 75%;">
         <div class="progressBar">
           <div class="completedProgress" style={completeWidth}>&nbsp;</div>
         </div>


### PR DESCRIPTION
## Changes proposed in this pull request

1. Display SnappyData build details along with version number on Pulse UI.
2. Shift SnappyData logo to right most side on top bar Keep Pulse on left side.
3. Create SnappyData and Pulse image in same font style.
4. Remove "SnappyData Application UI" text from UI
5. Increase Description column width and resized/reduced other columns widths in members list.
6. Move "Used / Total" text on next line or into tool tip for Heap and Off-Heap columns.
7. Used only status image to display Members Status in members list (Text Running or Stopped is shown in tool tip.
8. Displaying Members list sorted based on members type (All Data Servers followed by all Leads followed by all Locators).


## Patch testing

 - Tested Manully

## ReleaseNotes.txt changes

Yes.

## Other PRs 

Spark: https://github.com/SnappyDataInc/spark/pull/69
