### PR TITLE
[SNAP-2084] Handled dropStorageMemoryForObject in DefaultMemoryManager.

### DIFF
--- a/core/src/main/scala/org/apache/spark/memory/DefaultMemoryManager.scala
+++ b/core/src/main/scala/org/apache/spark/memory/DefaultMemoryManager.scala
@@ -1,0 +1,116 @@
+/*
+ * Copyright (c) 2017 SnappyData, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License. You
+ * may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License. See accompanying
+ * LICENSE file.
+ */
+package org.apache.spark.memory
+
+import java.nio.ByteBuffer
+
+import com.gemstone.gemfire.internal.snappy.UMMMemoryTracker
+import com.gemstone.gemfire.internal.snappy.memory.MemoryManagerStats
+import io.snappydata.collection.ObjectLongHashMap
+
+import org.apache.spark.{Logging, SparkEnv}
+import org.apache.spark.storage.BlockId
+
+
+class DefaultMemoryManager extends StoreUnifiedManager with Logging {
+
+  private val memoryForObject: ObjectLongHashMap[(String, MemoryMode)]
+  = ObjectLongHashMap.withExpectedSize[(String, MemoryMode)](16)
+
+
+  private val managerId = "DefaultMemoryManager"
+
+  override def acquireStorageMemoryForObject(objectName: String,
+      blockId: BlockId,
+      numBytes: Long,
+      memoryMode: MemoryMode,
+      buffer: UMMMemoryTracker,
+      shouldEvict: Boolean): Boolean = {
+    logDebug(s"Acquiring DefaultManager memory for $objectName $numBytes")
+    if (SparkEnv.get ne null) {
+      val success = SparkEnv.get.memoryManager.acquireStorageMemory(blockId, numBytes, memoryMode)
+      memoryForObject.addTo(objectName -> memoryMode, numBytes)
+      success
+    } else {
+      true
+    }
+  }
+
+  // This is not be called in connector mode. This api is called from
+  // region.clear hence only applicable for local mode
+  override def dropStorageMemoryForObject(
+      objectName: String,
+      memoryMode: MemoryMode,
+      ignoreNumBytes: Long): Long = {
+    if (SparkEnv.get ne null) {
+      val key = objectName -> memoryMode
+      val bytesToBeFreed = memoryForObject.getLong(key)
+      val numBytes = Math.max(0, bytesToBeFreed - ignoreNumBytes)
+      logDebug(s"Dropping $managerId memory for $objectName =" +
+          s" $numBytes (registered=$bytesToBeFreed)")
+      if (numBytes > 0) {
+        SparkEnv.get.memoryManager.releaseStorageMemory(numBytes, memoryMode)
+        memoryForObject.removeAsLong(key)
+      }
+    }
+    0L
+  }
+
+  override def releaseStorageMemoryForObject(
+      objectName: String,
+      numBytes: Long,
+      memoryMode: MemoryMode): Unit = {
+    logDebug(s"Releasing DefaultManager memory for $objectName $numBytes")
+    if (SparkEnv.get ne null) {
+      SparkEnv.get.memoryManager.releaseStorageMemory(numBytes, memoryMode)
+      val key = objectName -> memoryMode
+      if (memoryForObject.containsKey(key)) {
+        if (memoryForObject.addTo(key, -numBytes) == numBytes) {
+          memoryForObject.removeAsLong(key)
+        }
+      }
+    }
+  }
+
+  override def getStoragePoolMemoryUsed(memoryMode: MemoryMode): Long = 0L
+
+  override def getStoragePoolSize(memoryMode: MemoryMode): Long = 0L
+
+  override def getExecutionPoolUsedMemory(memoryMode: MemoryMode): Long = 0L
+
+  override def getExecutionPoolSize(memoryMode: MemoryMode): Long = 0L
+
+  override def getOffHeapMemory(objectName: String): Long = 0L
+
+  override def hasOffHeap: Boolean = false
+
+  override def logStats(): Unit = logInfo("No stats for NoOpSnappyMemoryManager")
+
+  override def changeOffHeapOwnerToStorage(buffer: ByteBuffer,
+      allowNonAllocator: Boolean): Unit = {}
+
+  override def shouldStopRecovery(): Boolean = false
+
+  override def initMemoryStats(stats: MemoryManagerStats): Unit = {}
+
+  override def close(): Unit = {}
+
+  /**
+    * Clears the internal map
+    */
+  override def clear(): Unit = {}
+}

--- a/core/src/main/scala/org/apache/spark/memory/StoreUnifiedManager.scala
+++ b/core/src/main/scala/org/apache/spark/memory/StoreUnifiedManager.scala
@@ -82,71 +82,7 @@ trait StoreUnifiedManager {
   def close()
 }
 
-/**
-  * A MemoryManager which simply delegates to configured Spark memory manager.
-  * This manager will be used in Connector mode. All SnappyData execution memory
-  * like encoder etc will account memory here.
-  */
-class DefaultMemoryManager extends StoreUnifiedManager with Logging {
 
-  override def acquireStorageMemoryForObject(objectName: String,
-      blockId: BlockId,
-      numBytes: Long,
-      memoryMode: MemoryMode,
-      buffer: UMMMemoryTracker,
-      shouldEvict: Boolean): Boolean = {
-    logDebug(s"Acquiring DefaultManager memory for $objectName $numBytes")
-    if (SparkEnv.get ne null) {
-      SparkEnv.get.memoryManager.acquireStorageMemory(blockId, numBytes, memoryMode)
-    } else {
-      true
-    }
-  }
-
-  // This should not be called in connector mode
-  override def dropStorageMemoryForObject(
-      objectName: String,
-      memoryMode: MemoryMode,
-      ignoreNumBytes: Long): Long = 0L
-
-  override def releaseStorageMemoryForObject(
-      objectName: String,
-      numBytes: Long,
-      memoryMode: MemoryMode): Unit = {
-    logDebug(s"Releasing DefaultManager memory for $objectName $numBytes")
-    if (SparkEnv.get ne null) {
-      SparkEnv.get.memoryManager.releaseStorageMemory(numBytes, memoryMode)
-    }
-  }
-
-  override def getStoragePoolMemoryUsed(memoryMode: MemoryMode): Long = 0L
-
-  override def getStoragePoolSize(memoryMode: MemoryMode): Long = 0L
-
-  override def getExecutionPoolUsedMemory(memoryMode: MemoryMode): Long = 0L
-
-  override def getExecutionPoolSize(memoryMode: MemoryMode): Long = 0L
-
-  override def getOffHeapMemory(objectName: String): Long = 0L
-
-  override def hasOffHeap: Boolean = false
-
-  override def logStats(): Unit = logInfo("No stats for NoOpSnappyMemoryManager")
-
-  override def changeOffHeapOwnerToStorage(buffer: ByteBuffer,
-      allowNonAllocator: Boolean): Unit = {}
-
-  override def shouldStopRecovery(): Boolean = false
-
-  override def initMemoryStats(stats: MemoryManagerStats): Unit = {}
-
-  override def close(): Unit = {}
-
-  /**
-    * Clears the internal map
-    */
-  override def clear(): Unit = {}
-}
 
 object MemoryManagerCallback extends Logging {
 


### PR DESCRIPTION
## Changes proposed in this pull request

We keep a map of memory used against each region. When we drop the region we release the total memory accumulated. This is not supported in DefaultMemoryManager( which gets used in local & connector mode). Hence the problem.
While acquiring memory for table it uses Spark's UMM , but does not release that memory when the table gets dropped.

## Patch testing

manual test. Pre-checkin pending

## ReleaseNotes.txt changes

NA

## Other PRs 

NA
