### PR TITLE
[SNAP-2033] use proper sort ordering for update/delete

### DIFF
--- a/cluster/src/main/scala/io/snappydata/ToolsCallbackImpl.scala
+++ b/cluster/src/main/scala/io/snappydata/ToolsCallbackImpl.scala
@@ -19,13 +19,12 @@ package io.snappydata
 import java.io.File
 
 import io.snappydata.impl.LeadImpl
-import org.apache.hadoop.conf.Configuration
 
+import org.apache.spark.SparkContext
 import org.apache.spark.sql.catalyst.expressions.{Attribute, Expression}
 import org.apache.spark.sql.catalyst.plans.physical.{OrderlessHashPartitioning, Partitioning}
 import org.apache.spark.ui.{SnappyDashboardTab, SparkUI}
 import org.apache.spark.util.SnappyUtils
-import org.apache.spark.{SparkConf, SparkContext}
 
 object ToolsCallbackImpl extends ToolsCallback {
 
@@ -35,15 +34,15 @@ object ToolsCallbackImpl extends ToolsCallback {
 
   def getOrderlessHashPartitioning(partitionColumns: Seq[Expression],
       partitionColumnAliases: Seq[Seq[Attribute]],
-      numPartitions: Int, numBuckets: Int): Partitioning = {
+      numPartitions: Int, numBuckets: Int, tableBuckets: Int): Partitioning = {
     OrderlessHashPartitioning(partitionColumns, partitionColumnAliases,
-      numPartitions, numBuckets)
+      numPartitions, numBuckets, tableBuckets)
   }
 
   override def checkOrderlessHashPartitioning(partitioning: Partitioning): Option[
-      (Seq[Expression], Seq[Seq[Attribute]], Int, Int)] = partitioning match {
+      (Seq[Expression], Seq[Seq[Attribute]], Int, Int, Int)] = partitioning match {
     case p: OrderlessHashPartitioning => Some(p.expressions, p.aliases,
-      p.numPartitions, p.numBuckets)
+      p.numPartitions, p.numBuckets, p.tableBuckets)
     case _ => None
   }
 

