### PR TITLE
[SNAP-2032] run old map GC task before throwing LME

### DIFF
--- a/cluster/src/main/scala/org/apache/spark/memory/SnappyUnifiedMemoryManager.scala
+++ b/cluster/src/main/scala/org/apache/spark/memory/SnappyUnifiedMemoryManager.scala
@@ -288,10 +288,10 @@ class SnappyUnifiedMemoryManager private[memory](
     val memoryForObject = self.memoryForObject
     if (!memoryForObject.isEmpty) {
       memoryLog.append("\n\t").append("Objects:\n")
-      val objects = memoryForObject.entrySet().iterator()
+      val objects = memoryForObject.object2LongEntrySet().iterator()
       while (objects.hasNext) {
         val o = objects.next()
-        memoryLog.append(separator).append(o.getKey).append(" = ").append(o.getValue)
+        memoryLog.append(separator).append(o.getKey).append(" = ").append(o.getLongValue)
       }
     }
     logInfo(memoryLog.toString())
@@ -616,6 +616,11 @@ class SnappyUnifiedMemoryManager private[memory](
         }
 
         var couldEvictSomeData = storagePool.acquireMemory(blockId, numBytes)
+        // run old map GC task explicitly before failing with low memory
+        if (!couldEvictSomeData) {
+          Misc.getGemFireCache.runOldEntriesCleanerThread()
+          couldEvictSomeData = storagePool.acquireMemory(blockId, numBytes)
+        }
         // for off-heap try harder before giving up since pending references
         // may be on heap (due to unexpected exceptions) that will go away on GC
         if (!couldEvictSomeData && offHeap) {

--- a/cluster/src/test/scala/io/snappydata/benchmark/TPCHColumnPartitionedTable.scala
+++ b/cluster/src/test/scala/io/snappydata/benchmark/TPCHColumnPartitionedTable.scala
@@ -563,8 +563,9 @@ object TPCHColumnPartitionedTable {
 
     for (i <- 1 to numberOfLoadingStage) {
       // use parquet data if available
-      if (isParquet) {
-        suppDF = sqlContext.read.format("parquet").load(s"$path/parquet_supplier_$i")
+      val parquetDir = s"$path/parquet_supplier_$i"
+      if (isParquet && new File(parquetDir).exists()) {
+        suppDF = sqlContext.read.format("parquet").load(parquetDir)
       } else {
         val suppData = sc.textFile(s"$path/supplier.tbl.$i")
         val suppReadings = suppData.map(s => s.split('|')).map(s => TPCHTableSchema


### PR DESCRIPTION
## Changes proposed in this pull request

Updated store for fixes to SNAP-2032

Also a change in TPCHColumnPartitionedTable to allow for text file
(and create parquet if specified) for supplier table even if it is configured
as column table (it can be configured as either a column table or row table)

## Patch testing

precheckin, manual TPCH testing with bulk updates to ~50% rows

## ReleaseNotes.txt changes

NA

## Other PRs 

https://github.com/SnappyDataInc/snappy-store/pull/316