### PR TITLE
[SNAP-2122] use DistributedMember.canonicalString() in block maps

### DIFF
--- a/cluster/bin/snappy
+++ b/cluster/bin/snappy
@@ -44,6 +44,12 @@ if echo $@ | grep -qw "rowstore"; then
     fi
   done
   exec "$SPARK_HOME"/bin/spark-class $JAVA_ARGS com.pivotal.gemfirexd.tools.GfxdUtilLauncher $newargs
+elif [ "$1" = "dataextractor" ]; then
+  shift
+  exec "$SPARK_HOME"/bin/spark-class $JAVA_ARGS com.pivotal.gemfirexd.tools.dataextractor.GemFireXDDataExtractor "$@"
+elif [ "$1" = "dataextractloader" ]; then
+  shift
+  exec "$SPARK_HOME"/bin/spark-class $JAVA_ARGS com.pivotal.gemfirexd.tools.dataextractor.GemFireXDDataExtractorLoader "$@"
 else
   #use snappy launcher
   exec "$SPARK_HOME"/bin/spark-class $JAVA_ARGS io.snappydata.tools.SnappyUtilLauncher "$@"

--- a/cluster/src/dunit/scala/io/snappydata/cluster/QueryRoutingDUnitTest.scala
+++ b/cluster/src/dunit/scala/io/snappydata/cluster/QueryRoutingDUnitTest.scala
@@ -824,7 +824,7 @@ class QueryRoutingDUnitTest(val s: String)
     def assertPrimaries(query: String): Unit = {
 
       def hostExecutorId(m: InternalDistributedMember): String =
-        Utils.getHostExecutorId(SnappyContext.getBlockId(m.toString).get.blockId)
+        Utils.getHostExecutorId(SnappyContext.getBlockId(m.canonicalString()).get.blockId)
 
       val rdd = session.sql(query).queryExecution.executedPlan.execute()
       val region = Misc.getRegionForTable(s"APP.$table", true)

--- a/cluster/src/main/scala/io/snappydata/cluster/ExecutorInitiator.scala
+++ b/cluster/src/main/scala/io/snappydata/cluster/ExecutorInitiator.scala
@@ -146,7 +146,7 @@ object ExecutorInitiator extends Logging {
                    */
                   val myId = GemFireCacheImpl.getExisting.getMyId
                   val executorHost = myId.getHost
-                  val memberId = myId.toString
+                  val memberId = myId.canonicalString()
                   SparkHadoopUtil.get.runAsSparkUser { () =>
 
                     // Fetch the driver's Spark properties.

--- a/cluster/src/main/scala/org/apache/spark/scheduler/cluster/SnappyCoarseGrainedSchedulerBackend.scala
+++ b/cluster/src/main/scala/org/apache/spark/scheduler/cluster/SnappyCoarseGrainedSchedulerBackend.scala
@@ -43,7 +43,7 @@ class SnappyCoarseGrainedSchedulerBackend(scheduler: TaskSchedulerImpl,
         whoSuspected: InternalDistributedMember): Unit = {}
 
     override def memberDeparted(id: InternalDistributedMember, crashed: Boolean): Unit = {
-      SnappyContext.removeBlockId(id.toString)
+      SnappyContext.removeBlockId(id.canonicalString())
     }
   }
 
@@ -78,7 +78,7 @@ class SnappyCoarseGrainedSchedulerBackend(scheduler: TaskSchedulerImpl,
       GemFireXDUtils.getGfxdAdvisor.getDistributionManager
           .removeMembershipListener(membershipListener)
     } catch {
-      case cce: CacheClosedException =>
+      case _: CacheClosedException =>
     }
     logInfo(s"stopped successfully")
   }

--- a/core/src/main/scala/org/apache/spark/sql/SnappyContext.scala
+++ b/core/src/main/scala/org/apache/spark/sql/SnappyContext.scala
@@ -853,17 +853,10 @@ object SnappyContext extends Logging {
     TrieMap.empty[String, BlockAndExecutorId]
   private[spark] val totalCoreCount = new AtomicInteger(0)
 
-  def containsBlockId(executorId: String): Boolean = {
-    storeToBlockMap.get(executorId) match {
-      case Some(b) => b.blockId != null
-      case None => false
-    }
-  }
-
   def getBlockId(executorId: String): Option[BlockAndExecutorId] = {
     storeToBlockMap.get(executorId) match {
-      case s@Some(b) if b.blockId != null => s
-      case None => None
+      case s@Some(b) if b.blockId ne null => s
+      case _ => None
     }
   }
 
@@ -935,7 +928,7 @@ object SnappyContext extends Logging {
       val blockId = new BlockAndExecutorId(
         SparkEnv.get.blockManager.blockManagerId,
         numCores, numCores)
-      storeToBlockMap(cache.getMyId.toString) = blockId
+      storeToBlockMap(cache.getMyId.canonicalString()) = blockId
       totalCoreCount.set(blockId.numProcessors)
       SnappySession.clearAllCache(onlyQueryPlanCache = true)
     }

--- a/core/src/main/scala/org/apache/spark/sql/execution/columnar/impl/JDBCSourceAsColumnarStore.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/columnar/impl/JDBCSourceAsColumnarStore.scala
@@ -687,13 +687,13 @@ final class ColumnarStorePartitionedRDD(
         } else {
           val pr = region.asInstanceOf[PartitionedRegion]
           val distMembers = StoreUtils.getBucketOwnersForRead(bucketId, pr)
-          val prefNodes = distMembers.collect {
-            case m if SnappyContext.containsBlockId(m.toString) =>
-              Utils.getHostExecutorId(SnappyContext.getBlockId(
-                m.toString).get.blockId)
-          }
+          val prefNodes = new ArrayBuffer[String](2)
+          distMembers.foreach(m => SnappyContext.getBlockId(m.canonicalString()) match {
+            case Some(b) => prefNodes += Utils.getHostExecutorId(b.blockId)
+            case _ =>
+          })
           Array(new MultiBucketExecutorPartition(0, ArrayBuffer(bucketId),
-            pr.getTotalNumberOfBuckets, prefNodes.toSeq))
+            pr.getTotalNumberOfBuckets, prefNodes))
         }
     }
   }

