### PR TITLE
After new job classloader changes executors not fetching driver files.

### DIFF
--- a/cluster/src/main/scala/org/apache/spark/util/SnappyUtils.scala
+++ b/cluster/src/main/scala/org/apache/spark/util/SnappyUtils.scala
@@ -18,7 +18,7 @@
 package org.apache.spark.util
 
 import java.io.File
-import java.net.{URL, URLClassLoader}
+import java.net.{URI, URL, URLClassLoader}
 import java.security.SecureClassLoader
 
 import _root_.io.snappydata.Constant
@@ -73,7 +73,10 @@ object SnappyUtils {
       classLoader: ClassLoader): Unit = {
     assert(classOf[URLClassLoader].isAssignableFrom(classLoader.getClass))
     val dependentJars = classLoader.asInstanceOf[URLClassLoader].getURLs
-    val localProperty = (Seq(appName, DateTime.now) ++ dependentJars.toSeq).mkString(",")
+    val sparkJars = dependentJars.map( url => {
+      sparkContext.env.rpcEnv.fileServer.addJar(new File(url.toURI))
+    })
+    val localProperty = (Seq(appName, DateTime.now) ++ sparkJars.toSeq).mkString(",")
     sparkContext.setLocalProperty(Constant.CHANGEABLE_JAR_NAME, localProperty)
   }
 


### PR DESCRIPTION
## Changes proposed in this pull request

As we have removed sc.addJar call, we need to add the driver jars to file server
at SnappyData level.

## Patch testing

NA

## ReleaseNotes.txt changes

NA

## Other PRs 

NA
