### PR TITLE
[SNAP-1989][SNAP-1986] merge concurrent column delta changes

### DIFF
--- a/cluster/src/dunit/scala/io/snappydata/cluster/SplitSnappyClusterDUnitTest.scala
+++ b/cluster/src/dunit/scala/io/snappydata/cluster/SplitSnappyClusterDUnitTest.scala
@@ -258,6 +258,7 @@ class SplitSnappyClusterDUnitTest(s: String)
     ColumnUpdateDeleteTests.testBasicDelete(session)
     ColumnUpdateDeleteTests.testSNAP1925(session)
     ColumnUpdateDeleteTests.testSNAP1926(session)
+    ColumnUpdateDeleteTests.testConcurrentOps(session)
   }
 }
 

--- a/cluster/src/main/scala/org/apache/spark/memory/SnappyUnifiedMemoryManager.scala
+++ b/cluster/src/main/scala/org/apache/spark/memory/SnappyUnifiedMemoryManager.scala
@@ -664,14 +664,14 @@ class SnappyUnifiedMemoryManager private[memory](
     val keys = memoryForObject.keySet().asScala
     val clearList = keys.filter(key => {
       if (key._2 eq memoryMode) {
-        val numBytes = memoryForObject.get(key)
+        val numBytes = memoryForObject.getLong(key)
         super.releaseStorageMemory(numBytes, memoryMode)
         val offHeap = memoryMode eq MemoryMode.OFF_HEAP
         wrapperStats.decStorageMemoryUsed(offHeap, numBytes)
         true
       } else false
     })
-    clearList.foreach(key => memoryForObject.remove(key))
+    clearList.foreach(key => memoryForObject.removeLong(key))
   }
 
   // Recovery is a special case. If any of the storage pool has reached 90% of

--- a/cluster/src/test/scala/org/apache/spark/sql/store/ColumnUpdateDeleteTest.scala
+++ b/cluster/src/test/scala/org/apache/spark/sql/store/ColumnUpdateDeleteTest.scala
@@ -68,6 +68,10 @@ class ColumnUpdateDeleteTest extends ColumnTablesTestBase {
     ColumnUpdateDeleteTests.testSNAP1926(this.snc.snappySession)
   }
 
+  test("concurrent ops") {
+    ColumnUpdateDeleteTests.testConcurrentOps(this.snc.snappySession)
+  }
+
   ignore("test update for all types") {
     val session = this.snc.snappySession
     // reduced size to ensure both column table and row buffer have data

--- a/core/src/dunit/scala/io/snappydata/cluster/SplitClusterDUnitTestBase.scala
+++ b/core/src/dunit/scala/io/snappydata/cluster/SplitClusterDUnitTestBase.scala
@@ -172,6 +172,7 @@ trait SplitClusterDUnitTestBase extends Logging {
         ColumnUpdateDeleteTests.testBasicDelete(session)
         ColumnUpdateDeleteTests.testSNAP1925(session)
         ColumnUpdateDeleteTests.testSNAP1926(session)
+        ColumnUpdateDeleteTests.testConcurrentOps(session)
       }
     })
   }

--- a/core/src/main/java/io/snappydata/impl/SnappyHiveCatalog.java
+++ b/core/src/main/java/io/snappydata/impl/SnappyHiveCatalog.java
@@ -140,10 +140,6 @@ public class SnappyHiveCatalog implements ExternalCatalog {
       System.setProperty(name, props.getProperty(name));
     }
     Hive.closeCurrent();
-    // clear the system properties else it causes trouble with integer values
-    for (String name : propertyNames) {
-      System.clearProperty(name);
-    }
 
     // set integer properties after the system properties have been used by
     // Hive static initialization so that these never go into system properties

