### PR TITLE
[SNAP-2039] correct null updates to column tables

### DIFF
--- a/cluster/src/test/resources/log4j.properties
+++ b/cluster/src/test/resources/log4j.properties
@@ -35,6 +35,8 @@ log4j.appender.console.layout.ConversionPattern=%d{yy/MM/dd HH:mm:ss.SSS zzz} %t
 # Ignore messages below warning level from Jetty, because it's a bit verbose
 log4j.logger.org.spark-project.jetty=WARN
 org.spark-project.jetty.LEVEL=WARN
+log4j.logger.org.mortbay.jetty=WARN
+log4j.logger.org.eclipse.jetty=WARN
 
 # Some packages are noisy for no good reason.
 log4j.additivity.org.apache.hadoop.hive.serde2.lazy.LazyStruct=false
@@ -66,15 +68,33 @@ log4j.logger.org.apache.spark.broadcast.TorrentBroadcast=WARN
 log4j.logger.org.apache.spark.ContextCleaner=WARN
 log4j.logger.org.apache.spark.MapOutputTracker=WARN
 log4j.logger.org.apache.spark.scheduler.TaskSchedulerImpl=WARN
-log4j.logger.org.apache.spark.storage.CoarseGrainedSchedulerBackend=WARN
 log4j.logger.org.apache.spark.storage.ShuffleBlockFetcherIterator=WARN
 log4j.logger.org.apache.spark.scheduler.DAGScheduler=WARN
 log4j.logger.org.apache.spark.scheduler.TaskSetManager=WARN
 log4j.logger.org.apache.spark.scheduler.FairSchedulableBuilder=WARN
 log4j.logger.org.apache.spark.scheduler.cluster.CoarseGrainedSchedulerBackend$DriverEndpoint=WARN
 log4j.logger.org.apache.spark.storage.BlockManagerInfo=WARN
-log4j.logger.org.apache.spark.executor.SnappyExecutor=WARN
+log4j.logger.org.apache.hadoop.hive=WARN
+# for all Spark generated code (including ad-hoc UnsafeProjection calls etc)
+log4j.logger.org.apache.spark.sql.catalyst.expressions.codegen.CodeGenerator=WARN
+log4j.logger.org.apache.spark.sql.execution.datasources=WARN
+log4j.logger.org.apache.spark.scheduler.SnappyTaskSchedulerImpl=WARN
+log4j.logger.org.apache.spark.MapOutputTrackerMasterEndpoint=WARN
+log4j.logger.org.apache.spark.MapOutputTrackerMaster=WARN
+log4j.logger.org.apache.spark.storage.memory.MemoryStore=WARN
+log4j.logger.org.apache.spark.MapOutputTrackerWorker=WARN
+log4j.logger.org.apache.parquet=ERROR
+log4j.logger.parquet=ERROR
+log4j.logger.org.apache.hadoop.io.compress=WARN
+log4j.logger.spark.jobserver.LocalContextSupervisorActor=WARN
+log4j.logger.spark.jobserver.JarManager=WARN
+log4j.logger.org.apache.spark.sql.hive.HiveClientUtil=WARN
+log4j.logger.org.datanucleus=ERROR
+# Task logger created in SparkEnv
+log4j.logger.org.apache.spark.Task=WARN
+log4j.logger.org.apache.spark.sql.catalyst.parser.CatalystSqlParser=WARN
 
+# for generated code of plans
 # log4j.logger.org.apache.spark.sql.execution.WholeStageCodegenExec=DEBUG
+# for SnappyData generated code used on store (ComplexTypeSerializer, JDBC inserts ...)
 # log4j.logger.org.apache.spark.sql.store.CodeGeneration=DEBUG
-# log4j.logger.org.apache.spark.sql.catalyst.expressions.codegen.CodeGenerator=DEBUG

--- a/core/src/main/scala/org/apache/spark/sql/execution/columnar/ColumnTableScan.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/columnar/ColumnTableScan.scala
@@ -848,7 +848,7 @@ private[sql] final case class ColumnTableScan(
            |    $isNullVar = true;
            |    $numNullsVar = -$numNullsVar;
            |  }
