### PR TITLE
[GITHUB-900] CREATE INDEX: quote case-sensitive columns

### DIFF
--- a/core/src/main/scala/org/apache/spark/sql/SnappySession.scala
+++ b/core/src/main/scala/org/apache/spark/sql/SnappySession.scala
@@ -1452,7 +1452,9 @@ class SnappySession(_sc: SparkContext) extends SparkSession(_sc) {
 
     val tableIdent = sessionCatalog.newQualifiedTableName(baseTable)
     val indexIdent = sessionCatalog.newQualifiedTableName(indexName)
-    createIndex(indexIdent, tableIdent, indexColumns, options)
+    // normalize index column names for API calls
+    val columnsWithDirection = indexColumns.map(p => sessionCatalog.formatName(p._1) -> p._2)
+    createIndex(indexIdent, tableIdent, columnsWithDirection, options)
   }
 
   /**

--- a/core/src/main/scala/org/apache/spark/sql/execution/columnar/ExternalStoreUtils.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/columnar/ExternalStoreUtils.scala
@@ -402,46 +402,58 @@ object ExternalStoreUtils {
     case _ => true
   }
 
-  val SOME_TRUE = Some(true)
-  val SOME_FALSE = Some(false)
-
   private def checkIndexedColumn(col: String,
-      indexedCols: scala.collection.Set[String]): Option[Boolean] =
-    if (indexedCols.contains(col)) SOME_TRUE else None
+      indexedCols: scala.collection.Set[String]): Option[String] = {
+    // quote identifiers when they could be case-sensitive
+    if (indexedCols.contains(col)) Some("\"" + col + '"')
+    else {
+      // case-insensitive check
+      val ucol = Utils.toUpperCase(col)
+      if ((col ne ucol) && indexedCols.contains(ucol)) Some(col)
+      else None
+    }
+  }
 
   // below should exactly match RowFormatScanRDD.compileFilter
   def handledFilter(f: Filter,
-      indexedCols: scala.collection.Set[String]): Option[Boolean] = f match {
+      indexedCols: scala.collection.Set[String]): Option[Filter] = f match {
     // only pushdown filters if there is an index on the column;
     // keeping a bit conservative and not pushing other filters because
     // Spark execution engine is much faster at filter apply (though
     //   its possible that not all indexed columns will be used for
     //   index lookup still push down all to keep things simple)
-    case EqualTo(col, _) => checkIndexedColumn(col, indexedCols)
-    case LessThan(col, _) => checkIndexedColumn(col, indexedCols)
-    case GreaterThan(col, _) => checkIndexedColumn(col, indexedCols)
-    case LessThanOrEqual(col, _) => checkIndexedColumn(col, indexedCols)
-    case GreaterThanOrEqual(col, _) => checkIndexedColumn(col, indexedCols)
-    case StringStartsWith(col, _) => checkIndexedColumn(col, indexedCols)
-    case In(col, _) => checkIndexedColumn(col, indexedCols)
+    case EqualTo(col, v) => checkIndexedColumn(col, indexedCols).map(EqualTo(_, v))
+    case LessThan(col, v) => checkIndexedColumn(col, indexedCols).map(LessThan(_, v))
+    case GreaterThan(col, v) => checkIndexedColumn(col, indexedCols).map(GreaterThan(_, v))
+    case LessThanOrEqual(col, v) => checkIndexedColumn(col, indexedCols).map(LessThanOrEqual(_, v))
+    case GreaterThanOrEqual(col, v) =>
+      checkIndexedColumn(col, indexedCols).map(GreaterThanOrEqual(_, v))
+    case StringStartsWith(col, v) =>
+      checkIndexedColumn(col, indexedCols).map(StringStartsWith(_, v))
+    case In(col, v) => checkIndexedColumn(col, indexedCols).map(In(_, v))
     // At least one column should be indexed for the AND condition to be
     // evaluated efficiently
-    case And(left, right) =>
-      val v = handledFilter(left, indexedCols)
-      if (v ne None) v
-      else handledFilter(right, indexedCols)
+    case And(left, right) => handledFilter(left, indexedCols) match {
+      case None => handledFilter(right, indexedCols)
+      case lf@Some(l) => handledFilter(right, indexedCols) match {
+        case None => lf
+        case Some(r) => Some(And(l, r))
+      }
+    }
     // ORList optimization requires all columns to have indexes
     // which is ensured by the condition below
-    case Or(left, right) => if ((handledFilter(left, indexedCols) eq
-        SOME_TRUE) && (handledFilter(right, indexedCols) eq SOME_TRUE)) {
-      SOME_TRUE
-    } else SOME_FALSE
-    case _ => SOME_FALSE
+    case Or(left, right) => handledFilter(left, indexedCols) match {
+      case None => None
+      case Some(l) => handledFilter(right, indexedCols) match {
+        case None => None
+        case Some(r) => Some(Or(l, r))
+      }
+    }
+    case _ => None
   }
 
-  def unhandledFilter(f: Filter,
-      indexedCols: scala.collection.Set[String]): Boolean =
-    handledFilter(f, indexedCols) ne SOME_TRUE
+  def unhandledFilter(f: Filter, indexedCols: scala.collection.Set[String]): Boolean =
+    handledFilter(f, indexedCols) eq None
 
   /**
    * Prune all but the specified columns from the specified Catalyst schema.

--- a/core/src/main/scala/org/apache/spark/sql/execution/row/RowFormatRelation.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/row/RowFormatRelation.scala
@@ -242,7 +242,7 @@ class RowFormatRelation(
   }
 
   private def getColumnStr(colWithDirection: (String, Option[SortDirection])): String = {
-    colWithDirection._1 + " " + (colWithDirection._2 match {
+    "\"" + colWithDirection._1 + "\" " + (colWithDirection._2 match {
       case Some(Ascending) => "ASC"
       case Some(Descending) => "DESC"
       case None => ""
@@ -332,7 +332,7 @@ final class DefaultSource extends MutableRelationProvider {
       Some(sqlContext.sparkSession), parameters)
 
     StoreUtils.validateConnProps(parameters)
-    val tableName = SnappyStoreHiveCatalog.processTableIdentifier(table, sqlContext.conf)
+    val tableName = SnappyStoreHiveCatalog.processIdentifier(table, sqlContext.conf)
     var success = false
     val relation = new RowFormatRelation(connProperties,
       tableName,

--- a/core/src/main/scala/org/apache/spark/sql/execution/row/RowFormatRelation.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/row/RowFormatRelation.scala
@@ -132,8 +132,7 @@ class RowFormatRelation(
 
   override def buildUnsafeScan(requiredColumns: Array[String],
       filters: Array[Filter]): (RDD[Any], Seq[RDD[InternalRow]]) = {
-    val handledFilters = filters.filter(ExternalStoreUtils
-        .handledFilter(_, indexedColumns) eq ExternalStoreUtils.SOME_TRUE)
+    val handledFilters = filters.flatMap(ExternalStoreUtils.handledFilter(_, indexedColumns))
     val session = sqlContext.sparkSession.asInstanceOf[SnappySession]
     val rdd = connectionType match {
       case ConnectionType.Embedded =>

--- a/core/src/main/scala/org/apache/spark/sql/hive/SnappyStoreHiveCatalog.scala
+++ b/core/src/main/scala/org/apache/spark/sql/hive/SnappyStoreHiveCatalog.scala
@@ -134,15 +134,15 @@ class SnappyStoreHiveCatalog(externalCatalog: SnappyExternalCatalog,
   /**
    * Format table name, taking into account case sensitivity.
    */
