### PR TITLE
Issues seen during concurrency testing

### DIFF
--- a/core/src/main/scala/org/apache/spark/sql/CachedDataFrame.scala
+++ b/core/src/main/scala/org/apache/spark/sql/CachedDataFrame.scala
@@ -88,7 +88,9 @@ class CachedDataFrame(session: SparkSession, queryExecution: QueryExecution,
   private lazy val boundEnc = exprEnc.resolveAndBind(logicalPlan.output,
     sparkSession.sessionState.analyzer)
 
-  def queryExecutionString: String = queryExecution.toString()
+  private lazy val queryExecutionString: String = queryExecution.toString()
+
+  private lazy val numPartitions: Int = cachedRDD.getNumPartitions
 
   private lazy val lastShuffleCleanups = new Array[Future[Unit]](
     shuffleDependencies.length)
@@ -146,7 +148,7 @@ class CachedDataFrame(session: SparkSession, queryExecution: QueryExecution,
       sessionState.conf.activeSchedulerPool
 
     // Check if it is pruned query, execute it automatically on the low latency pool
-    if ((cachedRDD ne null) && cachedRDD.getNumPartitions <= 2 /* some small number */ &&
+    if ((cachedRDD ne null) && numPartitions <= 2 /* some small number */ &&
       shuffleDependencies.length == 0 && pool == "default") {
       if (sparkSession.sparkContext.getAllPools.exists(_.name == "lowlatency")) {
         pool = "lowlatency"

--- a/core/src/main/scala/org/apache/spark/sql/CachedDataFrame.scala
+++ b/core/src/main/scala/org/apache/spark/sql/CachedDataFrame.scala
@@ -91,7 +91,7 @@ class CachedDataFrame(session: SparkSession, queryExecution: QueryExecution,
   private lazy val queryExecutionString: String = queryExecution.toString()
 
   private lazy val isLowLatencyQuery: Boolean =
-    cachedRDD.getNumPartitions <= 2 /* some small number */
+    (cachedRDD ne null) && cachedRDD.getNumPartitions <= 2 /* some small number */
 
   private lazy val lastShuffleCleanups = new Array[Future[Unit]](
     shuffleDependencies.length)
@@ -149,8 +149,7 @@ class CachedDataFrame(session: SparkSession, queryExecution: QueryExecution,
       sessionState.conf.activeSchedulerPool
 
     // Check if it is pruned query, execute it automatically on the low latency pool
-    if ((cachedRDD ne null) && isLowLatencyQuery &&
-      shuffleDependencies.length == 0 && pool == "default") {
+    if (isLowLatencyQuery && shuffleDependencies.length == 0 && pool == "default") {
       if (sparkSession.sparkContext.getAllPools.exists(_.name == "lowlatency")) {
         pool = "lowlatency"
       }

--- a/core/src/main/scala/org/apache/spark/sql/CachedDataFrame.scala
+++ b/core/src/main/scala/org/apache/spark/sql/CachedDataFrame.scala
@@ -90,7 +90,8 @@ class CachedDataFrame(session: SparkSession, queryExecution: QueryExecution,
 
   private lazy val queryExecutionString: String = queryExecution.toString()
 
-  private lazy val numPartitions: Int = cachedRDD.getNumPartitions
+  private lazy val isLowLatencyQuery: Boolean =
+    cachedRDD.getNumPartitions <= 2 /* some small number */
 
   private lazy val lastShuffleCleanups = new Array[Future[Unit]](
     shuffleDependencies.length)
@@ -148,7 +149,7 @@ class CachedDataFrame(session: SparkSession, queryExecution: QueryExecution,
       sessionState.conf.activeSchedulerPool
 
     // Check if it is pruned query, execute it automatically on the low latency pool
-    if ((cachedRDD ne null) && numPartitions <= 2 /* some small number */ &&
+    if ((cachedRDD ne null) && isLowLatencyQuery &&
       shuffleDependencies.length == 0 && pool == "default") {
       if (sparkSession.sparkContext.getAllPools.exists(_.name == "lowlatency")) {
         pool = "lowlatency"


### PR DESCRIPTION
## Changes proposed in this pull request

CachedDataFrame.queryExecutionString was a function which is getting evaluated every time the CDF is being executed. Changed it to lazy val so that it is evaluated once. Same for the number of partitions of the cached RDD.  

## Patch testing

precheckin 