--- a/core/src/main/java/org/apache/spark/sql/hive/SnappySharedState.java
+++ b/core/src/main/java/org/apache/spark/sql/hive/SnappySharedState.java
@@ -111,7 +111,7 @@ public final class SnappySharedState extends SharedState {
     try {
       // avoid inheritance of activeSession
       SparkSession.clearActiveSession();
-      this.client = new HiveClientUtil(sparkContext()).client();
+      this.client = HiveClientUtil$.MODULE$.newClient(sparkContext());
     } finally {
       SnappyHiveCatalog.SKIP_HIVE_TABLE_CALLS.set(oldFlag);
     }

--- a/core/src/main/scala/org/apache/spark/sql/execution/columnar/ColumnDeleteExec.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/columnar/ColumnDeleteExec.scala
@@ -113,8 +113,7 @@ case class ColumnDeleteExec(child: SparkPlan, columnTable: String,
     ctx.INPUT_ROW = null
     ctx.currentVars = input
     val keysInput = ctx.generateExpressions(keyColumns.map(
-      u => ExpressionCanonicalizer.execute(BindReferences.bindReference(
-        u, child.output))), doSubexpressionElimination = true)
+      u => ExpressionCanonicalizer.execute(BindReferences.bindReference(u, child.output))))
     ctx.currentVars = null
 
     val keyVars = keysInput.takeRight(3)