--- a/core/src/main/scala/org/apache/spark/sql/store/StoreUtils.scala
+++ b/core/src/main/scala/org/apache/spark/sql/store/StoreUtils.scala
@@ -126,7 +126,7 @@ object StoreUtils {
       bucketId: Int, forWrite: Boolean,
       preferPrimaries: Boolean = false): Seq[String] = {
     if (forWrite) {
-      val primary = region.getOrCreateNodeForBucketWrite(bucketId, null).toString
+      val primary = region.getOrCreateNodeForBucketWrite(bucketId, null).canonicalString()
       SnappyContext.getBlockId(primary) match {
         case Some(b) => Seq(Utils.getHostExecutorId(b.blockId))
         case None => Seq.empty
@@ -138,7 +138,7 @@ object StoreUtils {
       } else null
       val members = new mutable.ArrayBuffer[String](2)
       getBucketOwnersForRead(bucketId, region).foreach { m =>
-        SnappyContext.getBlockId(m.toString) match {
+        SnappyContext.getBlockId(m.canonicalString()) match {
           case Some(b) =>
             if (prependPrimary && m.equals(primary)) {
               // add primary for "preferPrimaries" at the start
@@ -204,10 +204,11 @@ object StoreUtils {
     } else {
       region.getCacheDistributionAdvisor.adviseInitializedReplicates().asScala
     }
-    val prefNodes = regionMembers.collect {
-      case m if SnappyContext.containsBlockId(m.toString) =>
-        Utils.getHostExecutorId(SnappyContext.getBlockId(m.toString).get.blockId)
-    }.toSeq
+    val prefNodes = new mutable.ArrayBuffer[String](8)
+    regionMembers.foreach(m => SnappyContext.getBlockId(m.canonicalString()) match {
+      case Some(b) => prefNodes += Utils.getHostExecutorId(b.blockId)
+      case _ =>
+    })
     partitions(0) = new MultiBucketExecutorPartition(0, null, 0, prefNodes)
     partitions
   }
@@ -226,12 +227,20 @@ object StoreUtils {
         prefNode = region.getOrCreateNodeForInitializedBucketRead(p, true)
       }
       // prefer another copy if this one does not have an executor
-      val prefBlockId = SnappyContext.getBlockId(prefNode.toString) match {
+      val prefBlockId = SnappyContext.getBlockId(prefNode.canonicalString()) match {
         case b@Some(_) => b
         case None =>
-          prefNode = adviser.getBucketOwners(p).asScala.find(m =>
-            SnappyContext.containsBlockId(m.toString)).getOrElse(prefNode)
-          SnappyContext.getBlockId(prefNode.toString)
+          adviser.getBucketOwners(p).asScala.collectFirst(
+            new PartialFunction[InternalDistributedMember, BlockAndExecutorId] {
+              private var b: Option[BlockAndExecutorId] = None
+              override def isDefinedAt(m: InternalDistributedMember): Boolean = {
+                b = SnappyContext.getBlockId(m.canonicalString())
+                b.isDefined
+              }
+              override def apply(m: InternalDistributedMember): BlockAndExecutorId = {
+                prefNode = m; b.get
+              }
+            })
       }
       val buckets = serverToBuckets.get(prefNode) match {
         case Some(b) => b._2
@@ -281,7 +290,7 @@ object StoreUtils {
         }
         partitionStart = partitionEnd
         val preferredLocations = (blockId :: alternates.map(mbr =>
-          SnappyContext.getBlockId(mbr.toString)).toList).collect {
+          SnappyContext.getBlockId(mbr.canonicalString())).toList).collect {
           case Some(b) => Utils.getHostExecutorId(b.blockId)
         }
         partitionIndex += 1


### PR DESCRIPTION
## Changes proposed in this pull request

- changed toString() to instead use the new canonicalString() for InternalDistributedMember
  so that it never changes on different nodes of the cluster
- changed two map lookups (contains+get) by a single get lookup in multiple places
- added optional "dataextractor"/"dataextractloader" options to snappy script to launch
  the respective tools (only for rowstore mode or when using only row tables)

## Patch testing

precheckin

## ReleaseNotes.txt changes

NA

## Other PRs 

https://github.com/SnappyDataInc/snappy-store/pull/348