### PR TITLE
[SNAP-2020] track in-progress insert size to avoid data skew

### DIFF
--- a/core/src/main/scala/org/apache/spark/sql/execution/columnar/impl/JDBCSourceAsColumnarStore.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/columnar/impl/JDBCSourceAsColumnarStore.scala
@@ -85,8 +85,18 @@ class JDBCSourceAsColumnarStore(private var _connProperties: ConnectionPropertie
   override def storeColumnBatch(tableName: String, batch: ColumnBatch,
       partitionId: Int, batchId: Long, maxDeltaRows: Int,
       conn: Option[Connection]): Unit = {
-    doInsertOrPut(tableName, batch, batchId, getPartitionID(tableName, partitionId),
-      maxDeltaRows, conn)
+    if (partitionId >= 0) {
+      doInsertOrPut(tableName, batch, batchId, partitionId, maxDeltaRows, conn)
+    } else {
+      val (bucketId, br, batchSize) = getPartitionID(tableName,
+        batch.buffers.foldLeft(0L)(_ + _.capacity()))
+      try {
+        doInsertOrPut(tableName, batch, batchId, bucketId, maxDeltaRows, conn)
+      } finally br match {
+        case None =>
+        case Some(bucket) => bucket.updateInProgressSize(-batchSize)
+      }
+    }
   }
 
   // begin should decide the connection which will be used by insert/commit/rollback
@@ -530,19 +540,22 @@ class JDBCSourceAsColumnarStore(private var _connProperties: ConnectionPropertie
     }
   }
 
+  private def getInProgressBucketSize(br: BucketRegion, shift: Int): Long =
+    (br.getTotalBytes + br.getInProgressSize) >> shift
+
   // use the same saved connection for all operation
-  private def getPartitionID(tableName: String, partitionId: Int = -1): Int = {
-    if (partitionId >= 0) return partitionId
+  private def getPartitionID(tableName: String,
+      batchSizeInBytes: => Long): (Int, Option[BucketRegion], Long) = {
     connectionType match {
       case ConnectionType.Embedded =>
         val region = Misc.getRegionForTable(tableName, true).asInstanceOf[LocalRegion]
         region match {
           case pr: PartitionedRegion =>
-            if (partitionId == -1) pr.synchronized {
+            pr.synchronized {
               val primaryBuckets = pr.getDataStore.getAllLocalPrimaryBucketRegions
               // if no local primary bucket, then select a random bucket
               if (primaryBuckets.isEmpty) {
-                Random.nextInt(pr.getTotalNumberOfBuckets)
+                (Random.nextInt(pr.getTotalNumberOfBuckets), None, 0L)
               } else {
                 // select the bucket with smallest size at this point
                 val iterator = primaryBuckets.iterator()
@@ -553,26 +566,27 @@ class JDBCSourceAsColumnarStore(private var _connProperties: ConnectionPropertie
                 val shift = if (GemFireCacheImpl.hasNewOffHeap) 5 else 13
                 assert(iterator.hasNext)
                 var smallestBucket = iterator.next()
-                var minBucketSize = smallestBucket.getTotalBytes >> shift
+                var minBucketSize = getInProgressBucketSize(smallestBucket, shift)
                 while (iterator.hasNext) {
                   val bucket = iterator.next()
-                  val bucketSize = bucket.getTotalBytes >> shift
+                  val bucketSize = getInProgressBucketSize(bucket, shift)
                   if (bucketSize < minBucketSize ||
                       (bucketSize == minBucketSize && Random.nextBoolean())) {
                     smallestBucket = bucket
                     minBucketSize = bucketSize
                   }
                 }
-                smallestBucket.getId
+                // update the in-progress size of the chosen bucket
+                val batchSize = batchSizeInBytes
+                smallestBucket.updateInProgressSize(batchSize)
+                (smallestBucket.getId, Some(smallestBucket), batchSize)
               }
-            } else {
-              partitionId
             }
-          case _ => partitionId
+          case _ => (-1, None, 0L)
         }
       // TODO: SW: for split mode, get connection to one of the
       // local servers and a bucket ID for only one of those
-      case _ => if (partitionId < 0) Random.nextInt(numPartitions) else partitionId
+      case _ => (Random.nextInt(numPartitions), None, 0L)
     }
   }
 }

--- a/core/src/main/scala/org/apache/spark/sql/execution/columnar/impl/JDBCSourceAsColumnarStore.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/columnar/impl/JDBCSourceAsColumnarStore.scala
@@ -577,9 +577,8 @@ class JDBCSourceAsColumnarStore(private var _connProperties: ConnectionPropertie
                   }
                 }
                 // update the in-progress size of the chosen bucket
-                val batchSize = batchSizeInBytes
-                smallestBucket.updateInProgressSize(batchSize)
-                (smallestBucket.getId, Some(smallestBucket), batchSize)
+                smallestBucket.updateInProgressSize(batchSizeInBytes)
+                (smallestBucket.getId, Some(smallestBucket), batchSizeInBytes)
               }
             }
           case _ => (-1, None, 0L)


### PR DESCRIPTION
## Changes proposed in this pull request

With many concurrent inserts/partitions on a node, significant data skew in inserts
was still observed (on machines with large number of cores like 32) due to same
smallest bucket being chosen by multiple partitions.

This change now tracks the in-progress size for bucket and adds that to determine smallest bucket.

## Patch testing

precheckin

## ReleaseNotes.txt changes

NA

## Other PRs 

The atomic long field in BucketRegion to keep track of in-progress size was added in https://github.com/SnappyDataInc/snappy-store/commit/8410b4d30aa82a6a2af6dc2d2481d913dc4b60cc