### PR TITLE
[SNAP-1611]  made spark.memory.fraction to 97%

### DIFF
--- a/cluster/src/main/scala/org/apache/spark/memory/SnappyUnifiedMemoryManager.scala
+++ b/cluster/src/main/scala/org/apache/spark/memory/SnappyUnifiedMemoryManager.scala
@@ -759,7 +759,7 @@ object SnappyUnifiedMemoryManager extends Logging {
 
     val usableMemory = systemMemory - reservedMemory
     // add a cushion for GC before CRITICAL_UP is reached
-    val memoryFraction = conf.getDouble("spark.memory.fraction", 0.92)
+    val memoryFraction = conf.getDouble("spark.memory.fraction", 0.97)
     (usableMemory * memoryFraction).toLong
   }
 

--- a/cluster/src/main/scala/org/apache/spark/memory/SnappyUnifiedMemoryManager.scala
+++ b/cluster/src/main/scala/org/apache/spark/memory/SnappyUnifiedMemoryManager.scala
@@ -571,15 +571,17 @@ class SnappyUnifiedMemoryManager private[memory](
     logDebug(s"Acquiring $managerId $memoryMode memory " +
       s"for $objectName = $numBytes (evict=$shouldEvict)")
     if (buffer ne null) {
-      if (buffer.freeMemory() > numBytes) {
+      if (buffer.freeMemory() >= numBytes) {
         buffer.incMemoryUsed(numBytes)
         true
       } else {
         val predictedMemory = numBytes * buffer.getTotalOperationsExpected
-        buffer.incAllocatedMemory(predictedMemory)
         val success = askStoragePool(objectName, blockId, predictedMemory, memoryMode, shouldEvict)
-        buffer.setFirstAllocationObject(objectName)
-        buffer.incMemoryUsed(numBytes)
+        if (success){
+          buffer.incAllocatedMemory(predictedMemory)
+          buffer.setFirstAllocationObject(objectName)
+          buffer.incMemoryUsed(numBytes)
+        }
         success
       }
     } else {


### PR DESCRIPTION
## Changes proposed in this pull request
Default spark memory fraction was 92% , after reserving memory for critical heap which is 10% default the total comes around 18% of reserved memory. This is a bit too much. We want to give a little buffer to JVM before it reaches the critical hep size. Hence increased default spark.memory.fraction to 97%

Also added couple of test changes. Enabled couple of tests which were failing frequently due to other problems. 
## Patch testing
precheckin pending

## ReleaseNotes.txt changes

(Does this change require an entry in ReleaseNotes.txt? If yes, has it been added to it?)

## Other PRs 

(Does this change require changes in other projects- store, spark, spark-jobserver, aqp? Add the links of PR of the other subprojects that are related to this change)
