### PR TITLE
[SNAP-1973][SNAP-1970] avoid clearing hive meta-store system properties

### DIFF
--- a/core/src/main/java/io/snappydata/impl/SnappyHiveCatalog.java
+++ b/core/src/main/java/io/snappydata/impl/SnappyHiveCatalog.java
@@ -140,10 +140,6 @@ public class SnappyHiveCatalog implements ExternalCatalog {
       System.setProperty(name, props.getProperty(name));
     }
     Hive.closeCurrent();
-    // clear the system properties else it causes trouble with integer values
-    for (String name : propertyNames) {
-      System.clearProperty(name);
-    }
 
     // set integer properties after the system properties have been used by
     // Hive static initialization so that these never go into system properties

--- a/dtests/src/test/java/io/snappydata/hydra/testDMLOps/SnappyDMLOpsUtil.java
+++ b/dtests/src/test/java/io/snappydata/hydra/testDMLOps/SnappyDMLOpsUtil.java
@@ -755,7 +755,8 @@ public class SnappyDMLOpsUtil extends SnappyTest {
     try (Stream<String> lines = Files.lines(Paths.get(csvFilePath + File.separator + csvFileName))) {
       row = lines.skip(insertCounter).findFirst().get();
     } catch (IOException io) {
-      throw new TestException("File not found at specified location.");
+      throw new TestException("File not found at specified location " +
+          (csvFilePath + File.separator + csvFileName));
     }
     return row;
   }


### PR DESCRIPTION
## Changes proposed in this pull request

The hive meta-store system properties are required to be set for static
initialization of Hive and should not be cleared because a concurrent
hive context initialization (from some other path) can see inconsistencies
like system property found but not available when actually read.

Also added file path location to file not found TestException message.

## Patch testing

precheckin

## ReleaseNotes.txt changes

NA

## Other PRs 

NA