--- a/core/src/main/scala/org/apache/spark/sql/execution/columnar/ColumnTableScan.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/columnar/ColumnTableScan.scala
@@ -506,7 +506,9 @@ private[sql] final case class ColumnTableScan(
       ctx.addMutableState(updatedDecoderClass, updatedDecoder, "")
 
       var deletedInit = ""
-      if (index == 0) {
+      // add deleted column check if there is at least one column to scan
+      // (else it is taken care of by deletedCount being reduced from batch size)
+      if (rsIndex == 0) {
         val incrementDeletedBatchCount = if (deletedBatchCount eq null) ""
         else s"\nif ($deletedDecoder != null) $deletedBatchCount.${metricAdd("1")};"
         deletedInit =

--- a/core/src/main/scala/org/apache/spark/sql/execution/columnar/encoding/BooleanBitSetEncoding.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/columnar/encoding/BooleanBitSetEncoding.scala
@@ -21,7 +21,6 @@ import java.nio.ByteBuffer
 import com.gemstone.gemfire.internal.shared.BufferAllocator
 
 import org.apache.spark.sql.types.{BooleanType, DataType, StructField}
-import org.apache.spark.unsafe.bitset.BitSetMethods
 
 trait BooleanBitSetEncoding extends ColumnEncoding {
 

--- a/core/src/main/scala/org/apache/spark/sql/execution/columnar/impl/ColumnDelta.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/columnar/impl/ColumnDelta.scala
@@ -26,8 +26,7 @@ import com.gemstone.gemfire.internal.cache.{DiskEntry, EntryEventImpl}
 import com.pivotal.gemfirexd.internal.engine.GfxdSerializable
 import com.pivotal.gemfirexd.internal.engine.store.GemFireContainer
 
-import org.apache.spark.sql.catalyst.expressions.codegen.{CodegenContext, ExprCode}
-import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeReference, AttributeSeq, BindReferences}
+import org.apache.spark.sql.catalyst.expressions.AttributeReference
 import org.apache.spark.sql.execution.columnar.encoding.ColumnDeltaEncoder
 import org.apache.spark.sql.types.{IntegerType, LongType, StructField, StructType}
 
@@ -146,17 +145,6 @@ object ColumnDelta {
     StructField(mutableKeyNames(2), IntegerType, nullable = false)
   )
   def mutableKeyAttributes: Seq[AttributeReference] = StructType(mutableKeyFields).toAttributes
-
-  def bindKeyColumns(keyColumns: Seq[Attribute], ctx: CodegenContext,
-      input: Seq[ExprCode], output: AttributeSeq): (ExprCode, ExprCode, ExprCode) = {
-    ctx.INPUT_ROW = null
-    ctx.currentVars = input
-    val ordinalId = BindReferences.bindReference(keyColumns.head, output).genCode(ctx)
-    val batchId = BindReferences.bindReference(keyColumns(1), output).genCode(ctx)
-    val bucketId = BindReferences.bindReference(keyColumns(2), output).genCode(ctx)
-    ctx.currentVars = null
-    (ordinalId, batchId, bucketId)
-  }
 
   def deltaHierarchyDepth(deltaColumnIndex: Int): Int = if (deltaColumnIndex < 0) {
     (-deltaColumnIndex + ColumnFormatEntry.DELETE_MASK_COL_INDEX - 1) % MAX_DEPTH

--- a/core/src/main/scala/org/apache/spark/sql/execution/row/RowDeleteExec.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/row/RowDeleteExec.scala
@@ -48,8 +48,7 @@ case class RowDeleteExec(child: SparkPlan, resolvedName: String,
     ctx.currentVars = input
     // bind the key columns
     val stmtInput = ctx.generateExpressions(keyColumns.map(
-      u => ExpressionCanonicalizer.execute(BindReferences.bindReference(
-        u, child.output))), doSubexpressionElimination = true)
+      u => ExpressionCanonicalizer.execute(BindReferences.bindReference(u, child.output))))
     ctx.currentVars = null
 
     val stmtSchema = StructType.fromAttributes(keyColumns)

--- a/core/src/main/scala/org/apache/spark/sql/hive/HiveClientUtil.scala
+++ b/core/src/main/scala/org/apache/spark/sql/hive/HiveClientUtil.scala
@@ -45,7 +45,7 @@ import org.apache.spark.{Logging, SparkContext}
  * Difference being we take a connection to underlying GemXD store.
  * TODO We need to investigate if we can phase out this class and use HiveUtils directly.
  */
-class HiveClientUtil(val sparkContext: SparkContext) extends Logging {
+private class HiveClientUtil(sparkContext: SparkContext) extends Logging {
 
   /** The version of hive used internally by Spark SQL. */
   private val hiveExecutionVersion = HiveUtils.hiveExecutionVersion
@@ -125,10 +125,6 @@ class HiveClientUtil(val sparkContext: SparkContext) extends Logging {
    * The version of the Hive client that is used here must match the
    * meta-store that is configured in the hive-site.xml file.
    */
-  @transient
-  protected[sql] var client: HiveClient = newClientWithLogSetting()
-
-
   private def newClientWithLogSetting(): HiveClient = {
     val currentLevel = ClientSharedUtils.converToJavaLogLevel(LogManager.getRootLogger.getLevel)
     try {
@@ -156,7 +152,7 @@ class HiveClientUtil(val sparkContext: SparkContext) extends Logging {
     }
   }
 
-  private def newClient(): HiveClient = synchronized {
+  private def newClient(): HiveClient = {
 
     val metaVersion = IsolatedClientLoader.hiveVersion(hiveMetastoreVersion)
     // We instantiate a HiveConf here to read in the hive-site.xml file and
@@ -291,5 +287,12 @@ class HiveClientUtil(val sparkContext: SparkContext) extends Logging {
       case ExternalClusterMode(_, _) =>
         (null, null)
     }
+  }
+}
+
+object HiveClientUtil {
+
+  def newClient(sparkContext: SparkContext): HiveClient = synchronized {
+    new HiveClientUtil(sparkContext).newClientWithLogSetting()
   }
 }

--- a/core/src/test/scala/io/snappydata/ColumnUpdateDeleteTests.scala
+++ b/core/src/test/scala/io/snappydata/ColumnUpdateDeleteTests.scala
@@ -404,7 +404,7 @@ object ColumnUpdateDeleteTests extends Assertions {
         res = snappy.sql(s"update updateTable set id = $idUpdate, " +
             s"addr = concat('addrUpd', cast(($idUpdate) as string)) " +
             s"where (id % $step) = $i").collect()
-        assert(res.map(_.getLong(0)).sum === numElements / step)
+        assert(res.map(_.getLong(0)).sum > 0)
       } catch {
         case t: Throwable =>
           exceptions += Thread.currentThread() -> t
@@ -432,7 +432,7 @@ object ColumnUpdateDeleteTests extends Assertions {
         barrier.await()
         res = snappy.sql(
           s"delete from updateTable where (id % $step) = ${step - i - 1}").collect()
-        assert(res.map(_.getLong(0)).sum === numElements / step)
+        assert(res.map(_.getLong(0)).sum > 0)
       } catch {
         case t: Throwable =>
           exceptions += Thread.currentThread() -> t

--- a/core/src/test/scala/io/snappydata/ColumnUpdateDeleteTests.scala
+++ b/core/src/test/scala/io/snappydata/ColumnUpdateDeleteTests.scala
@@ -432,7 +432,7 @@ object ColumnUpdateDeleteTests extends Assertions {
         barrier.await()
         res = snappy.sql(
           s"delete from updateTable where (id % $step) = ${step - i - 1}").collect()
-        assert(res.map(_.getLong(0)).sum >= 0)
+        assert(res.map(_.getLong(0)).sum === numElements / step)
       } catch {
         case t: Throwable =>
           exceptions += Thread.currentThread() -> t

--- a/core/src/test/scala/io/snappydata/ColumnUpdateDeleteTests.scala
+++ b/core/src/test/scala/io/snappydata/ColumnUpdateDeleteTests.scala
@@ -17,6 +17,12 @@
 
 package io.snappydata
 
+import java.util.concurrent.{CyclicBarrier, Executors}
+
+import scala.collection.concurrent.TrieMap
+import scala.concurrent.duration.Duration
+import scala.concurrent.{Await, ExecutionContext, Future}
+
 import org.scalatest.Assertions
 
 import org.apache.spark.sql.SnappySession
@@ -342,6 +348,109 @@ object ColumnUpdateDeleteTests extends Assertions {
     assert(result.length === numElements - 1)
 
     session.sql("drop table customers")
+    session.conf.unset(Property.ColumnBatchSize.name)
+  }
+
+  def testConcurrentOps(session: SnappySession): Unit = {
+    // reduced size to ensure both column table and row buffer have data
+    session.conf.set(Property.ColumnBatchSize.name, "10k")
+
+    val numElements = 100000
+    val concurrency = 8
+    // each thread will update/delete after these many rows
+    val step = 10
+
+    session.sql("drop table if exists updateTable")
+    session.sql("drop table if exists checkTable1")
+    session.sql("drop table if exists checkTable2")
+    session.sql("drop table if exists checkTable3")
+
+    session.sql("create table updateTable (id int, addr string, status boolean) " +
+        "using column options(buckets '5')")
+    session.sql("create table checkTable1 (id int, addr string, status boolean) " +
+        "using column options(buckets '3')")
+    session.sql("create table checkTable2 (id int, addr string, status boolean) " +
+        "using column options(buckets '7')")
+
+    session.range(numElements).selectExpr("id", "concat('addr', cast(id as string))",
+      "case when (id % 2) = 0 then true else false end").write.insertInto("updateTable")
+
+    // expected results after updates in this table
+    val idUpdate = s"id + ($numElements / 2)"
+    val idSet = s"case when (id % $step) < $concurrency then id + ($numElements / 2) else id end"
+    val addrSet = s"case when (id % $step) < $concurrency " +
+        s"then concat('addrUpd', cast(($idUpdate) as string)) " +
+        s"else concat('addr', cast(id as string)) end"
+    session.range(numElements).selectExpr(idSet, addrSet,
+      "case when (id % 2) = 0 then true else false end").write.insertInto("checkTable1")
+
+    // expected results after updates and deletes in this table
+    session.table("checkTable1").filter(s"(id % $step) < ${step - concurrency}")
+        .write.insertInto("checkTable2")
+
+    val exceptions = new TrieMap[Thread, Throwable]
+    val executionContext = ExecutionContext.fromExecutorService(
+      Executors.newFixedThreadPool(concurrency + 2))
+
+    // concurrent updates to different rows but same batches
+    val barrier = new CyclicBarrier(concurrency)
+    var tasks = Array.tabulate(concurrency)(i => Future {
+      try {
+        val snappy = new SnappySession(session.sparkContext)
+        var res = snappy.sql("select count(*) from updateTable").collect()
+        assert(res(0).getLong(0) === numElements)
+
+        barrier.await()
+        res = snappy.sql(s"update updateTable set id = $idUpdate, " +
+            s"addr = concat('addrUpd', cast(($idUpdate) as string)) " +
+            s"where (id % $step) = $i").collect()
+        assert(res.map(_.getLong(0)).sum === numElements / step)
+      } catch {
+        case t: Throwable =>
+          exceptions += Thread.currentThread() -> t
+          throw t
+      }
+    }(executionContext))
+    tasks.foreach(Await.ready(_, Duration.Inf))
+
+    assert(exceptions.isEmpty, s"Failed with exceptions: $exceptions")
+
+    session.table("updateTable").show()
+    session.table("checkTable1").show()
+
+    var res = session.sql(
+      "select * from updateTable EXCEPT select * from checkTable1").collect()
+    assert(res.length === 0)
+
+    // concurrent deletes
+    tasks = Array.tabulate(concurrency)(i => Future {
+      try {
+        val snappy = new SnappySession(session.sparkContext)
+        var res = snappy.sql("select count(*) from updateTable").collect()
+        assert(res(0).getLong(0) === numElements)
+
+        barrier.await()
+        res = snappy.sql(
+          s"delete from updateTable where (id % $step) = ${step - i - 1}").collect()
+        assert(res.map(_.getLong(0)).sum >= 0)
+      } catch {
+        case t: Throwable =>
+          exceptions += Thread.currentThread() -> t
+          throw t
+      }
+    }(executionContext))
+    tasks.foreach(Await.ready(_, Duration.Inf))
+
+    assert(exceptions.isEmpty, s"Failed with exceptions: $exceptions")
+
+    res = session.sql(
+      "select * from updateTable EXCEPT select * from checkTable2").collect()
+    assert(res.length === 0)
+
+    // cleanup
+    session.sql("drop table updateTable")
+    session.sql("drop table checkTable1")
+    session.sql("drop table checkTable2")
     session.conf.unset(Property.ColumnBatchSize.name)
   }
 }

--- a/dtests/src/test/java/io/snappydata/hydra/testDMLOps/SnappyDMLOpsUtil.java
+++ b/dtests/src/test/java/io/snappydata/hydra/testDMLOps/SnappyDMLOpsUtil.java
@@ -755,7 +755,8 @@ public class SnappyDMLOpsUtil extends SnappyTest {
     try (Stream<String> lines = Files.lines(Paths.get(csvFilePath + File.separator + csvFileName))) {
       row = lines.skip(insertCounter).findFirst().get();
     } catch (IOException io) {
-      throw new TestException("File not found at specified location.");
+      throw new TestException("File not found at specified location " +
+          (csvFilePath + File.separator + csvFileName));
     }
     return row;
   }


### PR DESCRIPTION
## Changes proposed in this pull request

- update store link for the fix to SNAP-1989
- added unit tests for concurrenct updates/deletes
- use sync on a singleton object HiveClientUtil to fix SNAP-1986
- also fixed code generation issue with subExpressionElimination=true
  that need InternalRow to be present (which is not created in
      snappy plans) -- see Codegenerator.scala:765;
  instead using wholestage subExpression elimination as done
  in HashAggregateExec for update plans and removed from delete
  plans which is not required since there are no update expressions

## Patch testing

precheckin

## ReleaseNotes.txt changes

NA

## Other PRs 

https://github.com/SnappyDataInc/snappy-store/pull/298