### PR TITLE
[SNAP-1984] Code to copy UMM state.

### DIFF
--- a/cluster/src/dunit/scala/io/snappydata/cluster/ClusterMgrDUnitTest.scala
+++ b/cluster/src/dunit/scala/io/snappydata/cluster/ClusterMgrDUnitTest.scala
@@ -100,7 +100,7 @@ object ClusterMgrDUnitTest {
 
   def failTheExecutors: Unit = {
     sc.parallelize(1 until 100, 5).map { i =>
-      throw new InternalError()
+      throw new OutOfMemoryError("Some message")
     }.collect()
   }
 

--- a/cluster/src/dunit/scala/org/apache/spark/memory/MemoryManagerRestartDUnitTest.scala
+++ b/cluster/src/dunit/scala/org/apache/spark/memory/MemoryManagerRestartDUnitTest.scala
@@ -1,0 +1,205 @@
+/*
+ * Copyright (c) 2017 SnappyData, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License. You
+ * may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License. See accompanying
+ * LICENSE file.
+ */
+package org.apache.spark.memory
+
+import java.util.Properties
+
+import io.snappydata.cluster.{ClusterManagerTestBase, ExecutorInitiator}
+import io.snappydata.test.dunit.SerializableRunnable
+
+import org.apache.spark.SparkEnv
+import org.apache.spark.sql.SnappyContext
+
+
+class MemoryManagerRestartDUnitTest(s: String) extends ClusterManagerTestBase(s) {
+
+  import MemoryManagerRestartDUnitTest._
+
+  def testExecutorRestart(): Unit = {
+    vm1.invoke(getClass, "waitForExecutorInit")
+
+    val oldID = vm1.invoke(getClass, "getMemoryManagerIdentity").asInstanceOf[Int]
+
+    assert(vm1.invoke(getClass, "allocateStorage",
+      Array("testExecutorRestart", false, 1000L).asInstanceOf[Array[Object]]).asInstanceOf[Boolean])
+
+    val t1 = new Thread(new Runnable {
+      override def run() = try {
+        failTheExecutors
+      } catch {
+        case _: Throwable =>
+      }
+    })
+    t1.start()
+    vm1.invoke(getClass, "waitForExecutor")
+    t1.join()
+
+    val newID = vm1.invoke(getClass, "getMemoryManagerIdentity").asInstanceOf[Int]
+    assert(newID != oldID, "The MemoryManager instance has not changed as expected")
+
+    val value1 = vm1.invoke(getClass, "getMemoryForTable", "testExecutorRestart").asInstanceOf[Long]
+    assert(value1 == 1000L, s"The storage for object should be 1000 rather than $value1")
+  }
+
+  def testCacheCloseRestart(): Unit = {
+    vm1.invoke(getClass, "waitForExecutorInit")
+
+    val props = bootProps.clone().asInstanceOf[java.util.Properties]
+    val port = ClusterManagerTestBase.locPort
+
+    val oldID = vm1.invoke(getClass, "getMemoryManagerIdentity").asInstanceOf[Int]
+
+    assert(vm1.invoke(getClass, "allocateStorage",
+      Array("testCacheCloseRestart", false, 1000L).
+          asInstanceOf[Array[Object]]).asInstanceOf[Boolean])
+
+    vm1.invoke(classOf[ClusterManagerTestBase], "stopAny")
+    vm1.invoke(restartServerRunnable(props, port))
+
+    val newID = vm1.invoke(getClass, "getMemoryManagerIdentity").asInstanceOf[Int]
+    assert(newID != oldID, "The MemoryManager instance has not changed as expected")
+
+    val value1 = vm1.invoke(getClass, "getMemoryForTable", "testExecutorRestart").asInstanceOf[Long]
+    assert(value1 == 0L, s"The storage for object should be 0L rather than $value1")
+  }
+
+  private def restartServerRunnable(props: Properties, port: Int): SerializableRunnable = {
+    new SerializableRunnable() {
+      override def run(): Unit = {
+        ClusterManagerTestBase.startSnappyServer(port, props)
+        ClusterManagerTestBase.waitForCriterion(SparkEnv.get != null,
+          "Executor Service did not start in specified time ", 20000, 5000, true)
+      }
+    }
+  }
+
+  def testCacheClose(): Unit = {
+    vm1.invoke(getClass, "waitForExecutorInit")
+    val props = bootProps.clone().asInstanceOf[java.util.Properties]
+    val port = ClusterManagerTestBase.locPort
+
+    assert(vm1.invoke(getClass, "allocateStorage",
+      Array("testCacheCloseRestart", false, 1000L).
+          asInstanceOf[Array[Object]]).asInstanceOf[Boolean])
+
+    vm1.invoke(classOf[ClusterManagerTestBase], "stopAny")
+
+    try {
+      val bootMemorySize = vm1.invoke(getClass, "getBootMemoryManagerSize").asInstanceOf[Long]
+      assert(bootMemorySize == 0L, "After cache close bootMemory map size is greater than 0L")
+    } finally {
+      vm1.invoke(restartServerRunnable(props, port))
+    }
+
+  }
+
+  def testDriverRestart(): Unit = {
+    var stopped = false
+    var oldID = -1
+    try {
+      vm1.invoke(getClass, "waitForExecutorInit")
+      oldID = vm1.invoke(getClass, "getMemoryManagerIdentity").asInstanceOf[Int]
+      assert(vm1.invoke(getClass, "allocateStorage",
+        Array("testDriverRestart", false, 1000L).asInstanceOf[Array[Object]]).asInstanceOf[Boolean])
+
+      ClusterManagerTestBase.stopSpark()
+      stopped = true
+    } finally {
+      val t1 = new Thread(new Runnable {
+        override def run() = if (stopped) {
+          ClusterManagerTestBase.startSnappyLead(ClusterManagerTestBase.locatorPort, bootProps)
+        }
+      })
+
+      t1.start()
+      vm1.invoke(getClass, "waitForExecutor")
+      t1.join(30000)
+      val newID = vm1.invoke(getClass, "getMemoryManagerIdentity").asInstanceOf[Int]
+      assert(newID != oldID, "The MemoryManager instance has not changed as expected")
+    }
+    val value1 = vm1.invoke(getClass, "getMemoryForTable", "testDriverRestart").asInstanceOf[Long]
+    assert(value1 == 1000L, s"The storage for object should be 1000 rather than $value1")
+  }
+}
+
+object MemoryManagerRestartDUnitTest {
+
+  def waitForExecutor(): Unit = {
+    ExecutorInitiator.waitForExecutor()
+  }
+
+  def getBootMemoryManagerSize(): Long = {
+    MemoryManagerCallback.bootMemoryManager.
+        asInstanceOf[SnappyUnifiedMemoryManager].memoryForObject.size()
+  }
+
+  def waitForExecutorInit(): Unit = {
+    var l = 0L
+    while (SparkEnv.get eq null) {
+      if (l > 30000) throw new Exception(s"Executors did not start in 30 seconds")
+      Thread.sleep(500)
+      l += 500
+    }
+  }
+
+  def failTheExecutors: Unit = {
+    sc.parallelize(1 until 100, 5).map { i =>
+      throw new OutOfMemoryError("Some Random message") // See SystemFailure.isJVMFailureError
+    }.collect()
+  }
+
+  private def sc = SnappyContext.globalSparkContext
+
+  def getMemoryManagerIdentity(): Int = {
+    assert(SparkEnv.get != null, "Executor is still not initialized")
+    assert(SparkEnv.get.memoryManager.isInstanceOf[SnappyUnifiedMemoryManager])
+    val memoryManager = SparkEnv.get.memoryManager.asInstanceOf[SnappyUnifiedMemoryManager]
+    System.identityHashCode(memoryManager)
+  }
+
+  def getMemoryForTable(tableName: String): Long = {
+    assert(SparkEnv.get != null, "Executor is still not initialized")
+    assert(SparkEnv.get.memoryManager.isInstanceOf[SnappyUnifiedMemoryManager])
+    val memoryManager = SparkEnv.get.memoryManager.asInstanceOf[SnappyUnifiedMemoryManager]
+    val mMap = memoryManager.memoryForObject
+    memoryManager.logStats()
+    val keys = mMap.keySet().iterator()
+    var sum = 0L
+    while (keys.hasNext) {
+      val key = keys.next()
+      if (key._1.toLowerCase().contains(tableName.toLowerCase())) {
+        sum = sum + mMap.getLong(key)
+      }
+    }
+    sum
+  }
+
+  def allocateStorage(tableName: String, offHeap: Boolean, numBytes: Long): Boolean = {
+    assert(SparkEnv.get != null, "Executor is still not initialized")
+    assert(SparkEnv.get.memoryManager.isInstanceOf[SnappyUnifiedMemoryManager])
+    val success = SparkEnv.get.memoryManager
+        .asInstanceOf[SnappyUnifiedMemoryManager]
+        .acquireStorageMemoryForObject(objectName = tableName,
+          blockId = MemoryManagerCallback.storageBlockId,
+          numBytes = numBytes,
+          memoryMode = if (offHeap) MemoryMode.OFF_HEAP else MemoryMode.ON_HEAP,
+          buffer = null,
+          shouldEvict = false)
+
+    success
+  }
+}

--- a/cluster/src/dunit/scala/org/apache/spark/memory/SnappyUnifiedMemoryManagerDUnitTest.scala
+++ b/cluster/src/dunit/scala/org/apache/spark/memory/SnappyUnifiedMemoryManagerDUnitTest.scala
@@ -473,8 +473,8 @@ object SnappyUnifiedMemoryManagerDUnitTest {
       if (SparkEnv.get.memoryManager.isInstanceOf[SnappyUnifiedMemoryManager]) {
         val umm = SparkEnv.get.memoryManager
             .asInstanceOf[SnappyUnifiedMemoryManager]
-        if (umm._memoryForObjectMap ne null) {
-          umm._memoryForObjectMap.clear()
+        if (umm.memoryForObject ne null) {
+          umm.memoryForObject.clear()
         }
         MemoryManagerCallback.resetMemoryManager()
       }
@@ -494,7 +494,7 @@ object SnappyUnifiedMemoryManagerDUnitTest {
     if (SparkEnv.get != null) {
       if (SparkEnv.get.memoryManager.isInstanceOf[SnappyUnifiedMemoryManager]) {
         val mMap = SparkEnv.get.memoryManager
-            .asInstanceOf[SnappyUnifiedMemoryManager]._memoryForObjectMap
+            .asInstanceOf[SnappyUnifiedMemoryManager].memoryForObject
         SparkEnv.get.memoryManager
             .asInstanceOf[SnappyUnifiedMemoryManager].logStats()
         val keys = mMap.keySet().iterator()

--- a/cluster/src/main/scala/io/snappydata/cluster/ExecutorInitiator.scala
+++ b/cluster/src/main/scala/io/snappydata/cluster/ExecutorInitiator.scala
@@ -86,7 +86,7 @@ object ExecutorInitiator extends Logging {
 
     // Test hook. Not to be used in other situations
     def waitForExecutor(retry: Boolean = true): Unit = testLock.synchronized {
-      testLock.wait (30000)
+      testLock.wait(30000)
     }
 
     def getRetryFlag: Boolean = lock.synchronized {

--- a/cluster/src/main/scala/org/apache/spark/SparkCallbacks.scala
+++ b/cluster/src/main/scala/org/apache/spark/SparkCallbacks.scala
@@ -19,6 +19,7 @@ package org.apache.spark
 import org.apache.spark
 
 import org.apache.spark.deploy.SparkHadoopUtil
+import org.apache.spark.memory.StoreUnifiedManager
 import org.apache.spark.rpc.RpcEnv
 import org.apache.spark.scheduler.cluster.CoarseGrainedClusterMessages.{RetrieveSparkAppConfig, SparkAppConfig}
 import org.apache.spark.ui.{JettyUtils, SnappyBasicAuthenticator}
@@ -49,6 +50,8 @@ object SparkCallbacks {
   def stopExecutor(env: SparkEnv): Unit = {
     if (env != null) {
       SparkHadoopUtil.get.runAsSparkUser { () =>
+        // Copy the memory state to boot memory manager
+        SparkEnv.get.memoryManager.asInstanceOf[StoreUnifiedManager].close
         env.stop()
         SparkEnv.set(null)
         SparkHadoopUtil.get.stopCredentialUpdater()

--- a/cluster/src/main/scala/org/apache/spark/memory/SnappyUnifiedMemoryManager.scala
+++ b/cluster/src/main/scala/org/apache/spark/memory/SnappyUnifiedMemoryManager.scala
@@ -170,7 +170,7 @@ class SnappyUnifiedMemoryManager private[memory](
     * Clears the internal map
     */
   override def clear(): Unit = {
-    memoryForObject.clear()
+    if (_memoryForObjectMap ne null) _memoryForObjectMap.clear()
   }
 
   val threadsWaitingForStorage = new AtomicInteger()

--- a/cluster/src/main/scala/org/apache/spark/memory/SnappyUnifiedMemoryManager.scala
+++ b/cluster/src/main/scala/org/apache/spark/memory/SnappyUnifiedMemoryManager.scala
@@ -17,7 +17,7 @@
 package org.apache.spark.memory
 
 import java.nio.ByteBuffer
-import java.util.concurrent.atomic.{AtomicInteger, AtomicReference}
+import java.util.concurrent.atomic.{AtomicInteger}
 import java.util.function.Consumer
 
 import scala.collection.JavaConverters._
@@ -163,6 +163,7 @@ class SnappyUnifiedMemoryManager private[memory](
           bootManager.memoryForObject.addTo(objectName -> memoryMode, entry.getLongValue)
         }
       }
+      memoryForObject.clear()
     }
   }
 
@@ -732,22 +733,6 @@ class SnappyUnifiedMemoryManager private[memory](
 }
 
 object SnappyUnifiedMemoryManager extends Logging {
-
-  private val LOCK = new Object()
-
-  private val activeManager = new AtomicReference[SnappyUnifiedMemoryManager](null)
-
-  def getInstance(): Option[SnappyUnifiedMemoryManager] = {
-    LOCK.synchronized {
-      Option(activeManager.get())
-    }
-  }
-
-  private def setActiveContext(snsc: SnappyUnifiedMemoryManager): Unit = {
-    LOCK.synchronized {
-      activeManager.set(snsc)
-    }
-  }
 
   // Reserving minimum 500MB data for unaccounted data, GC headroom etc
   private val RESERVED_SYSTEM_MEMORY_BYTES = {

--- a/core/src/main/scala/org/apache/spark/memory/StoreUnifiedManager.scala
+++ b/core/src/main/scala/org/apache/spark/memory/StoreUnifiedManager.scala
@@ -70,6 +70,8 @@ trait StoreUnifiedManager {
     */
   def changeOffHeapOwnerToStorage(buffer: ByteBuffer,
       allowNonAllocator: Boolean): Unit
+
+  def close
 }
 
 /**
@@ -129,6 +131,8 @@ class DefaultMemoryManager extends StoreUnifiedManager with Logging {
   override def shouldStopRecovery(): Boolean = false
 
   override def initMemoryStats(stats: MemoryManagerStats): Unit = {}
+
+  override def close: Unit = {}
 }
 
 object MemoryManagerCallback extends Logging {
@@ -139,7 +143,7 @@ object MemoryManagerCallback extends Logging {
   val ummClass = "org.apache.spark.memory.SnappyUnifiedMemoryManager"
 
   // This memory manager will be used while GemXD is booting up and SparkEnv is not ready.
-  private[memory] lazy val tempMemoryManager = {
+  private[memory] lazy val bootMemoryManager = {
     try {
       val conf = new SparkConf()
       Utils.classForName(ummClass)
@@ -158,8 +162,9 @@ object MemoryManagerCallback extends Logging {
 
   private lazy val defaultManager: StoreUnifiedManager = new DefaultMemoryManager
 
+  // Is called from UMM.close()
   def resetMemoryManager(): Unit = synchronized {
-    snappyUnifiedManager = null // For local mode testing
+    snappyUnifiedManager = null
   }
 
 
@@ -167,7 +172,6 @@ object MemoryManagerCallback extends Logging {
     try {
       org.apache.spark.util.Utils.classForName(ummClass)
       // Class is loaded means we are running in SnappyCluster mode.
-
       true
     } catch {
       case _: ClassNotFoundException =>
@@ -203,7 +207,7 @@ object MemoryManagerCallback extends Logging {
           defaultManager
       }
     } else { // Spark.env will be null only with gemxd boot time
-      tempMemoryManager
+      bootMemoryManager
     }
   }
 }

--- a/core/src/main/scala/org/apache/spark/memory/StoreUnifiedManager.scala
+++ b/core/src/main/scala/org/apache/spark/memory/StoreUnifiedManager.scala
@@ -71,6 +71,14 @@ trait StoreUnifiedManager {
   def changeOffHeapOwnerToStorage(buffer: ByteBuffer,
       allowNonAllocator: Boolean): Unit
 
+  /**
+    * Clears the internal map
+    */
+  def clear
+
+  /**
+    * Closes the memory manager.
+    */
   def close
 }
 
@@ -133,6 +141,11 @@ class DefaultMemoryManager extends StoreUnifiedManager with Logging {
   override def initMemoryStats(stats: MemoryManagerStats): Unit = {}
 
   override def close: Unit = {}
+
+  /**
+    * Clears the internal map
+    */
+  override def clear: Unit = {}
 }
 
 object MemoryManagerCallback extends Logging {
@@ -143,7 +156,7 @@ object MemoryManagerCallback extends Logging {
   val ummClass = "org.apache.spark.memory.SnappyUnifiedMemoryManager"
 
   // This memory manager will be used while GemXD is booting up and SparkEnv is not ready.
-  private[memory] lazy val bootMemoryManager = {
+  lazy val bootMemoryManager = {
     try {
       val conf = new SparkConf()
       Utils.classForName(ummClass)
@@ -162,8 +175,9 @@ object MemoryManagerCallback extends Logging {
 
   private lazy val defaultManager: StoreUnifiedManager = new DefaultMemoryManager
 
-  // Is called from UMM.close()
+  // Is called from cache.close() && session.close() & umm.close
   def resetMemoryManager(): Unit = synchronized {
+    bootMemoryManager.clear
     snappyUnifiedManager = null
   }
 


### PR DESCRIPTION
There is a problem with the UMM when a executor goes down and comes up again. It will create a new UMM and its pools sizes will start from 0. The old state is not maintained. Also store reads SnappyUnifiedMemoryManager reference from MemoryManagerCallback which is a static field.
This means store & spark will account in two seprate UMM instance. 

## Changes proposed in this pull request
To avoid that problem piggy backed on the temporary memory manager which is create when store boots up and Spark env is not ready. 
When executor goes down it will now call close() method of UMM. UMM will copy the old state to the temporary memory manager. When spark env is ready it will copy from temp manager as before.

Also, fixed one potential problem when multiple tasks fails for some reason, then executor sometimes restarts multiple times. Although its not a big issue, avoiding this in this PR

Changed ClusterMgrDunit test to fail the executors properly. 

## Patch testing

Added test. Precheckin pending. 

## ReleaseNotes.txt changes

(Does this change require an entry in ReleaseNotes.txt? If yes, has it been added to it?)

## Other PRs 

(Does this change require changes in other projects- store, spark, spark-jobserver, aqp? Add the links of PR of the other subprojects that are related to this change)
