### PR TITLE
[SNAP-2072][SNAP-2073] fix external connectors; support VIEWs

### DIFF
--- a/cluster/src/main/scala/org/apache/spark/ui/SnappyMemberDetailsPage.scala
+++ b/cluster/src/main/scala/org/apache/spark/ui/SnappyMemberDetailsPage.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2017 SnappyData, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License. You
+ * may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License. See accompanying
+ * LICENSE file.
+ */
 package org.apache.spark.ui
 
 import java.io.File

--- a/core/src/main/java/io/snappydata/impl/SnappyHiveCatalog.java
+++ b/core/src/main/java/io/snappydata/impl/SnappyHiveCatalog.java
@@ -36,10 +36,10 @@ import com.pivotal.gemfirexd.internal.impl.sql.catalog.GfxdDataDictionary;
 import com.pivotal.gemfirexd.internal.shared.common.reference.SQLState;
 import org.apache.commons.collections.map.CaseInsensitiveMap;
 import org.apache.hadoop.hive.conf.HiveConf;
-import org.apache.hadoop.hive.metastore.HiveMetaStoreClient;
-import org.apache.hadoop.hive.metastore.api.NoSuchObjectException;
-import org.apache.hadoop.hive.metastore.api.Table;
 import org.apache.hadoop.hive.ql.metadata.Hive;
+import org.apache.hadoop.hive.ql.metadata.HiveException;
+import org.apache.hadoop.hive.ql.metadata.InvalidTableException;
+import org.apache.hadoop.hive.ql.metadata.Table;
 import org.apache.spark.sql.collection.Utils;
 import org.apache.spark.sql.execution.columnar.ExternalStoreUtils;
 import org.apache.spark.sql.execution.datasources.jdbc.DriverRegistry;
@@ -48,13 +48,10 @@ import org.apache.spark.sql.hive.SnappyStoreHiveCatalog;
 import org.apache.spark.sql.sources.JdbcExtendedUtils;
 import org.apache.spark.sql.store.StoreUtils;
 import org.apache.spark.sql.types.StructType;
