### PR TITLE
[AQP-293] changes for JNI UTF8String.contains

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -671,11 +671,12 @@ task product(type: Zip) {
 
   def clusterProject = project(":snappy-cluster_${scalaBinaryVersion}")
   def targetProject = clusterProject
-  def hasAQPProject = new File(rootDir, 'aqp/build.gradle').exists()
+  def isEnterpriseProduct = new File(rootDir, 'aqp/build.gradle').exists() &&
+      rootProject.hasProperty('snappydata.enterprise')
   def hasJdbcConnectorProject = new File(rootDir,
       'snappy-connectors/jdbc-stream-connector/build.gradle').exists()
 
-  if (hasAQPProject && rootProject.hasProperty('snappydata.enterprise')) {
+  if (isEnterpriseProduct) {
     dependsOn ":snappy-aqp_${scalaBinaryVersion}:jar"
     targetProject = project(":snappy-aqp_${scalaBinaryVersion}")
   }
@@ -772,13 +773,20 @@ task product(type: Zip) {
     if (new File(rootDir, 'store/build.gradle').exists()) {
       // copy snappy-store shared libraries for optimized JNI calls
       copy {
-        from "${project(':snappy-store:snappydata-store-core').projectDir}/lib"
+        from project(':snappy-store:snappydata-store-core').projectDir.path + '/lib'
         into "${snappyProductDir}/jars"
       }
       copy {
         from "${project(':snappy-store:snappydata-store-core').projectDir}/../quickstart"
         into "${snappyProductDir}/quickstart/store"
         exclude '.git*'
+      }
+    }
+    if (isEnterpriseProduct) {
+      // copy enterprise shared libraries for optimized JNI calls
+      copy {
+        from project(":snappy-aqp_${scalaBinaryVersion}").projectDir.path + '/lib'
+        into "${snappyProductDir}/jars"
       }
     }
     copy {

--- a/cluster/src/main/scala/io/snappydata/gemxd/SparkSQLExecuteImpl.scala
+++ b/cluster/src/main/scala/io/snappydata/gemxd/SparkSQLExecuteImpl.scala
@@ -90,14 +90,14 @@ class SparkSQLExecuteImpl(val sql: String,
   // check for query hint to serialize complex types as JSON strings
   private[this] val complexTypeAsJson = session.getPreviousQueryHints.get(
     QueryHint.ComplexTypeAsJson.toString) match {
-    case Some(v) => Misc.parseBoolean(v)
     case None => false
+    case Some(v) => Misc.parseBoolean(v)
   }
 
   private val (allAsClob, columnsAsClob) = session.getPreviousQueryHints.get(
     QueryHint.ColumnsAsClob.toString) match {
-    case Some(v) => Utils.parseColumnsAsClob(v)
     case None => (false, Set.empty[String])
+    case Some(v) => Utils.parseColumnsAsClob(v)
   }
 
   override def packRows(msg: LeadNodeExecutorMsg,

--- a/cluster/src/test/scala/io/snappydata/cluster/PreparedQueryRoutingSingleNodeSuite.scala
+++ b/cluster/src/test/scala/io/snappydata/cluster/PreparedQueryRoutingSingleNodeSuite.scala
@@ -460,12 +460,14 @@ class PreparedQueryRoutingSingleNodeSuite extends SnappyFunSuite with BeforeAndA
   }
 
   test("update delete on column table") {
+    val snc = this.snc
     val serverHostPort = TestUtil.startNetServer()
     // println("network server started")
     PreparedQueryRoutingSingleNodeSuite.updateDeleteOnColumnTable(snc, serverHostPort)
   }
 
   test("SNAP-1981: Equality on string columns") {
+    val snc = this.snc
     val serverHostPort = TestUtil.startNetServer()
     // println("network server started")
     PreparedQueryRoutingSingleNodeSuite.equalityOnStringColumn(snc, serverHostPort)
@@ -694,7 +696,7 @@ object PreparedQueryRoutingSingleNodeSuite{
       prepStatement0.setString(2, "4")
       prepStatement0.setString(3, "94%")
       verifyResults("equalityOnStringColumn_query1-select1", prepStatement0.executeQuery,
-        Array(3, 4, 94, 940, 941, 942, 943, 944, 945, 946, 947, 948, 949), cacheMapSize + 1)
+        Array(3, 4, 94, 940, 941, 942, 943, 944, 945, 946, 947, 948, 949), cacheMapSize)
 
       prepStatement1 = conn.prepareStatement( s"select ol_1_int_id, ol_1_int2_id, ol_1_str_id" +
           s" from $tableName1" +
@@ -704,13 +706,13 @@ object PreparedQueryRoutingSingleNodeSuite{
       prepStatement1.setString(2, "2")
       prepStatement1.setString(3, "99%")
       verifyResults("equalityOnStringColumn_query2-select0", prepStatement1.executeQuery,
-        Array(1, 2, 99, 990, 991, 992, 993, 994, 995, 996, 997, 998, 999), cacheMapSize + 2)
+        Array(1, 2, 99, 990, 991, 992, 993, 994, 995, 996, 997, 998, 999), cacheMapSize + 1)
 
       prepStatement1.setString(1, "3")
       prepStatement1.setString(2, "4")
       prepStatement1.setString(3, "94%")
       verifyResults("equalityOnStringColumn_query2-select1", prepStatement1.executeQuery,
-        Array(3, 4, 94, 940, 941, 942, 943, 944, 945, 946, 947, 948, 949), cacheMapSize + 3)
+        Array(3, 4, 94, 940, 941, 942, 943, 944, 945, 946, 947, 948, 949), cacheMapSize + 1)
 
       prepStatement2 = conn.prepareStatement( s"select ol_1_int_id, ol_1_int2_id, ol_1_str_id" +
           s" from $tableName1" +
@@ -718,12 +720,12 @@ object PreparedQueryRoutingSingleNodeSuite{
       prepStatement2.setString(1, "5")
       prepStatement2.setString(2, "6")
       verifyResults("equalityOnStringColumn_query3-select0", prepStatement2.executeQuery,
-        Array(5, 6), cacheMapSize + 4)
+        Array(5, 6), cacheMapSize + 2)
 
       prepStatement2.setString(1, "7")
       prepStatement2.setString(2, "8")
       verifyResults("equalityOnStringColumn_query3-select1", prepStatement2.executeQuery,
-        Array(7, 8), cacheMapSize + 4)
+        Array(7, 8), cacheMapSize + 2)
     } finally {
       def close(prepStatement: java.sql.PreparedStatement) =
         if (prepStatement != null) prepStatement.close()
@@ -753,7 +755,7 @@ object PreparedQueryRoutingSingleNodeSuite{
       insertRows(tableName1, 1000, serverHostPort)
       insertRows(tableName2, 1000, serverHostPort)
       equalityOnStringColumn_query1(tableName1, 1, serverHostPort)
-      equalityOnStringColumn_query1(tableName2, 6, serverHostPort)
+      equalityOnStringColumn_query1(tableName2, 4, serverHostPort)
     } finally {
       SnappyTableStatsProviderService.suspendCacheInvalidation = false
     }

--- a/cluster/src/test/scala/org/apache/spark/unsafe/NativeUTF8StringPropertyCheckSuite.scala
+++ b/cluster/src/test/scala/org/apache/spark/unsafe/NativeUTF8StringPropertyCheckSuite.scala
@@ -54,6 +54,14 @@ class NativeUTF8StringPropertyCheckSuite extends SnappyFunSuite
 
   private val allocatedMemoryList: LongArrayList = new LongArrayList
 
+  // scalastyle:off println
+  if (Native.isLoaded) {
+    println("NATIVE: using native JNI library")
+  } else {
+    println("NATIVE: failed to load native JNI library")
+  }
+  // scalastyle:on println
+
   after {
     if (allocatedMemoryList.size() > 0) {
       val iter = allocatedMemoryList.iterator()

--- a/cluster/src/test/scala/org/apache/spark/unsafe/NativeUTF8StringPropertyCheckSuite.scala
+++ b/cluster/src/test/scala/org/apache/spark/unsafe/NativeUTF8StringPropertyCheckSuite.scala
@@ -1,0 +1,293 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/*
+ * Changes for SnappyData data platform.
+ *
+ * Portions Copyright (c) 2017 SnappyData, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License. You
+ * may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License. See accompanying
+ * LICENSE file.
+ */
+
+package org.apache.spark.unsafe
+
+import java.nio.charset.StandardCharsets
+
+import io.snappydata.SnappyFunSuite
+import it.unimi.dsi.fastutil.longs.LongArrayList
+import org.apache.commons.lang3.StringUtils
+import org.scalacheck.{Arbitrary, Gen}
+import org.scalatest.prop.GeneratorDrivenPropertyChecks
+import org.scalatest.{BeforeAndAfter, Matchers}
+
+import org.apache.spark.unsafe.types.UTF8String
+
+/**
+ * This TestSuite utilize ScalaCheck to generate randomized inputs for UTF8String testing.
+ */
+class NativeUTF8StringPropertyCheckSuite extends SnappyFunSuite
+    with GeneratorDrivenPropertyChecks with Matchers with BeforeAndAfter {
+
+  private val allocatedMemoryList: LongArrayList = new LongArrayList
+
+  after {
+    if (allocatedMemoryList.size() > 0) {
+      val iter = allocatedMemoryList.iterator()
+      while (iter.hasNext) {
+        Platform.freeMemory(iter.nextLong())
+      }
+      allocatedMemoryList.clear()
+    }
+  }
+
+  private def toUTF8(s: String): UTF8String = {
+    if (s eq null) return null
+    val b = s.getBytes(StandardCharsets.UTF_8)
+    val numBytes = b.length
+    val ub = Platform.allocateMemory(numBytes)
+    allocatedMemoryList.add(ub)
+    Platform.copyMemory(b, Platform.BYTE_ARRAY_OFFSET, null, ub, numBytes)
+    UTF8String.fromAddress(null, ub, numBytes)
+  }
+
+  test("toString") {
+    forAll { (s: String) =>
+      assert(toUTF8(s).toString === s)
+    }
+  }
+
+  test("numChars") {
+    forAll { (s: String) =>
+      assert(toUTF8(s).numChars() === s.length)
+    }
+  }
+
+  test("startsWith") {
+    forAll { (s: String) =>
+      val utf8 = toUTF8(s)
+      assert(utf8.startsWith(utf8))
+      for (i <- 1 to s.length) {
+        assert(utf8.startsWith(toUTF8(s.dropRight(i))))
+      }
+    }
+  }
+
+  test("endsWith") {
+    forAll { (s: String) =>
+      val utf8 = toUTF8(s)
+      assert(utf8.endsWith(utf8))
+      for (i <- 1 to s.length) {
+        assert(utf8.endsWith(toUTF8(s.drop(i))))
+      }
+    }
+  }
+
+  test("toUpperCase") {
+    forAll { (s: String) =>
+      assert(toUTF8(s).toUpperCase === toUTF8(s.toUpperCase))
+    }
+  }
+
+  test("toLowerCase") {
+    forAll { (s: String) =>
+      assert(toUTF8(s).toLowerCase === toUTF8(s.toLowerCase))
+    }
+  }
+
+  test("compare") {
+    forAll { (s1: String, s2: String) =>
+      assert(Math.signum(toUTF8(s1).compareTo(toUTF8(s2))) === Math.signum(s1.compareTo(s2)))
+    }
+  }
+
+  test("substring") {
+    forAll { (s: String) =>
+      for (start <- 0 to s.length; end <- 0 to s.length; if start <= end) {
+        assert(toUTF8(s).substring(start, end).toString === s.substring(start, end))
+      }
+    }
+  }
+
+  test("contains") {
+    forAll { (s: String) =>
+      for (start <- 0 to s.length; end <- 0 to s.length; if start <= end) {
+        val substring = s.substring(start, end)
+        assert(toUTF8(s).contains(toUTF8(substring)) === s.contains(substring))
+      }
+    }
+  }
+
+  val whitespaceChar: Gen[Char] = Gen.const(0x20.toChar)
+  val whitespaceString: Gen[String] = Gen.listOf(whitespaceChar).map(_.mkString)
+  val randomString: Gen[String] = Arbitrary.arbString.arbitrary
+
+  test("trim, trimLeft, trimRight") {
+    // lTrim and rTrim are both modified from java.lang.String.trim
+    def lTrim(s: String): String = {
+      var st = 0
+      val array: Array[Char] = s.toCharArray
+      while ((st < s.length) && (array(st) == ' ')) {
+        st += 1
+      }
+      if (st > 0) s.substring(st, s.length) else s
+    }
+
+    def rTrim(s: String): String = {
+      var len = s.length
+      val array: Array[Char] = s.toCharArray
+      while ((len > 0) && (array(len - 1) == ' ')) {
+        len -= 1
+      }
+      if (len < s.length) s.substring(0, len) else s
+    }
+
+    forAll(
+      whitespaceString,
+      randomString,
+      whitespaceString
+    ) { (start: String, middle: String, end: String) =>
+      val s = start + middle + end
+      assert(toUTF8(s).trim() === toUTF8(rTrim(lTrim(s))))
+      assert(toUTF8(s).trimLeft() === toUTF8(lTrim(s)))
+      assert(toUTF8(s).trimRight() === toUTF8(rTrim(s)))
+    }
+  }
+
+  test("reverse") {
+    forAll { (s: String) =>
+      assert(toUTF8(s).reverse === toUTF8(s.reverse))
+    }
+  }
+
+  test("indexOf") {
+    forAll { (s: String) =>
+      for (start <- 0 to s.length; end <- 0 to s.length; if start <= end) {
+        val substring = s.substring(start, end)
+        assert(toUTF8(s).indexOf(toUTF8(substring), 0) === s.indexOf(substring))
+      }
+    }
+  }
+
+  private val randomInt = Gen.choose(-100, 100)
+
+  test("repeat") {
+    def repeat(str: String, times: Int): String = {
+      if (times > 0) str * times else ""
+    }
+
+    // ScalaCheck always generating too large repeat times which might hang the test forever.
+    forAll(randomString, randomInt) { (s: String, times: Int) =>
+      assert(toUTF8(s).repeat(times) === toUTF8(repeat(s, times)))
+    }
+  }
+
+  test("lpad, rpad") {
+    def padding(origin: String, pad: String, length: Int, isLPad: Boolean): String = {
+      if (length <= 0) return ""
+      if (length <= origin.length) {
+        if (length <= 0) "" else origin.substring(0, length)
+      } else {
+        if (pad.length == 0) return origin
+        val toPad = length - origin.length
+        val partPad = if (toPad % pad.length == 0) "" else pad.substring(0, toPad % pad.length)
+        if (isLPad) {
+          pad * (toPad / pad.length) + partPad + origin
+        } else {
+          origin + pad * (toPad / pad.length) + partPad
+        }
+      }
+    }
+
+    forAll(
+      randomString,
+      randomString,
+      randomInt
+    ) { (s: String, pad: String, length: Int) =>
+      assert(toUTF8(s).lpad(length, toUTF8(pad)) ===
+          toUTF8(padding(s, pad, length, isLPad = true)))
+      assert(toUTF8(s).rpad(length, toUTF8(pad)) ===
+          toUTF8(padding(s, pad, length, isLPad = false)))
+    }
+  }
+
+  private val nullalbeSeq = Gen.listOf(Gen.oneOf[String](null: String, randomString))
+
+  test("concat") {
+    def concat(orgin: Seq[String]): String =
+      if (orgin.contains(null)) null else orgin.mkString
+
+    forAll { (inputs: Seq[String]) =>
+      assert(UTF8String.concat(inputs.map(toUTF8): _*) === toUTF8(inputs.mkString))
+    }
+    forAll(nullalbeSeq) { (inputs: Seq[String]) =>
+      assert(UTF8String.concat(inputs.map(toUTF8): _*) === toUTF8(concat(inputs)))
+    }
+  }
+
+  test("concatWs") {
+    def concatWs(sep: String, inputs: Seq[String]): String = {
+      if (sep == null) return null
+      inputs.filter(_ != null).mkString(sep)
+    }
+
+    forAll { (sep: String, inputs: Seq[String]) =>
+      assert(UTF8String.concatWs(toUTF8(sep), inputs.map(toUTF8): _*) ===
+          toUTF8(inputs.mkString(sep)))
+    }
+    forAll(randomString, nullalbeSeq) { (sep: String, inputs: Seq[String]) =>
+      assert(UTF8String.concatWs(toUTF8(sep), inputs.map(toUTF8): _*) ===
+          toUTF8(concatWs(sep, inputs)))
+    }
+  }
+
+  // TODO: enable this when we find a proper way to generate valid patterns
+  ignore("split") {
+    forAll { (s: String, pattern: String, limit: Int) =>
+      assert(toUTF8(s).split(toUTF8(pattern), limit) ===
+          s.split(pattern, limit).map(toUTF8))
+    }
+  }
+
+  test("levenshteinDistance") {
+    forAll { (one: String, another: String) =>
+      assert(toUTF8(one).levenshteinDistance(toUTF8(another)) ===
+          StringUtils.getLevenshteinDistance(one, another))
+    }
+  }
+
+  test("hashCode") {
+    forAll { (s: String) =>
+      assert(toUTF8(s).hashCode() === toUTF8(s).hashCode())
+    }
+  }
+
+  test("equals") {
+    forAll { (one: String, another: String) =>
+      assert(toUTF8(one).equals(toUTF8(another)) === one.equals(another))
+    }
+  }
+}

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -81,7 +81,7 @@ dependencies {
     testCompile group: 'io.snappydata', name: 'snappydata-store-tools', version: snappyStoreVersion, classifier: 'tests'
   }
 
-  compile("org.parboiled:parboiled_${scalaBinaryVersion}:2.1.3") {
+  compile("org.parboiled:parboiled_${scalaBinaryVersion}:2.1.4") {
     exclude(group: 'org.scala-lang', module: 'scala-library')
     exclude(group: 'org.scala-lang', module: 'scala-reflect')
     exclude(group: 'org.scala-lang', module: 'scala-compiler')

--- a/core/src/main/scala/org/apache/spark/sql/SnappyBaseParser.scala
+++ b/core/src/main/scala/org/apache/spark/sql/SnappyBaseParser.scala
@@ -303,6 +303,9 @@ object SnappyParserConsts {
 
   final val allKeywords: mutable.Set[String] = mutable.Set[String]()
 
+  final val optimizableLikePattern: java.util.regex.Pattern =
+    java.util.regex.Pattern.compile("%?[^_%]*[^_%\\\\]%?")
+
   /**
    * Registering a Keyword with this method marks it a reserved keyword,
    * i.e. it is interpreted as a keyword wherever it may appear and is never


### PR DESCRIPTION
## Changes proposed in this pull request

- convert UTF8Strings in ParamLiteral to off-heap when snappy off-heap is enabled;
  added DirectStringConsumer to acquire/release the required off-heap memory
- refactored the common code for TaskContext.get() into a separate method
  which caches the result to avoid repeated thread-local lookups (Utils.genTaskContextFunction
      should be used by snappydata code that needs it)
- SnappyParser changes:
  - added a "likeExpression" method that will directly convert to StartsWith/EndsWith/Contains
    expressions as per the like pattern with ParamLiteral so that off-heap conversion happens
    for the pattern string (else Spark's LikeSimplification replaces with a Literal)
  - enabled "inlineTable" rule which was commented out due to non-availabiity of
    UnresolvedInlineTable plan in 2.0.1 (present since 2.0.2); now INSERT ... VALUES
    or SELECT ... VALUES or just VALUES ... will work in SnappySession too (tests to be added later)
  - simplified comparisonExpression
- build support to copy JNI libraries from the AQP project if present
- test suite NativeUTF8StringPropertyCheckSuite adapted from Spark's
  UTF8StringPropertyCheckSuite
  but using off-heap UTF8Strings to test the new JNI implementation
- added off-heap test case to StringBenchmark
- updated parboiled2 to latest release
- removed an unused method in Utils

## Patch testing

precheckin

## ReleaseNotes.txt changes

NA

## Other PRs 

https://github.com/SnappyDataInc/spark/pull/80