--- a/cluster/src/main/scala/org/apache/spark/memory/SnappyUnifiedMemoryManager.scala
+++ b/cluster/src/main/scala/org/apache/spark/memory/SnappyUnifiedMemoryManager.scala
@@ -288,10 +288,10 @@ class SnappyUnifiedMemoryManager private[memory](
     val memoryForObject = self.memoryForObject
     if (!memoryForObject.isEmpty) {
       memoryLog.append("\n\t").append("Objects:\n")
-      val objects = memoryForObject.entrySet().iterator()
+      val objects = memoryForObject.object2LongEntrySet().iterator()
       while (objects.hasNext) {
         val o = objects.next()
-        memoryLog.append(separator).append(o.getKey).append(" = ").append(o.getValue)
+        memoryLog.append(separator).append(o.getKey).append(" = ").append(o.getLongValue)
       }
     }
     logInfo(memoryLog.toString())
@@ -616,6 +616,11 @@ class SnappyUnifiedMemoryManager private[memory](
         }
 
         var couldEvictSomeData = storagePool.acquireMemory(blockId, numBytes)
+        // run old map GC task explicitly before failing with low memory
+        if (!couldEvictSomeData) {
+          Misc.getGemFireCache.runOldEntriesCleanerThread()
+          couldEvictSomeData = storagePool.acquireMemory(blockId, numBytes)
+        }
         // for off-heap try harder before giving up since pending references
         // may be on heap (due to unexpected exceptions) that will go away on GC
         if (!couldEvictSomeData && offHeap) {

--- a/cluster/src/test/scala/io/snappydata/benchmark/TPCHColumnPartitionedTable.scala
+++ b/cluster/src/test/scala/io/snappydata/benchmark/TPCHColumnPartitionedTable.scala
@@ -563,8 +563,9 @@ object TPCHColumnPartitionedTable {
 
     for (i <- 1 to numberOfLoadingStage) {
       // use parquet data if available
-      if (isParquet) {
-        suppDF = sqlContext.read.format("parquet").load(s"$path/parquet_supplier_$i")
+      val parquetDir = s"$path/parquet_supplier_$i"
+      if (isParquet && new File(parquetDir).exists()) {
+        suppDF = sqlContext.read.format("parquet").load(parquetDir)
       } else {
         val suppData = sc.textFile(s"$path/supplier.tbl.$i")
         val suppReadings = suppData.map(s => s.split('|')).map(s => TPCHTableSchema

--- a/core/src/main/scala/io/snappydata/ToolsCallback.scala
+++ b/core/src/main/scala/io/snappydata/ToolsCallback.scala
@@ -18,9 +18,7 @@ package io.snappydata
 
 import java.io.File
 
-import org.apache.hadoop.conf.Configuration
-
-import org.apache.spark.{SecurityManager, SparkConf, SparkContext}
+import org.apache.spark.SparkContext
 import org.apache.spark.sql.catalyst.expressions.{Attribute, Expression}
 import org.apache.spark.sql.catalyst.plans.physical.Partitioning
 
@@ -30,10 +28,10 @@ trait ToolsCallback {
 
   def getOrderlessHashPartitioning(partitionColumns: Seq[Expression],
       partitionColumnAliases: Seq[Seq[Attribute]],
-      numPartitions: Int, numBuckets: Int): Partitioning
+      numPartitions: Int, numBuckets: Int, tableBuckets: Int): Partitioning
 
   def checkOrderlessHashPartitioning(partitioning: Partitioning): Option[
-      (Seq[Expression], Seq[Seq[Attribute]], Int, Int)]
+      (Seq[Expression], Seq[Seq[Attribute]], Int, Int, Int)]
 
   def updateUI(scUI: Option[Any]): Unit // Option[SparkUI] is expected
 

--- a/core/src/main/scala/org/apache/spark/sql/collection/Utils.scala
+++ b/core/src/main/scala/org/apache/spark/sql/collection/Utils.scala
@@ -1004,7 +1004,7 @@ object ToolsCallbackInit extends Logging {
 
 object OrderlessHashPartitioningExtract {
   def unapply(partitioning: Partitioning): Option[(Seq[Expression],
-      Seq[Seq[Attribute]], Int, Int)] = {
+      Seq[Seq[Attribute]], Int, Int, Int)] = {
     val callbacks = ToolsCallbackInit.toolsCallback
     if (callbacks ne null) {
       callbacks.checkOrderlessHashPartitioning(partitioning)

--- a/core/src/main/scala/org/apache/spark/sql/execution/CodegenSparkFallback.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/CodegenSparkFallback.scala
@@ -22,7 +22,8 @@ import com.gemstone.gemfire.SystemFailure
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.SnappySession
 import org.apache.spark.sql.catalyst.InternalRow
-import org.apache.spark.sql.catalyst.expressions.Attribute
+import org.apache.spark.sql.catalyst.expressions.{Attribute, SortOrder}
+import org.apache.spark.sql.catalyst.plans.physical.Partitioning
 import org.apache.spark.sql.internal.CodeGenerationException
 
 /**
@@ -32,6 +33,10 @@ import org.apache.spark.sql.internal.CodeGenerationException
 case class CodegenSparkFallback(var child: SparkPlan) extends UnaryExecNode {
 
   override def output: Seq[Attribute] = child.output
+
+  override def outputPartitioning: Partitioning = child.outputPartitioning
+
+  override def outputOrdering: Seq[SortOrder] = child.outputOrdering
 
   private def executeWithFallback[T](f: SparkPlan => T, plan: SparkPlan): T = {
     try {

--- a/core/src/main/scala/org/apache/spark/sql/execution/ExistingPlans.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/ExistingPlans.scala
@@ -96,7 +96,7 @@ private[sql] abstract class PartitionedPhysicalScan(
 
   /** Specifies how data is partitioned across different nodes in the cluster. */
   override lazy val outputPartitioning: Partitioning = {
-    if (numPartitions == 1) {
+    if (numPartitions == 1 && numBuckets == 1) {
       SinglePartition
     } else if (partitionColumns.nonEmpty) {
       val callbacks = ToolsCallbackInit.toolsCallback
@@ -106,7 +106,7 @@ private[sql] abstract class PartitionedPhysicalScan(
         val session = sqlContext.sparkSession.asInstanceOf[SnappySession]
         callbacks.getOrderlessHashPartitioning(partitionColumns,
           partitionColumnAliases, numPartitions,
-          if (session.hasLinkPartitionsToBuckets) 0 else numBuckets)
+          if (session.hasLinkPartitionsToBuckets) 0 else numBuckets, numBuckets)
       } else {
         HashPartitioning(partitionColumns, numPartitions)
       }

--- a/core/src/main/scala/org/apache/spark/sql/execution/aggregate/SnappyHashAggregateExec.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/aggregate/SnappyHashAggregateExec.scala
@@ -131,12 +131,12 @@ case class SnappyHashAggregateExec(
     if (callbacks ne null) {
       partitioning match {
         case OrderlessHashPartitioningExtract(expressions, aliases,
-        nPartitions, nBuckets) => callbacks.getOrderlessHashPartitioning(
-          expressions, getAliases(expressions, aliases), nPartitions, nBuckets)
+        nPartitions, nBuckets, tBuckets) => callbacks.getOrderlessHashPartitioning(
+          expressions, getAliases(expressions, aliases), nPartitions, nBuckets, tBuckets)
 
         case HashPartitioning(expressions, nPartitions) =>
           callbacks.getOrderlessHashPartitioning(expressions,
-            getAliases(expressions, Nil), nPartitions, 0)
+            getAliases(expressions, Nil), nPartitions, 0, 0)
 
         case _ => partitioning
       }

--- a/core/src/main/scala/org/apache/spark/sql/execution/columnar/ColumnUpdateExec.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/columnar/ColumnUpdateExec.scala
@@ -18,7 +18,7 @@
 package org.apache.spark.sql.execution.columnar
 
 import org.apache.spark.sql.catalyst.expressions.codegen.{CodegenContext, ExprCode, ExpressionCanonicalizer}
-import org.apache.spark.sql.catalyst.expressions.{Attribute, BindReferences, Expression}
+import org.apache.spark.sql.catalyst.expressions.{Attribute, BindReferences, Expression, SortOrder}
 import org.apache.spark.sql.collection.Utils
 import org.apache.spark.sql.execution.SparkPlan
 import org.apache.spark.sql.execution.columnar.encoding.ColumnDeltaEncoder
@@ -59,6 +59,12 @@ case class ColumnUpdateExec(child: SparkPlan, columnTable: String,
   override protected def opType: String = "Update"
 
   override def nodeName: String = "ColumnUpdate"
+
+  // Require per-partition sort on batchId because deltas are accumulated for
+  // consecutive batchIds else it will  be very inefficient for bulk updates
+  // (e.g. for putInto). BatchId attribute is always third last in the keyColumns.
+  override def requiredChildOrdering: Seq[Seq[SortOrder]] =
+    Seq(Seq(StoreUtils.getColumnUpdateDeleteOrdering(keyColumns(keyColumns.length - 3))))
 
   override lazy val metrics: Map[String, SQLMetric] = {
     if (onExecutor) Map.empty

--- a/core/src/main/scala/org/apache/spark/sql/store/StoreUtils.scala
+++ b/core/src/main/scala/org/apache/spark/sql/store/StoreUtils.scala
@@ -27,6 +27,7 @@ import com.gemstone.gemfire.internal.cache.{CacheDistributionAdvisee, Partitione
 import com.pivotal.gemfirexd.internal.engine.Misc
 
 import org.apache.spark.Partition
+import org.apache.spark.sql.catalyst.expressions.{Ascending, Attribute, SortOrder}
 import org.apache.spark.sql.collection.{MultiBucketExecutorPartition, ToolsCallbackInit, Utils}
 import org.apache.spark.sql.execution.columnar.ExternalStoreUtils
 import org.apache.spark.sql.hive.SnappyStoreHiveCatalog
@@ -469,6 +470,13 @@ object StoreUtils {
     parameters.get(PARTITION_BY).map(v => {
       v.split(",").toSeq.map(a => a.trim)
     }).getOrElse(Seq.empty[String])
+  }
+
+  def getColumnUpdateDeleteOrdering(batchIdColumn: Attribute): SortOrder = {
+    // this always sets ascending order though no particular ordering is required rather
+    // just grouping on batchId column, but does not matter so table scan should also
+    // set the same to not introduce any extra sorting for simple updates/deletes
+    SortOrder(batchIdColumn, Ascending)
   }
 
   def validateConnProps(parameters: mutable.Map[String, String]): Unit = {


### PR DESCRIPTION
## Changes proposed in this pull request

The update/delete plans expect that input is ordered on batchIds in each
partition to minimize delta creation since they will end the previous
delta when a new batchId run-length is seen.

- instead of explicit check for Exchange in the plan to add sort on batchId
  for above, use SparkPlan's outputOrdering and requiredChildOrdering for the
  same which will be handled by EnsureRequirements automatically
- ColumnTableScan sends out ordering as that on batchId for update/delete case,
  while those plans expect the child to be ordered on the same
- update the condition to introduce exchange; earlier it used to match
  number of child partitions against target table buckets but that introduces
  unnecessary exchange for bucket pruning; now carrying the table buckets in
  OrderlessHashPartitioning and comparing that before introducing exchange
- skip DelegateRDD wrapping (for preferred locations) for the case of child having
  partition pruning since exchange will not be there in such a case

With above changes the second large update in SNAP-1914 takes just ~8mins as opposed
to over an hour before on a single AWS machine (gp2 disk).

## Patch testing

precheckin, manual TPCH testing with large number of updates as mentioned in SNAP-1914

## ReleaseNotes.txt changes

NA

## Other PRs 

NA