### PR TITLE
[SNAP-2007] fix deadlock between UMM and RegionEntry

### DIFF
--- a/cluster/src/main/scala/org/apache/spark/memory/SnappyUnifiedMemoryManager.scala
+++ b/cluster/src/main/scala/org/apache/spark/memory/SnappyUnifiedMemoryManager.scala
@@ -346,7 +346,9 @@ class SnappyUnifiedMemoryManager private[memory](
   }
 
   private def getMinOffHeapEviction(required: Long): Long = {
-    // off-heap calculations are precise so evict exactly as much as required
+    // off-heap calculations are precise so evict exactly as much as required;
+    // bit of "padding" (1M) to account for inaccuracies in pre-allocation by
+    // putAll threads
     math.max(0, required - offHeapStorageMemoryPool.memoryFree + (1024 * 1024))
   }
 

--- a/core/src/main/scala/org/apache/spark/memory/StoreUnifiedManager.scala
+++ b/core/src/main/scala/org/apache/spark/memory/StoreUnifiedManager.scala
@@ -206,7 +206,7 @@ object MemoryManagerCallback extends Logging {
   def poolForAsyncOperation: ExecutorService = {
     val cache = Misc.getGemFireCacheNoThrow
     if ((cache ne null) && !Thread.holdsLock(memoryManager)) {
-      cache.getDistributionManager.getWaitingThreadPool
+      cache.getDistributionManager.getHighPriorityThreadPool
     } else null
   }
 

--- a/core/src/main/scala/org/apache/spark/memory/StoreUnifiedManager.scala
+++ b/core/src/main/scala/org/apache/spark/memory/StoreUnifiedManager.scala
@@ -17,10 +17,12 @@
 package org.apache.spark.memory
 
 import java.nio.ByteBuffer
+import java.util.concurrent.ExecutorService
 
 import com.gemstone.gemfire.internal.shared.BufferAllocator
 import com.gemstone.gemfire.internal.snappy.UMMMemoryTracker
 import com.gemstone.gemfire.internal.snappy.memory.MemoryManagerStats
+import com.pivotal.gemfirexd.internal.engine.Misc
 
 import org.apache.spark.storage.{BlockId, TestBlockId}
 import org.apache.spark.util.Utils
@@ -74,12 +76,12 @@ trait StoreUnifiedManager {
   /**
     * Clears the internal map
     */
-  def clear
+  def clear()
 
   /**
     * Closes the memory manager.
     */
-  def close
+  def close()
 }
 
 /**
@@ -140,12 +142,12 @@ class DefaultMemoryManager extends StoreUnifiedManager with Logging {
 
   override def initMemoryStats(stats: MemoryManagerStats): Unit = {}
 
-  override def close: Unit = {}
+  override def close(): Unit = {}
 
   /**
     * Clears the internal map
     */
-  override def clear: Unit = {}
+  override def clear(): Unit = {}
 }
 
 object MemoryManagerCallback extends Logging {
@@ -156,7 +158,7 @@ object MemoryManagerCallback extends Logging {
   val ummClass = "org.apache.spark.memory.SnappyUnifiedMemoryManager"
 
   // This memory manager will be used while GemXD is booting up and SparkEnv is not ready.
-  lazy val bootMemoryManager = {
+  private[memory] lazy val bootMemoryManager = {
     try {
       val conf = new SparkConf()
       Utils.classForName(ummClass)
@@ -177,7 +179,7 @@ object MemoryManagerCallback extends Logging {
 
   // Is called from cache.close() && session.close() & umm.close
   def resetMemoryManager(): Unit = synchronized {
-    bootMemoryManager.clear
+    bootMemoryManager.clear()
     snappyUnifiedManager = null
   }
 
@@ -199,6 +201,13 @@ object MemoryManagerCallback extends Logging {
     val manager = snappyUnifiedManager
     if ((manager ne null) && isCluster) manager
     else getMemoryManager
+  }
+
+  def poolForAsyncOperation: ExecutorService = {
+    val cache = Misc.getGemFireCacheNoThrow
+    if ((cache ne null) && !Thread.holdsLock(memoryManager)) {
+      cache.getDistributionManager.getWaitingThreadPool
+    } else null
   }
 
   private def getMemoryManager: StoreUnifiedManager = synchronized {

--- a/core/src/main/scala/org/apache/spark/sql/execution/columnar/encoding/ColumnDeleteEncoder.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/columnar/encoding/ColumnDeleteEncoder.scala
@@ -229,9 +229,9 @@ final class ColumnDeleteDelta extends ColumnFormatValue with Delta {
       try {
         new ColumnFormatValue(encoder.merge(existingBuffer, columnBuffer))
       } finally {
-        oldColumnValue.release()
+        oldColumnValue.release(true)
         // release own buffer too and delta should be unusable now
-        release()
+        release(true)
       }
     }
   }

--- a/core/src/main/scala/org/apache/spark/sql/execution/columnar/impl/ColumnDelta.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/columnar/impl/ColumnDelta.scala
@@ -84,9 +84,9 @@ final class ColumnDelta extends ColumnFormatValue with Delta {
           new ColumnFormatValue(encoder.merge(columnBuffer, existingBuffer,
             columnIndex < ColumnFormatEntry.DELETE_MASK_COL_INDEX, schema(tableColumnIndex)))
         } finally {
-          oldColumnValue.release()
+          oldColumnValue.release(true)
           // release own buffer too and delta should be unusable now
-          release()
+          release(true)
         }
       }
     }

--- a/core/src/main/scala/org/apache/spark/sql/execution/columnar/impl/StoreCallbacksImpl.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/columnar/impl/StoreCallbacksImpl.scala
@@ -17,6 +17,7 @@
 package org.apache.spark.sql.execution.columnar.impl
 
 import java.util.Collections
+import java.util.concurrent.ExecutorService
 
 import scala.collection.JavaConverters._
 
@@ -290,6 +291,9 @@ object StoreCallbacksImpl extends StoreCallbacks with Logging with Serializable 
     MemoryManagerCallback.memoryManager.
         releaseStorageMemoryForObject(objectName, numBytes, mode)
   }
+
+  override def poolForAsyncOperation: ExecutorService =
+    MemoryManagerCallback.poolForAsyncOperation
 
   override def dropStorageMemory(objectName: String, ignoreBytes: Long): Unit =
     // off-heap will be cleared via ManagedDirectBufferAllocator


### PR DESCRIPTION
## Changes proposed in this pull request

- free the buffer in a separate thread in background
- more precise data for eviction (with background it should not be too much eviction)

## Patch testing

precheckin

## ReleaseNotes.txt changes

NA

## Other PRs 

https://github.com/SnappyDataInc/snappy-store/pull/304