### PR TITLE
[SNAP-1956] avoid derby booting in Hive's static initializer

### DIFF
--- a/core/src/main/java/io/snappydata/impl/SnappyHiveCatalog.java
+++ b/core/src/main/java/io/snappydata/impl/SnappyHiveCatalog.java
@@ -117,12 +117,13 @@ public class SnappyHiveCatalog implements ExternalCatalog {
     // set the system properties because this can initialize Hive static
     // instance that will try to boot default derby otherwise
     Properties props = metadataConf.getAllProperties();
-    for (String name : props.stringPropertyNames()) {
+    Set<String> propertyNames = props.stringPropertyNames();
+    for (String name : propertyNames) {
       System.setProperty(name, props.getProperty(name));
     }
     Hive.closeCurrent();
     // clear the system properties else it causes trouble with integer values
-    for (String name : props.stringPropertyNames()) {
+    for (String name : propertyNames) {
       System.clearProperty(name);
     }
 

--- a/core/src/main/java/io/snappydata/impl/SnappyHiveCatalog.java
+++ b/core/src/main/java/io/snappydata/impl/SnappyHiveCatalog.java
@@ -89,9 +89,10 @@ public class SnappyHiveCatalog implements ExternalCatalog {
   }
 
   /**
-   * Set the common hive metastore properties and also initialize the invoke
+   * Set the common hive metastore properties and also invoke
    * the static initialization for Hive with system properties
    * which tries booting default derby otherwise (SNAP-1956, SNAP-1961).
+   *
    * Should be called after all other properties have been filled in.
    *
    * @return the location of hive warehouse (unused but hive creates the directory)
@@ -125,7 +126,8 @@ public class SnappyHiveCatalog implements ExternalCatalog {
       System.clearProperty(name);
     }
 
-    // set integer properties after the system properties are cleared
+    // set integer properties after the system properties have been used by
+    // Hive static initialization so that these never go into system properties
 
     // every session has own hive client, so a small pool
     metadataConf.set("datanucleus.connectionPool.maxPoolSize", "4");

--- a/core/src/main/java/io/snappydata/impl/SnappyHiveCatalog.java
+++ b/core/src/main/java/io/snappydata/impl/SnappyHiveCatalog.java
@@ -17,12 +17,7 @@
 package io.snappydata.impl;
 
 import java.sql.SQLException;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -44,6 +39,7 @@ import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.metastore.HiveMetaStoreClient;
 import org.apache.hadoop.hive.metastore.api.NoSuchObjectException;
 import org.apache.hadoop.hive.metastore.api.Table;
+import org.apache.hadoop.hive.ql.metadata.Hive;
 import org.apache.spark.sql.collection.Utils;
 import org.apache.spark.sql.execution.columnar.ExternalStoreUtils;
 import org.apache.spark.sql.execution.datasources.jdbc.DriverRegistry;
@@ -92,15 +88,21 @@ public class SnappyHiveCatalog implements ExternalCatalog {
     }
   }
 
-  public static String setCommonHiveMetastoreProperties(HiveConf metadataConf) {
+  /**
+   * Set the common hive metastore properties and also initialize the invoke
+   * the static initialization for Hive with system properties
+   * which tries booting default derby otherwise (SNAP-1956, SNAP-1961).
+   * Should be called after all other properties have been filled in.
+   *
+   * @return the location of hive warehouse (unused but hive creates the directory)
+   */
+  public static synchronized String initCommonHiveMetaStoreProperties(
+      HiveConf metadataConf) {
     metadataConf.set("datanucleus.mapping.Schema", Misc.SNAPPY_HIVE_METASTORE);
     // Tomcat pool has been shown to work best but does not work in split mode
     // because upstream spark does not ship with it (and the one in snappydata-core
     //   cannot be loaded by datanucleus which should apparently be in its CLASSPATH)
     metadataConf.setVar(HiveConf.ConfVars.METASTORE_CONNECTION_POOLING_TYPE, "BONECP");
-    // every session has own hive client, so a small pool
-    metadataConf.set("datanucleus.connectionPool.maxPoolSize", "4");
-    metadataConf.set("datanucleus.connectionPool.minPoolSize", "0");
     String warehouse = metadataConf.get(HiveConf.ConfVars.METASTOREWAREHOUSE.varname);
     if (warehouse == null || warehouse.isEmpty() ||
         warehouse.equals(HiveConf.ConfVars.METASTOREWAREHOUSE.getDefaultExpr())) {
@@ -109,6 +111,26 @@ public class SnappyHiveCatalog implements ExternalCatalog {
       metadataConf.setVar(HiveConf.ConfVars.METASTOREWAREHOUSE, warehouse);
     }
     metadataConf.setVar(HiveConf.ConfVars.HADOOPFS, "file:///");
+
+    // ensure no other Hive instance is alive for this thread but also
+    // set the system properties because this can initialize Hive static
+    // instance that will try to boot default derby otherwise
+    Properties props = metadataConf.getAllProperties();
+    for (String name : props.stringPropertyNames()) {
+      System.setProperty(name, props.getProperty(name));
+    }
+    Hive.closeCurrent();
+    // clear the system properties else it causes trouble with integer values
+    for (String name : props.stringPropertyNames()) {
+      System.clearProperty(name);
+    }
+
+    // set integer properties after the system properties are cleared
+
+    // every session has own hive client, so a small pool
+    metadataConf.set("datanucleus.connectionPool.maxPoolSize", "4");
+    metadataConf.set("datanucleus.connectionPool.minPoolSize", "0");
+
     return warehouse;
   }
 
@@ -412,10 +434,10 @@ public class SnappyHiveCatalog implements ExternalCatalog {
         metadataConf.setVar(HiveConf.ConfVars.METASTORE_CONNECTION_USER_NAME,
             Misc.SNAPPY_HIVE_METASTORE);
       }
-      setCommonHiveMetastoreProperties(metadataConf);
       metadataConf.setVar(HiveConf.ConfVars.METASTORECONNECTURLKEY, urlSecure);
       metadataConf.setVar(HiveConf.ConfVars.METASTORE_CONNECTION_DRIVER,
           "io.snappydata.jdbc.EmbeddedDriver");
+      initCommonHiveMetaStoreProperties(metadataConf);
 
       final short numRetries = 40;
       short count = 0;


### PR DESCRIPTION
## Changes proposed in this pull request

The static initializer of Hive boots up with default properties i.e. derby causing
the issue reported in SNAP-1956. Setting hive metastore conf as system properties
avoids that and uses in-built snappy store as database instead. However, integer
value properties as system properties cause trouble so they are set later after
static initialization is done.

## Patch testing

precheckin

## ReleaseNotes.txt changes

NA

## Other PRs 

NA