-           |} else if ($updateDecoder.notNull()) {
+           |} else if ($updateDecoder.readNotNull()) {
            |  $updatedAssign
            |} else {
            |  $col = $defaultValue;

--- a/core/src/main/scala/org/apache/spark/sql/execution/columnar/encoding/ColumnDeleteEncoder.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/columnar/encoding/ColumnDeleteEncoder.scala
@@ -48,6 +48,8 @@ final class ColumnDeleteEncoder extends ColumnEncoder {
 
   override protected[sql] def getNumNullWords: Int = 0
 
+  override protected[sql] def getNullWords: AnyRef = null
+
   override protected[sql] def initializeNulls(initSize: Int): Int =
     throw new UnsupportedOperationException(s"initializeNulls for $toString")
 

--- a/core/src/main/scala/org/apache/spark/sql/execution/columnar/encoding/ColumnDeltaDecoder.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/columnar/encoding/ColumnDeltaDecoder.scala
@@ -57,7 +57,6 @@ final class ColumnDeltaDecoder(buffer: ByteBuffer, field: StructField) {
     val cursor = positionCursor
     if (cursor < positionEndCursor) {
       positionCursor += 4
-      positionOrdinal += 1
       ColumnEncoding.readInt(deltaBytes, cursor)
     } else {
       // convention used by ColumnDeltaDecoder to denote the end
@@ -68,8 +67,9 @@ final class ColumnDeltaDecoder(buffer: ByteBuffer, field: StructField) {
 
   @inline def hasNulls: Boolean = realDecoder.hasNulls
 
-  @inline def notNull: Boolean = {
+  @inline def readNotNull: Boolean = {
     val n = realDecoder.numNulls(deltaBytes, positionOrdinal, numNulls)
+    positionOrdinal += 1
     if (n >= 0) {
       numNulls = n
       true
@@ -79,7 +79,7 @@ final class ColumnDeltaDecoder(buffer: ByteBuffer, field: StructField) {
     }
   }
 
-  @inline def nextNonNullOrdinal(): Unit = nonNullOrdinal += 1
+  @inline private[encoding] def nextNonNullOrdinal(): Unit = nonNullOrdinal += 1
 
   @inline def readBoolean: Boolean = {
     val ordinal = nonNullOrdinal

--- a/core/src/main/scala/org/apache/spark/sql/execution/columnar/encoding/ColumnDeltaEncoder.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/columnar/encoding/ColumnDeltaEncoder.scala
@@ -136,6 +136,8 @@ final class ColumnDeltaEncoder(val hierarchyDepth: Int) extends ColumnEncoder {
 
   override protected[sql] def getNumNullWords: Int = realEncoder.getNumNullWords
 
+  override protected[sql] def getNullWords: AnyRef = realEncoder.getNullWords
+
   override protected[sql] def writeNulls(columnBytes: AnyRef, cursor: Long,
       numWords: Int): Long = realEncoder.writeNulls(columnBytes, cursor, numWords)
 
@@ -255,16 +257,15 @@ final class ColumnDeltaEncoder(val hierarchyDepth: Int) extends ColumnEncoder {
 
   private def consumeDecoder(decoder: ColumnDecoder,
       decoderAbsolutePosition: Int /* for random access */ ,
-      decoderOrdinal: Int /* for sequential access */ ,
-      decoderBytes: AnyRef, writer: DeltaWriter, encoderCursor: Long,
+      decoderNullOrdinal: Int, decoderBytes: AnyRef,
+      decoderNullBytes: AnyRef, writer: DeltaWriter, encoderCursor: Long,
       encoderOrdinal: Int, forMerge: Boolean, doWrite: Boolean = true): Long = {
     assert(doWrite || decoderAbsolutePosition < 0)
-    if (realEncoder.isNullable) {
-      val isNull = if (decoderAbsolutePosition < 0) {
-        decoder.isNullAt(decoderBytes, decoderOrdinal)
-      } else decoder.isNullAt(decoderBytes, decoderAbsolutePosition)
-      if (isNull) {
-        if (doWrite) realEncoder.writeIsNull(encoderOrdinal)
+    if (decoderNullOrdinal >= 0) {
+      // nulls are always written as per relative position in decoder
+      if (decoder.isNullAt(decoderNullBytes, decoderNullOrdinal)) {
+        // null words are copied as is in initial creation so only write in merge
+        if (forMerge && doWrite) realEncoder.writeIsNull(encoderOrdinal)
         return encoderCursor
       }
     }
@@ -344,6 +345,7 @@ final class ColumnDeltaEncoder(val hierarchyDepth: Int) extends ColumnEncoder {
     // new delta is on the "left" while the previous delta in the table is on "right"
     val (decoder1, columnBytes1) = ColumnEncoding.getColumnDecoderAndBuffer(
       newValue, field, initializeDecoder)
+    val nullable1 = decoder1.hasNulls
     val numBaseRows = tmpNumBaseRows
     val numPositions1 = tmpNumPositions
     var positionCursor1 = tmpPositionCursor
@@ -356,6 +358,7 @@ final class ColumnDeltaEncoder(val hierarchyDepth: Int) extends ColumnEncoder {
       ColumnEncoding.getColumnDecoderAndBuffer(
         existingValue, field, ColumnEncoding.identityLong)
     }
+    val nullable2 = decoder2.hasNulls
     var numPositions2 = 0
     var positionCursor2 = 0L
     val existingValueSize = existingValue.remaining()
@@ -408,8 +411,9 @@ final class ColumnDeltaEncoder(val hierarchyDepth: Int) extends ColumnEncoder {
         if (existingIsDelta && !areEqual) positionsArray(encoderOrdinal) = position2
         // consume data at position2 and move it if position2 is smaller
         // else if they are equal then newValue gets precedence
-        cursor = consumeDecoder(decoder2, decoderAbsolutePosition = -1, relativePosition2,
-          columnBytes2, writer, cursor, encoderOrdinal, forMerge = true, doWrite = !areEqual)
+        cursor = consumeDecoder(decoder2, decoderAbsolutePosition = -1,
+          if (nullable2) relativePosition2 else -1, columnBytes2, columnBytes2,
+          writer, cursor, encoderOrdinal, forMerge = true, doWrite = !areEqual)
         relativePosition2 += 1
         if (relativePosition2 < numPositions2) {
           if (existingIsDelta) {
@@ -428,8 +432,9 @@ final class ColumnDeltaEncoder(val hierarchyDepth: Int) extends ColumnEncoder {
         // set next update position to be from first
         if (existingIsDelta) positionsArray(encoderOrdinal) = position1
         // consume data at position1 and move it
-        cursor = consumeDecoder(decoder1, decoderAbsolutePosition = -1, relativePosition1,
-          columnBytes1, writer, cursor, encoderOrdinal, forMerge = true)
+        cursor = consumeDecoder(decoder1, decoderAbsolutePosition = -1,
+          if (nullable1) relativePosition1 else -1, columnBytes1, columnBytes1,
+          writer, cursor, encoderOrdinal, forMerge = true)
         relativePosition1 += 1
         if (relativePosition1 < numPositions1) {
           position1 = ColumnEncoding.readInt(columnBytes1, positionCursor1)
@@ -449,8 +454,9 @@ final class ColumnDeltaEncoder(val hierarchyDepth: Int) extends ColumnEncoder {
         positionsArray(encoderOrdinal) = ColumnEncoding.readInt(columnBytes1, positionCursor1)
         positionCursor1 += 4
       }
-      cursor = consumeDecoder(decoder1, decoderAbsolutePosition = -1, relativePosition1,
-        columnBytes1, writer, cursor, encoderOrdinal, forMerge = true)
+      cursor = consumeDecoder(decoder1, decoderAbsolutePosition = -1,
+        if (nullable1) relativePosition1 else -1, columnBytes1, columnBytes1,
+        writer, cursor, encoderOrdinal, forMerge = true)
       relativePosition1 += 1
     }
     positionCursor2 -= 4
@@ -461,8 +467,9 @@ final class ColumnDeltaEncoder(val hierarchyDepth: Int) extends ColumnEncoder {
         positionsArray(encoderOrdinal) = ColumnEncoding.readInt(columnBytes2, positionCursor2)
         positionCursor2 += 4
       }
-      cursor = consumeDecoder(decoder2, decoderAbsolutePosition = -1, relativePosition2,
-        columnBytes2, writer, cursor, encoderOrdinal, forMerge = true)
+      cursor = consumeDecoder(decoder2, decoderAbsolutePosition = -1,
+        if (nullable2) relativePosition2 else -1, columnBytes2, columnBytes2,
+        writer, cursor, encoderOrdinal, forMerge = true)
       relativePosition2 += 1
     }
 
@@ -543,6 +550,7 @@ final class ColumnDeltaEncoder(val hierarchyDepth: Int) extends ColumnEncoder {
     val endIndex = startIndex + numDeltas
     val decoder = realEncoder.decoderBeforeFinish(encoderCursor)
     val decoderBuffer = realEncoder.buffer
+    val decoderNullBytes = realEncoder.getNullWords
     val decoderData = realEncoder.columnData
     val decoderAllocator = realEncoder.allocator
     val allocator = this.storageAllocator
@@ -565,12 +573,14 @@ final class ColumnDeltaEncoder(val hierarchyDepth: Int) extends ColumnEncoder {
     cursor = realEncoder.writeInternals(columnBytes, cursor)
 
     // write the encoded values
+    val nullable = decoder.hasNulls
     var i = startIndex
     while (i < endIndex) {
       val position = positionsArray(i)
       val decoderPosition = (position >> 32L).toInt
-      cursor = consumeDecoder(decoder, decoderPosition, decoderOrdinal = -1,
-        decoderBuffer, writer, cursor, i - startIndex, forMerge = false)
+      val ordinal = i - startIndex
+      cursor = consumeDecoder(decoder, decoderPosition, if (nullable) ordinal else -1,
+        decoderBuffer, decoderNullBytes, writer, cursor, ordinal, forMerge = false)
       i += 1
     }
     // finally flush the encoder

--- a/core/src/main/scala/org/apache/spark/sql/execution/columnar/encoding/ColumnEncoding.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/columnar/encoding/ColumnEncoding.scala
@@ -744,6 +744,8 @@ trait ColumnEncoder extends ColumnEncoding {
 
   protected[sql] def getNumNullWords: Int
 
+  protected[sql] def getNullWords: AnyRef
+
   protected[sql] def writeNulls(columnBytes: AnyRef, cursor: Long,
       numWords: Int): Long
 
@@ -1058,7 +1060,7 @@ trait NullableDecoder extends ColumnDecoder {
   private[this] final var nextNullOrdinal: Int = _
   private[this] final var numNullBytes: Int = _
 
-  private final def updateNextNullOrdinal(columnBytes: AnyRef, nextNull: Int) {
+  private final def updateNextNullOrdinal(columnBytes: AnyRef, nextNull: Int): Unit = {
     nextNullOrdinal = BitSet.nextSetBit(columnBytes, baseNullOffset, nextNull, numNullBytes)
   }
 
@@ -1140,6 +1142,8 @@ trait NotNullEncoder extends ColumnEncoder {
 
   override protected[sql] def getNumNullWords: Int = 0
 
+  override protected[sql] def getNullWords: AnyRef = null
+
   override protected[sql] def writeNulls(columnBytes: AnyRef, cursor: Long,
       numWords: Int): Long = cursor
 
@@ -1184,6 +1188,8 @@ trait NullableEncoder extends NotNullEncoder {
     while (numWords > 0 && nullWords(numWords - 1) == 0L) numWords -= 1
     numWords
   }
+
+  override protected[sql] def getNullWords: AnyRef = nullWords
 
   override protected[sql] def initializeNulls(initSize: Int): Int = {
     if (nullWords eq null) {

--- a/core/src/main/scala/org/apache/spark/sql/execution/columnar/encoding/UpdatedColumnDecoder.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/columnar/encoding/UpdatedColumnDecoder.scala
@@ -39,7 +39,7 @@ final class UpdatedColumnDecoder(decoder: ColumnDecoder, field: StructField,
 
   protected def nullable: Boolean = false
 
-  def notNull: Boolean = true
+  def readNotNull: Boolean = true
 }
 
 /**
@@ -54,7 +54,7 @@ final class UpdatedColumnDecoderNullable(decoder: ColumnDecoder, field: StructFi
 
   protected def nullable: Boolean = true
 
-  def notNull: Boolean = currentDeltaBuffer.notNull
+  def readNotNull: Boolean = currentDeltaBuffer.readNotNull
 }
 
 object UpdatedColumnDecoder {
@@ -112,7 +112,7 @@ abstract class UpdatedColumnDecoderBase(decoder: ColumnDecoder, field: StructFie
   final def getCurrentDeltaBuffer: ColumnDeltaDecoder = currentDeltaBuffer
 
   @inline protected final def skipUpdatedPosition(delta: ColumnDeltaDecoder): Unit = {
-    if (!nullable || delta.notNull) delta.nextNonNullOrdinal()
+    if (!nullable || delta.readNotNull) delta.nextNonNullOrdinal()
   }
 
   protected final def moveToNextUpdatedPosition(ordinal: Int): Int = {
@@ -192,7 +192,7 @@ abstract class UpdatedColumnDecoderBase(decoder: ColumnDecoder, field: StructFie
     else skipUntil(ordinal)
   }
 
-  def notNull: Boolean
+  def readNotNull: Boolean
 
   // TODO: SW: need to create a combined delta+full value dictionary for this to work
 

--- a/core/src/test/resources/log4j.properties
+++ b/core/src/test/resources/log4j.properties
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-log4j.rootCategory=DEBUG, file
+log4j.rootCategory=INFO, file
 
 # RollingFile appender
 log4j.appender.file=org.apache.log4j.RollingFileAppender
@@ -35,6 +35,8 @@ log4j.appender.console.layout.ConversionPattern=%d{yy/MM/dd HH:mm:ss.SSS zzz} %t
 # Ignore messages below warning level from Jetty, because it's a bit verbose
 log4j.logger.org.spark-project.jetty=WARN
 org.spark-project.jetty.LEVEL=WARN
+log4j.logger.org.mortbay.jetty=WARN
+log4j.logger.org.eclipse.jetty=WARN
 
 # Some packages are noisy for no good reason.
 log4j.additivity.org.apache.hadoop.hive.serde2.lazy.LazyStruct=false
@@ -66,15 +68,33 @@ log4j.logger.org.apache.spark.broadcast.TorrentBroadcast=WARN
 log4j.logger.org.apache.spark.ContextCleaner=WARN
 log4j.logger.org.apache.spark.MapOutputTracker=WARN
 log4j.logger.org.apache.spark.scheduler.TaskSchedulerImpl=WARN
-log4j.logger.org.apache.spark.storage.CoarseGrainedSchedulerBackend=WARN
 log4j.logger.org.apache.spark.storage.ShuffleBlockFetcherIterator=WARN
 log4j.logger.org.apache.spark.scheduler.DAGScheduler=WARN
 log4j.logger.org.apache.spark.scheduler.TaskSetManager=WARN
 log4j.logger.org.apache.spark.scheduler.FairSchedulableBuilder=WARN
 log4j.logger.org.apache.spark.scheduler.cluster.CoarseGrainedSchedulerBackend$DriverEndpoint=WARN
 log4j.logger.org.apache.spark.storage.BlockManagerInfo=WARN
-log4j.logger.org.apache.spark.executor.SnappyExecutor=WARN
+log4j.logger.org.apache.hadoop.hive=WARN
+# for all Spark generated code (including ad-hoc UnsafeProjection calls etc)
+log4j.logger.org.apache.spark.sql.catalyst.expressions.codegen.CodeGenerator=DEBUG
+log4j.logger.org.apache.spark.sql.execution.datasources=WARN
+log4j.logger.org.apache.spark.scheduler.SnappyTaskSchedulerImpl=WARN
+log4j.logger.org.apache.spark.MapOutputTrackerMasterEndpoint=WARN
+log4j.logger.org.apache.spark.MapOutputTrackerMaster=WARN
+log4j.logger.org.apache.spark.storage.memory.MemoryStore=WARN
+log4j.logger.org.apache.spark.MapOutputTrackerWorker=WARN
+log4j.logger.org.apache.parquet=ERROR
+log4j.logger.parquet=ERROR
+log4j.logger.org.apache.hadoop.io.compress=WARN
+log4j.logger.spark.jobserver.LocalContextSupervisorActor=WARN
+log4j.logger.spark.jobserver.JarManager=WARN
+log4j.logger.org.apache.spark.sql.hive.HiveClientUtil=WARN
+log4j.logger.org.datanucleus=ERROR
+# Task logger created in SparkEnv
+log4j.logger.org.apache.spark.Task=WARN
+log4j.logger.org.apache.spark.sql.catalyst.parser.CatalystSqlParser=WARN
 
+# for generated code of plans
 # log4j.logger.org.apache.spark.sql.execution.WholeStageCodegenExec=DEBUG
-# log4j.logger.org.apache.spark.sql.catalyst.expressions.codegen.CodeGenerator=DEBUG
+# for SnappyData generated code used on store (ComplexTypeSerializer, JDBC inserts ...)
 # log4j.logger.org.apache.spark.sql.store.CodeGeneration=DEBUG

--- a/core/src/test/scala/org/apache/spark/sql/store/TokenizationTest.scala
+++ b/core/src/test/scala/org/apache/spark/sql/store/TokenizationTest.scala
@@ -772,13 +772,59 @@ class TokenizationTest
         s" where (taxiin > 20 or taxiout > 20) and dest in  (select dest from $colTableName " +
         s" where distance = 658 group by dest having count ( * ) > 100) group by dest order " +
         s" by avgTaxiTime desc")
-    val res2 = df.collect()
+    var res2 = df.collect()
     val r2 = normalizeRow(res2)
     assert(!r1.sameElements(r2))
     // assert( SnappySession.getPlanCache.asMap().size() == 1)
 
     // also check partial delete followed by a full delete
     val count = snc.table(colTableName).count()
+
+    // null, non-null combinations of updates
+
+    // implicit int to string cast should fail (SNAP-2039)
+    res2 = snc.sql(s"update $colTableName set DEST = DEST + 1000 where " +
+        "depdelay = 0 and arrdelay > 0 and airtime > 350").collect()
+    val numUpdated0 = res2.foldLeft(0L)(_ + _.getLong(0))
+    assert(numUpdated0 > 0)
+    assert(snc.sql(s"select * from $colTableName where depdelay = 0 and arrdelay > 0 " +
+        "and airtime > 350 and dest is not null").collect().length === 0)
+
+    // check null updates
+    res2 = snc.sql(s"update $colTableName set DEST = null where " +
+        "depdelay = 0 and arrdelay > 0 and airtime > 350").collect()
+    val numUpdated1 = res2.foldLeft(0L)(_ + _.getLong(0))
+    assert(numUpdated1 > 0)
+    assert(snc.sql(s"select * from $colTableName where depdelay = 0 and arrdelay > 0 " +
+        "and airtime > 350 and dest is not null").collect().length === 0)
+
+    // check normal non-null updates
+    res2 = snc.sql(s"update $colTableName set DEST = 'DEST__UPDATED' where " +
+        "depdelay = 0 and arrdelay > 0 and airtime > 350").collect()
+    val numUpdated2 = res2.foldLeft(0L)(_ + _.getLong(0))
+    assert(numUpdated1 === numUpdated2)
+    assert(snc.sql(s"select * from $colTableName where depdelay = 0 and arrdelay > 0 " +
+        "and airtime > 350 and dest not like '%__UPDATED'").collect().length === 0)
+
+    // new overlapping null updates
+    res2 = snc.sql(s"update $colTableName set DEST = null where " +
+        "depdelay = 0 and arrdelay > 0 and airtime > 250").collect()
+    val numUpdated3 = res2.foldLeft(0L)(_ + _.getLong(0))
+    assert(numUpdated3 > numUpdated1)
+    assert(snc.sql(s"select * from $colTableName where depdelay = 0 and arrdelay > 0 " +
+        "and airtime > 250 and dest is not null").collect().length === 0)
+
+    // new overlapping non-null updates
+    res2 = snc.sql(s"update $colTableName set DEST = concat(DEST, '__UPDATED') where " +
+        "depdelay = 0 and arrdelay > 0 and airtime > 100").collect()
+    val numUpdated4 = res2.foldLeft(0L)(_ + _.getLong(0))
+    assert(numUpdated4 > numUpdated3)
+    assert(snc.sql(s"select * from $colTableName where depdelay = 0 and arrdelay > 0 " +
+        s"and airtime > 250 and dest is not null").collect().length === 0)
+    assert(snc.sql(s"select * from $colTableName where depdelay = 0 and arrdelay > 0 " +
+        "and airtime > 100 and airtime <= 250 and dest not like '%__UPDATED'")
+        .collect().length === 0)
+
     val del1 = snc.sql(s"delete from $colTableName where depdelay = 0 and arrdelay > 0")
     val delCount1 = del1.collect().foldLeft(0L)(_ + _.getLong(0))
     assert(delCount1 > 0)


### PR DESCRIPTION
## Changes proposed in this pull request

- use the encoder nullWords array when reading from decoder on top of it in
  final update delta creation
- moved null ordinal increment to notNull method to correct off by one error
  (moveNext is one step ahead); renamed notNull method to readNotNull to indicate
  that this increments cursor
- added test for null, not-null combinations
- updated cluster/core log4j.properties with latest defaults from store-log4j.properties

## Patch testing

precheckin

## ReleaseNotes.txt changes

NA

## Other PRs 

NA