-import org.apache.thrift.TException;
 
 public class SnappyHiveCatalog implements ExternalCatalog {
 
   final private static String THREAD_GROUP_NAME = "HiveMetaStore Client Group";
-
-  private ThreadLocal<HiveMetaStoreClient> hmClients = new ThreadLocal<>();
 
   public static final ThreadLocal<Boolean> SKIP_HIVE_TABLE_CALLS =
       new ThreadLocal<>();
@@ -293,6 +290,7 @@ public class SnappyHiveCatalog implements ExternalCatalog {
     @Override
     public Object call() throws Exception {
       SKIP_HIVE_TABLE_CALLS.set(Boolean.TRUE);
+      Hive hmc;
       try {
         if (this.skipLock) {
           GfxdDataDictionary.SKIP_LOCKS.set(true);
@@ -305,25 +303,25 @@ public class SnappyHiveCatalog implements ExternalCatalog {
           return true;
 
         case ISROWTABLE_QUERY:
-          HiveMetaStoreClient hmc = SnappyHiveCatalog.this.hmClients.get();
+          hmc = Hive.get();
           String type = getType(hmc);
           return type.equalsIgnoreCase(ExternalTableType.Row().name());
 
         case ISCOLUMNTABLE_QUERY:
-          hmc = SnappyHiveCatalog.this.hmClients.get();
+          hmc = Hive.get();
           type = getType(hmc);
           return !type.equalsIgnoreCase(ExternalTableType.Row().name());
 
         case COLUMNTABLE_SCHEMA:
-          hmc = SnappyHiveCatalog.this.hmClients.get();
+          hmc = Hive.get();
           return getSchema(hmc);
 
         case GET_TABLE:
-          hmc = SnappyHiveCatalog.this.hmClients.get();
+          hmc = Hive.get();
           return getTable(hmc, this.dbName, this.tableName);
 
         case GET_HIVE_TABLES: {
-          hmc = SnappyHiveCatalog.this.hmClients.get();
+          hmc = Hive.get();
           List<String> schemas = hmc.getAllDatabases();
           ArrayList<ExternalTableMetaData> externalTables = new ArrayList<>();
           for (String schema : schemas) {
@@ -342,7 +340,7 @@ public class SnappyHiveCatalog implements ExternalCatalog {
                 metaData.provider = table.getParameters().get(
                     SnappyStoreHiveCatalog.HIVE_PROVIDER());
                 metaData.columns = ExternalStoreUtils.getColumnMetadata(
-                    ExternalStoreUtils.getTableSchema(table.getParameters()));
+                    ExternalStoreUtils.getTableSchema(table));
                 externalTables.add(metaData);
               }
             }
@@ -351,7 +349,7 @@ public class SnappyHiveCatalog implements ExternalCatalog {
         }
 
         case GET_ALL_TABLES_MANAGED_IN_DD:
-          hmc = SnappyHiveCatalog.this.hmClients.get();
+          hmc = Hive.get();
           List<String> dbList = hmc.getAllDatabases();
           HashMap<String, List<String>> dbTablesMap = new HashMap<>();
           for (String db : dbList) {
@@ -369,17 +367,16 @@ public class SnappyHiveCatalog implements ExternalCatalog {
           }
           return dbTablesMap;
         case REMOVE_TABLE:
-          hmc = SnappyHiveCatalog.this.hmClients.get();
+          hmc = Hive.get();
           hmc.dropTable(this.dbName, this.tableName);
           return true;
         case GET_COL_TABLE:
-          hmc = SnappyHiveCatalog.this.hmClients.get();
+          hmc = Hive.get();
           Table table = getTableWithRetry(hmc);
           if (table == null) return null;
           String fullyQualifiedName = Utils.toUpperCase(table.getDbName()) +
               "." + Utils.toUpperCase(table.getTableName());
-          StructType schema = ExternalStoreUtils.getTableSchema(
-              table.getParameters()).get();
+          StructType schema = ExternalStoreUtils.getTableSchema(table);
           @SuppressWarnings("unchecked")
           Map<String, String> parameters = new CaseInsensitiveMap(
               table.getSd().getSerdeInfo().getParameters());
@@ -413,9 +410,7 @@ public class SnappyHiveCatalog implements ExternalCatalog {
               dependentRelations);
 
         case CLOSE_HMC:
-          hmc = SnappyHiveCatalog.this.hmClients.get();
-          hmc.close();
-          SnappyHiveCatalog.this.hmClients.remove();
+          Hive.closeCurrent();
           return true;
 
         default:
@@ -466,8 +461,7 @@ public class SnappyHiveCatalog implements ExternalCatalog {
       short count = 0;
       while (true) {
         try {
-          HiveMetaStoreClient hmc = new HiveMetaStoreClient(metadataConf);
-          SnappyHiveCatalog.this.hmClients.set(hmc);
+          Hive hmc = Hive.get(metadataConf);
           // a dummy table query to pre-initialize most of hive metastore tables
           try {
             getTable(hmc, "APP", "DUMMY");
@@ -508,23 +502,22 @@ public class SnappyHiveCatalog implements ExternalCatalog {
       }
     }
 
-    private Table getTable(HiveMetaStoreClient hmc,
-        String dbName, String tableName) throws SQLException {
+    private Table getTable(Hive hmc, String dbName, String tableName) throws SQLException {
       try {
         return hmc.getTable(dbName, tableName);
-      } catch (NoSuchObjectException ignored) {
+      } catch (InvalidTableException ignored) {
         return null;
-      } catch (TException te) {
+      } catch (HiveException he) {
         throw Util.generateCsSQLException(SQLState.TABLE_NOT_FOUND,
-            tableName, te);
+            tableName, he);
       }
     }
 
-    private String getType(HiveMetaStoreClient hmc) throws SQLException {
+    private String getType(Hive hmc) throws SQLException {
       return ExternalTableType.getTableType(getTable(hmc, this.dbName, this.tableName));
     }
 
-    private Table getTableWithRetry(HiveMetaStoreClient hmc) throws SQLException {
+    private Table getTableWithRetry(Hive hmc) throws SQLException {
       Table table = null;
       try {
         table = getTable(hmc, this.dbName, this.tableName);
@@ -537,7 +530,7 @@ public class SnappyHiveCatalog implements ExternalCatalog {
       return table;
     }
 
-    private String getSchema(HiveMetaStoreClient hmc) throws SQLException {
+    private String getSchema(Hive hmc) throws SQLException {
       Table table = getTableWithRetry(hmc);
       if (table != null) {
         return SnappyStoreHiveCatalog.getSchemaStringFromHiveTable(table);

--- a/core/src/main/java/org/apache/spark/sql/hive/SnappySharedState.java
+++ b/core/src/main/java/org/apache/spark/sql/hive/SnappySharedState.java
@@ -18,17 +18,21 @@ package org.apache.spark.sql.hive;
 
 import io.snappydata.impl.SnappyHiveCatalog;
 import org.apache.spark.SparkContext;
+import org.apache.spark.SparkException;
 import org.apache.spark.sql.ClusterMode;
 import org.apache.spark.sql.SnappyContext;
 import org.apache.spark.sql.SparkSession;
 import org.apache.spark.sql.ThinClientConnectorMode;
 import org.apache.spark.sql.catalyst.catalog.ExternalCatalog;
+import org.apache.spark.sql.catalyst.catalog.GlobalTempViewManager;
+import org.apache.spark.sql.collection.Utils;
 import org.apache.spark.sql.execution.columnar.ExternalStoreUtils;
 import org.apache.spark.sql.execution.ui.SQLListener;
 import org.apache.spark.sql.execution.ui.SQLTab;
 import org.apache.spark.sql.execution.ui.SnappySQLListener;
 import org.apache.spark.sql.hive.client.HiveClient;
 import org.apache.spark.sql.internal.SharedState;
+import org.apache.spark.sql.internal.StaticSQLConf;
 import org.apache.spark.ui.SparkUI;
 
 /**
@@ -39,13 +43,19 @@ public final class SnappySharedState extends SharedState {
   /**
    * A Hive client used to interact with the meta-store.
    */
-  private volatile HiveClient client;
+  private final HiveClient client;
 
   /**
    * The ExternalCatalog implementation used for SnappyData (either
    * for embedded cluster or for connector).
    */
-  private volatile SnappyExternalCatalog snappyCatalog;
+  private final SnappyExternalCatalog snappyCatalog;
+
+  /**
+   * Overrides to use upper-case "database" name as assumed by SnappyData
+   * conventions to follow other normal DBs.
+   */
+  private final GlobalTempViewManager globalViewManager;
 
   /**
    * Used to skip initializing meta-store in super's constructor.
@@ -55,7 +65,7 @@ public final class SnappySharedState extends SharedState {
   private static final String CATALOG_IMPLEMENTATION = "spark.sql.catalogImplementation";
 
   /**
-   *  Create Snappy's SQL Listener instead of SQLListener
+   * Create Snappy's SQL Listener instead of SQLListener
    */
   private static SQLListener createListenerAndUI(SparkContext sc) {
     SQLListener initListener = ExternalStoreUtils.getSQLListener().get();
@@ -69,18 +79,50 @@ public final class SnappySharedState extends SharedState {
         }
       }
       return ExternalStoreUtils.getSQLListener().get();
-    }
-    else {
+    } else {
       return initListener;
     }
   }
 
-  private SnappySharedState(SparkContext sparkContext) {
+  private SnappySharedState(SparkContext sparkContext) throws SparkException {
     super(sparkContext);
+
+    Boolean oldFlag = SnappyHiveCatalog.SKIP_HIVE_TABLE_CALLS.get();
+    SnappyHiveCatalog.SKIP_HIVE_TABLE_CALLS.set(Boolean.TRUE);
+    try {
+      // avoid inheritance of activeSession
+      SparkSession.clearActiveSession();
+      this.client = HiveClientUtil$.MODULE$.newClient(sparkContext());
+    } finally {
+      SnappyHiveCatalog.SKIP_HIVE_TABLE_CALLS.set(oldFlag);
+    }
+
+    ClusterMode mode = SnappyContext.getClusterMode(sparkContext());
+    if (mode instanceof ThinClientConnectorMode) {
+      this.snappyCatalog = new SnappyConnectorExternalCatalog(this.client,
+          sparkContext().hadoopConfiguration());
+    } else {
+      this.snappyCatalog = new SnappyExternalCatalog(this.client,
+          sparkContext().hadoopConfiguration());
+    }
+
+    // Initialize global temporary view manager.
+    // Use upper-case database to match the convention used by SnappySession.
+    String globalDBName = Utils.toUpperCase(sparkContext().conf().get(
+        StaticSQLConf.GLOBAL_TEMP_DATABASE()));
+    if (this.snappyCatalog.databaseExists(globalDBName)) {
+      throw new SparkException(globalDBName + " is a system reserved schema, " +
+          "please drop your existing schema to resolve the name conflict, " +
+          "or set a different value for " + StaticSQLConf.GLOBAL_TEMP_DATABASE().key() +
+          ", and start the cluster again.");
+    }
+    this.globalViewManager = new GlobalTempViewManager(globalDBName);
+
     this.initialized = true;
   }
 
-  public static synchronized SnappySharedState create(SparkContext sparkContext) {
+  public static synchronized SnappySharedState create(SparkContext sparkContext)
+      throws SparkException {
     // force in-memory catalog to avoid initializing hive for SnappyData
     final String catalogImpl = sparkContext.conf().get(CATALOG_IMPLEMENTATION, null);
     // there is a small thread-safety issue in that if multiple threads
@@ -101,46 +143,11 @@ public final class SnappySharedState extends SharedState {
     return sharedState;
   }
 
-  private synchronized void initMetaStore() {
-    if (this.client != null) {
-      assert this.snappyCatalog != null;
-      return;
-    }
-    Boolean oldFlag = SnappyHiveCatalog.SKIP_HIVE_TABLE_CALLS.get();
-    SnappyHiveCatalog.SKIP_HIVE_TABLE_CALLS.set(Boolean.TRUE);
-    try {
-      // avoid inheritance of activeSession
-      SparkSession.clearActiveSession();
-      this.client = HiveClientUtil$.MODULE$.newClient(sparkContext());
-    } finally {
-      SnappyHiveCatalog.SKIP_HIVE_TABLE_CALLS.set(oldFlag);
-    }
-
-    ClusterMode mode = SnappyContext.getClusterMode(sparkContext());
-    if (mode instanceof ThinClientConnectorMode) {
-      this.snappyCatalog = new SnappyConnectorExternalCatalog(metadataHive(),
-          sparkContext().hadoopConfiguration());
-    } else {
-      this.snappyCatalog = new SnappyExternalCatalog(metadataHive(),
-          sparkContext().hadoopConfiguration());
-    }
-  }
-
   public HiveClient metadataHive() {
-    final HiveClient client = this.client;
-    if (client != null) {
-      return client;
-    }
-    initMetaStore();
     return this.client;
   }
 
   public SnappyExternalCatalog snappyCatalog() {
-    final SnappyExternalCatalog snappyCatalog = this.snappyCatalog;
-    if (snappyCatalog != null) {
-      return snappyCatalog;
-    }
-    initMetaStore();
     return this.snappyCatalog;
   }
 
@@ -152,5 +159,19 @@ public final class SnappySharedState extends SharedState {
       // in super constructor, no harm in returning super's value at this point
       return super.externalCatalog();
     }
+  }
+
+  @Override
+  public GlobalTempViewManager globalTempViewManager() {
+    if (this.initialized) {
+      return this.globalViewManager;
+    } else {
+      // in super constructor, no harm in returning super's value at this point
+      return super.globalTempViewManager();
+    }
+  }
+
+  public void close() {
+    snappyCatalog().close();
   }
 }

--- a/core/src/main/scala/org/apache/spark/sql/SmartConnectorHelper.scala
+++ b/core/src/main/scala/org/apache/spark/sql/SmartConnectorHelper.scala
@@ -223,7 +223,7 @@ class SmartConnectorHelper(snappySession: SnappySession) extends Logging {
       ois.readObject().asInstanceOf[Table]
     }
 
-    if (ExternalTableType.isTableBackedByRegion(t)) {
+    if (ExternalTableType.isTableBackedByRegion(ExternalTableType.getTableType(t))) {
       val bucketCount = getMetaDataStmt.getInt(3)
       val indexColsString = getMetaDataStmt.getString(5)
       val indexCols = Option(indexColsString) match {

--- a/core/src/main/scala/org/apache/spark/sql/SmartConnectorHelper.scala
+++ b/core/src/main/scala/org/apache/spark/sql/SmartConnectorHelper.scala
@@ -39,7 +39,7 @@ class SmartConnectorHelper(snappySession: SnappySession) extends Logging {
   private var conn: Connection = _
   private var connectionURL: String = _
   private val createSnappyTblString = "call sys.CREATE_SNAPPY_TABLE(?, ?, ?, ?, ?, ?, ?)"
-  private val dropSnappyTblString = "call sys.DROP_SNAPPY_TABLE(?, ?)"
+  private val dropSnappyTblString = "call sys.DROP_SNAPPY_TABLE(?, ?, ?)"
   private val createSnappyIdxString = "call sys.CREATE_SNAPPY_INDEX(?, ?, ?, ?)"
   private val dropSnappyIdxString = "call sys.DROP_SNAPPY_INDEX(?, ?)"
   private val getMetaDataStmtString = "call sys.GET_TABLE_METADATA(?, ?, ?, ?, ?, ?, ?, ?)"
@@ -142,9 +142,10 @@ class SmartConnectorHelper(snappySession: SnappySession) extends Logging {
     createSnappyTblStmt.execute()
   }
 
-  def dropTable(tableIdent: QualifiedTableName, ifExists: Boolean = false): Unit = {
+  def dropTable(tableIdent: QualifiedTableName, ifExists: Boolean,
+      isExternal: Boolean): Unit = {
     snappySession.sessionCatalog.invalidateTable(tableIdent)
-    runStmtWithExceptionHandling(executeDropTableStmt(tableIdent, ifExists))
+    runStmtWithExceptionHandling(executeDropTableStmt(tableIdent, ifExists, isExternal))
     SnappyStoreHiveCatalog.registerRelationDestroy()
     SnappySession.clearAllCache()
   }
@@ -167,9 +168,10 @@ class SmartConnectorHelper(snappySession: SnappySession) extends Logging {
   }
 
   private def executeDropTableStmt(tableIdent: QualifiedTableName,
-      ifExists: Boolean): Unit = {
+      ifExists: Boolean, isExternal: Boolean): Unit = {
     dropSnappyTblStmt.setString(1, tableIdent.schemaName + "." + tableIdent.table)
     dropSnappyTblStmt.setBoolean(2, ifExists)
+    dropSnappyTblStmt.setBoolean(3, isExternal)
     dropSnappyTblStmt.execute()
   }
 

--- a/core/src/main/scala/org/apache/spark/sql/SmartConnectorHelper.scala
+++ b/core/src/main/scala/org/apache/spark/sql/SmartConnectorHelper.scala
@@ -23,7 +23,7 @@ import com.pivotal.gemfirexd.Attribute
 import com.pivotal.gemfirexd.internal.shared.common.reference.SQLState
 import io.snappydata.Constant
 import io.snappydata.impl.SparkConnectorRDDHelper
-import org.apache.hadoop.hive.metastore.api.Table
+import org.apache.hadoop.hive.ql.metadata.Table
 
 import org.apache.spark.sql.catalyst.expressions.SortDirection
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
@@ -223,9 +223,7 @@ class SmartConnectorHelper(snappySession: SnappySession) extends Logging {
       ois.readObject().asInstanceOf[Table]
     }
 
-    val tableType = if (t ne null) ExternalTableType.getTableType(t.getTableType, t.getParameters)
-    else ExternalTableType.External.name
-    if (ExternalTableType.isTableBackedByRegion(tableType)) {
+    if (ExternalTableType.isTableBackedByRegion(ExternalTableType.getTableType(t))) {
       val bucketCount = getMetaDataStmt.getInt(3)
       val indexColsString = getMetaDataStmt.getString(5)
       val indexCols = Option(indexColsString) match {

--- a/core/src/main/scala/org/apache/spark/sql/SmartConnectorHelper.scala
+++ b/core/src/main/scala/org/apache/spark/sql/SmartConnectorHelper.scala
@@ -223,7 +223,9 @@ class SmartConnectorHelper(snappySession: SnappySession) extends Logging {
       ois.readObject().asInstanceOf[Table]
     }
 
-    if (ExternalTableType.isTableBackedByRegion(ExternalTableType.getTableType(t))) {
+    val tableType = if (t ne null) ExternalTableType.getTableType(t.getTableType, t.getParameters)
+    else ExternalTableType.External.name
+    if (ExternalTableType.isTableBackedByRegion(tableType)) {
       val bucketCount = getMetaDataStmt.getInt(3)
       val indexColsString = getMetaDataStmt.getString(5)
       val indexCols = Option(indexColsString) match {

--- a/core/src/main/scala/org/apache/spark/sql/SnappyBaseParser.scala
+++ b/core/src/main/scala/org/apache/spark/sql/SnappyBaseParser.scala
@@ -296,10 +296,6 @@ object SnappyParserConsts {
   final val numericSuffix: CharPredicate = CharPredicate('D', 'L')
   final val plural: CharPredicate = CharPredicate('s', 'S')
 
-  final val trueFn: () => Boolean = () => true
-
-  final val falseFn: () => Boolean = () => false
-
   final val reservedKeywords: mutable.Set[String] = mutable.Set[String]()
 
   final val allKeywords: mutable.Set[String] = mutable.Set[String]()
@@ -442,6 +438,7 @@ object SnappyParserConsts {
   final val PUT: Keyword = nonReservedKeyword("put")
   final val REFRESH: Keyword = nonReservedKeyword("refresh")
   final val REGEXP: Keyword = nonReservedKeyword("regexp")
+  final val REPLACE: Keyword = nonReservedKeyword("replace")
   final val RETURNS: Keyword = nonReservedKeyword("returns")
   final val RLIKE: Keyword = nonReservedKeyword("rlike")
   final val SEMI: Keyword = nonReservedKeyword("semi")
@@ -457,6 +454,7 @@ object SnappyParserConsts {
   final val UNCACHE: Keyword = nonReservedKeyword("uncache")
   final val USING: Keyword = nonReservedKeyword("using")
   final val VALUES: Keyword = nonReservedKeyword("values")
+  final val VIEW: Keyword = nonReservedKeyword("view")
 
   // Window analytical functions are non-reserved
   final val DURATION: Keyword = nonReservedKeyword("duration")

--- a/core/src/main/scala/org/apache/spark/sql/SnappyContext.scala
+++ b/core/src/main/scala/org/apache/spark/sql/SnappyContext.scala
@@ -1147,6 +1147,26 @@ object SnappyContext extends Logging {
       else providerName)
   }
 
+  /**
+   * Check if given provider is builtin (including qualified names) and return
+   * the short name and a flag indicating whether provider is a builtin or not.
+   */
+  def getBuiltInProvider(providerName: String): (String, Boolean) = {
+    if (builtinSources.contains(providerName)) {
+      (providerName, true)
+    } else {
+      // check in values too
+      val fullProvider = if (providerName.endsWith(".DefaultSource")) providerName
+      else providerName + ".DefaultSource"
+      builtinSources.collectFirst {
+        case (p, c) if c == providerName ||
+            ((fullProvider ne providerName) && c == fullProvider) => p
+      } match {
+        case Some(p) => (p, true)
+        case _ => (providerName, false)
+      }
+    }
+  }
 
   def flushSampleTables(): Unit = {
     val sampleRelations = _anySNContext.sessionState.catalog.

--- a/core/src/main/scala/org/apache/spark/sql/SnappyContext.scala
+++ b/core/src/main/scala/org/apache/spark/sql/SnappyContext.scala
@@ -28,6 +28,7 @@ import scala.reflect.runtime.universe.TypeTag
 import com.pivotal.gemfirexd.internal.engine.Misc
 import io.snappydata.util.ServiceUtils
 import io.snappydata.{Constant, Property, SnappyTableStatsProviderService}
+import org.apache.hadoop.hive.ql.metadata.Hive
 
 import org.apache.spark._
 import org.apache.spark.annotation.{DeveloperApi, Experimental}
@@ -42,7 +43,7 @@ import org.apache.spark.sql.execution.ConnectionPool
 import org.apache.spark.sql.execution.columnar.ExternalStoreUtils
 import org.apache.spark.sql.execution.datasources.csv.CSVFileFormat
 import org.apache.spark.sql.execution.joins.HashedObjectCache
-import org.apache.spark.sql.hive.{ExternalTableType, QualifiedTableName, SnappyStoreHiveCatalog}
+import org.apache.spark.sql.hive.{ExternalTableType, QualifiedTableName, SnappySharedState}
 import org.apache.spark.sql.internal.SnappySessionState
 import org.apache.spark.sql.store.CodeGeneration
 import org.apache.spark.sql.streaming._
@@ -84,7 +85,7 @@ class SnappyContext protected[spark](val snappySession: SnappySession)
   self =>
 
   protected[spark] def this(sc: SparkContext) {
-    this(new SnappySession(sc, None))
+    this(new SnappySession(sc))
   }
 
   override def newSession(): SnappyContext =
@@ -810,6 +811,7 @@ object SnappyContext extends Logging {
 
   @volatile private[this] var _anySNContext: SnappyContext = _
   @volatile private[this] var _clusterMode: ClusterMode = _
+  @volatile private[this] var _sharedState: SnappySharedState = _
 
   @volatile private[this] var _globalSNContextInitialized: Boolean = false
   private[this] var _globalClear: () => Unit = _
@@ -1061,12 +1063,15 @@ object SnappyContext extends Logging {
           invokeServices(sc)
           sc.addSparkListener(new SparkContextListener)
           initMemberBlockMap(sc)
+          _sharedState = SnappySharedState.create(sc)
           _globalClear = session.snappyContextFunctions.clearStatic()
           _globalSNContextInitialized = true
         }
       }
     }
   }
+
+  private[sql] def sharedState: SnappySharedState = _sharedState
 
   private class SparkContextListener extends SparkListener {
     override def onApplicationEnd(applicationEnd: SparkListenerApplicationEnd): Unit = {
@@ -1103,6 +1108,7 @@ object SnappyContext extends Logging {
       // clear static objects on the driver
       clearStaticArtifacts()
 
+      _sharedState = null
       if (_globalClear ne null) {
         _globalClear()
         _globalClear = null
@@ -1110,7 +1116,7 @@ object SnappyContext extends Logging {
       SnappyTableStatsProviderService.stop()
 
       // clear current hive catalog connection
-      SnappyStoreHiveCatalog.closeCurrent()
+      Hive.closeCurrent()
       if (ExternalStoreUtils.isLocalMode(sc)) {
         ServiceUtils.invokeStopFabricServer(sc)
       }

--- a/core/src/main/scala/org/apache/spark/sql/SnappyDDLParser.scala
+++ b/core/src/main/scala/org/apache/spark/sql/SnappyDDLParser.scala
@@ -360,7 +360,7 @@ abstract class SnappyDDLParser(session: SparkSession)
   }
 
   protected def dropTable: Rule1[LogicalPlan] = rule {
-    DROP ~ TABLE ~ ifExists ~ tableIdentifier ~> DropTable
+    DROP ~ (TABLE | VIEW) ~ ifExists ~ tableIdentifier ~> DropTable
   }
 
   protected def truncateTable: Rule1[LogicalPlan] = rule {

--- a/core/src/main/scala/org/apache/spark/sql/SnappySession.scala
+++ b/core/src/main/scala/org/apache/spark/sql/SnappySession.scala
@@ -1340,7 +1340,7 @@ class SnappySession(_sc: SparkContext) extends SparkSession(_sc) {
         br match {
           case d: DestroyRelation => d.destroy(ifExists)
             sessionCatalog.unregisterDataSourceTable(tableIdent, Some(br))
-          case _ => if (!isTempTable) {
+          case _ => if (!isTempTable && !sessionCatalog.unregisterGlobalView(tableIdent)) {
             sessionCatalog.unregisterDataSourceTable(tableIdent, Some(br))
           }
         }
@@ -1349,7 +1349,9 @@ class SnappySession(_sc: SparkContext) extends SparkSession(_sc) {
         sessionCatalog.unregisterTable(tableIdent)
       case _ =>
         // this is a table in smart connector remote call or a view
-        sessionCatalog.unregisterDataSourceTable(tableIdent, None)
+        if (!sessionCatalog.unregisterGlobalView(tableIdent)) {
+          sessionCatalog.unregisterDataSourceTable(tableIdent, None)
+        }
     }
   }
 

--- a/core/src/main/scala/org/apache/spark/sql/SnappySession.scala
+++ b/core/src/main/scala/org/apache/spark/sql/SnappySession.scala
@@ -1401,7 +1401,7 @@ class SnappySession(_sc: SparkContext) extends SparkSession(_sc) {
    * @param schemaName schema name which goes in the catalog
    */
   def setSchema(schemaName: String): Unit = {
-    sessionCatalog.setCurrentDatabase(schemaName)
+    sessionCatalog.setSchema(schemaName)
   }
 
   /**

--- a/core/src/main/scala/org/apache/spark/sql/SnappySession.scala
+++ b/core/src/main/scala/org/apache/spark/sql/SnappySession.scala
@@ -1344,16 +1344,12 @@ class SnappySession(_sc: SparkContext) extends SparkSession(_sc) {
             sessionCatalog.unregisterDataSourceTable(tableIdent, Some(br))
           }
         }
-      case Some(plan) => // This is a temp table with no relation as source
-        Dataset.ofRows(this, plan).unpersist(blocking = true)
+      case _ if isTempTable => // This is a temp table with no relation as source
+        planOpt.foreach(Dataset.ofRows(this, _).unpersist(blocking = true))
         sessionCatalog.unregisterTable(tableIdent)
-      case None =>
-        // this is a table in smart connector remote call
-        if (isTempTable) {
-          sessionCatalog.unregisterTable(tableIdent)
-        } else {
-          sessionCatalog.unregisterDataSourceTable(tableIdent, None)
-        }
+      case _ =>
+        // this is a table in smart connector remote call or a view
+        sessionCatalog.unregisterDataSourceTable(tableIdent, None)
     }
   }
 

--- a/core/src/main/scala/org/apache/spark/sql/aqp/SnappyContextFunctions.scala
+++ b/core/src/main/scala/org/apache/spark/sql/aqp/SnappyContextFunctions.scala
@@ -31,7 +31,7 @@ class SnappyContextFunctions {
 
   def clearStatic(): () => Unit = () => {}
 
-  def postRelationCreation(relation: BaseRelation, session: SnappySession): Unit = {}
+  def postRelationCreation(relation: Option[BaseRelation], session: SnappySession): Unit = {}
 
   def registerAQPErrorFunctions(session: SnappySession) {}
 

--- a/core/src/main/scala/org/apache/spark/sql/execution/columnar/impl/ColumnFormatRelation.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/columnar/impl/ColumnFormatRelation.scala
@@ -863,7 +863,7 @@ final class DefaultSource extends SchemaRelationProvider
         catalog.registerDataSourceTable(qualifiedTableName, Some(relation.schema),
           partitioningColumns.toArray,
           classOf[execution.columnar.impl.DefaultSource].getCanonicalName,
-          options, relation)
+          options, Some(relation))
       }
       success = true
       relation

--- a/core/src/main/scala/org/apache/spark/sql/execution/columnar/impl/StoreCallbacksImpl.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/columnar/impl/StoreCallbacksImpl.scala
@@ -205,15 +205,20 @@ object StoreCallbacksImpl extends StoreCallbacks with Logging with Serializable 
         val isBuiltIn = context.getIsBuiltIn
 
         logDebug(s"StoreCallbacksImpl.performConnectorOp creating table $tableIdent")
+        // don't attempt resolution for external tables
         session.createTable(session.sessionCatalog.newQualifiedTableName(tableIdent),
-          provider, userSpecifiedSchema, schemaDDL, mode, options, isBuiltIn)
+          provider, userSpecifiedSchema, schemaDDL, mode, options,
+          isBuiltIn, resolveRelation = isBuiltIn)
 
       case LeadNodeSmartConnectorOpContext.OpType.DROP_TABLE =>
         val tableIdent = context.getTableIdentifier
         val ifExists = context.getIfExists
+        val isBuiltIn = context.getIsBuiltIn
 
         logDebug(s"StoreCallbacksImpl.performConnectorOp dropping table $tableIdent")
-        session.dropTable(session.sessionCatalog.newQualifiedTableName(tableIdent), ifExists)
+        // don't attempt resolution for external tables
+        session.dropTable(session.sessionCatalog.newQualifiedTableName(tableIdent),
+          ifExists, resolveRelation = isBuiltIn)
 
       case LeadNodeSmartConnectorOpContext.OpType.CREATE_INDEX =>
         val tableIdent = context.getTableIdentifier

--- a/core/src/main/scala/org/apache/spark/sql/execution/ddl.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/ddl.scala
@@ -79,27 +79,25 @@ private[sql] case class CreateMetastoreTableUsingSelect(
   }
 }
 
-private[sql] case class DropTableCommand(ifExists: Any,
+private[sql] case class DropTableCommand(ifExists: Boolean,
     tableIdent: TableIdentifier) extends RunnableCommand {
 
   override def run(session: SparkSession): Seq[Row] = {
     val snc = session.asInstanceOf[SnappySession]
     val catalog = snc.sessionState.catalog
-    snc.dropTable(catalog.newQualifiedTableName(tableIdent),
-      ifExists.asInstanceOf[Option[Boolean]].isDefined)
+    snc.dropTable(catalog.newQualifiedTableName(tableIdent), ifExists, resolveRelation = false)
     Seq.empty
   }
 }
 
-private[sql] case class TruncateTableCommand(ifExists: Any,
+private[sql] case class TruncateTableCommand(ifExists: Boolean,
     tableIdent: TableIdentifier) extends RunnableCommand {
 
   override def run(session: SparkSession): Seq[Row] = {
     val snc = session.asInstanceOf[SnappySession]
     val catalog = snc.sessionState.catalog
     snc.truncateTable(catalog.newQualifiedTableName(tableIdent),
-      ifExists.asInstanceOf[Option[Boolean]].isDefined,
-      ignoreIfUnsupported = false)
+      ifExists, ignoreIfUnsupported = false)
     Seq.empty
   }
 }

--- a/core/src/main/scala/org/apache/spark/sql/execution/row/RowFormatRelation.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/row/RowFormatRelation.scala
@@ -349,7 +349,7 @@ final class DefaultSource extends MutableRelationProvider {
       catalog.registerDataSourceTable(
         catalog.newQualifiedTableName(tableName), None, Array.empty[String],
         classOf[execution.row.DefaultSource].getCanonicalName,
-        options, relation)
+        options, Some(relation))
       
       data match {
         case Some(plan) =>

--- a/core/src/main/scala/org/apache/spark/sql/hive/ConnectorCatalog.scala
+++ b/core/src/main/scala/org/apache/spark/sql/hive/ConnectorCatalog.scala
@@ -18,9 +18,14 @@ package org.apache.spark.sql.hive
 
 import java.util.concurrent.ExecutionException
 
+import scala.collection.JavaConverters._
+import scala.collection.mutable.ArrayBuffer
+
 import com.google.common.cache.{CacheBuilder, CacheLoader, LoadingCache}
 import com.google.common.util.concurrent.UncheckedExecutionException
-import org.apache.hadoop.hive.metastore.api.{FieldSchema, Table}
+import org.apache.hadoop.hive.metastore.api.FieldSchema
+import org.apache.hadoop.hive.ql.metadata.Table
+
 import org.apache.spark.SparkException
 import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.catalog.{CatalogStorageFormat, CatalogTable}
@@ -31,9 +36,6 @@ import org.apache.spark.sql.sources.{BaseRelation, DependencyCatalog, JdbcExtend
 import org.apache.spark.sql.streaming.StreamBaseRelation
 import org.apache.spark.sql.types.{MetadataBuilder, StructField, StructType}
 import org.apache.spark.sql.{AnalysisException, SaveMode, SmartConnectorHelper}
-
-import scala.collection.JavaConverters._
-import scala.collection.mutable.ArrayBuffer
 
 trait ConnectorCatalog extends SnappyStoreHiveCatalog {
 
@@ -74,8 +76,7 @@ trait ConnectorCatalog extends SnappyStoreHiveCatalog {
           connectorHelper.getHiveTableAndMetadata(in)
 
         //        val table: CatalogTable = in.getTable(client)
-        val table: CatalogTable = getCatalogTable(
-          new org.apache.hadoop.hive.ql.metadata.Table(hiveTable)).get
+        val table: CatalogTable = getCatalogTable(hiveTable).get
 
         val userSpecifiedSchema = ExternalStoreUtils.getTableSchema(
           table.properties)

--- a/core/src/main/scala/org/apache/spark/sql/hive/ConnectorCatalog.scala
+++ b/core/src/main/scala/org/apache/spark/sql/hive/ConnectorCatalog.scala
@@ -206,7 +206,7 @@ trait ConnectorCatalog extends SnappyStoreHiveCatalog {
       partitionColumns: Array[String],
       provider: String,
       options: Map[String, String],
-      relation: BaseRelation): Unit = {
+      relation: Option[BaseRelation]): Unit = {
     // no op
   }
 

--- a/core/src/main/scala/org/apache/spark/sql/hive/SnappyStoreHiveCatalog.scala
+++ b/core/src/main/scala/org/apache/spark/sql/hive/SnappyStoreHiveCatalog.scala
@@ -431,6 +431,13 @@ class SnappyStoreHiveCatalog(externalCatalog: SnappyExternalCatalog,
     }
   }
 
+  def unregisterGlobalView(tableIdent: QualifiedTableName): Boolean = synchronized {
+    val schema = tableIdent.schemaName
+    if ((schema eq null) || schema == currentSchema || schema == globalTempViewManager.database) {
+      dropGlobalTempView(tableIdent.table)
+    } else false
+  }
+
   final def setSchema(schema: String): Unit = {
     this.currentSchema = schema
   }

--- a/core/src/main/scala/org/apache/spark/sql/hive/SnappyStoreHiveCatalog.scala
+++ b/core/src/main/scala/org/apache/spark/sql/hive/SnappyStoreHiveCatalog.scala
@@ -36,13 +36,14 @@ import com.pivotal.gemfirexd.internal.engine.distributed.utils.GemFireXDUtils
 import io.snappydata.Constant
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.Path
+import org.apache.hadoop.hive.metastore.TableType
 import org.apache.hadoop.hive.metastore.api.Table
 import org.apache.hadoop.hive.ql.metadata.{Hive, HiveException}
 
 import org.apache.spark.SparkConf
 import org.apache.spark.sql._
 import org.apache.spark.sql.catalyst.analysis.FunctionRegistry.FunctionBuilder
-import org.apache.spark.sql.catalyst.analysis.{FunctionRegistry, NoSuchDatabaseException, NoSuchPermanentFunctionException}
+import org.apache.spark.sql.catalyst.analysis.{FunctionRegistry, NoSuchDatabaseException, NoSuchPermanentFunctionException, NoSuchTableException}
 import org.apache.spark.sql.catalyst.catalog.SessionCatalog._
 import org.apache.spark.sql.catalyst.catalog._
 import org.apache.spark.sql.catalyst.expressions.{Expression, ExpressionInfo}
@@ -123,7 +124,7 @@ class SnappyStoreHiveCatalog(externalCatalog: SnappyExternalCatalog,
 
 
   override def setCurrentDatabase(db: String): Unit = {
-    val dbName = formatTableName(db)
+    val dbName = formatDatabaseName(db)
     requireDbExists(dbName)
     synchronized {
       currentSchema = dbName
@@ -374,7 +375,7 @@ class SnappyStoreHiveCatalog(externalCatalog: SnappyExternalCatalog,
   def newQualifiedTableName(tableIdent: TableIdentifier): QualifiedTableName = {
     tableIdent match {
       case q: QualifiedTableName => q
-      case _ => new QualifiedTableName(formatTableName(
+      case _ => new QualifiedTableName(formatDatabaseName(
         tableIdent.database.getOrElse(currentSchema)),
         formatTableName(tableIdent.table))
     }
@@ -431,10 +432,6 @@ class SnappyStoreHiveCatalog(externalCatalog: SnappyExternalCatalog,
     }
   }
 
-  final def setSchema(schema: String): Unit = {
-    this.currentSchema = schema
-  }
-
   /**
    * Return whether a table with the specified name is a temporary table.
    */
@@ -448,8 +445,6 @@ class SnappyStoreHiveCatalog(externalCatalog: SnappyExternalCatalog,
         if (table.properties.contains(HIVE_PROVIDER)) {
           getCachedHiveTable(tableIdent)
         } else if (table.tableType == CatalogTableType.VIEW) {
-          // @TODO Confirm from Sumedh
-          // Difference between VirtualView & View
           val viewText = table.viewText
               .getOrElse(sys.error("Invalid view without text."))
           snappySession.sessionState.sqlParser.parsePlan(viewText)
@@ -459,40 +454,34 @@ class SnappyStoreHiveCatalog(externalCatalog: SnappyExternalCatalog,
         }
 
       case None => synchronized {
-        tempTables.getOrElse(tableIdent.table,
-          throw new TableNotFoundException(s"Table '$tableIdent' not found")) match {
-          case lr: LogicalRelation => lr.catalogTable match {
+        val schema = tableIdent.schemaName
+        val table = tableIdent.table
+        val plan = if (schema == globalTempViewManager.database) {
+          globalTempViewManager.get(table)
+        } else if ((schema == null) || schema.isEmpty || schema == currentSchema) {
+          tempTables.get(table).orElse(globalTempViewManager.get(table))
+        } else None
+        plan match {
+          case Some(lr: LogicalRelation) => lr.catalogTable match {
             case Some(_) => lr
             case None => lr.copy(catalogTable = Some(CatalogTable(tableIdent,
               CatalogTableType.VIEW, null, lr.schema)))
           }
-          case x => x
+          case Some(p) => p
+          case None =>
+            throw new TableNotFoundException(s"Table '$tableIdent' not found")
         }
       }
     }
   }
 
   final def lookupRelationOption(tableIdent: QualifiedTableName): Option[LogicalPlan] = {
-    tableIdent.getTableOption(this) match {
-      case Some(table) =>
-        if (table.properties.contains(HIVE_PROVIDER)) {
-          Some(getCachedHiveTable(tableIdent))
-        } else if (table.tableType == CatalogTableType.VIEW) {
-          // @TODO Confirm from Sumedh
-          // Difference between VirtualView & View
-          val viewText = table.viewText
-              .getOrElse(sys.error("Invalid view without text."))
-          Some(snappySession.sessionState.sqlParser.parsePlan(viewText))
-        } else {
-          None
-        }
-
-      case None => synchronized {
-        tempTables.get(tableIdent.table).orElse(None)
-      }
+    try {
+      Some(lookupRelation(tableIdent))
+    } catch {
+      case _: TableNotFoundException | _: NoSuchTableException => None
     }
   }
-
 
   override def lookupRelation(tableIdent: TableIdentifier,
       alias: Option[String]): LogicalPlan = {
@@ -681,7 +670,7 @@ class SnappyStoreHiveCatalog(externalCatalog: SnappyExternalCatalog,
     } catch {
       case he: HiveException if isDisconnectException(he) =>
         // stale JDBC connection
-        Hive.closeCurrent()
+        SnappyStoreHiveCatalog.closeHive(client)
         SnappyStoreHiveCatalog.suspendActiveSession {
           client = externalCatalog.client.newSession()
         }
@@ -1050,6 +1039,10 @@ class SnappyStoreHiveCatalog(externalCatalog: SnappyExternalCatalog,
   def getTableOption(qtn: QualifiedTableName): Option[CatalogTable] = {
     client.getTableOption(qtn.schemaName, qtn.table)
   }
+
+  def close(): Unit = synchronized {
+    closeHive(client)
+  }
 }
 
 object SnappyStoreHiveCatalog {
@@ -1140,8 +1133,16 @@ object SnappyStoreHiveCatalog {
     }
   }
 
-  def closeCurrent(): Unit = {
-    Hive.closeCurrent()
+  def closeHive(client: HiveClient): Unit = {
+    if (client ne null) {
+      val loader = client.asInstanceOf[HiveClientImpl].clientLoader
+      val hive = loader.cachedHive
+      if (hive != null) {
+        loader.cachedHive = null
+        Hive.set(hive.asInstanceOf[Hive])
+        Hive.closeCurrent()
+      }
+    }
   }
 }
 
@@ -1184,14 +1185,24 @@ object ExternalTableType {
   val TopK = ExternalTableType("TOPK")
   val External = ExternalTableType("EXTERNAL")
 
-  def isTableBackedByRegion(t: Table): Boolean = {
-    val tableType = t.getParameters.get(JdbcExtendedUtils.TABLETYPE_PROPERTY)
-    tableType match {
-      case _ if tableType == ExternalTableType.Row.name ||
-          tableType == ExternalTableType.Column.name ||
-          tableType == ExternalTableType.Sample.name ||
-          tableType == ExternalTableType.Index.name => true
-      case _ => false
+  def getTableType(t: Table): String = {
+    if (t ne null) {
+      // check for VIEW types
+      if (TableType.VIRTUAL_VIEW.name.equalsIgnoreCase(t.getTableType)) {
+        return "VIEW"
+      } else {
+        val tableType = t.getParameters.get(JdbcExtendedUtils.TABLETYPE_PROPERTY)
+        if (tableType ne null) return tableType
+      }
     }
+    // assume EXTERNAL type
+    ExternalTableType.External.name
+  }
+
+  def isTableBackedByRegion(tableType: String): Boolean = {
+    tableType.equalsIgnoreCase(ExternalTableType.Row.name) ||
+        tableType.equalsIgnoreCase(ExternalTableType.Column.name) ||
+        tableType.equalsIgnoreCase(ExternalTableType.Sample.name) ||
+        tableType.equalsIgnoreCase(ExternalTableType.Index.name)
   }
 }

--- a/core/src/main/scala/org/apache/spark/sql/hive/SnappyStoreHiveCatalog.scala
+++ b/core/src/main/scala/org/apache/spark/sql/hive/SnappyStoreHiveCatalog.scala
@@ -431,6 +431,10 @@ class SnappyStoreHiveCatalog(externalCatalog: SnappyExternalCatalog,
     }
   }
 
+  final def setSchema(schema: String): Unit = {
+    this.currentSchema = schema
+  }
+
   /**
    * Return whether a table with the specified name is a temporary table.
    */
@@ -1185,18 +1189,18 @@ object ExternalTableType {
   val External = ExternalTableType("EXTERNAL")
 
   def getTableType(t: Table): String = {
-    if (t ne null) getTableType(t.getTableType.name(), t.getParameters)
-    // assume EXTERNAL type
-    else ExternalTableType.External.name
-  }
-
-  def getTableType(typeName: String, parameters: java.util.Map[String, String]): String = {
-    // check for VIEW types
-    if (TableType.VIRTUAL_VIEW.name.equalsIgnoreCase(typeName)) "VIEW"
-    else {
-      val tableType = parameters.get(JdbcExtendedUtils.TABLETYPE_PROPERTY)
-      if (tableType ne null) tableType else ExternalTableType.External.name
+    if (t ne null) {
+      // check for VIEW types
+      if (TableType.VIRTUAL_VIEW.name.equalsIgnoreCase(t.getTableType.name())) {
+        return "VIEW"
+      }
+      else {
+        val tableType = t.getParameters.get(JdbcExtendedUtils.TABLETYPE_PROPERTY)
+        if (tableType ne null) return tableType
+      }
     }
+    // assume EXTERNAL type
+    ExternalTableType.External.name
   }
 
   def isTableBackedByRegion(tableType: String): Boolean = {

--- a/core/src/main/scala/org/apache/spark/sql/sources/MutableRelationProvider.scala
+++ b/core/src/main/scala/org/apache/spark/sql/sources/MutableRelationProvider.scala
@@ -83,7 +83,7 @@ abstract class MutableRelationProvider
       catalog.registerDataSourceTable(
         catalog.newQualifiedTableName(tableName), None, Array.empty[String],
         classOf[org.apache.spark.sql.row.DefaultSource].getCanonicalName,
-        options, relation)
+        options, Some(relation))
       success = true
       relation
     } finally {

--- a/core/src/main/scala/org/apache/spark/sql/sources/StoreStrategy.scala
+++ b/core/src/main/scala/org/apache/spark/sql/sources/StoreStrategy.scala
@@ -20,9 +20,9 @@ import org.apache.spark.rdd.RDD
 import org.apache.spark.sql._
 import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeReference, Expression}
 import org.apache.spark.sql.catalyst.plans.logical.{InsertIntoTable, LogicalPlan, OverwriteOptions}
+import org.apache.spark.sql.execution._
 import org.apache.spark.sql.execution.command.{ExecutedCommandExec, RunnableCommand}
 import org.apache.spark.sql.execution.datasources.{CreateTable, LogicalRelation}
-import org.apache.spark.sql.execution._
 import org.apache.spark.sql.types.{DataType, LongType, StructType}
 
 /**
@@ -42,21 +42,21 @@ object StoreStrategy extends Strategy {
       val optionsWithPath: Map[String, String] = if (tableDesc.storage.locationUri.isDefined) {
         options + ("path" -> tableDesc.storage.locationUri.get)
       } else options
+      val (provider, isBuiltIn) = SnappyContext.getBuiltInProvider(tableDesc.provider.get)
       val cmd =
         CreateMetastoreTableUsing(tableDesc.identifier, None, userSpecifiedSchema,
-          None, SnappyContext.getProvider(tableDesc.provider.get, onlyBuiltIn = false),
-          mode != SaveMode.ErrorIfExists, optionsWithPath, isBuiltIn = false)
+          None, provider, mode != SaveMode.ErrorIfExists, optionsWithPath, isBuiltIn)
       ExecutedCommandExec(cmd) :: Nil
 
     case CreateTable(tableDesc, mode, Some(query)) =>
       val userSpecifiedSchema = SparkSession.getActiveSession.get
         .asInstanceOf[SnappySession].normalizeSchema(query.schema)
       val options = Map.empty[String, String] ++ tableDesc.storage.properties
+      val (provider, isBuiltIn) = SnappyContext.getBuiltInProvider(tableDesc.provider.get)
       val cmd =
         CreateMetastoreTableUsingSelect(tableDesc.identifier, None, Some(userSpecifiedSchema), None,
-          SnappyContext.getProvider(tableDesc.provider.get, onlyBuiltIn = false),
-          temporary = false, tableDesc.partitionColumnNames.toArray, mode,
-          options, query, isBuiltIn = false)
+          provider, temporary = false, tableDesc.partitionColumnNames.toArray, mode,
+          options, query, isBuiltIn)
       ExecutedCommandExec(cmd) :: Nil
 
     case CreateTableUsing(tableIdent, baseTable, userSpecifiedSchema, schemaDDL,
@@ -85,7 +85,7 @@ object StoreStrategy extends Strategy {
     case CreateIndex(indexName, baseTable, indexColumns, options) =>
       ExecutedCommandExec(CreateIndexCommand(indexName, baseTable, indexColumns, options)) :: Nil
 
-    case DropIndex(indexName, ifExists) =>
+    case DropIndex(ifExists, indexName) =>
       ExecutedCommandExec(DropIndexCommand(indexName, ifExists)) :: Nil
 
     case SetSchema(schemaName) => ExecutedCommandExec(SetSchemaCommand(schemaName)) :: Nil

--- a/core/src/main/scala/org/apache/spark/sql/sources/StoreStrategy.scala
+++ b/core/src/main/scala/org/apache/spark/sql/sources/StoreStrategy.scala
@@ -53,10 +53,9 @@ object StoreStrategy extends Strategy {
         .asInstanceOf[SnappySession].normalizeSchema(query.schema)
       val options = Map.empty[String, String] ++ tableDesc.storage.properties
       val (provider, isBuiltIn) = SnappyContext.getBuiltInProvider(tableDesc.provider.get)
-      val cmd =
-        CreateMetastoreTableUsingSelect(tableDesc.identifier, None, Some(userSpecifiedSchema), None,
-          provider, temporary = false, tableDesc.partitionColumnNames.toArray, mode,
-          options, query, isBuiltIn)
+      val cmd = CreateMetastoreTableUsingSelect(tableDesc.identifier, None,
+        Some(userSpecifiedSchema), None, provider, tableDesc.partitionColumnNames.toArray,
+        mode, options, query, isBuiltIn)
       ExecutedCommandExec(cmd) :: Nil
 
     case CreateTableUsing(tableIdent, baseTable, userSpecifiedSchema, schemaDDL,
@@ -65,9 +64,9 @@ object StoreStrategy extends Strategy {
         userSpecifiedSchema, schemaDDL, provider, allowExisting, options, isBuiltIn)) :: Nil
 
     case CreateTableUsingSelect(tableIdent, baseTable, userSpecifiedSchema, schemaDDL,
-    provider, temporary, partitionColumns, mode, options, query, isBuiltIn) =>
+    provider, partitionColumns, mode, options, query, isBuiltIn) =>
       ExecutedCommandExec(CreateMetastoreTableUsingSelect(tableIdent, baseTable,
-        userSpecifiedSchema, schemaDDL, provider, temporary, partitionColumns, mode,
+        userSpecifiedSchema, schemaDDL, provider, partitionColumns, mode,
         options, query, isBuiltIn)) :: Nil
 
     case DropTable(ifExists, tableIdent) =>

--- a/core/src/main/scala/org/apache/spark/streaming/SnappyStreamingContext.scala
+++ b/core/src/main/scala/org/apache/spark/streaming/SnappyStreamingContext.scala
@@ -56,7 +56,7 @@ class SnappyStreamingContext protected[spark](
         "both SparkContext and checkpoint as null")
   }
 
-  val snappySession = new SnappySession(sc, None)
+  val snappySession = new SnappySession(sc)
 
   val snappyContext = snappySession.snappyContext
 

--- a/core/src/test/scala/io/snappydata/ColumnUpdateDeleteTests.scala
+++ b/core/src/test/scala/io/snappydata/ColumnUpdateDeleteTests.scala
@@ -29,12 +29,13 @@ import com.pivotal.gemfirexd.internal.engine.store.GemFireContainer
 import io.snappydata.test.dunit.{DistributedTestBase, SerializableRunnable}
 import org.scalatest.Assertions
 
+import org.apache.spark.Logging
 import org.apache.spark.sql.{Row, SnappySession}
 
 /**
  * Common tests for updates/deletes on column table.
  */
-object ColumnUpdateDeleteTests extends Assertions {
+object ColumnUpdateDeleteTests extends Assertions with Logging {
 
   def testBasicUpdate(session: SnappySession): Unit = {
     session.conf.set(Property.ColumnBatchSize.name, "10k")
@@ -481,11 +482,12 @@ object ColumnUpdateDeleteTests extends Assertions {
         assert(res.map(_.getLong(0)).sum > 0)
       } catch {
         case t: Throwable =>
+          logError(t.getMessage, t)
           exceptions += Thread.currentThread() -> t
           throw t
       }
     }(executionContext))
-    tasks.foreach(Await.ready(_, Duration.Inf))
+    tasks.foreach(Await.ready(_, Duration(300, "s")))
 
     assert(exceptions.isEmpty, s"Failed with exceptions: $exceptions")
 
@@ -508,11 +510,12 @@ object ColumnUpdateDeleteTests extends Assertions {
         assert(res.map(_.getLong(0)).sum > 0)
       } catch {
         case t: Throwable =>
+          logError(t.getMessage, t)
           exceptions += Thread.currentThread() -> t
           throw t
       }
     }(executionContext))
-    tasks.foreach(Await.ready(_, Duration.Inf))
+    tasks.foreach(Await.ready(_, Duration(300, "s")))
 
     assert(exceptions.isEmpty, s"Failed with exceptions: $exceptions")
 

--- a/core/src/test/scala/org/apache/spark/sql/store/TokenizationTest.scala
+++ b/core/src/test/scala/org/apache/spark/sql/store/TokenizationTest.scala
@@ -258,7 +258,7 @@ class TokenizationTest
     snc.sql("SELECT json_tuple('{\"f1\": \"value11\", \"f2\": \"value22\"}','f1')"
     ).collect().foreach(println)
 
-    assert( cacheMap.size() == 2)
+    assert(cacheMap.size() == 0) // no caching since JsonTuple is not code-generated
   }
 
   test("Test tokenize and queryHints and noTokenize if limit or projection") {
@@ -325,35 +325,35 @@ class TokenizationTest
 
       query = s"select a, 'y' from $table where a = 0"
       res2 = snc.sql(query).collect()
-      assert( cacheMap.size() == 6)
+      assert( cacheMap.size() == 5)
 
       // check in based queries
       query = s"select * from $table where a in (0, 1)"
       res1 = snc.sql(query).collect()
-      assert( cacheMap.size() == 7)
+      assert( cacheMap.size() == 6)
 
-      assert( getAllValidKeys() == 7)
+      assert( getAllValidKeys() == 6)
       // new plan should not be generated so size should be same
       query = s"select * from $table where a in (5, 7)"
       res2 = snc.sql(query).collect()
-      assert( cacheMap.size() == 7)
+      assert( cacheMap.size() == 6)
       assert(!(res1.sameElements(res2)))
 
       // test fetch first syntax also
       // Cache map size changes because limit '3' is different
       query = s"select * from $table where a = 0 fetch first 3 row only"
       res1 = snc.sql(query).collect()
-      assert( cacheMap.size() == 8)
+      assert( cacheMap.size() == 7)
 
       // Cache map size changes because limit '4' is different
       query = s"select * from $table where a = 0 fetch first 4 rows only"
       res1 = snc.sql(query).collect()
-      assert( cacheMap.size() == 9)
+      assert( cacheMap.size() == 8)
 
       // fetch first with actual result validation
       query = s"select a from $table order by a desc fetch first 1 row only"
       res1 = snc.sql(query).collect()
-      assert( cacheMap.size() == 10)
+      assert( cacheMap.size() == 9)
       assert (res1.size == 1)
       res1 foreach { r =>
         assert (r.get(0) == 10)
@@ -717,81 +717,8 @@ class TokenizationTest
       val rows11 = rs11.collect()
       assert(!rows11.sameElements(rows1))
       assert(cacheMap.size() == 1)
-    }
-    finally {
-      SnappyTableStatsProviderService.suspendCacheInvalidation = false
-    }
-  }
 
-  test("Test BUG SNAP-1642") {
-    SnappyTableStatsProviderService.suspendCacheInvalidation = true
-    val maxquery = s"select * from $table where a = (select max(a) from $table)"
-    val numRows = 10
-    createSimpleTableAndPoupulateData(numRows, s"$table", true)
-
-    val rs1 = snc.sql(maxquery)
-    val rows1 = rs1.collect()
-
-    val data = ((11 to 12), (11 to 12), (11 to 12)).zipped.toArray
-    val rdd = sc.parallelize(data, data.length)
-        .map(s => Data(s._1, s._2, s._3))
-    val dataDF = snc.createDataFrame(rdd)
-    dataDF.write.mode(SaveMode.Append).saveAsTable(table)
-
-    val rs2 = snc.sql(maxquery)
-    val rows2 = rs2.collect()
-
-    var uncachedResult = snc.sqlUncached(maxquery).collect()
-    assert(rows2.sameElements(uncachedResult))
-  }
-
-  test("Test broadcast hash joins and scalar sub-queries - 2") {
-    SnappyTableStatsProviderService.suspendCacheInvalidation = true
-    // val th = 10L * 1024 * 1024 * 1024
-    snc.sql(s"set spark.sql.autoBroadcastJoinThreshold=-1")
-    val ddlStr = "(YearI INT," + // NOT NULL
-        "MonthI INT," + // NOT NULL
-        "DayOfMonth INT," + // NOT NULL
-        "DayOfWeek INT," + // NOT NULL
-        "DepTime INT," +
-        "CRSDepTime INT," +
-        "ArrTime INT," +
-        "CRSArrTime INT," +
-        "UniqueCarrier VARCHAR(20)," + // NOT NULL
-        "FlightNum INT," +
-        "TailNum VARCHAR(20)," +
-        "ActualElapsedTime INT," +
-        "CRSElapsedTime INT," +
-        "AirTime INT," +
-        "ArrDelay INT," +
-        "DepDelay INT," +
-        "Origin VARCHAR(20)," +
-        "Dest VARCHAR(20)," +
-        "Distance INT," +
-        "TaxiIn INT," +
-        "TaxiOut INT," +
-        "Cancelled INT," +
-        "CancellationCode VARCHAR(20)," +
-        "Diverted INT," +
-        "CarrierDelay INT," +
-        "WeatherDelay INT," +
-        "NASDelay INT," +
-        "SecurityDelay INT," +
-        "LateAircraftDelay INT," +
-        "ArrDelaySlot INT)"
-
-    val hfile: String = getClass.getResource("/2015.parquet").getPath
-    val snContext = snc
-    snContext.sql("set spark.sql.shuffle.partitions=6")
-
-    val airlineDF = snContext.read.load(hfile)
-    val airlineparquetTable = "airlineparquetTable"
-    airlineDF.registerTempTable(airlineparquetTable)
-
-    snc.sql(s"CREATE TABLE $colTableName $ddlStr" +
-        "USING column options()")
-
-    airlineDF.write.insertInto(colTableName)
+    // Test broadcast hash joins and scalar sub-queries - 2
 
     var df = snc.sql("select avg(taxiin + taxiout) avgTaxiTime, count( * ) numFlights, " +
         s"dest, avg(arrDelay) arrivalDelay from $colTableName " +
@@ -872,7 +799,32 @@ class TokenizationTest
 
     snc.dropTable(colTableName)
 
-    SnappyTableStatsProviderService.suspendCacheInvalidation = false
+    }
+    finally {
+      SnappyTableStatsProviderService.suspendCacheInvalidation = false
+    }
+  }
+
+  test("Test BUG SNAP-1642") {
+    SnappyTableStatsProviderService.suspendCacheInvalidation = true
+    val maxquery = s"select * from $table where a = (select max(a) from $table)"
+    val numRows = 10
+    createSimpleTableAndPoupulateData(numRows, s"$table", true)
+
+    val rs1 = snc.sql(maxquery)
+    val rows1 = rs1.collect()
+
+    val data = ((11 to 12), (11 to 12), (11 to 12)).zipped.toArray
+    val rdd = sc.parallelize(data, data.length)
+        .map(s => Data(s._1, s._2, s._3))
+    val dataDF = snc.createDataFrame(rdd)
+    dataDF.write.mode(SaveMode.Append).saveAsTable(table)
+
+    val rs2 = snc.sql(maxquery)
+    val rows2 = rs2.collect()
+
+    var uncachedResult = snc.sqlUncached(maxquery).collect()
+    assert(rows2.sameElements(uncachedResult))
   }
 
   test("Test CachedDataFrame.head ") {

--- a/core/src/test/scala/org/apache/spark/sql/store/ViewTest.scala
+++ b/core/src/test/scala/org/apache/spark/sql/store/ViewTest.scala
@@ -1,0 +1,233 @@
+/*
+ * Copyright (c) 2017 SnappyData, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License. You
+ * may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License. See accompanying
+ * LICENSE file.
+ */
+
+package org.apache.spark.sql.store
+
+import com.gemstone.gemfire.distributed.internal.InternalDistributedSystem
+import io.snappydata.SnappyFunSuite
+
+import org.apache.spark.sql.{Row, SnappySession}
+
+/**
+ * Tests for temporary, global and persistent views.
+ */
+class ViewTest extends SnappyFunSuite {
+
+  private val columnTable = "viewColTable"
+  private val rowTable = "viewRowTable"
+  private val numRows = 10
+  private val viewQuery = "select id, addr, rank() over (order by id) as rank"
+  private val viewTempMeta = Array(Row("ID", "int", null), Row("ADDR", "string", null),
+    Row("RANK", "int", null))
+
+  override def beforeAll(): Unit = {
+    super.beforeAll()
+    val session = this.snc.snappySession
+    session.sql(s"create table $columnTable (id int, addr varchar(20)) using column")
+    session.sql(s"create table $rowTable (id int, addr varchar(20)) using row")
+
+    val rows = (0 until numRows).map(i => Row(i, "address_" + (i + 1)))
+    snc.insert(columnTable, rows: _*)
+    snc.insert(rowTable, rows: _*)
+  }
+
+  private def getExpectedResult: Array[Row] = {
+    Array.tabulate(numRows)(i => Row(i, "address_" + (i + 1), i + 1))
+  }
+
+  test("temporary view") {
+    val session = this.snc.snappySession
+
+    val tableMeta = Array(Row("id", "int", null), Row("addr", "string", null))
+
+    assert(session.sql(s"describe $columnTable").collect() === tableMeta)
+    assert(session.sql(s"describe $rowTable").collect() === tableMeta)
+
+    val expected = getExpectedResult
+
+    // check temporary view and its meta-data for column table
+    session.sql(s"create temporary view viewOnTable as $viewQuery from $columnTable")
+
+    assert(session.sessionCatalog.tableExists("viewOnTable") === true)
+    assert(session.sql(s"describe viewOnTable").collect() === viewTempMeta)
+    assert(session.sql("select * from viewOnTable").collect() === expected)
+
+    // should not be visible from another session
+    val session2 = session.newSession()
+    assert(session2.sessionCatalog.tableExists("viewOnTable") === false)
+
+    // drop and check unavailability
+    session.sql("drop view viewOnTable")
+    assert(session.sessionCatalog.tableExists("viewOnTable") === false)
+    assert(session2.sessionCatalog.tableExists("viewOnTable") === false)
+
+    // check the same for view on row table
+    session.sql(s"create temporary view viewOnTable as $viewQuery from $rowTable")
+
+    assert(session.sessionCatalog.tableExists("viewOnTable") === true)
+    assert(session.sql(s"describe viewOnTable").collect() === viewTempMeta)
+    assert(session.sql("select * from viewOnTable").collect() === expected)
+
+    assert(session2.sessionCatalog.tableExists("viewOnTable") === false)
+    session.sql("drop view viewOnTable")
+    assert(session.sessionCatalog.tableExists("viewOnTable") === false)
+    assert(session2.sessionCatalog.tableExists("viewOnTable") === false)
+
+    session2.close()
+  }
+
+  test("global temporary view") {
+    val session = this.snc.snappySession
+
+    val expected = getExpectedResult
+
+    // check temporary view and its meta-data for column table
+    session.sql(s"create global temporary view viewOnTable as $viewQuery from $columnTable")
+
+    assert(session.sessionCatalog.getGlobalTempView("viewOnTable").isDefined)
+    assert(session.sql(s"describe global_temp.viewOnTable").collect() === viewTempMeta)
+    assert(session.sql("select * from viewOnTable").collect() === expected)
+
+    // should be visible from another session
+    val session2 = session.newSession()
+    assert(session2.sessionCatalog.getGlobalTempView("viewOnTable").isDefined)
+    assert(session2.sql(s"describe global_temp.viewOnTable").collect() === viewTempMeta)
+    assert(session2.sql("select * from viewOnTable").collect() === expected)
+
+    // drop and check unavailability
+    session.sql("drop view viewOnTable")
+    assert(session.sessionCatalog.getGlobalTempView("viewOnTable").isEmpty)
+    assert(session2.sessionCatalog.getGlobalTempView("viewOnTable").isEmpty)
+
+    // check the same for view on row table
+    session.sql(s"create global temporary view viewOnTable as $viewQuery from $columnTable")
+
+    assert(session.sessionCatalog.getGlobalTempView("viewOnTable").isDefined)
+    assert(session.sql(s"describe global_temp.viewOnTable").collect() === viewTempMeta)
+    assert(session.sql("select * from viewOnTable").collect() === expected)
+
+    assert(session2.sessionCatalog.getGlobalTempView("viewOnTable").isDefined)
+    assert(session2.sql(s"describe global_temp.viewOnTable").collect() === viewTempMeta)
+    assert(session2.sql("select * from viewOnTable").collect() === expected)
+
+    session.sql("drop view viewOnTable")
+    assert(session.sessionCatalog.getGlobalTempView("viewOnTable").isEmpty)
+    assert(session2.sessionCatalog.getGlobalTempView("viewOnTable").isEmpty)
+
+    session2.close()
+  }
+
+  test("temporary view using") {
+    val session = this.snc.snappySession
+
+    // check temporary view with USING and its meta-data
+    val hfile: String = getClass.getResource("/2015.parquet").getPath
+    val airline = session.read.parquet(hfile)
+    session.sql(s"create temporary view airlineView using parquet options(path '$hfile')")
+    val airlineView = session.table("airlineView")
+
+    assert(session.sessionCatalog.tableExists("airlineView") === true)
+    assert(airlineView.schema === airline.schema)
+    assert(session.sql("select count(*) from airlineView").collect()(0).getLong(0) ===
+        airline.count())
+    assert(airlineView.count() == airline.count())
+
+    // should not be visible from another session
+    val session2 = session.newSession()
+    assert(session2.sessionCatalog.tableExists("airlineView") === false)
+
+    // drop and check unavailability
+    session.sql("drop view airlineView")
+    assert(session.sessionCatalog.tableExists("airlineView") === false)
+    assert(session2.sessionCatalog.tableExists("airlineView") === false)
+
+    session2.close()
+  }
+
+  test("global temporary view using") {
+    val session = this.snc.snappySession
+
+    // check global temporary view with USING and its meta-data
+    val hfile: String = getClass.getResource("/2015.parquet").getPath
+    val airline = session.read.parquet(hfile)
+    session.sql(s"create global temporary view airlineView using parquet options(path '$hfile')")
+    val airlineView = session.table("airlineView")
+
+    assert(session.sessionCatalog.getGlobalTempView("airlineView").isDefined)
+    assert(airlineView.schema === airline.schema)
+    assert(session.sql("select count(*) from airlineView").collect()(0).getLong(0) ===
+        airline.count())
+    assert(airlineView.count() == airline.count())
+
+    // should be visible from another session
+    val session2 = session.newSession()
+    assert(session2.sessionCatalog.getGlobalTempView("airlineView").isDefined)
+    assert(session2.sql("select count(*) from airlineView").collect()(0).getLong(0) ===
+        airline.count())
+
+    // drop and check unavailability
+    session.sql("drop view airlineView")
+    assert(session.sessionCatalog.getGlobalTempView("airlineView").isEmpty)
+    assert(session2.sessionCatalog.getGlobalTempView("airlineView").isEmpty)
+
+    session2.close()
+  }
+
+  test("persistent view") {
+    val expected = getExpectedResult
+    // check temporary view and its meta-data for column table
+    checkPersistentView(columnTable, snc.snappySession, expected)
+    // check the same for view on row table
+    checkPersistentView(rowTable, snc.snappySession, expected)
+  }
+
+  private def checkPersistentView(table: String, session: SnappySession,
+      expectedResult: Array[Row]): Unit = {
+    session.sql(s"create view viewOnTable as $viewQuery from $table")
+
+    val viewMeta = Array(Row("id", "int", null), Row("addr", "string", null),
+      Row("rank", "int", null))
+
+    assert(session.sessionCatalog.tableExists("viewOnTable") === true)
+    assert(session.sql(s"describe viewOnTable").collect() === viewMeta)
+    assert(session.sql("select * from viewOnTable").collect() === expectedResult)
+
+    // should be visible from another session
+    var session2 = session.newSession()
+    assert(session2.sessionCatalog.tableExists("viewOnTable") === true)
+    assert(session2.sql(s"describe viewOnTable").collect() === viewMeta)
+    assert(session2.sql("select * from viewOnTable").collect() === expectedResult)
+
+    // should be available after a restart
+    session.close()
+    session2.close()
+    stopAll()
+    val sys = InternalDistributedSystem.getConnectedInstance
+    if (sys ne null) {
+      sys.disconnect()
+    }
+
+    session2 = new SnappySession(sc)
+    assert(session2.sessionCatalog.tableExists("viewOnTable") === true)
+    assert(session2.sql(s"describe viewOnTable").collect() === viewMeta)
+    assert(session2.sql("select * from viewOnTable").collect() === expectedResult)
+
+    // drop and check unavailability
+    session2.sql("drop view viewOnTable")
+    assert(session2.sessionCatalog.tableExists("viewOnTable") === false)
+  }
+}


### PR DESCRIPTION
This fixes two issues:

1. External connectors not working in smart connector mode as reported by Jags since the
required libraries may not be available in the embedded cluster. This happens because
the BaseRelation is attempted to be resolved in both "CREATE EXTERNAL TABLE" and
"DROP TABLE". Now resolve all required information (schema, inbuilt or not) at the
driver connector JVM and send that in the procedure calls for external providers.

2. Support for VIEW, VIEW...USING in the parser. Also cleaned up a few things in parser.

## Changes proposed in this pull request

- fix external connectors in smart connector mode; resolve everything required
  on the source connector and never try to resolve in embedded mode because it
  may not have requisite libraries available
- added VIEW and VIEW...USING support to parser (createView, createTempViewUsing)
- refactored IF NOT EXISTS, IF EXISTS, clauses as separate rules
- replaced remaining uses of trueFn/falseFn by a cleaner push(true)/push(false)

TODO: tests for VIEW to be added shortly. Tests for external connectors in smart connector
mode are better done manually and need to be added to release criteria.

## Patch testing

precheckin, manual test for external cassandra connector in smart connector mode

## ReleaseNotes.txt changes

NA

## Other PRs 

https://github.com/SnappyDataInc/snappy-store/pull/333