### PR TITLE
Fixed a couple of issues in parser.

### DIFF
--- a/core/src/main/scala/org/apache/spark/sql/SnappyParser.scala
+++ b/core/src/main/scala/org/apache/spark/sql/SnappyParser.scala
@@ -689,9 +689,9 @@ class SnappyParser(session: SnappySession)
         commaSep)).? ~ ((ORDER | SORT) ~ BY ~ ordering).? ~ windowFrame.? ~ ')' ~
         ws ~> ((p: Any, o: Any, w: Any) =>
       WindowSpecDefinition(
-      p.asInstanceOf[Option[Seq[Expression]]].getOrElse(Seq.empty),
+        p.asInstanceOf[Option[Seq[Expression]]].getOrElse(Seq.empty),
         o.asInstanceOf[Option[Seq[SortOrder]]].getOrElse(Seq.empty),
-      w.asInstanceOf[Option[SpecifiedWindowFrame]]
+        w.asInstanceOf[Option[SpecifiedWindowFrame]]
           .getOrElse(UnspecifiedFrame))) |
     identifier ~> WindowSpecReference
   }

--- a/core/src/main/scala/org/apache/spark/sql/SnappyParser.scala
+++ b/core/src/main/scala/org/apache/spark/sql/SnappyParser.scala
@@ -686,9 +686,11 @@ class SnappyParser(session: SnappySession)
 
   protected final def windowSpec: Rule1[WindowSpec] = rule {
     '(' ~ ws ~ ((PARTITION | DISTRIBUTE | CLUSTER) ~ BY ~ (expression +
-        commaSep)).? ~ (ORDER | SORT) ~ BY ~ ordering ~ windowFrame.? ~ ')' ~
-        ws ~> ((p: Any, o: Seq[SortOrder], w: Any) => WindowSpecDefinition(
-      p.asInstanceOf[Option[Seq[Expression]]].getOrElse(Seq.empty), o,
+        commaSep)).? ~ ((ORDER | SORT) ~ BY ~ ordering).? ~ windowFrame.? ~ ')' ~
+        ws ~> ((p: Any, o: Any, w: Any) =>
+      WindowSpecDefinition(
+      p.asInstanceOf[Option[Seq[Expression]]].getOrElse(Seq.empty),
+        o.asInstanceOf[Option[Seq[SortOrder]]].getOrElse(Seq.empty),
       w.asInstanceOf[Option[SpecifiedWindowFrame]]
           .getOrElse(UnspecifiedFrame))) |
     identifier ~> WindowSpecReference
@@ -789,6 +791,7 @@ class SnappyParser(session: SnappySession)
   } else exprs
 
   protected final def primary: Rule1[Expression] = rule {
+    ( ( test(tokenize) ~ paramLiteral ) | literal | paramLiteralQuestionMark) |
     identifier ~ (
       ('.' ~ identifier).? ~ '(' ~ ws ~ (
         '*' ~ ws ~ ')' ~ ws ~> ((n1: String, n2: Option[String]) =>
@@ -842,7 +845,6 @@ class SnappyParser(session: SnappySession)
           case f => UnresolvedFunction(f, exprs, isDistinct = false)
         }
     } |
-    ( ( test(tokenize) ~ paramLiteral ) | literal | paramLiteralQuestionMark) |
     CAST ~ '(' ~ ws ~ expression ~ AS ~ dataType ~ ')' ~ ws ~> (Cast(_, _)) |
     CASE ~ (
         whenThenElse ~> (s => CaseWhen(s._1, s._2)) |


### PR DESCRIPTION
## Changes proposed in this pull request

1. Order by and sort by clauses after partition by can be optional. It was
always expecting that.
2. INTERVAL non reserved key word was being treated as an identifier because
of optional clauses ordering.

## Patch testing

Added a unit test.

## ReleaseNotes.txt changes

None

## Other PRs 

No.
