### PR TITLE
[SNAP-1919][SNAP-1916] added isPartitioned flag to determine partitioned tables

### DIFF
--- a/cluster/src/main/scala/org/apache/spark/executor/SnappyExecutor.scala
+++ b/cluster/src/main/scala/org/apache/spark/executor/SnappyExecutor.scala
@@ -26,7 +26,6 @@ import com.pivotal.gemfirexd.internal.engine.Misc
 
 import org.apache.spark.deploy.SparkHadoopUtil
 import org.apache.spark.serializer.KryoSerializerPool
-import org.apache.spark.sql.catalyst.expressions.codegen.CodeGenerator
 import org.apache.spark.util.{MutableURLClassLoader, ShutdownHookManager, SparkExitCode, Utils}
 import org.apache.spark.{Logging, SparkEnv, SparkFiles}
 
@@ -47,7 +46,7 @@ class SnappyExecutor(
     Thread.setDefaultUncaughtExceptionHandler(exceptionHandler)
   }
 
-  val classLoaderCache = {
+  private val classLoaderCache = {
     val loader = new CacheLoader[ClassLoaderKey, SnappyMutableURLClassLoader]() {
       override def load(key: ClassLoaderKey): SnappyMutableURLClassLoader = {
         val appName = key.appName
@@ -96,13 +95,13 @@ class SnappyExecutor(
       if (null != taskDeserializationProps) {
         val appDetails = taskDeserializationProps.getProperty(io.snappydata.Constant
             .CHANGEABLE_JAR_NAME, "")
-        logInfo(s"Submitted Application Details $appDetails")
+        logDebug(s"Submitted Application Details $appDetails")
         if (!appDetails.isEmpty) {
           val appNameAndJars = appDetails.split(",")
           val threadClassLoader =
             classLoaderCache.getUnchecked(new ClassLoaderKey(appNameAndJars(0),
               appNameAndJars(1), appNameAndJars))
-          logInfo(s"Setting thread classloader  $threadClassLoader")
+          logDebug(s"Setting thread classloader  $threadClassLoader")
           Thread.currentThread().setContextClassLoader(threadClassLoader)
         }
       }

--- a/core/src/main/scala/org/apache/spark/sql/SnappyStrategies.scala
+++ b/core/src/main/scala/org/apache/spark/sql/SnappyStrategies.scala
@@ -160,7 +160,7 @@ private[sql] trait SnappyStrategies {
         case PhysicalOperation(_, _, r@LogicalRelation(
         scan: PartitionedDataSourceScan, _, _)) =>
           // send back numPartitions=1 for replicated table since collocated
-          if (scan.numBuckets == 1) return (Nil, Nil, 1)
+          if (!scan.isPartitioned) return (Nil, Nil, 1)
 
           // use case-insensitive resolution since partitioning columns during
           // creation could be using the same as opposed to during scan
@@ -292,8 +292,7 @@ private[sql] object JoinStrategy {
   def canLocalJoin(plan: LogicalPlan): Boolean = {
     plan match {
       case PhysicalOperation(_, _, LogicalRelation(
-      t: PartitionedDataSourceScan, _, _)) =>
-        t.numBuckets == 1
+      t: PartitionedDataSourceScan, _, _)) => !t.isPartitioned
       case PhysicalOperation(_, _, Join(left, right, _, _)) =>
         // If join is a result of join of replicated tables, this
         // join result should also be a local join with any other table

--- a/core/src/main/scala/org/apache/spark/sql/execution/ExistingPlans.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/ExistingPlans.scala
@@ -248,6 +248,8 @@ trait PartitionedDataSourceScan extends PrunedUnsafeFilteredScan {
 
   def numBuckets: Int
 
+  def isPartitioned: Boolean
+
   def partitionColumns: Seq[String]
 
   def connectionType: ConnectionType.Value

--- a/core/src/main/scala/org/apache/spark/sql/execution/TableExec.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/TableExec.scala
@@ -51,6 +51,8 @@ trait TableExec extends UnaryExecNode with CodegenSupportOnExecutor {
 
   def numBuckets: Int
 
+  def isPartitioned: Boolean
+
   protected def opType: String
 
   protected def isInsert: Boolean = false
@@ -58,7 +60,7 @@ trait TableExec extends UnaryExecNode with CodegenSupportOnExecutor {
   override lazy val output: Seq[Attribute] =
     AttributeReference("count", LongType, nullable = false)() :: Nil
 
-  val partitioned: Boolean = numBuckets > 1 && partitionExpressions.nonEmpty
+  val partitioned: Boolean = isPartitioned && partitionExpressions.nonEmpty
 
   // Enforce default shuffle partitions to match table buckets.
   // Only one insert plan possible in the plan tree, so no clashes.

--- a/core/src/main/scala/org/apache/spark/sql/execution/columnar/ColumnBatchCreator.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/columnar/ColumnBatchCreator.scala
@@ -87,7 +87,7 @@ final class ColumnBatchCreator(
           // sending negative values for batch size and delta rows will create
           // only one column batch that will not be checked for size again
           val insertPlan = ColumnInsertExec(tableScan, Seq.empty, Seq.empty,
-            -1, None, (-bufferRegion.getColumnBatchSize, -1,
+            numBuckets = -1, isPartitioned = false, None, (-bufferRegion.getColumnBatchSize, -1,
                 Property.CompressionCodec.defaultValue.get), tableName,
             onExecutor = true, schema, store, useMemberVariables = false)
           // now generate the code with the help of WholeStageCodegenExec
@@ -139,7 +139,7 @@ final class ColumnBatchCreator(
       // no puts into row buffer for now since it causes split of rows held
       // together and thus failures in ClosedFormAccuracySuite etc
       val insertPlan = ColumnInsertExec(bufferPlan, Seq.empty, Seq.empty,
-        -1, None, (columnBatchSize, -1, compressionCodec),
+        numBuckets = -1, isPartitioned = false, None, (columnBatchSize, -1, compressionCodec),
         tableName, onExecutor = true, schema, externalStore,
         useMemberVariables = true)
       // now generate the code with the help of WholeStageCodegenExec

--- a/core/src/main/scala/org/apache/spark/sql/execution/columnar/ColumnDeleteExec.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/columnar/ColumnDeleteExec.scala
@@ -37,8 +37,8 @@ import org.apache.spark.sql.types.StructType
  */
 case class ColumnDeleteExec(child: SparkPlan, columnTable: String,
     partitionColumns: Seq[String], partitionExpressions: Seq[Expression],
-    numBuckets: Int, tableSchema: StructType, externalStore: ExternalStore,
-    relation: Option[DestroyRelation], keyColumns: Seq[Attribute],
+    numBuckets: Int, isPartitioned: Boolean, tableSchema: StructType,
+    externalStore: ExternalStore, relation: Option[DestroyRelation], keyColumns: Seq[Attribute],
     connProps: ConnectionProperties, onExecutor: Boolean) extends RowExec {
 
   override def resolvedName: String = externalStore.tableName

--- a/core/src/main/scala/org/apache/spark/sql/execution/columnar/ColumnInsertExec.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/columnar/ColumnInsertExec.scala
@@ -34,7 +34,7 @@ import scala.collection.mutable.ArrayBuffer
  * Generated code plan for bulk insertion into a column table.
  */
 case class ColumnInsertExec(child: SparkPlan, partitionColumns: Seq[String],
-    partitionExpressions: Seq[Expression], numBuckets: Int,
+    partitionExpressions: Seq[Expression], numBuckets: Int, isPartitioned: Boolean,
     relation: Option[DestroyRelation], batchParams: (Int, Int, String),
     columnTable: String, onExecutor: Boolean, tableSchema: StructType,
     externalStore: ExternalStore, useMemberVariables: Boolean)
@@ -45,8 +45,8 @@ case class ColumnInsertExec(child: SparkPlan, partitionColumns: Seq[String],
       relation: JDBCAppendableRelation, table: String) = {
     // TODO: add compression for binary/complex types
     this(child, partitionColumns, partitionExpressions, relation.numBuckets,
-      Some(relation), relation.getColumnBatchParams, table, onExecutor = false,
-      relation.schema, relation.externalStore, useMemberVariables = false)
+      relation.isPartitioned, Some(relation), relation.getColumnBatchParams, table,
+      onExecutor = false, relation.schema, relation.externalStore, useMemberVariables = false)
   }
 
   @transient private var encoderCursorTerms: Seq[(String, String)] = _

--- a/core/src/main/scala/org/apache/spark/sql/execution/columnar/ColumnUpdateExec.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/columnar/ColumnUpdateExec.scala
@@ -39,10 +39,10 @@ import org.apache.spark.util.TaskCompletionListener
  */
 case class ColumnUpdateExec(child: SparkPlan, columnTable: String,
     partitionColumns: Seq[String], partitionExpressions: Seq[Expression], numBuckets: Int,
-    tableSchema: StructType, externalStore: ExternalStore, relation: Option[DestroyRelation],
-    updateColumns: Seq[Attribute], updateExpressions: Seq[Expression],
-    keyColumns: Seq[Attribute], connProps: ConnectionProperties, onExecutor: Boolean)
-    extends RowExec {
+    isPartitioned: Boolean, tableSchema: StructType, externalStore: ExternalStore,
+    relation: Option[DestroyRelation], updateColumns: Seq[Attribute],
+    updateExpressions: Seq[Expression], keyColumns: Seq[Attribute],
+    connProps: ConnectionProperties, onExecutor: Boolean) extends RowExec {
 
   assert(updateColumns.length == updateExpressions.length)
 

--- a/core/src/main/scala/org/apache/spark/sql/execution/columnar/JDBCAppendableRelation.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/columnar/JDBCAppendableRelation.scala
@@ -74,6 +74,8 @@ abstract case class JDBCAppendableRelation(
 
   def numBuckets: Int = -1
 
+  def isPartitioned: Boolean = true
+
   override def sizeInBytes: Long = {
     SnappyTableStatsProviderService.getService.getTableStatsFromService(table) match {
       case Some(s) => s.getTotalSize

--- a/core/src/main/scala/org/apache/spark/sql/execution/columnar/impl/JDBCSourceAsColumnarStore.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/columnar/impl/JDBCSourceAsColumnarStore.scala
@@ -531,8 +531,8 @@ class JDBCSourceAsColumnarStore(private var _connProperties: ConnectionPropertie
             baseRelation = null, schema, allFilters = Seq.empty, schemaAttrs,
             caseSensitive = true)
           val insertPlan = RowInsertExec(tableScan, putInto = true,
-            Seq.empty, Seq.empty, -1, schema, None, onExecutor = true,
-            tableName, connProperties)
+            Seq.empty, Seq.empty, numBuckets = -1, isPartitioned = false, schema,
+            None, onExecutor = true, tableName, connProperties)
           // now generate the code with the help of WholeStageCodegenExec
           // this is only used for local code generation while its RDD
           // semantics and related methods are all ignored

--- a/core/src/main/scala/org/apache/spark/sql/execution/row/RowDeleteExec.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/row/RowDeleteExec.scala
@@ -27,9 +27,9 @@ import org.apache.spark.sql.types.StructType
  */
 case class RowDeleteExec(child: SparkPlan, resolvedName: String,
     partitionColumns: Seq[String], partitionExpressions: Seq[Expression],
-    numBuckets: Int, tableSchema: StructType, relation: Option[DestroyRelation],
-    keyColumns: Seq[Attribute], connProps: ConnectionProperties, onExecutor: Boolean)
-    extends RowExec {
+    numBuckets: Int, isPartitioned: Boolean, tableSchema: StructType,
+    relation: Option[DestroyRelation], keyColumns: Seq[Attribute],
+    connProps: ConnectionProperties, onExecutor: Boolean) extends RowExec {
 
   override protected def opType: String = "Delete"
 

--- a/core/src/main/scala/org/apache/spark/sql/execution/row/RowInsertExec.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/row/RowInsertExec.scala
@@ -27,9 +27,9 @@ import org.apache.spark.sql.types.StructType
  */
 case class RowInsertExec(child: SparkPlan, putInto: Boolean,
     partitionColumns: Seq[String], partitionExpressions: Seq[Expression],
-    numBuckets: Int, tableSchema: StructType, relation: Option[DestroyRelation],
-    onExecutor: Boolean, resolvedName: String, connProps: ConnectionProperties)
-    extends RowExec {
+    numBuckets: Int, isPartitioned: Boolean, tableSchema: StructType,
+    relation: Option[DestroyRelation], onExecutor: Boolean, resolvedName: String,
+    connProps: ConnectionProperties) extends RowExec {
 
   override def opType: String = if (putInto) "Put" else "Inserted"
 

--- a/core/src/main/scala/org/apache/spark/sql/execution/row/RowUpdateExec.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/row/RowUpdateExec.scala
@@ -27,10 +27,10 @@ import org.apache.spark.sql.types.StructType
  */
 case class RowUpdateExec(child: SparkPlan, resolvedName: String,
     partitionColumns: Seq[String], partitionExpressions: Seq[Expression],
-    numBuckets: Int, tableSchema: StructType, relation: Option[DestroyRelation],
-    updateColumns: Seq[Attribute], updateExpressions: Seq[Expression],
-    keyColumns: Seq[Attribute], connProps: ConnectionProperties, onExecutor: Boolean)
-    extends RowExec {
+    numBuckets: Int, isPartitioned: Boolean, tableSchema: StructType,
+    relation: Option[DestroyRelation], updateColumns: Seq[Attribute],
+    updateExpressions: Seq[Expression], keyColumns: Seq[Attribute],
+    connProps: ConnectionProperties, onExecutor: Boolean) extends RowExec {
 
   assert(updateColumns.length == updateExpressions.length)
 

--- a/core/src/main/scala/org/apache/spark/sql/hive/ConnectorCatalog.scala
+++ b/core/src/main/scala/org/apache/spark/sql/hive/ConnectorCatalog.scala
@@ -220,6 +220,7 @@ trait ConnectorCatalog extends SnappyStoreHiveCatalog {
 }
 
 case class RelationInfo(numBuckets: Int = 1,
+    isPartitioned: Boolean = false,
     partitioningCols: Seq[String] = Seq.empty,
     indexCols: Array[String] = Array.empty,
     pkCols: Array[String] = Array.empty,

--- a/core/src/main/scala/org/apache/spark/sql/hive/SnappyStoreHiveCatalog.scala
+++ b/core/src/main/scala/org/apache/spark/sql/hive/SnappyStoreHiveCatalog.scala
@@ -207,7 +207,7 @@ class SnappyStoreHiveCatalog(externalCatalog: SnappyExternalCatalog,
         }
 
         (LogicalRelation(relation, catalogTable = Some(table)), table, RelationInfo(
-          0, Seq.empty, Array.empty, Array.empty, Array.empty, -1))
+          0, isPartitioned = false, Seq.empty, Array.empty, Array.empty, Array.empty, -1))
       }
     }
 

--- a/core/src/main/scala/org/apache/spark/sql/row/JDBCMutableRelation.scala
+++ b/core/src/main/scala/org/apache/spark/sql/row/JDBCMutableRelation.scala
@@ -96,6 +96,8 @@ case class JDBCMutableRelation(
 
   def numBuckets: Int = -1
 
+  def isPartitioned: Boolean = false
+
   override def unhandledFilters(filters: Array[Filter]): Array[Filter] =
     filters.filter(ExternalStoreUtils.unhandledFilter)
 
@@ -188,7 +190,7 @@ case class JDBCMutableRelation(
   override def getInsertPlan(relation: LogicalRelation,
       child: SparkPlan): SparkPlan = {
     RowInsertExec(child, putInto = false, partitionColumns,
-      partitionExpressions(relation), numBuckets, schema, Some(this),
+      partitionExpressions(relation), numBuckets, isPartitioned, schema, Some(this),
       onExecutor = false, table, connProperties)
   }
 
@@ -200,8 +202,8 @@ case class JDBCMutableRelation(
       updateColumns: Seq[Attribute], updateExpressions: Seq[Expression],
       keyColumns: Seq[Attribute]): SparkPlan = {
     RowUpdateExec(child, resolvedName, partitionColumns, partitionExpressions(relation),
-      numBuckets, schema, Some(this), updateColumns, updateExpressions, keyColumns,
-      connProperties, onExecutor = false)
+      numBuckets, isPartitioned, schema, Some(this), updateColumns, updateExpressions,
+      keyColumns, connProperties, onExecutor = false)
   }
 
   /**
@@ -211,7 +213,8 @@ case class JDBCMutableRelation(
   override def getDeletePlan(relation: LogicalRelation, child: SparkPlan,
       keyColumns: Seq[Attribute]): SparkPlan = {
     RowDeleteExec(child, resolvedName, partitionColumns, partitionExpressions(relation),
-      numBuckets, schema, Some(this), keyColumns, connProperties, onExecutor = false)
+      numBuckets, isPartitioned, schema, Some(this), keyColumns, connProperties,
+      onExecutor = false)
   }
 
   /**


### PR DESCRIPTION

## Changes proposed in this pull request

- use "isPartitioned" flag to determined partitioned region instead of relying on numBuckets=1
- cleaned up SnappyParser a bit to use match-case; the real fix to SNAP-1919 is on AQP side

## Patch testing

precheckin

## ReleaseNotes.txt changes

NA

## Other PRs 

https://github.com/SnappyDataInc/snappy-aqp/pull/155