### PR TITLE
[SNAP-1986] use a global lock throughout hive client initialization

### DIFF
--- a/core/src/main/java/io/snappydata/impl/SnappyHiveCatalog.java
+++ b/core/src/main/java/io/snappydata/impl/SnappyHiveCatalog.java
@@ -59,6 +59,8 @@ public class SnappyHiveCatalog implements ExternalCatalog {
   public static final ThreadLocal<Boolean> SKIP_HIVE_TABLE_CALLS =
       new ThreadLocal<>();
 
+  public static final Object hiveClientSync = new Object();
+
   private final ExecutorService hmsQueriesExecutorService;
 
   public SnappyHiveCatalog() {
@@ -109,7 +111,7 @@ public class SnappyHiveCatalog implements ExternalCatalog {
    *
    * @return the location of hive warehouse (unused but hive creates the directory)
    */
-  public static synchronized String initCommonHiveMetaStoreProperties(
+  public static String initCommonHiveMetaStoreProperties(
       HiveConf metadataConf) {
     metadataConf.set("datanucleus.mapping.Schema", Misc.SNAPPY_HIVE_METASTORE);
     // Tomcat pool has been shown to work best but does not work in split mode
@@ -297,7 +299,9 @@ public class SnappyHiveCatalog implements ExternalCatalog {
         }
       switch (this.qType) {
         case INIT:
-          initHMC();
+          synchronized (hiveClientSync) {
+            initHMC();
+          }
           return true;
 
         case ISROWTABLE_QUERY:

--- a/core/src/main/scala/org/apache/spark/sql/hive/HiveClientUtil.scala
+++ b/core/src/main/scala/org/apache/spark/sql/hive/HiveClientUtil.scala
@@ -152,7 +152,7 @@ private class HiveClientUtil(sparkContext: SparkContext) extends Logging {
     }
   }
 
-  private def newClient(): HiveClient = {
+  private def newClient(): HiveClient = SnappyHiveCatalog.hiveClientSync.synchronized {
 
     val metaVersion = IsolatedClientLoader.hiveVersion(hiveMetastoreVersion)
     // We instantiate a HiveConf here to read in the hive-site.xml file and


### PR DESCRIPTION
Global lock ensures no two hive client initializations end up trying  to
create the hive directory causing SNAP-1986

## Changes proposed in this pull request

Removed the sync on initCommonHiveMetaStoreProperties and instead synchronize
on a common SnappyHiveCatalog.hiveClientSync for all hive client initializations
from SnappyHiveCatalog and HiveClientUtil.

## Patch testing

precheckin

## ReleaseNotes.txt changes

NA

## Other PRs 

NA