-  override def formatTableName(name: String): String = {
-    SnappyStoreHiveCatalog.processTableIdentifier(name, sqlConf)
-  }
+  override def formatTableName(name: String): String = formatName(name)
 
   /**
    * Format database name, taking into account case sensitivity.
    */
-  override def formatDatabaseName(name: String): String = {
-    SnappyStoreHiveCatalog.processTableIdentifier(name, sqlConf)
+  override def formatDatabaseName(name: String): String = formatName(name)
+
+  private[sql] def formatName(name: String): String = {
+    SnappyStoreHiveCatalog.processIdentifier(name, sqlConf)
   }
 
   // TODO: SW: cleanup this schema/database stuff
@@ -1090,11 +1090,11 @@ object SnappyStoreHiveCatalog {
     })
 
 
-  def processTableIdentifier(tableIdentifier: String, conf: SQLConf): String = {
+  def processIdentifier(identifier: String, conf: SQLConf): String = {
     if (conf.caseSensitiveAnalysis) {
-      tableIdentifier
+      identifier
     } else {
-      Utils.toUpperCase(tableIdentifier)
+      Utils.toUpperCase(identifier)
     }
   }
 

--- a/core/src/main/scala/org/apache/spark/sql/sources/MutableRelationProvider.scala
+++ b/core/src/main/scala/org/apache/spark/sql/sources/MutableRelationProvider.scala
@@ -65,7 +65,7 @@ abstract class MutableRelationProvider
         numPartitions.get.toInt)
     }
     val parts = JDBCRelation.columnPartition(partitionInfo)
