### PR TITLE
[SNAP-1917] Fix for SNAP-1917 by proper comparing datatype of complex schema

### DIFF
--- a/core/src/test/scala/org/apache/spark/sql/store/ColumnTableTest.scala
+++ b/core/src/test/scala/org/apache/spark/sql/store/ColumnTableTest.scala
@@ -1178,9 +1178,9 @@ class ColumnTableTest
 
     val rawData=Seq(Seq(1,"emp1",1),Seq(2,"emp2",2),Seq(3,"emp3",3))
 
-    val rdd=sc.parallelize(rawData,1).map(s=> Record(s(0).asInstanceOf[Int],Employee(s(1)
+    val rdd = sc.parallelize(rawData,1).map(s=> Record(s(0).asInstanceOf[Int],Employee(s(1)
       .toString,s(2).asInstanceOf[Int])))
-    val df=snc.createDataFrame(rdd)
+    val df = snc.createDataFrame(rdd)
     df.write.format("column").saveAsTable("test")
 
     snc.sql("drop table if exists test")

--- a/core/src/test/scala/org/apache/spark/sql/store/ColumnTableTest.scala
+++ b/core/src/test/scala/org/apache/spark/sql/store/ColumnTableTest.scala
@@ -1171,4 +1171,20 @@ class ColumnTableTest
     snc.sql("drop table if exists t1")
     FileUtils.deleteDirectory(new java.io.File(tempPath))
   }
+
+  test("Creating column table from dataframe with complex datatype ") {
+
+    snc.sql("drop table if exists test")
+
+    val rawData=Seq(Seq(1,"emp1",1),Seq(2,"emp2",2),Seq(3,"emp3",3))
+
+    val rdd=sc.parallelize(rawData,1).map(s=> Record(s(0).asInstanceOf[Int],Employee(s(1)
+      .toString,s(2).asInstanceOf[Int])))
+    val df=snc.createDataFrame(rdd)
+    df.write.format("column").saveAsTable("test")
+
+    snc.sql("drop table if exists test")
+  }
 }
+case class Record(id:Int, data: Employee)
+case class Employee(empName: String, empId: Int)


### PR DESCRIPTION
## Changes proposed in this pull request
* Added a method similar to DataType.equalsIgnoreNullability but without comparing column names 
* This issue was caused due to improper comparision of complex datatype with that of base dataframe


## Patch testing
* Added Unit test
* Precheckin in progress 

## ReleaseNotes.txt changes
NA

## Other PRs 
No