### PR TITLE
Check for any exception in the output of running commands in spark-shell

### DIFF
--- a/core/src/dunit/scala/io/snappydata/cluster/SplitClusterDUnitSecurityTest.scala
+++ b/core/src/dunit/scala/io/snappydata/cluster/SplitClusterDUnitSecurityTest.scala
@@ -202,41 +202,10 @@ class SplitClusterDUnitSecurityTest(s: String)
 
   // Test to make sure that stock spark-shell works with SnappyData core jar
   def testSparkShell(): Unit = {
-    // perform some operation thru spark-shell
-    val jars = Files.newDirectoryStream(Paths.get(s"$snappyProductDir/../distributions/"),
-      "snappydata-core*.jar")
-    val snappyDataCoreJar = jars.iterator().next().toAbsolutePath.toString
-    // SparkSqlTestCode.txt file contains the commands executed on spark-shell
-    val scriptFile: String = getClass.getResource("/SparkSqlTestCode.txt").getPath
-    val sparkShellCommand = productDir + "/bin/spark-shell  --master local[3]" +
-        s" --conf spark.snappydata.connection=localhost:$locatorClientPort" +
-        s" --conf spark.snappydata.store.user=$jdbcUser1" +
-        s" --conf spark.snappydata.store.password=$jdbcUser1" +
-        s" --jars $snappyDataCoreJar" +
-        s" -i $scriptFile"
-
-    val cwd = new java.io.File("spark-shell-out")
-    FileUtils.deleteQuietly(cwd)
-    cwd.mkdirs()
-    logInfo(s"about to invoke spark-shell with command: $sparkShellCommand in $cwd")
-
-    Process(sparkShellCommand, cwd).!!
-    FileUtils.deleteQuietly(cwd)
-
     val props = new Properties()
     props.setProperty(Attribute.USERNAME_ATTR, jdbcUser1)
     props.setProperty(Attribute.PASSWORD_ATTR, jdbcUser1)
-    val conn = SplitClusterDUnitTest.getConnection(locatorClientPort, props)
-    val stmt = conn.createStatement()
-
-    // accessing tables created thru spark-shell
-    val rs1 = stmt.executeQuery("select count(*) from coltable")
-    rs1.next()
-    assert(rs1.getInt(1) == 5)
-
-    val rs2 = stmt.executeQuery("select count(*) from rowtable")
-    rs2.next()
-    assert(rs2.getInt(1) == 5)
+    SplitClusterDUnitTest.invokeSparkShell(snappyProductDir, locatorClientPort, props)
   }
 
   def testPreparedStatements(): Unit = {

--- a/tests/common/src/main/resources/SparkSqlTestCode.txt
+++ b/tests/common/src/main/resources/SparkSqlTestCode.txt
@@ -32,12 +32,12 @@ assert(result1.length == 5)
 println("Creating a row table")
 snappy.sql("CREATE TABLE ROWTABLE (COL1 INT, COL2 INT, COL3 STRING)")
 snappy.sql("INSERT INTO ROWTABLE VALUES (1, 1, '1'), (2, 2, '2'), (3, 3, '3'), (4, 4, '4'), (5, 5, '5')")
-val result2 = snappy.sql("SELECT COL1 FROM COLTABLE ORDER BY COL1").collect
+val result2 = snappy.sql("SELECT COL1 FROM ROWTABLE ORDER BY COL1").collect
 assert(result2.length == 5)
 
 // also check SparkSession
 val sparkTable = spark.range(1000000).selectExpr("id", "concat('sym', cast((id % 100) as STRING)) as sym")
 sparkTable.createOrReplaceTempView("sparkTable")
-spark.sql("select sym, avg(id) from sparkCacheTable group by sym").collect()
+spark.sql("select sym, avg(id) from sparkTable group by sym").collect()
 
 System.exit(0)


### PR DESCRIPTION
## Changes proposed in this pull request
* Check for any exception in the output of running commands in spark-shell
* This was needed as some stack traces are shown on the spark console on rc1 branch which the test could have caught. Also, it also silently passed with some typos/bugs in the SparkSqlTestCode.txt
* Refactor testSparkShell() so that same code is re-used by SplitClusterDUnitSecurityTest

## Patch testing
SplitClusterDUnitTest. precheckin NOT REQUIRED.

## ReleaseNotes.txt changes
NA

## Other PRs 
NA