### PR TITLE
[SNAP-2016] Released old decoder buffer.

### DIFF
--- a/core/src/main/scala/org/apache/spark/sql/execution/columnar/encoding/ColumnEncoding.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/columnar/encoding/ColumnEncoding.scala
@@ -176,7 +176,7 @@ abstract class ColumnDecoder(columnDataRef: AnyRef, startCursor: Long,
 
 trait ColumnEncoder extends ColumnEncoding {
 
-  protected final var allocator: BufferAllocator = _
+  protected[sql] final var allocator: BufferAllocator = _
   private final var finalAllocator: BufferAllocator = _
   protected[sql] final var columnData: ByteBuffer = _
   protected[sql] final var columnBeginPosition: Long = _


### PR DESCRIPTION
Fix from @sumwale 
## Changes proposed in this pull request

Called release for a buffer, which was causing the memory release by reference cleaner.

## Patch testing

precheckin

## ReleaseNotes.txt changes



## Other PRs 

(Does this change require changes in other projects- store, spark, spark-jobserver, aqp? Add the links of PR of the other subprojects that are related to this change)
