### PR TITLE
[SNAP-2022] Remove the check which tested if any lead is already stopped, in snappy-stop-all.sh

### DIFF
--- a/cluster/sbin/snappy-start-all.sh
+++ b/cluster/sbin/snappy-start-all.sh
@@ -32,16 +32,31 @@ if [ -f "${MEMBERS_FILE}" ]; then
   rm $MEMBERS_FILE
 fi
 
-# Check for foreground start
 BACKGROUND=-bg
-if [ "$1" = "-bg" -o "$1" = "--background" ]; then
+clustermode=
+
+while (( "$#" )); do
+  param="$1"
+  case $param in
+    -bg | --background)
+      # Check for background start
+      BACKGROUND="$1"
+    ;;
+    -fg | --foreground)
+      # Check for foreground start
+      BACKGROUND=-bg
+    ;;
+    rowstore)
+      clustermode="rowstore"
+    ;;
+    *)
+      echo "Invalid option: $param"
+    ;;
+  esac
   shift
-fi
-if [ "$1" = "-fg" -o "$1" = "--foreground" ]; then
-  BACKGROUND=""
-  shift
-fi
-  
+done
+
+
 # Start Locators
 "$sbin"/snappy-locators.sh start "$@"
 
@@ -49,6 +64,6 @@ fi
 "$sbin"/snappy-servers.sh $BACKGROUND start "$@"
 
 # Start Leads
-if [ "$1" != "rowstore" ]; then
+if [ "$clustermode" != "rowstore" ]; then
   "$sbin"/snappy-leads.sh start
 fi

--- a/cluster/sbin/snappy-start-all.sh
+++ b/cluster/sbin/snappy-start-all.sh
@@ -40,11 +40,11 @@ while (( "$#" )); do
   case $param in
     -bg | --background)
       # Check for background start
-      BACKGROUND="$1"
+      BACKGROUND=-bg
     ;;
     -fg | --foreground)
       # Check for foreground start
-      BACKGROUND=-bg
+      BACKGROUND=""
     ;;
     rowstore)
       clustermode="rowstore"

--- a/cluster/sbin/snappy-status-all.sh
+++ b/cluster/sbin/snappy-status-all.sh
@@ -35,4 +35,6 @@ sbin="`cd "$sbin"; pwd`"
 "$sbin"/snappy-servers.sh status "$@"
 
 # Start Leads
-"$sbin"/snappy-leads.sh status "$@"
+if [ "$1" != "rowstore" ]; then
+  "$sbin"/snappy-leads.sh status "$@"
+fi

--- a/cluster/sbin/snappy-stop-all.sh
+++ b/cluster/sbin/snappy-stop-all.sh
@@ -36,7 +36,7 @@ while (( "$#" )); do
   case $param in
     -bg | --background)
       # Check for background stop
-      BACKGROUND="$1"
+      BACKGROUND="$param"
     ;;
     rowstore)
       clustermode="rowstore"

--- a/cluster/sbin/snappy-stop-all.sh
+++ b/cluster/sbin/snappy-stop-all.sh
@@ -28,17 +28,32 @@ sbin="`cd "$sbin"; pwd`"
 . "$sbin/spark-config.sh"
 . "$sbin/snappy-config.sh"
 
-
-# Check for background stop
 BACKGROUND=
-if [ "$1" = "-bg" -o "$1" = "--background" ]; then
-  BACKGROUND="$1"
+clustermode=
+
+while (( "$#" )); do
+  param="$1"
+  case $param in
+    -bg)
+      # Check for background stop
+      BACKGROUND="$1"
+    ;;
+    --background)
+      # Check for background stop
+      BACKGROUND="$1"
+    ;;
+    rowstore)
+      clustermode="rowstore"
+    ;;
+    *)
+      echo "Invalid option: $param"
+    ;;
+  esac
   shift
-fi
+done
 
 # Stop Leads
-leadStatus=`"$sbin"/snappy-leads.sh status`
-if ! echo $leadStatus | grep -qw "status: stopped"; then
+if [ "$clustermode" != "rowstore" ]; then
   "$sbin"/snappy-leads.sh stop
 fi
 

--- a/cluster/sbin/snappy-stop-all.sh
+++ b/cluster/sbin/snappy-stop-all.sh
@@ -34,11 +34,7 @@ clustermode=
 while (( "$#" )); do
   param="$1"
   case $param in
-    -bg)
-      # Check for background stop
-      BACKGROUND="$1"
-    ;;
-    --background)
+    -bg | --background)
       # Check for background stop
       BACKGROUND="$1"
     ;;


### PR DESCRIPTION
## Changes proposed in this pull request
[SNAP-2022] Remove the check which tested if any lead is already stopped, in snappy-stop-all.sh
* Add a check for rowstore, so that 'sbin/snappy-stop-all.sh rowstore' doesn't see the message.
* Add a while + case to handle option in any order.

## Patch testing
Manual

## ReleaseNotes.txt changes
NA

## Other PRs 
NA