### PR TITLE
Fix for SNAP-1985

### DIFF
--- a/cluster/src/test/scala/org/apache/spark/sql/store/ColumnUpdateDeleteTest.scala
+++ b/cluster/src/test/scala/org/apache/spark/sql/store/ColumnUpdateDeleteTest.scala
@@ -78,7 +78,7 @@ class ColumnUpdateDeleteTest extends ColumnTablesTestBase {
     session.conf.unset(Property.ColumnBatchSize.name)
   }
 
-  ignore("SNAP-1985: update delete on string type") {
+  test("SNAP-1985: update delete on string type") {
     val tableName1 = "order_line_1_col_str"
     val tableName2 = "order_line_2_ud_str"
 

--- a/core/src/main/scala/org/apache/spark/sql/execution/columnar/encoding/BooleanBitSetEncoding.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/columnar/encoding/BooleanBitSetEncoding.scala
@@ -82,7 +82,7 @@ trait BooleanBitSetEncoderBase
   }
 
   override def initialize(dataType: DataType, nullable: Boolean, initSize: Int,
-      withHeader: Boolean, allocator: BufferAllocator): Long = {
+      withHeader: Boolean, allocator: BufferAllocator, minBufferSize: Int = -1): Long = {
     byteCursor = super.initialize(dataType, nullable, initSize,
       withHeader, allocator)
     dataOffset = byteCursor - columnBeginPosition

--- a/core/src/main/scala/org/apache/spark/sql/execution/columnar/encoding/BooleanBitSetEncoding.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/columnar/encoding/BooleanBitSetEncoding.scala
@@ -84,7 +84,7 @@ trait BooleanBitSetEncoderBase
   override def initialize(dataType: DataType, nullable: Boolean, initSize: Int,
       withHeader: Boolean, allocator: BufferAllocator, minBufferSize: Int = -1): Long = {
     byteCursor = super.initialize(dataType, nullable, initSize,
-      withHeader, allocator)
+      withHeader, allocator, minBufferSize)
     dataOffset = byteCursor - columnBeginPosition
     currentWord = 0L
     // returns the OR mask to use for currentWord

--- a/core/src/main/scala/org/apache/spark/sql/execution/columnar/encoding/ColumnDeleteEncoder.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/columnar/encoding/ColumnDeleteEncoder.scala
@@ -66,7 +66,8 @@ final class ColumnDeleteEncoder extends ColumnEncoder {
   }
 
   override def initialize(dataType: DataType, nullable: Boolean, initSize: Int,
-      withHeader: Boolean, allocator: BufferAllocator): Long = initialize(initSize)
+      withHeader: Boolean, allocator: BufferAllocator,
+      minBufferSize: Int = -1): Long = initialize(initSize)
 
   override def writeInt(cursor: Long, value: Int): Long = {
     if (cursor >= deletedPositions.length) {

--- a/core/src/main/scala/org/apache/spark/sql/execution/columnar/encoding/ColumnDeltaEncoder.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/columnar/encoding/ColumnDeltaEncoder.scala
@@ -150,7 +150,7 @@ final class ColumnDeltaEncoder(val hierarchyDepth: Int) extends ColumnEncoder {
    * @return initial position of the cursor that caller must use to write
    */
   override def initialize(dataType: DataType, nullable: Boolean, initSize: Int,
-      withHeader: Boolean, allocator: BufferAllocator): Long = {
+      withHeader: Boolean, allocator: BufferAllocator, minBufferSize: Int = -1): Long = {
     if (initSize < 4 || (initSize < ColumnDelta.INIT_SIZE && hierarchyDepth > 0)) {
       throw new IllegalStateException(
         s"Batch size = $initSize too small for hierarchy depth = $hierarchyDepth")
@@ -361,9 +361,8 @@ final class ColumnDeltaEncoder(val hierarchyDepth: Int) extends ColumnEncoder {
     var positionCursor2 = 0L
     val existingValueSize = existingValue.remaining()
 
-    realEncoder = ColumnEncoding.getColumnEncoder(dataType,
-      field.nullable && (decoder1.hasNulls || decoder2.hasNulls))
-    realEncoder.setAllocator(allocator)
+    val nullable = field.nullable && (decoder1.hasNulls || decoder2.hasNulls)
+    realEncoder = ColumnEncoding.getColumnEncoder(dataType, nullable)
     // Set the source of encoder with an upper limit for bytes that also avoids
     // checking buffer limit when writing position integers.
     // realEncoder will contain the intermediate and final merged and encoded delta.
@@ -371,12 +370,11 @@ final class ColumnDeltaEncoder(val hierarchyDepth: Int) extends ColumnEncoder {
     // so one copy of the encoded bytes has to be made. An alternative could be
     // to do one traversal to determine duplicates and get final size but that
     // would be overall slower than making one extra flat byte array copy.
-    realEncoder.setSource(allocator.allocateForStorage(ColumnEncoding.checkBufferSize(
-      newValueSize + existingValueSize)), releaseOld = false)
+    var cursor = realEncoder.initialize(dataType, nullable, ColumnDelta.INIT_SIZE,
+      withHeader = false, allocator, newValueSize + existingValueSize)
 
     val writer = DeltaWriter(dataType)
-    // merge and write the sorted positions and corresponding values;
-    var cursor = realEncoder.columnBeginPosition
+    // merge and write the sorted positions and corresponding values
     // the positions are written to this encoder if the end result is a delta
     if (existingIsDelta) {
       positionIndex = 0

--- a/core/src/main/scala/org/apache/spark/sql/execution/columnar/encoding/ColumnEncoding.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/columnar/encoding/ColumnEncoding.scala
@@ -273,8 +273,24 @@ trait ColumnEncoder extends ColumnEncoding {
    * @param allocator  the [[BufferAllocator]] to use for the data
    * @return initial position of the cursor that caller must use to write
    */
-  def initialize(dataType: DataType, nullable: Boolean, initSize: Int,
+  final def initialize(dataType: DataType, nullable: Boolean, initSize: Int,
       withHeader: Boolean, allocator: BufferAllocator): Long = {
+    initialize(dataType, nullable, initSize, withHeader, allocator, minBufferSize = -1)
+  }
+
+  /**
+   * Initialize this ColumnEncoder.
+   *
+   * @param dataType   DataType of the field to be written
+   * @param nullable   True if the field is nullable, false otherwise
+   * @param initSize   Initial estimated number of elements to be written
+   * @param withHeader True if header is to be written to data (typeId etc)
+   * @param allocator  the [[BufferAllocator]] to use for the data
+   * @param minBufferSize the minimum size of initial buffer to use (ignored if <= 0)
+   * @return initial position of the cursor that caller must use to write
+   */
+  def initialize(dataType: DataType, nullable: Boolean, initSize: Int,
+      withHeader: Boolean, allocator: BufferAllocator, minBufferSize: Int): Long = {
     setAllocator(allocator)
     val defSize = defaultSize(dataType)
 
@@ -302,7 +318,7 @@ trait ColumnEncoder extends ColumnEncoding {
       } else {
         initByteSize = initSizeInBytes(dataType, initSize, defSize) + baseSize
       }
-      setSource(allocator.allocate(checkBufferSize(initByteSize),
+      setSource(allocator.allocate(checkBufferSize(math.max(initByteSize, minBufferSize)),
         ColumnEncoding.BUFFER_OWNER), releaseOld = true)
     } else {
       // for primitive types optimistically trim to exact size

--- a/core/src/main/scala/org/apache/spark/sql/execution/columnar/encoding/DictionaryEncoding.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/columnar/encoding/DictionaryEncoding.scala
@@ -175,6 +175,7 @@ trait DictionaryEncoderBase extends ColumnEncoder with DictionaryEncoding {
   private final var longMap: ObjectHashSet[LongIndexKey] = _
   private final var longArray: TLongArrayList = _
   private final var isIntMap: Boolean = _
+  private final var writeHeader: Boolean = true
 
   @transient private final var isShortDictionary: Boolean = _
 
@@ -197,20 +198,19 @@ trait DictionaryEncoderBase extends ColumnEncoder with DictionaryEncoding {
     case _ => dataType.defaultSize // accommodate values without expansion
   }
 
-  protected def initializeIndexBytes(initSize: Int,
+  protected def initializeIndexBytes(initSize: Int, minSize: Int,
       releaseOld: Boolean): Unit = {
     if (!releaseOld || (columnData eq null)) {
       // 2 byte indexes for short dictionary while 4 bytes for big dictionary
       val numBytes = if (isShortDictionary) initSize << 1L else initSize << 2L
-      setSource(allocator.allocate(numBytes, ColumnEncoding.BUFFER_OWNER),
-        releaseOld)
+      setSource(allocator.allocate(math.max(numBytes, minSize),
+        ColumnEncoding.BUFFER_OWNER), releaseOld)
     }
   }
 
   override def initialize(dataType: DataType, nullable: Boolean, initSize: Int,
-      withHeader: Boolean, allocator: BufferAllocator): Long = {
-    assert(withHeader, "DictionaryEncoding not supported without header")
-
+      withHeader: Boolean, allocator: BufferAllocator, minBufferSize: Int): Long = {
+    writeHeader = withHeader
     setAllocator(allocator)
     dataType match {
       case StringType =>
@@ -233,11 +233,11 @@ trait DictionaryEncoderBase extends ColumnEncoder with DictionaryEncoding {
         longArray = new TLongArrayList(mapSize)
         isIntMap = t.isInstanceOf[IntegerType]
     }
-    initializeLimits()
+    if (withHeader) initializeLimits()
     initializeNulls(initSize)
     // start with the short dictionary having 2 byte indexes
     isShortDictionary = true
-    initializeIndexBytes(initSize, releaseOld = true)
+    initializeIndexBytes(initSize, minBufferSize, releaseOld = true)
     // return the cursor for index bytes
     columnBeginPosition
   }
@@ -294,7 +294,7 @@ trait DictionaryEncoderBase extends ColumnEncoder with DictionaryEncoding {
     val oldIndexBytes = columnBytes
     var oldCursor = columnBeginPosition
     // force new columnData creation since need to copy in different format
-    initializeIndexBytes(newNumIndexes, releaseOld = false)
+    initializeIndexBytes(newNumIndexes, minSize = -1, releaseOld = false)
     var cursor = columnBeginPosition
     // copy over short indexes from previous index bytes
     var i = 0
@@ -431,12 +431,14 @@ trait DictionaryEncoderBase extends ColumnEncoder with DictionaryEncoding {
     val columnBytes = storageAllocator.baseObject(columnData)
     val baseOffset = storageAllocator.baseOffset(columnData)
     var cursor = baseOffset
-    // typeId
-    ColumnEncoding.writeInt(columnBytes, cursor, typeId)
-    cursor += 4
-    // number of nulls
-    ColumnEncoding.writeInt(columnBytes, cursor, numNullBytes)
-    cursor += 4
+    if (writeHeader) {
+      // typeId
+      ColumnEncoding.writeInt(columnBytes, cursor, typeId)
+      cursor += 4
+      // number of nulls
+      ColumnEncoding.writeInt(columnBytes, cursor, numNullBytes)
+      cursor += 4
+    }
     // write the null bytes
     cursor = writeNulls(columnBytes, cursor, numNullWords)
 


### PR DESCRIPTION
## Changes proposed in this pull request

Issue is with merging of two deltas. While merging, we create a decoder and initialize it properties based on the decoders that are being merged. But encoder.initialize is not called and stringMap field of the DictionaryEncoder remains uninitialized and hence a null pointer exception. This code calls the initialize passing a minimum size.
Also allows "withHeader=false" for dictionary encoding 

Fix from @sumwale 

## Patch testing

Enabled the test and precheckin. 