-    val tableName = SnappyStoreHiveCatalog.processTableIdentifier(qualifiedTableName.toString,
+    val tableName = SnappyStoreHiveCatalog.processIdentifier(qualifiedTableName.toString,
       sqlContext.conf)
     var success = false
     val relation = JDBCMutableRelation(connProperties, tableName,

--- a/core/src/test/scala/org/apache/spark/sql/store/CreateIndexTest.scala
+++ b/core/src/test/scala/org/apache/spark/sql/store/CreateIndexTest.scala
@@ -16,22 +16,24 @@
  */
 package org.apache.spark.sql.store
 
+import java.sql.SQLException
 import java.util.concurrent.atomic.AtomicReference
 
 import scala.collection.mutable.ListBuffer
 
 import io.snappydata.app.{Data1, Data2, Data3}
-import io.snappydata.{Property, QueryHint, SnappyFunSuite}
+import io.snappydata.{QueryHint, SnappyFunSuite}
 import org.scalatest.BeforeAndAfterEach
 
+import org.apache.spark.sql.catalyst.encoders.RowEncoder
 import org.apache.spark.sql.catalyst.expressions.{Ascending, Descending}
 import org.apache.spark.sql.execution.PartitionedPhysicalScan
 import org.apache.spark.sql.execution.columnar.impl.{ColumnFormatRelation, IndexColumnFormatRelation}
 import org.apache.spark.sql.execution.datasources.LogicalRelation
-import org.apache.spark.sql.execution.joins.{HashJoinExec, SortMergeJoinExec}
+import org.apache.spark.sql.execution.joins.HashJoinExec
 import org.apache.spark.sql.execution.row.RowFormatRelation
 import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.{AnalysisException, DataFrame, Row, SaveMode, SnappyContext}
+import org.apache.spark.sql.{AnalysisException, DataFrame, QueryTest, Row, SaveMode, SnappyContext}
 
 class CreateIndexTest extends SnappyFunSuite with BeforeAndAfterEach {
   self =>
@@ -202,6 +204,73 @@ class CreateIndexTest extends SnappyFunSuite with BeforeAndAfterEach {
     // drop non-existent indexes with if exist clause
     snContext.dropIndex("test1", true)
     snContext.sql("drop index if exists test1")
+  }
+
+  test("Test case-sensitivity of index column names (GITHUB-900)") {
+    val tableName = "SCHEMA_MIGRATIONS_2"
+    val indexName = "SCHEMA_MIGRATIONS_VERSION_IDX"
+    val snContext = context.get
+    val data = Seq(Row(111L, "aaa"), Row(222L, "bbb"), Row(333L, "aaa"),
+      Row(444L, "bbb"), Row(555L, "ccc"), Row(666L, "ccc"))
+
+    import snContext.implicits._
+
+    // test using SQL first
+    snContext.sql("drop table if exists " + tableName)
+    snContext.sql(
+      s"""create table $tableName("version" BIGINT NOT NULL,
+        "value" VARCHAR(20), PRIMARY KEY ("version"))""")
+    // fail index creation with incorrect case
+    try {
+      snContext.sql(s"CREATE UNIQUE INDEX $indexName ON $tableName (version)")
+      fail("expected exception with unquoted identifier")
+    } catch {
+      case sqle: SQLException if sqle.getSQLState == "42X14" => // expected
+    }
+    snContext.sql(s"""CREATE UNIQUE INDEX $indexName ON $tableName ("version")""")
+    val schema = snContext.table(tableName).schema
+
+    implicit val encoder = RowEncoder(schema)
+    val ds = snContext.createDataset(data)
+    ds.write.insertInto(tableName)
+
+    QueryTest.checkAnswer(snContext.sql(s"select * from $tableName"), data)
+    QueryTest.checkAnswer(snContext.sql(
+      s"""select "value" from $tableName where `version`=111"""), Seq(Row("aaa")))
+    QueryTest.checkAnswer(snContext.sql(s"""select * from $tableName where "version" >= 555"""),
+      Seq(Row(555, "ccc"), Row(666, "ccc")))
+
+    snContext.sql("drop table " + tableName)
+
+    // test using API
+    snContext.setConf(SQLConf.CASE_SENSITIVE, true)
+    snContext.createTable(tableName, "row",
+      """("version" BIGINT NOT NULL,
+        "value" VARCHAR(20), PRIMARY KEY ("version"))""",
+      Map.empty[String, String], allowExisting = false)
+    // fail index creation with incorrect case
+    try {
+      snContext.createIndex(indexName, tableName, Map("Version" -> None),
+        Map("INDEX_TYPE" -> "UNIQUE"))
+      fail("expected exception with incorrect case")
+    } catch {
+      case sqle: SQLException if sqle.getSQLState == "42X14" => // expected
+    }
+    snContext.createIndex(indexName, tableName, Map("version" -> None),
+      Map("INDEX_TYPE" -> "UNIQUE"))
+
+    ds.write.insertInto(tableName)
+
+    QueryTest.checkAnswer(snContext.table(tableName), data)
+    QueryTest.checkAnswer(snContext.table(tableName).filter($"version" === 111)
+        .select($"value"), Seq(Row("aaa")))
+    QueryTest.checkAnswer(snContext.table(tableName).filter($"version" >= 555),
+      Seq(Row(555, "ccc"), Row(666, "ccc")))
+
+    snContext.setConf(SQLConf.CASE_SENSITIVE, false)
+
+    snContext.dropIndex(indexName, ifExists = false)
+    snContext.dropTable(tableName)
   }
 
   private def createBase3Tables(snContext: SnappyContext,


### PR DESCRIPTION
Fix case-sensitivity of columns in CREATE INDEX.

## Changes proposed in this pull request

- quote column names when executing CREATE INDEX against snappy-store to ensure
  case-sensitivity
- format names as per case-sensitivity settings for API calls
  (parser calls already handle that)
- refactored to add SnappyStoreHiveCatalog.formatName for all case conversions
- cleaned up and correct case-sensitivity in filter pushdown
  - now quote columns pushed down for row table indexes and update Filter accordingly
  - also lookup with upper-case names (case-insensitive) and avoid quoting for that case;
    need to do this way because case-sensitivity information has been lost in filter pushdown
    (i.e. coming from parser names are properly cased, but from API they may not and depend
     on session case-sensitivity setting)

## Patch testing

precheckin

## ReleaseNotes.txt changes

NA

## Other PRs 

NA