### PR TITLE
[SNAP-2004] skip stats check for updated batches

### DIFF
--- a/cluster/src/test/scala/io/snappydata/cluster/PreparedQueryRoutingSingleNodeSuite.scala
+++ b/cluster/src/test/scala/io/snappydata/cluster/PreparedQueryRoutingSingleNodeSuite.scala
@@ -16,7 +16,7 @@
  */
 package io.snappydata.cluster
 
-import java.sql.{Connection, DriverManager, PreparedStatement, ResultSet, SQLException}
+import java.sql.{Connection, DriverManager, PreparedStatement, ResultSet}
 
 import com.pivotal.gemfirexd.TestUtil
 import com.pivotal.gemfirexd.internal.engine.distributed.utils.GemFireXDUtils
@@ -856,8 +856,8 @@ object PreparedQueryRoutingSingleNodeSuite{
     }
   }
 
-  def verifyResults(qry: String, rs: ResultSet, results: Array[Int], cacheMapSize: Int,
-      assertResults: Boolean = true): Unit = {
+  def verifyResults(qry: String, rs: ResultSet, results: Array[Int],
+      cacheMapSize: Int): Unit = {
     val cacheMap = SnappySession.getPlanCache.asMap()
 
     var index = 0
@@ -875,7 +875,7 @@ object PreparedQueryRoutingSingleNodeSuite{
     // scalastyle:off println
     println(s"$qry Number of rows read " + index)
     // scalastyle:on println
-    if (assertResults) assert(index == results.length)
+    assert(index == results.length)
     rs.close()
 
     // scalastyle:off println
@@ -981,9 +981,8 @@ object PreparedQueryRoutingSingleNodeSuite{
           s" from $tableName1" +
           " where ol_1_str_id like ?")
       prepStatement1.setString(1, "7777")
-      // TODO: removing result check temporarily due to SNAP-2004
       verifyResults("update_delete_query2-select1", prepStatement1.executeQuery, Array(4000),
-        cacheMapSize, assertResults = false)
+        cacheMapSize)
 
       prepStatement0.setString(1, "8888")
       prepStatement0.setInt(2, 501)
@@ -991,9 +990,8 @@ object PreparedQueryRoutingSingleNodeSuite{
       assert(update2 == 1, update2)
 
       prepStatement1.setString(1, "8888")
-      // TODO: removing result check temporarily due to SNAP-2004
       verifyResults("update_delete_query2-select1", prepStatement1.executeQuery, Array(5000),
-        cacheMapSize, assertResults = false)
+        cacheMapSize)
       // Thread.sleep(1000000)
     } finally {
       if (prepStatement0 != null) prepStatement0.close()

--- a/core/src/dunit/scala/io/snappydata/cluster/SplitClusterDUnitSecurityTest.scala
+++ b/core/src/dunit/scala/io/snappydata/cluster/SplitClusterDUnitSecurityTest.scala
@@ -280,8 +280,7 @@ class SplitClusterDUnitSecurityTest(s: String)
       // delete
       snc.sql(s"delete from $embeddedColTab1 where col1 = 5000").collect()
       var rows = snc.sql(s"select * from $embeddedColTab1").collect().length
-      //  TODO uncomment after SNAP-2004 is fixed
-      // assert(rows == 0, s"expected 0 rows but found $rows in $embeddedColTab1")
+      assert(rows == 0, s"expected 0 rows but found $rows in $embeddedColTab1")
       snc.sql(s"delete from $embeddedRowTab1 where col1 = 5000")
       rows = snc.sql(s"select * from $embeddedRowTab1").collect().length
       assert(rows == 0, s"expected 0 rows but found $rows in $embeddedRowTab1")
@@ -291,8 +290,7 @@ class SplitClusterDUnitSecurityTest(s: String)
       SplitClusterDUnitTest.populateTable(embeddedRowTab1, user1Conn)
 
       rows = snc.sql(s"select * from $embeddedColTab1").collect().length
-      //  TODO Expected rows 1005 after SNAP-2004 is fixed
-      assert(rows == 1006, s"expected 1005 rows but found $rows in $embeddedColTab1")
+      assert(rows == 1005, s"expected 1005 rows but found $rows in $embeddedColTab1")
       rows = snc.sql(s"select * from $embeddedRowTab1").collect().length
       assert(rows == 1005, s"expected 1005 rows but found $rows in $embeddedRowTab1")
 
@@ -344,8 +342,7 @@ class SplitClusterDUnitSecurityTest(s: String)
       stmt.execute(s"delete from $smartColTab1 where col1 = 0")
       checkCount(s"select * from $smartColTab1", 1005, false)
       stmt.execute(s"delete from $smartRowTab1 where col1 = 0")
-      //  TODO uncomment after SNAP-2004 is fixed
-      // checkCount(s"select * from $smartRowTab1", 1005, false)
+      checkCount(s"select * from $smartRowTab1", 1005, false)
 
       // drop
       stmt.execute(s"drop table $smartColTab1")

--- a/core/src/main/scala/org/apache/spark/sql/execution/columnar/ColumnTableScan.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/columnar/ColumnTableScan.scala
@@ -633,7 +633,7 @@ private[sql] final case class ColumnTableScan(
       s"""
         while (true) {
           $batchAssign
-          if ($filterFunction($unsafeRow)) {
+          if ($colInput.hasUpdatedColumns() || $filterFunction($unsafeRow)) {
             break;
           }
           if (!$colInput.hasNext()) return false;


### PR DESCRIPTION
This is an intermediate fix for the issue. Changes for full fix were done but
became unfeasible to get those in due to new issues like SNAP-2007, SNAP-2012.

## Changes proposed in this pull request

- skip stats if current batch has any updates in ColumnTableScan (very inefficient working fix)
- added a method "hasUpdatedColumns" to batch iterators for above
- uncommented checks in existing tests that were disabled due to SNAP-2004

## Patch testing

precheckin with existing commented out checks enabled.
More comprehensive tests for this will be added with the full fix.

## ReleaseNotes.txt changes

NA

## Other PRs 

NA