### PR TITLE
Changes in the help displayed on snappy commandline

### DIFF
--- a/cluster/src/main/scala/io/snappydata/gemxd/SnappySystemAdmin.java
+++ b/cluster/src/main/scala/io/snappydata/gemxd/SnappySystemAdmin.java
@@ -31,6 +31,12 @@ import com.pivotal.gemfirexd.tools.GfxdSystemAdmin;
 
 public class SnappySystemAdmin extends GfxdSystemAdmin {
 
+  SnappySystemAdmin() {
+    super();
+    UTIL_Tools_DSProps = "UTIL_Snappy_Tools_DSProps";
+    UTIL_DSProps_HelpPost = "UTIL_Snappy_Tools_DSProps_HelpPost";
+  }
+
   public static void main(String[] args) {
     try {
       SnappyDataVersion.loadProperties();
@@ -51,6 +57,7 @@ public class SnappySystemAdmin extends GfxdSystemAdmin {
           .entrySet()) {
         admin.helpMap.put(overrideHelp.getKey(), overrideHelp.getValue());
       }
+
       admin.invoke(args);
     } catch (GemFireTerminateError term) {
       System.exit(term.getExitCode());
@@ -62,6 +69,14 @@ public class SnappySystemAdmin extends GfxdSystemAdmin {
     String productDirMessage = LocalizedResource.getMessage(
         "UTIL_version_ProductDirectory", getProductDir());
     System.out.println(utilMain.convertGfxdMessageToSnappy(productDirMessage));
+  }
+
+  @Override
+  protected String getUsageString(String cmd) {
+    final StringBuilder result = new StringBuilder(80);
+    result.append("snappy").append(' ');
+    result.append(this.usageMap.get(cmd.toLowerCase()));
+    return result.toString();
   }
 
   @Override

--- a/cluster/src/main/scala/io/snappydata/tools/GfxdLauncherOverrides.scala
+++ b/cluster/src/main/scala/io/snappydata/tools/GfxdLauncherOverrides.scala
@@ -41,10 +41,10 @@ class ServerLauncher(baseName: String) extends GfxdServerLauncher(baseName) {
   override protected def usage(): Unit = {
     val script: String = LocalizedMessages.res.getTextMessage("SD_SERVER_SCRIPT")
     val name: String = LocalizedMessages.res.getTextMessage("SD_SERVER_NAME")
-    val extraHelp = LocalizedResource.getMessage("FS_EXTRA_HELP",
+    val extraHelp = LocalizedResource.getMessage("FS_SNAPPY_EXTRA_HELP",
       LocalizedMessages.res.getTextMessage("FS_PRODUCT"))
     val usageOutput: String = LocalizedResource.getMessage("SERVER_HELP",
-      script, name, LocalizedResource.getMessage("FS_ADDRESS_ARG"), extraHelp)
+      script, name, LocalizedResource.getMessage("FS_SNAPPY_ADDRESS_ARG"), extraHelp)
 
     printUsage(usageOutput, SanityManager.DEFAULT_MAX_OUT_LINES)
   }


### PR DESCRIPTION
## Changes proposed in this pull request
Hiding commands not applicable to snappy (will continued to be displayed for gfxd and rowstoremode)
Removed following commands:-
agent
modify-disk-store
export-disk-store
upgrade-disk-store
encrypt-password
shut-down-all
write-schema-to-xml
write-schema-to-sql 
write-data-to-xml
write-data-dtd-to-file
write-schema-to-db
write-data-to-db
replay-failed-dmls

SnappyUtilLauncher#getTypes uses SnappySystemAdmin (which uses help message modified for snappy "UTIL_Tools_DSProps" and "UTIL_Snappy_Tools_DSProps_HelpPost"). Earlier this was getting used only for "version" command.

Also hidden mcast related args from commands help (refer to store PR)
Also in SnappyData mode, error out if locators is not specified as an arg rather than using mcast port (refer to store PR). 

## Patch testing
still to run precheckin
did some manual testing


## ReleaseNotes.txt changes

## Other PRs 
https://github.com/SnappyDataInc/snappy-store/pull/306