### PR TITLE
Fix the case of remote pull from smart connector

### DIFF
--- a/cluster/src/dunit/scala/io/snappydata/cluster/SplitSnappyClusterDUnitTest.scala
+++ b/cluster/src/dunit/scala/io/snappydata/cluster/SplitSnappyClusterDUnitTest.scala
@@ -66,6 +66,8 @@ class SplitSnappyClusterDUnitTest(s: String)
   }
 
   def testCreateTablesFromOtherTables(): Unit = {
+    // stop a network server to test remote fetch
+    vm0.invoke(classOf[ClusterManagerTestBase], "stopNetworkServers")
     vm3.invoke(getClass, "createTablesFromOtherTablesTest",
       startArgs :+
           Int.box(locatorClientPort))

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -95,7 +95,7 @@ dependencies {
     exclude(group: 'org.scala-lang', module: 'scala-reflect')
     exclude(group: 'org.scala-lang', module: 'scala-compiler')
   }
-  compile 'org.apache.tomcat:tomcat-jdbc:8.5.21'
+  compile 'org.apache.tomcat:tomcat-jdbc:8.5.23'
   compile 'com.zaxxer:HikariCP:2.7.1'
   // compile 'org.spark-project:dstream-twitter_2.11:0.1.0'
   compile 'org.twitter4j:twitter4j-stream:4.0.6'

--- a/core/src/main/scala/io/snappydata/impl/SparkConnectorRDDHelper.scala
+++ b/core/src/main/scala/io/snappydata/impl/SparkConnectorRDDHelper.scala
@@ -17,23 +17,19 @@
 package io.snappydata.impl
 
 import java.sql.{Connection, ResultSet, SQLException, Statement}
+import java.util.Collections
 
-import scala.collection.JavaConverters._
-import scala.collection.mutable
 import scala.collection.mutable.ArrayBuffer
 import scala.util.Random
 
-import com.gemstone.gemfire.cache.Region
-import com.gemstone.gemfire.distributed.internal.membership.InternalDistributedMember
 import com.gemstone.gemfire.internal.SocketCreator
-import com.gemstone.gemfire.internal.cache.{DistributedRegion, PartitionedRegion}
-import com.pivotal.gemfirexd.internal.engine.Misc
-import com.pivotal.gemfirexd.internal.engine.distributed.utils.GemFireXDUtils
 import com.pivotal.gemfirexd.jdbc.ClientAttribute
 import io.snappydata.Constant
+import io.snappydata.collection.ObjectObjectHashMap
+import io.snappydata.thrift.internal.ClientStatement
 
 import org.apache.spark.Partition
-import org.apache.spark.sql.collection.ExecutorMultiBucketLocalShellPartition
+import org.apache.spark.sql.collection.SmartExecutorBucketPartition
 import org.apache.spark.sql.execution.ConnectionPool
 import org.apache.spark.sql.execution.columnar.ExternalStoreUtils
 import org.apache.spark.sql.execution.columnar.impl.{ColumnDelta, ColumnFormatEntry}
@@ -51,65 +47,54 @@ final class SparkConnectorRDDHelper {
       schema: StructType): (String, String) = {
 
     val schemaWithIndex = schema.zipWithIndex
-    // to fetch columns create a union all string
+    // To fetch columns create an IN query on columnIndex
+    // with other two columns fixed (uuid and partitionId).
     // (select data, columnIndex from table where
-    //  partitionId = 1 and uuid = ? and columnIndex = 1)
-    // union all
-    // (select data, columnIndex from table where
-    //  partitionId = 1 and uuid = ? and columnIndex = 7)
-    // An OR query like the following results in a bulk table scan
-    // select data, columnIndex from table where partitionId = 1 and
-    //  (columnIndex = 1 or columnIndex = 7)
+    //  partitionId = 1 and uuid = ? and columnIndex in (1, 2, -3, ...))
+    // Store QueryInfo has been enhanced to convert such queries
+    // to getAll for best performance (and also enable remote
+    //   fetch if required).
+    // Note that partitionId is required in where clause even though it
+    // is fixed and already set by BUCKETIDs list set for the scan
+    // to enable conversion to getAll since it is part of PK.
+    // Also the queries use a "select *" instead of projection since
+    // store getAll with ProjectionRow does not work for object tables
+    // and the additional columns are minuscule in size compared to data blob.
     val fetchCols = requiredColumns.toSeq.map(col => {
       schemaWithIndex.filter(_._1.name.equalsIgnoreCase(col)).last._2 + 1
     })
-    val fetchColString = (fetchCols.flatMap { col =>
+    val fetchColString = (fetchCols ++ fetchCols.flatMap { col =>
       val deltaCol = ColumnDelta.deltaColumnIndex(col - 1 /* zero based */, 0)
-      (col +: (deltaCol until (deltaCol - ColumnDelta.MAX_DEPTH, -1))).map(
-        i => s"(select data, columnIndex from $resolvedTableName where " +
-            s"partitionId = $partitionId and uuid = ? and columnIndex = $i)")
-    } :+ s"(select data, columnIndex from $resolvedTableName where " +
-        s"partitionId = $partitionId and uuid = ? and columnIndex = " +
-        s"${ColumnFormatEntry.DELETE_MASK_COL_INDEX})").mkString(" union all ")
+      deltaCol until(deltaCol - ColumnDelta.MAX_DEPTH, -1)
+    } :+ ColumnFormatEntry.DELETE_MASK_COL_INDEX).mkString(
+      s"select * from $resolvedTableName where " +
+          s"partitionId = $partitionId and uuid = ? and columnIndex in (", ",", ")")
     // fetch stats query and fetch columns query
-    (s"select data, uuid from $resolvedTableName where columnIndex = " +
+    (s"select * from $resolvedTableName where columnIndex = " +
         s"${ColumnFormatEntry.STATROW_COL_INDEX}", fetchColString)
   }
 
   def executeQuery(conn: Connection, tableName: String,
       split: Partition, query: String, relDestroyVersion: Int): (Statement, ResultSet, String) = {
     DriverRegistry.register(Constant.JDBC_CLIENT_DRIVER)
-    val partition = split.asInstanceOf[ExecutorMultiBucketLocalShellPartition]
+    val partition = split.asInstanceOf[SmartExecutorBucketPartition]
     val statement = conn.createStatement()
-    if (!useLocatorURL) {
-      val buckets = partition.buckets.mkString(",")
-      statement.execute(
-        s"call sys.SET_BUCKETS_FOR_LOCAL_EXECUTION('$tableName', '$buckets', $relDestroyVersion)")
-      // TODO: currently clientStmt.setLocalExecutionBucketIds is not taking effect probably
-      // due to a bug. Need to be looked into before enabling the code below.
-
-//      statement match {
-//        case clientStmt: ClientStatement =>
-//          val numBuckets = partition.buckets.size
-//          val bucketSet = if (numBuckets == 1) {
-//            Collections.singleton[Integer](partition.buckets.head)
-//          } else {
-//            val buckets = new java.util.HashSet[Integer](numBuckets)
-//            partition.buckets.foreach(buckets.add(_))
-//            buckets
-//          }
-//          clientStmt.setLocalExecutionBucketIds(bucketSet, resolvedName)
-//        case _ =>
-//          val buckets = partition.buckets.mkString(",")
-//          statement.execute(
-//            s"call sys.SET_BUCKETS_FOR_LOCAL_EXECUTION('$resolvedName', '$buckets')")
-//      }
+    val txId = SparkConnectorRDDHelper.snapshotTxIdForRead.get() match {
+      case "null" => null
+      case id => id
     }
-
-    val txId = SparkConnectorRDDHelper.snapshotTxIdForRead.get()
-    if (!txId.equals("null")) {
-      statement.execute(
-        s"call sys.USE_SNAPSHOT_TXID('$txId')")
+    statement match {
+      case clientStmt: ClientStatement =>
+        val bucketSet = Collections.singleton(Int.box(partition.index))
+        clientStmt.setLocalExecutionBucketIds(bucketSet, tableName, true)
+        clientStmt.setMetadataVersion(relDestroyVersion)
+        clientStmt.setSnapshotTransactionId(txId)
+      case _ =>
+        statement.execute("call sys.SET_BUCKETS_FOR_LOCAL_EXECUTION(" +
+            s"'$tableName', '${partition.index}', $relDestroyVersion)")
+        if (txId ne null) {
+          statement.execute(s"call sys.USE_SNAPSHOT_TXID('$txId')")
+        }
     }
 
     val rs = statement.executeQuery(query)
@@ -119,7 +104,7 @@ final class SparkConnectorRDDHelper {
   def getConnection(connectionProperties: ConnectionProperties,
       split: Partition): Connection = {
     val urlsOfNetServerHost = split.asInstanceOf[
-        ExecutorMultiBucketLocalShellPartition].hostList
+        SmartExecutorBucketPartition].hostList
     useLocatorURL = SparkConnectorRDDHelper.useLocatorUrl(urlsOfNetServerHost)
     createConnection(connectionProperties, urlsOfNetServerHost)
   }
@@ -163,105 +148,17 @@ object SparkConnectorRDDHelper {
   var snapshotTxIdForRead: ThreadLocal[String] = new ThreadLocal[String]
   var snapshotTxIdForWrite: ThreadLocal[String] = new ThreadLocal[String]
 
-  def getPartitions(tableName: String): Array[Partition] = {
-    val bucketToServerList = getBucketToServerMapping(tableName)
-    getPartitions(bucketToServerList)
-  }
-
   def getPartitions(bucketToServerList: Array[ArrayBuffer[(String, String)]]): Array[Partition] = {
     val numPartitions = bucketToServerList.length
     val partitions = new Array[Partition](numPartitions)
     for (p <- 0 until numPartitions) {
-      var buckets = new mutable.HashSet[Int]()
-      buckets += p
-      partitions(p) = new ExecutorMultiBucketLocalShellPartition(p,
-        buckets, bucketToServerList(p))
+      partitions(p) = new SmartExecutorBucketPartition(p, bucketToServerList(p))
     }
     partitions
   }
 
   private def useLocatorUrl(hostList: ArrayBuffer[(String, String)]): Boolean =
     hostList.isEmpty
-
-  private def fillNetUrlsForServer(node: InternalDistributedMember,
-      membersToNetServers: java.util.Map[InternalDistributedMember, String],
-      urlPrefix: String, urlSuffix: String,
-      netUrls: ArrayBuffer[(String, String)]): Unit = {
-    val netServers: String = membersToNetServers.get(node)
-    if (netServers != null && !netServers.isEmpty) {
-      // check the rare case of multiple network servers
-      if (netServers.indexOf(',') > 0) {
-        for (netServer <- netServers.split(",")) {
-          netUrls += node.getIpAddress.getHostAddress ->
-              (urlPrefix + org.apache.spark.sql.collection.Utils
-                  .getClientHostPort(netServer) + urlSuffix)
-        }
-      } else {
-        netUrls += node.getIpAddress.getHostAddress ->
-            (urlPrefix + org.apache.spark.sql.collection.Utils
-                .getClientHostPort(netServers) + urlSuffix)
-      }
-    }
-  }
-
-  /**
-   * Called when using smart connector mode that uses accessor
-   * to get SnappyData cluster info.
-   */
-  private def getBucketToServerMapping(
-      resolvedName: String): Array[ArrayBuffer[(String, String)]] = {
-    val urlPrefix = "jdbc:" + Constant.JDBC_URL_PREFIX
-    // no query routing or load-balancing
-    val urlSuffix = "/" + ClientAttribute.ROUTE_QUERY + "=false;" +
-        ClientAttribute.LOAD_BALANCE + "=false"
-    val membersToNetServers = GemFireXDUtils.getGfxdAdvisor.
-        getAllNetServersWithMembers
-    val availableNetUrls = ArrayBuffer.empty[(String, String)]
-    val orphanBuckets = ArrayBuffer.empty[Int]
-    Misc.getRegionForTable(resolvedName, true).asInstanceOf[Region[_, _]] match {
-      case pr: PartitionedRegion =>
-        val bidToAdvisorMap = pr.getRegionAdvisor.
-            getAllBucketAdvisorsHostedAndProxies
-        val numBuckets = bidToAdvisorMap.size()
-        val allNetUrls = new Array[ArrayBuffer[(String, String)]](numBuckets)
-        for (bid <- 0 until numBuckets) {
-          val pbr = bidToAdvisorMap.get(bid).getProxyBucketRegion
-          // throws PartitionOfflineException if appropriate
-          pbr.checkBucketRedundancyBeforeGrab(null, false)
-          val bOwners = pbr.getBucketOwners
-          val netUrls = ArrayBuffer.empty[(String, String)]
-          bOwners.asScala.foreach(fillNetUrlsForServer(_,
-            membersToNetServers, urlPrefix, urlSuffix, netUrls))
-
-          if (netUrls.isEmpty) {
-            // Save the bucket which does not have a neturl,
-            // and later assign available ones to it.
-            orphanBuckets += bid
-          } else {
-            for (e <- netUrls) {
-              if (!availableNetUrls.contains(e)) {
-                availableNetUrls += e
-              }
-            }
-            allNetUrls(bid) = netUrls
-          }
-        }
-        for (bucket <- orphanBuckets) {
-          allNetUrls(bucket) = availableNetUrls
-        }
-        allNetUrls
-
-      case dr: DistributedRegion =>
-        val owners = dr.getDistributionAdvisor.adviseInitializedReplicates()
-        val netUrls = ArrayBuffer.empty[(String, String)]
-        owners.asScala.foreach(fillNetUrlsForServer(_, membersToNetServers,
-          urlPrefix, urlSuffix, netUrls))
-        Array(netUrls)
-
-      case r => sys.error("unexpected region with dataPolicy=" +
-          s"${r.getAttributes.getDataPolicy} attributes: ${r.getAttributes}")
-    }
-  }
 
   def setBucketToServerMappingInfo(
       bucketToServerMappingStr: String): Array[ArrayBuffer[(String, String)]] = {
@@ -271,36 +168,46 @@ object SparkConnectorRDDHelper {
         ClientAttribute.LOAD_BALANCE + "=false"
     if (bucketToServerMappingStr != null) {
       val arr: Array[String] = bucketToServerMappingStr.split(":")
-      val orphanBuckets = ArrayBuffer.empty[Int]
+      var orphanBuckets: ArrayBuffer[Int] = null
       val noOfBuckets = arr(0).toInt
       // val redundancy = arr(1).toInt
       val allNetUrls = new Array[ArrayBuffer[(String, String)]](noOfBuckets)
       val bucketsServers: String = arr(2)
       val newarr: Array[String] = bucketsServers.split("\\|")
-      val availableNetUrls = ArrayBuffer.empty[(String, String)]
+      val availableNetUrls = ObjectObjectHashMap.withExpectedSize[String, String](4)
       for (x <- newarr) {
         val aBucketInfo: Array[String] = x.split(";")
         val bid: Int = aBucketInfo(0).toInt
         if (!(aBucketInfo(1) == "null")) {
           // get (addr,host,port)
           val hostAddressPort = returnHostPortFromServerString(aBucketInfo(1))
-          val netUrls = ArrayBuffer.empty[(String, String)]
-          netUrls += hostAddressPort._1 ->
-              (urlPrefix + hostAddressPort._2 + "[" + hostAddressPort._3 + "]" + urlSuffix)
+          val host = hostAddressPort._1
+          val netUrl = urlPrefix + hostAddressPort._2 + "[" + hostAddressPort._3 + "]" + urlSuffix
+          val netUrls = new ArrayBuffer[(String, String)](1)
+          netUrls += host -> netUrl
           allNetUrls(bid) = netUrls
-          for (e <- netUrls) {
-            if (!availableNetUrls.contains(e)) {
-              availableNetUrls += e
-            }
+          if (!availableNetUrls.contains(host)) {
+            availableNetUrls.put(host, netUrl)
           }
         } else {
           // Save the bucket which does not have a neturl,
           // and later assign available ones to it.
+          if (orphanBuckets eq null) {
+            orphanBuckets = new ArrayBuffer[Int](2)
+          }
           orphanBuckets += bid
         }
       }
-      for (bucket <- orphanBuckets) {
-        allNetUrls(bucket) = availableNetUrls
+      if (orphanBuckets ne null) {
+        val netUrls = new ArrayBuffer[(String, String)](availableNetUrls.size())
+        val netUrlsIter = availableNetUrls.entrySet().iterator()
+        while (netUrlsIter.hasNext) {
+          val entry = netUrlsIter.next()
+          netUrls += entry.getKey -> entry.getValue
+        }
+        for (bucket <- orphanBuckets) {
+          allNetUrls(bucket) = netUrls
+        }
       }
       return allNetUrls
     }

--- a/core/src/main/scala/io/snappydata/util/ServiceUtils.scala
+++ b/core/src/main/scala/io/snappydata/util/ServiceUtils.scala
@@ -74,7 +74,7 @@ object ServiceUtils {
     }
     // try hard to maintain executor_ locality
     if (!storePropNames.contains("spark.locality.wait.process")) {
-      storeProps.setProperty("spark.locality.wait.process", "30s")
+      storeProps.setProperty("spark.locality.wait.process", "20s")
     }
     storeProps
   }

--- a/core/src/main/scala/io/snappydata/util/ServiceUtils.scala
+++ b/core/src/main/scala/io/snappydata/util/ServiceUtils.scala
@@ -72,6 +72,10 @@ object ServiceUtils {
     if (!storePropNames.contains(DistributionConfig.MEMBER_TIMEOUT_NAME)) {
       storeProps.setProperty(DistributionConfig.MEMBER_TIMEOUT_NAME, "30000")
     }
+    // try hard to maintain executor_ locality
+    if (!storePropNames.contains("spark.locality.wait.process")) {
+      storeProps.setProperty("spark.locality.wait.process", "30s")
+    }
     storeProps
   }
 

--- a/core/src/main/scala/org/apache/spark/serializer/PooledKryoSerializer.scala
+++ b/core/src/main/scala/org/apache/spark/serializer/PooledKryoSerializer.scala
@@ -35,7 +35,7 @@ import org.apache.spark.scheduler._
 import org.apache.spark.scheduler.cluster.CoarseGrainedClusterMessages.{LaunchTask, StatusUpdate}
 import org.apache.spark.sql.catalyst.expressions.UnsafeRow
 import org.apache.spark.sql.catalyst.expressions.codegen.CodeAndComment
-import org.apache.spark.sql.collection.{MultiBucketExecutorPartition, NarrowExecutorLocalSplitDep}
+import org.apache.spark.sql.collection.{SmartExecutorBucketPartition, MultiBucketExecutorPartition, NarrowExecutorLocalSplitDep}
 import org.apache.spark.sql.execution.columnar.impl.{ColumnarStorePartitionedRDD, JDBCSourceAsColumnarStore, SmartConnectorColumnRDD, SmartConnectorRowRDD}
 import org.apache.spark.sql.execution.joins.CacheKey
 import org.apache.spark.sql.execution.metric.SQLMetric
@@ -138,6 +138,8 @@ final class PooledKryoSerializer(conf: SparkConf)
     kryo.register(classOf[SmartConnectorColumnRDD],
       new KryoSerializableSerializer)
     kryo.register(classOf[MultiBucketExecutorPartition],
+      new KryoSerializableSerializer)
+    kryo.register(classOf[SmartExecutorBucketPartition],
       new KryoSerializableSerializer)
     kryo.register(classOf[PartitionResult], PartitionResultSerializer)
     kryo.register(classOf[CacheKey], new KryoSerializableSerializer)

--- a/core/src/main/scala/org/apache/spark/sql/SnappyContext.scala
+++ b/core/src/main/scala/org/apache/spark/sql/SnappyContext.scala
@@ -1266,15 +1266,6 @@ case class ThinClientConnectorMode(override val sc: SparkContext,
 }
 
 /**
- * This is for the "old-way" of starting GemFireXD inside an existing
- * Spark/Yarn cluster where cluster nodes themselves boot up as GemXD cluster.
- */
-case class ExternalEmbeddedMode(override val sc: SparkContext,
-    override val url: String) extends ClusterMode {
-  override val description: String = "External embedded mode"
-}
-
-/**
  * The local mode which hosts the data, executor, driver
  * (and optionally even jobserver) all in the same node.
  */

--- a/core/src/main/scala/org/apache/spark/sql/execution/ConnectionPool.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/ConnectionPool.scala
@@ -116,6 +116,7 @@ object ConnectionPool {
               if (connectionProps != null) {
                 tconf.setDbProperties(connectionProps)
               }
+              tconf.setUseStatementFacade(false)
               new TDataSource(tconf)
             }
             pools(poolKey) = (newDS, mutable.Set(id))

--- a/core/src/main/scala/org/apache/spark/sql/execution/TableExec.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/TableExec.scala
@@ -22,7 +22,7 @@ import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.codegen.CodegenContext
 import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeReference, Expression}
 import org.apache.spark.sql.catalyst.plans.physical._
-import org.apache.spark.sql.collection.{ExecutorMultiBucketLocalShellPartition, Utils}
+import org.apache.spark.sql.collection.{SmartExecutorBucketPartition, Utils}
 import org.apache.spark.sql.execution.columnar.JDBCAppendableRelation
 import org.apache.spark.sql.execution.metric.{SQLMetric, SQLMetrics}
 import org.apache.spark.sql.hive.ConnectorCatalog
@@ -137,7 +137,7 @@ trait TableExec extends UnaryExecNode with CodegenSupportOnExecutor {
       val locations = new Array[Seq[String]](numBuckets)
       var i = 0
       relInfo.partitions.foreach(x => {
-          locations(i) = x.asInstanceOf[ExecutorMultiBucketLocalShellPartition].
+          locations(i) = x.asInstanceOf[SmartExecutorBucketPartition].
           hostList.map(_._1.asInstanceOf[String])
           i = i + 1
       })

--- a/core/src/main/scala/org/apache/spark/sql/execution/columnar/impl/ColumnFormatRelation.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/columnar/impl/ColumnFormatRelation.scala
@@ -29,6 +29,7 @@ import org.apache.spark.rdd.RDD
 import org.apache.spark.sql._
 import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeReference, DynamicReplacableConstant, Expression, SortDirection, SpecificInternalRow, UnsafeProjection}
 import org.apache.spark.sql.catalyst.plans.physical.HashPartitioning
+import org.apache.spark.sql.catalyst.util.CaseInsensitiveMap
 import org.apache.spark.sql.catalyst.{InternalRow, analysis}
 import org.apache.spark.sql.collection.Utils
 import org.apache.spark.sql.execution.columnar.ExternalStoreUtils.CaseInsensitiveMutableHashMap
@@ -588,13 +589,12 @@ class ColumnFormatRelation(
     val parameters = new CaseInsensitiveMutableHashMap(options)
     val snappySession = sqlContext.sparkSession.asInstanceOf[SnappySession]
     val indexTblName = snappySession.getIndexTable(indexIdent).toString()
-    val caseInsensitiveMap = new CaseInsensitiveMutableHashMap(tableRelation.origOptions)
-    val tempOptions = caseInsensitiveMap.filterNot(pair => {
+    val tempOptions = tableRelation.origOptions.filterNot(pair => {
       pair._1.equalsIgnoreCase(StoreUtils.PARTITION_BY) ||
           pair._1.equalsIgnoreCase(StoreUtils.COLOCATE_WITH) ||
           pair._1.equalsIgnoreCase(JdbcExtendedUtils.DBTABLE_PROPERTY) ||
           pair._1.equalsIgnoreCase(ExternalStoreUtils.INDEX_NAME)
-    }).toMap + (StoreUtils.PARTITION_BY -> indexColumns.keys.mkString(",")) +
+    }) + (StoreUtils.PARTITION_BY -> indexColumns.keys.mkString(",")) +
         (StoreUtils.GEM_INDEXED_TABLE -> tableIdent.toString) +
         (JdbcExtendedUtils.DBTABLE_PROPERTY -> indexTblName)
 
@@ -781,6 +781,7 @@ final class DefaultSource extends SchemaRelationProvider
     val table = ExternalStoreUtils.removeInternalProps(parameters)
     val partitions = ExternalStoreUtils.getAndSetTotalPartitions(
       Some(sqlContext.sparkContext), parameters, forManagedTable = true)
+    val tableOptions = new CaseInsensitiveMap(parameters.toMap)
     val parametersForShadowTable = new CaseInsensitiveMutableHashMap(parameters)
 
     val partitioningColumns = StoreUtils.getPartitioningColumns(parameters)
@@ -828,7 +829,7 @@ final class DefaultSource extends SchemaRelationProvider
       partitions, tableName, schema)
 
     // create an index relation if it is an index table
-    val baseTable = options.get(StoreUtils.GEM_INDEXED_TABLE)
+    val baseTable = parameters.get(StoreUtils.GEM_INDEXED_TABLE)
     val relation = baseTable match {
       case Some(btable) => new IndexColumnFormatRelation(
         tableName,
@@ -837,7 +838,7 @@ final class DefaultSource extends SchemaRelationProvider
         schema,
         schemaExtension,
         ddlExtensionForShadowTable,
-        options,
+        tableOptions,
         externalStore,
         partitioningColumns,
         sqlContext,
@@ -849,12 +850,12 @@ final class DefaultSource extends SchemaRelationProvider
         schema,
         schemaExtension,
         ddlExtensionForShadowTable,
-        options,
+        tableOptions,
         externalStore,
         partitioningColumns,
         sqlContext)
     }
-    val isRelationforSample = options.get(ExternalStoreUtils.RELATION_FOR_SAMPLE)
+    val isRelationforSample = parameters.get(ExternalStoreUtils.RELATION_FOR_SAMPLE)
         .exists(_.toBoolean)
 
     try {
@@ -863,7 +864,7 @@ final class DefaultSource extends SchemaRelationProvider
         catalog.registerDataSourceTable(qualifiedTableName, Some(relation.schema),
           partitioningColumns.toArray,
           classOf[execution.columnar.impl.DefaultSource].getCanonicalName,
-          options, Some(relation))
+          tableOptions, Some(relation))
       }
       success = true
       relation
@@ -874,6 +875,7 @@ final class DefaultSource extends SchemaRelationProvider
       }
     }
   }
+
   override def createRelation(sqlContext: SQLContext,
       options: Map[String, String], schema: StructType): JDBCAppendableRelation = {
 

--- a/core/src/main/scala/org/apache/spark/sql/execution/columnar/impl/JDBCSourceAsColumnarStore.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/columnar/impl/JDBCSourceAsColumnarStore.scala
@@ -18,6 +18,7 @@ package org.apache.spark.sql.execution.columnar.impl
 
 import java.nio.ByteBuffer
 import java.sql.{Connection, ResultSet, Statement}
+import java.util.Collections
 
 import scala.annotation.meta.param
 import scala.collection.mutable.ArrayBuffer
@@ -33,7 +34,8 @@ import com.pivotal.gemfirexd.internal.engine.{GfxdConstants, Misc}
 import com.pivotal.gemfirexd.internal.iapi.services.context.ContextService
 import com.pivotal.gemfirexd.internal.impl.jdbc.{EmbedConnection, EmbedConnectionContext}
 import io.snappydata.impl.SparkConnectorRDDHelper
-import io.snappydata.thrift.internal.ClientBlob
+import io.snappydata.thrift.StatementAttrs
+import io.snappydata.thrift.internal.{ClientBlob, ClientPreparedStatement, ClientStatement}
 
 import org.apache.spark.rdd.RDD
 import org.apache.spark.serializer.{ConnectionPropertiesSerializer, StructTypeSerializer}
@@ -145,9 +147,9 @@ class JDBCSourceAsColumnarStore(private var _connProperties: ConnectionPropertie
   }
 
   def commitTx(txId: String, conn: Option[Connection]): Unit = {
-    // noinspection RedundantDefaultArgument
-    tryExecute(tableName, closeOnSuccessOrFailure = true, onExecutor = true) {
-      (conn: Connection) => {
+    tryExecute(tableName, closeOnSuccessOrFailure = false, onExecutor = true)(conn => {
+      var success = false
+      try {
         connectionType match {
           case ConnectionType.Embedded =>
             // if(SparkConnectorRDDHelper.snapshotTxIdForRead.get)
@@ -166,8 +168,17 @@ class JDBCSourceAsColumnarStore(private var _connProperties: ConnectionPropertie
               logDebug(s"Committed $txId the transaction on server ")
             }
         }
+        success = true
+      } finally {
+        try {
+          if (!success && !conn.isClosed) {
+            conn.rollback()
+          }
+        } finally {
+          conn.close()
+        }
       }
-    }(conn)
+    })(conn)
   }
 
 
@@ -317,16 +328,6 @@ class JDBCSourceAsColumnarStore(private var _connProperties: ConnectionPropertie
               conn.close()
             }
           case _ =>
-            // it should always be not null.
-            // get clears the state from connection
-            // the tx would have been committed earlier
-            // or it will be committed later
-            val txId = SparkConnectorRDDHelper.snapshotTxIdForWrite.get
-            if (txId != null && !txId.equals("null")) {
-              val statement = conn.prepareStatement("values sys.GET_SNAPSHOT_TXID()")
-              statement.executeQuery()
-              statement.close()
-            }
             // conn commit removed txState from the conn context.
             conn.commit()
             conn.close()
@@ -508,8 +509,8 @@ class JDBCSourceAsColumnarStore(private var _connProperties: ConnectionPropertie
             val catalog = snappySession.sessionCatalog.asInstanceOf[ConnectorCatalog]
             val relInfo = catalog.getCachedRelationInfo(catalog.newQualifiedTableName(rowBuffer))
             (relInfo.partitions, relInfo.embdClusterRelDestroyVersion)
-          case _ =>
-            (Array.empty[Partition], -1)
+          case m => throw new UnsupportedOperationException(
+            s"SnappyData table scan not supported in mode: $m")
         }
 
         new SmartConnectorColumnRDD(snappySession,
@@ -704,7 +705,7 @@ final class ColumnarStorePartitionedRDD(
     // val txId = txMgr.getTransactionId
     val bucketIds = part match {
       case p: MultiBucketExecutorPartition => p.buckets
-      case _ => java.util.Collections.singleton(Int.box(part.index))
+      case _ => Collections.singleton(Int.box(part.index))
     }
     // val container = GemFireXDUtils.getGemFireContainer(tableName, true)
     // ColumnBatchIterator(container, bucketIds)
@@ -765,14 +766,13 @@ final class SmartConnectorColumnRDD(
 
         // if ((txId ne null) && !txId.equals("null")) {
         val ps = conn.prepareStatement(s"call sys.COMMIT_SNAPSHOT_TXID(?)")
-        ps.setString(1, if (txId == null) "null" else txId)
+        ps.setString(1, if (txId eq null) "null" else txId)
         ps.executeUpdate()
         logDebug(s"The txid being committed is $txId")
         ps.close()
         SparkConnectorRDDHelper.snapshotTxIdForRead.set(null)
         logDebug(s"closed connection for task from listener $partitionId")
         try {
-          conn.commit()
           conn.close()
           logDebug("closed connection for task " + context.partitionId())
         } catch {
@@ -785,16 +785,11 @@ final class SmartConnectorColumnRDD(
   }
 
   override def getPreferredLocations(split: Partition): Seq[String] = {
-    split.asInstanceOf[ExecutorMultiBucketLocalShellPartition]
+    split.asInstanceOf[SmartExecutorBucketPartition]
         .hostList.map(_._1.asInstanceOf[String])
   }
 
-  override def getPartitions: Array[Partition] = {
-    if (parts != null && parts.length > 0) {
-      return parts
-    }
-    SparkConnectorRDDHelper.getPartitions(tableName)
-  }
+  override def getPartitions: Array[Partition] = parts
 
   override def write(kryo: Kryo, output: Output): Unit = {
     super.write(kryo, output)
@@ -861,7 +856,6 @@ class SmartConnectorRowRDD(_session: SnappySession,
       context.addTaskCompletionListener { _ =>
         logDebug(s"closed connection for task from listener $partitionId")
         try {
-          conn.commit()
           conn.close()
           logDebug("closed connection for task " + context.partitionId())
         } catch {
@@ -869,12 +863,24 @@ class SmartConnectorRowRDD(_session: SnappySession,
         }
       }
     }
-    if (isPartitioned) {
+
+    val statement = conn.createStatement()
+    val thriftConn = statement match {
+      case clientStmt: ClientStatement =>
+        val clientConn = clientStmt.getConnection
+        if (isPartitioned) {
+          clientConn.setCommonStatementAttributes(ClientStatement.setLocalExecutionBucketIds(
+            new StatementAttrs(), Collections.singleton(Int.box(thePart.index)),
+            tableName, true).setMetadataVersion(_relDestroyVersion))
+        }
+        clientConn
+      case _ => null
+    }
+    if (isPartitioned && (thriftConn eq null)) {
       val ps = conn.prepareStatement(
         s"call sys.SET_BUCKETS_FOR_LOCAL_EXECUTION(?, ?, ${_relDestroyVersion})")
       ps.setString(1, tableName)
-      val partition = thePart.asInstanceOf[ExecutorMultiBucketLocalShellPartition]
-      val bucketString = partition.buckets.mkString(",")
+      val bucketString = thePart.index.toString
       ps.setString(2, bucketString)
       ps.executeUpdate()
       ps.close()
@@ -896,9 +902,10 @@ class SmartConnectorRowRDD(_session: SnappySession,
     }
 
     val txId = SparkConnectorRDDHelper.snapshotTxIdForRead.get
-    if (txId != null) {
+    if (thriftConn ne null) {
+      stmt.asInstanceOf[ClientPreparedStatement].setSnapshotTransactionId(txId)
+    } else if (txId != null) {
       if (!txId.equals("null")) {
-        val statement = conn.createStatement()
         statement.execute(
           s"call sys.USE_SNAPSHOT_TXID('$txId')")
       }
@@ -917,30 +924,19 @@ class SmartConnectorRowRDD(_session: SnappySession,
       SparkConnectorRDDHelper.snapshotTxIdForRead.set(txId)
       logDebug(s"The snapshot tx id is $txId and tablename is $tableName")
     }
+    if (thriftConn ne null) {
+      thriftConn.setCommonStatementAttributes(null)
+    }
     logDebug(s"The previous snapshot tx id is $txId and tablename is $tableName")
     (conn, stmt, rs)
   }
 
   override def getPreferredLocations(split: Partition): Seq[String] = {
-    split.asInstanceOf[ExecutorMultiBucketLocalShellPartition]
+    split.asInstanceOf[SmartExecutorBucketPartition]
         .hostList.map(_._1.asInstanceOf[String])
   }
 
-  override def getPartitions: Array[Partition] = {
-    // use incoming partitions if provided (e.g. for collocated tables)
-    val parts = partitionEvaluator()
-    if (parts != null && parts.length > 0) {
-      return parts
-    }
-    val conn = ExternalStoreUtils.getConnection(tableName, connProperties,
-      forExecutor = true)
-    try {
-      SparkConnectorRDDHelper.getPartitions(tableName)
-    } finally {
-      conn.commit()
-      conn.close()
-    }
-  }
+  override def getPartitions: Array[Partition] = partitionEvaluator()
 
   def getSQLStatement(resolvedTableName: String,
       requiredColumns: Array[String], partitionId: Int): String = {

--- a/core/src/main/scala/org/apache/spark/sql/execution/row/RowFormatRelation.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/row/RowFormatRelation.scala
@@ -29,6 +29,7 @@ import org.apache.spark.rdd.RDD
 import org.apache.spark.sql._
 import org.apache.spark.sql.catalyst.expressions.{Ascending, Descending, Expression, SortDirection}
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
+import org.apache.spark.sql.catalyst.util.CaseInsensitiveMap
 import org.apache.spark.sql.catalyst.{InternalRow, analysis}
 import org.apache.spark.sql.execution.columnar.ExternalStoreUtils.CaseInsensitiveMutableHashMap
 import org.apache.spark.sql.execution.columnar.impl.SmartConnectorRowRDD
@@ -164,14 +165,13 @@ class RowFormatRelation(
     (rdd, Nil)
   }
 
-  def relInfo: RelationInfo = {
+  @transient private lazy val relInfo: RelationInfo = {
     clusterMode match {
       case ThinClientConnectorMode(_, _) =>
         val catalog = _context.sparkSession.sessionState.catalog.asInstanceOf[ConnectorCatalog]
         catalog.getCachedRelationInfo(catalog.newQualifiedTableName(table))
-      case _ =>
-         RelationInfo(numBuckets, isPartitioned, partitionColumns, Array.empty[String],
-           Array.empty[String], Array.empty[Partition], -1)
+      case m => throw new UnsupportedOperationException(
+        s"SnappyData table scan not supported in mode: $m")
     }
   }
 
@@ -322,6 +322,7 @@ final class DefaultSource extends MutableRelationProvider {
     ExternalStoreUtils.getAndSetTotalPartitions(
       Some(sqlContext.sparkContext), parameters,
       forManagedTable = true, forColumnTable = false)
+    val tableOptions = new CaseInsensitiveMap(parameters.toMap)
     val ddlExtension = StoreUtils.ddlExtensionString(parameters,
       isRowTable = true, isShadowTable = false)
     val schemaExtension = s"$schema $ddlExtension"
@@ -340,7 +341,7 @@ final class DefaultSource extends MutableRelationProvider {
       mode,
       schemaExtension,
       Array[Partition](JDBCPartition(null, 0)),
-      options,
+      tableOptions,
       sqlContext)
     try {
       relation.createTable(mode)
@@ -349,7 +350,7 @@ final class DefaultSource extends MutableRelationProvider {
       catalog.registerDataSourceTable(
         catalog.newQualifiedTableName(tableName), None, Array.empty[String],
         classOf[execution.row.DefaultSource].getCanonicalName,
-        options, Some(relation))
+        tableOptions, Some(relation))
       
       data match {
         case Some(plan) =>

--- a/core/src/main/scala/org/apache/spark/sql/hive/SnappyStoreHiveCatalog.scala
+++ b/core/src/main/scala/org/apache/spark/sql/hive/SnappyStoreHiveCatalog.scala
@@ -172,11 +172,18 @@ class SnappyStoreHiveCatalog(externalCatalog: SnappyExternalCatalog,
     val cacheLoader = new CacheLoader[QualifiedTableName,
         (LogicalRelation, CatalogTable, RelationInfo)]() {
       override def load(in: QualifiedTableName): (LogicalRelation, CatalogTable, RelationInfo) = {
-        logDebug(s"Creating new cached data source for $in")
+        // table names are always case-insensitive in hive
+        val qualifiedName = Utils.toUpperCase(in.toString)
+        logDebug(s"Creating new cached data source for $qualifiedName")
         val table = in.getTable(client)
         val partitionColumns = table.partitionSchema.map(_.name)
         val provider = table.properties(HIVE_PROVIDER)
-        val options = new CaseInsensitiveMap(table.storage.properties)
+        var options: Map[String, String] = new CaseInsensitiveMap(table.storage.properties)
+        // add dbtable property if not present
+        val dbtableProp = JdbcExtendedUtils.DBTABLE_PROPERTY
+        if (!options.contains(dbtableProp)) {
+          options += dbtableProp -> qualifiedName
+        }
         val userSpecifiedSchema = if (table.properties.contains(
           ExternalStoreUtils.USER_SPECIFIED_SCHEMA)) {
           ExternalStoreUtils.getTableSchema(table.properties)
@@ -202,7 +209,7 @@ class SnappyStoreHiveCatalog(externalCatalog: SnappyExternalCatalog,
             }
 
             dependentRelations.foreach(rel => {
-              DependencyCatalog.addDependent(in.toString, rel)
+              DependencyCatalog.addDependent(qualifiedName, rel)
             })
           case _ => // Do nothing
         }
@@ -587,22 +594,22 @@ class SnappyStoreHiveCatalog(externalCatalog: SnappyExternalCatalog,
       client.getTableOption(tableIdent.schemaName, tableIdent.table)) match {
       case None =>
 
-        var newOptions = new CaseInsensitiveMutableHashMap(options)
-        options.get(ExternalStoreUtils.COLUMN_BATCH_SIZE) match {
+        val newOptions = new CaseInsensitiveMutableHashMap(options)
+        newOptions.get(ExternalStoreUtils.COLUMN_BATCH_SIZE) match {
           case Some(_) =>
           case None => newOptions += (ExternalStoreUtils.COLUMN_BATCH_SIZE ->
               ExternalStoreUtils.defaultColumnBatchSize(snappySession).toString)
             // mark this as transient since can change as per session configuration later
             newOptions += (ExternalStoreUtils.COLUMN_BATCH_SIZE_TRANSIENT -> "true")
         }
-        options.get(ExternalStoreUtils.COLUMN_MAX_DELTA_ROWS) match {
+        newOptions.get(ExternalStoreUtils.COLUMN_MAX_DELTA_ROWS) match {
           case Some(_) =>
           case None => newOptions += (ExternalStoreUtils.COLUMN_MAX_DELTA_ROWS ->
               ExternalStoreUtils.defaultColumnMaxDeltaRows(snappySession).toString)
             // mark this as transient since can change as per session configuration later
             newOptions += (ExternalStoreUtils.COLUMN_MAX_DELTA_ROWS_TRANSIENT -> "true")
         }
-        options.get(ExternalStoreUtils.COMPRESSION_CODEC) match {
+        newOptions.get(ExternalStoreUtils.COMPRESSION_CODEC) match {
           case Some(_) =>
           case None => newOptions += (ExternalStoreUtils.COMPRESSION_CODEC ->
               ExternalStoreUtils.defaultCompressionCodec(snappySession).toString)

--- a/core/src/main/scala/org/apache/spark/sql/sources/MutableRelationProvider.scala
+++ b/core/src/main/scala/org/apache/spark/sql/sources/MutableRelationProvider.scala
@@ -18,10 +18,10 @@ package org.apache.spark.sql.sources
 
 import java.util.Properties
 
-import scala.collection.mutable
-
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
+import org.apache.spark.sql.catalyst.util.CaseInsensitiveMap
 import org.apache.spark.sql.execution.columnar.ExternalStoreUtils
+import org.apache.spark.sql.execution.columnar.ExternalStoreUtils.CaseInsensitiveMutableHashMap
 import org.apache.spark.sql.execution.datasources.jdbc.{JDBCPartitioningInfo, JDBCRelation}
 import org.apache.spark.sql.hive.SnappyStoreHiveCatalog
 import org.apache.spark.sql.jdbc.{JdbcDialect, JdbcDialects}
@@ -38,14 +38,14 @@ abstract class MutableRelationProvider
   override def createRelation(sqlContext: SQLContext, mode: SaveMode,
       options: Map[String, String], schema: String,
       data: Option[LogicalPlan]): JDBCMutableRelation = {
-    val parameters = new mutable.HashMap[String, String]
-    parameters ++= options
+    val parameters = new CaseInsensitiveMutableHashMap(options)
     val partitionColumn = parameters.remove("partitioncolumn")
     val lowerBound = parameters.remove("lowerbound")
     val upperBound = parameters.remove("upperbound")
     val numPartitions = parameters.remove("numpartitions")
 
     val table = ExternalStoreUtils.removeInternalProps(parameters)
+    val tableOptions = new CaseInsensitiveMap(parameters.toMap)
     val catalog = sqlContext.sparkSession.asInstanceOf[SnappySession].sessionCatalog
     val qualifiedTableName = catalog.newQualifiedTableName(table)
     val connProperties = ExternalStoreUtils.validateAndGetAllProps(
@@ -69,7 +69,7 @@ abstract class MutableRelationProvider
       sqlContext.conf)
     var success = false
     val relation = JDBCMutableRelation(connProperties, tableName,
-      getClass.getCanonicalName, mode, schema, parts, options, sqlContext)
+      getClass.getCanonicalName, mode, schema, parts, tableOptions, sqlContext)
     try {
       relation.createTable(mode)
 
@@ -83,7 +83,7 @@ abstract class MutableRelationProvider
       catalog.registerDataSourceTable(
         catalog.newQualifiedTableName(tableName), None, Array.empty[String],
         classOf[org.apache.spark.sql.row.DefaultSource].getCanonicalName,
-        options, Some(relation))
+        tableOptions, Some(relation))
       success = true
       relation
     } finally {

--- a/core/src/main/scala/org/apache/spark/sql/streaming/DirectKafkaStreamSource.scala
+++ b/core/src/main/scala/org/apache/spark/sql/streaming/DirectKafkaStreamSource.scala
@@ -41,9 +41,9 @@ class DirectKafkaStreamSource extends StreamPlanProvider {
 
 final class DirectKafkaStreamRelation(
     @transient override val sqlContext: SQLContext,
-    options: Map[String, String],
+    opts: Map[String, String],
     override val schema: StructType)
-    extends StreamBaseRelation(options)
+    extends StreamBaseRelation(opts)
     with Logging with Serializable {
 
   val topicsSet = options("topics").split(",").toSet

--- a/core/src/main/scala/org/apache/spark/sql/streaming/FileStreamSource.scala
+++ b/core/src/main/scala/org/apache/spark/sql/streaming/FileStreamSource.scala
@@ -34,9 +34,9 @@ final class FileStreamSource extends StreamPlanProvider {
 
 final class FileStreamRelation(
     @transient override val sqlContext: SQLContext,
-    options: Map[String, String],
+    opts: Map[String, String],
     override val schema: StructType)
-    extends StreamBaseRelation(options) {
+    extends StreamBaseRelation(opts) {
 
   // HDFS directory to monitor for new file
   val DIRECTORY = "directory"

--- a/core/src/main/scala/org/apache/spark/sql/streaming/KafkaStreamSource.scala
+++ b/core/src/main/scala/org/apache/spark/sql/streaming/KafkaStreamSource.scala
@@ -40,9 +40,9 @@ class KafkaStreamSource extends StreamPlanProvider {
 
 final class KafkaStreamRelation(
     @transient override val sqlContext: SQLContext,
-    options: Map[String, String],
+    opts: Map[String, String],
     override val schema: StructType)
-    extends StreamBaseRelation(options) {
+    extends StreamBaseRelation(opts) {
 
   val kafkaParams: Map[String, String] = options.get("kafkaParams").map { t =>
     t.split(";").map { s =>

--- a/core/src/main/scala/org/apache/spark/sql/streaming/RabbitMQStreamSource.scala
+++ b/core/src/main/scala/org/apache/spark/sql/streaming/RabbitMQStreamSource.scala
@@ -37,9 +37,9 @@ final class RabbitMQStreamSource extends StreamPlanProvider {
 
 final class RabbitMQStreamRelation(
     @transient override val sqlContext: SQLContext,
-    options: Map[String, String],
+    opts: Map[String, String],
     override val schema: StructType)
-    extends StreamBaseRelation(options) {
+    extends StreamBaseRelation(opts) {
 
   val T = options.getOrElse("T", "java.lang.String")
   val D = options.getOrElse("D", "org.apache.spark.sql.streaming.RabbitMQStringDecoder")

--- a/core/src/main/scala/org/apache/spark/sql/streaming/RawSocketStreamSource.scala
+++ b/core/src/main/scala/org/apache/spark/sql/streaming/RawSocketStreamSource.scala
@@ -36,9 +36,9 @@ final class RawSocketStreamSource extends StreamPlanProvider {
 
 final class RawSocketStreamRelation(
     @transient override val sqlContext: SQLContext,
-    options: Map[String, String],
+    opts: Map[String, String],
     override val schema: StructType)
-    extends StreamBaseRelation(options) {
+    extends StreamBaseRelation(opts) {
 
   val hostname: String = options("hostname")
   val port: Int = options.get("port").map(_.toInt).get

--- a/core/src/main/scala/org/apache/spark/sql/streaming/SocketStreamSource.scala
+++ b/core/src/main/scala/org/apache/spark/sql/streaming/SocketStreamSource.scala
@@ -35,9 +35,9 @@ final class SocketStreamSource extends StreamPlanProvider {
 
 final class SocketStreamRelation(
     @transient override val sqlContext: SQLContext,
-    options: Map[String, String],
+    opts: Map[String, String],
     override val schema: StructType)
-    extends StreamBaseRelation(options) {
+    extends StreamBaseRelation(opts) {
 
   val hostname: String = options("hostname")
 

--- a/core/src/main/scala/org/apache/spark/sql/streaming/StreamBaseRelation.scala
+++ b/core/src/main/scala/org/apache/spark/sql/streaming/StreamBaseRelation.scala
@@ -21,6 +21,7 @@ import scala.collection.mutable
 import org.apache.spark.rdd.{EmptyRDD, RDD}
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.util.CaseInsensitiveMap
 import org.apache.spark.sql.collection.Utils
 import org.apache.spark.sql.hive.SnappyStoreHiveCatalog
 import org.apache.spark.sql.sources._
@@ -29,13 +30,15 @@ import org.apache.spark.streaming.dstream.{DStream, InputDStream, ReceiverInputD
 import org.apache.spark.streaming.{SnappyStreamingContext, StreamUtils, StreamingContextState, Time}
 import org.apache.spark.{Logging, util}
 
-abstract class StreamBaseRelation(options: Map[String, String])
+abstract class StreamBaseRelation(opts: Map[String, String])
     extends ParentRelation with StreamPlan with TableScan
         with DestroyRelation with Serializable with Logging {
 
   final def context: SnappyStreamingContext =
     SnappyStreamingContext.getInstance().getOrElse(
       throw new IllegalStateException("No initialized streaming context"))
+
+  protected val options = new CaseInsensitiveMap(opts)
 
   @transient val tableName = options(JdbcExtendedUtils.DBTABLE_PROPERTY)
 

--- a/core/src/main/scala/org/apache/spark/sql/streaming/TextSocketStreamSource.scala
+++ b/core/src/main/scala/org/apache/spark/sql/streaming/TextSocketStreamSource.scala
@@ -33,9 +33,9 @@ final class TextSocketStreamSource extends StreamPlanProvider {
 
 final class TextSocketStreamRelation(
     @transient override val sqlContext: SQLContext,
-    options: Map[String, String],
+    opts: Map[String, String],
     override val schema: StructType)
-    extends StreamBaseRelation(options) {
+    extends StreamBaseRelation(opts) {
 
   val hostname: String = options("hostname") // .getOrElse("localhost")
 

--- a/core/src/main/scala/org/apache/spark/sql/streaming/TwitterStreamSource.scala
+++ b/core/src/main/scala/org/apache/spark/sql/streaming/TwitterStreamSource.scala
@@ -39,9 +39,9 @@ final class TwitterStreamSource extends StreamPlanProvider {
 
 final class TwitterStreamRelation(
     @transient override val sqlContext: SQLContext,
-    options: Map[String, String],
+    opts: Map[String, String],
     override val schema: StructType)
-    extends StreamBaseRelation(options) {
+    extends StreamBaseRelation(opts) {
 
   val consumerKey = options("consumerKey")
   val consumerSecret = options("consumerSecret")

--- a/dtests/src/test/java/io/snappydata/hydra/tpch/TPCHPerfComparerTest.java
+++ b/dtests/src/test/java/io/snappydata/hydra/tpch/TPCHPerfComparerTest.java
@@ -12,29 +12,23 @@ import java.util.List;
 import java.util.Set;
 
 import hydra.ClientVmInfo;
-import hydra.FileUtil;
-import hydra.Log;
-import io.snappydata.hydra.cluster.SnappyBB;
 import io.snappydata.hydra.cluster.SnappyTest;
 import util.TestException;
 
-/**
- * Created by kishor on 12/5/17.
- */
 public class TPCHPerfComparerTest extends SnappyTest {
 
+  @SuppressWarnings("unused")
   public static void HydraTask_CompareQueryPerformance() {
 
     String primaryLeadDir = null;
-    Object[] tmpArr = null;
-    String leadPort = null;
+    Object[] tmpArr;
     tmpArr = getPrimaryLeadVM(cycleLeadVMTarget);
     List<ClientVmInfo> vmList;
+    // noinspection unchecked
     vmList = (List<ClientVmInfo>)(tmpArr[0]);
-    Set<String> myDirList = new LinkedHashSet<String>();
+    Set<String> myDirList = new LinkedHashSet<>();
     myDirList = getFileContents("logDir_", myDirList);
-    for (int i = 0; i < vmList.size(); i++) {
-      ClientVmInfo targetVm = vmList.get(i);
+    for (ClientVmInfo targetVm : vmList) {
       String clientName = targetVm.getClientName();
       for (String vmDir : myDirList) {
         if (vmDir.contains(clientName)) {
@@ -48,44 +42,47 @@ public class TPCHPerfComparerTest extends SnappyTest {
       BufferedWriter buffer = new BufferedWriter(writer);
       buffer.write("Query   Snappy   Spark   PercentageDiff");
 
-      FileInputStream snappyFS = new FileInputStream(primaryLeadDir + File.separator + "1_Snappy_Average.out");
-      FileInputStream sparkFS = new FileInputStream(primaryLeadDir + File.separator + "1_Spark_Average.out");
+      FileInputStream snappyFS = new FileInputStream(primaryLeadDir +
+          File.separator + "1_Snappy_Average.out");
+      FileInputStream sparkFS = new FileInputStream(primaryLeadDir +
+          File.separator + "1_Spark_Average.out");
       BufferedReader snappyBR = new BufferedReader(new InputStreamReader(snappyFS));
       BufferedReader sparkBR = new BufferedReader(new InputStreamReader(sparkFS));
-      String snappyLine = null;
-      String sparkLine = null;
       String line1 = snappyBR.readLine();
       String line2 = sparkBR.readLine();
 
-      boolean areEqual = true;
       int lineNum = 1;
 
       String degradedPerfs = "";
 
       while (line1 != null || line2 != null) {
-        String[] snappyQueryPerformance = line1.split(",");
-        String[] sparkQueryPerformance = line2.split(",");
-        if (snappyQueryPerformance[0].equals(sparkQueryPerformance[0])) {
+        String[] snappyQueryPerformance = line1 != null ? line1.split(",") : new String[0];
+        String[] sparkQueryPerformance = line2 != null ? line2.split(",") : new String[0];
+        if (snappyQueryPerformance.length == sparkQueryPerformance.length &&
+            snappyQueryPerformance[0].equals(sparkQueryPerformance[0])) {
           Double snappyValue = new Double(snappyQueryPerformance[1]);
           Double sparkValue = new Double(sparkQueryPerformance[1]);
 
           double diff = sparkValue - snappyValue;
           double percentageDiff = (diff / sparkValue) * 100;
 
-          buffer.write("\n  " + snappyQueryPerformance[0] + "         " + snappyQueryPerformance[1] + "        " + sparkQueryPerformance[1] + "              " + percentageDiff);
+          buffer.write("\n  " + snappyQueryPerformance[0] + "         " +
+              snappyQueryPerformance[1] + "        " + sparkQueryPerformance[1] +
+              "              " + percentageDiff);
 
           if (percentageDiff < -5) {
-            degradedPerfs +=  "For query " + snappyQueryPerformance[0] + "Snappy Performance is degraded by " + percentageDiff + "% \n";
+            degradedPerfs += "For query " + snappyQueryPerformance[0] +
+                "Snappy Performance is degraded by " + percentageDiff + "% \n";
           }
         } else {
-          new TestException("Query execution is not aligned");
+          throw new TestException("Query execution is not aligned");
         }
         line1 = snappyBR.readLine();
         line2 = sparkBR.readLine();
         lineNum++;
       }
-      if(!degradedPerfs.isEmpty()){
-        new TestException("Performance degradation observed for below queries " + degradedPerfs);
+      if (!degradedPerfs.isEmpty()) {
+        throw new TestException("Performance degradation observed for below queries " + degradedPerfs);
       }
       buffer.close();
       snappyBR.close();

--- a/dunit/src/main/java/io/snappydata/test/dunit/standalone/ProcessManager.java
+++ b/dunit/src/main/java/io/snappydata/test/dunit/standalone/ProcessManager.java
@@ -186,7 +186,7 @@ public class ProcessManager {
       "-DsecurityLogLevel=" + DUnitLauncher.SECURITY_LOG_LEVEL,
       "-Dgemfire.security-log-level=" + DUnitLauncher.SECURITY_LOG_LEVEL,
       "-Djava.library.path=" + System.getProperty("java.library.path"),
-      "-Xrunjdwp:transport=dt_socket,server=y,suspend=n",
+      "-agentlib:jdwp=transport=dt_socket,server=y,suspend=n",
       "-XX:+HeapDumpOnOutOfMemoryError",
       "-Xmx1g",
       "-Xms1g",


### PR DESCRIPTION
## Changes proposed in this pull request

- SparkConnectorRDDHelper.scala: changed the UNION ALL query to a much smaller
  IN query that is now correctly converted to getAll on store-side (note the
      use of "select *" rather than projection that still cannot be dealt by store)
- SparkConnectorRDDHelper.scala: added the optimized path for thrift connection/statement
  to set properties on it rather than making procedure call round-trips;
- SparkConnectorRDDHelper.scala: also removed obsolete code used by old accessor/peer
  smart connector; copied its code for "orphanBuckets" i.e. data nodes having no network server
- removed some unnecessary commit() calls since snapshot commit is explicitly invoked
- make bucket sizes consistent in embedded and smart connector; these now always
  go into the table properties else the defaults can be interpreted differently
  in embedded vs smart connector
- fixed case-sensitivity of table properties and table name making it consistent (case-insensitive)
- renamed ExecutorMultiBucketLocalShellPartition to SmartExecutorBucketPartition and made
  it kryo serializable
- reduced number of default buckets for a localhost-only cluster
- increased executor locality wait by default in embedded mode

## Patch testing

precheckin

## ReleaseNotes.txt changes

NA

## Other PRs 

https://github.com/SnappyDataInc/snappy-store/pull/337