### PR TITLE
[SNAP-2121] mark delta regions to use the delta diskstore

### DIFF
--- a/core/src/main/java/io/snappydata/impl/SnappyHiveCatalog.java
+++ b/core/src/main/java/io/snappydata/impl/SnappyHiveCatalog.java
@@ -94,6 +94,14 @@ public class SnappyHiveCatalog implements ExternalCatalog {
   }
 
   /**
+   * Common connection properties set on metastore JDBC connections.
+   */
+  public static String getCommonJDBCSuffix() {
+    return ";disable-streaming=true;default-persistent=true;" +
+        "sync-commits=true;internal-connection=true";
+  }
+
+  /**
    * Set the common hive metastore properties and also invoke
    * the static initialization for Hive with system properties
    * which tries booting default derby otherwise (SNAP-1956, SNAP-1961).
@@ -436,7 +444,7 @@ public class SnappyHiveCatalog implements ExternalCatalog {
       HiveConf metadataConf = new HiveConf();
       String urlSecure = "jdbc:snappydata:" +
           ";user=" + SnappyStoreHiveCatalog.HIVE_METASTORE() +
-          ";disable-streaming=true;default-persistent=true;internal-connection=true";
+          getCommonJDBCSuffix();
       final Map<Object, Object> bootProperties = Misc.getMemStore().getBootProperties();
       if (bootProperties.containsKey(Attribute.USERNAME_ATTR) && bootProperties.containsKey
           (Attribute.PASSWORD_ATTR)) {
@@ -444,7 +452,7 @@ public class SnappyHiveCatalog implements ExternalCatalog {
             ";user=" + bootProperties.get(Attribute.USERNAME_ATTR) +
             ";password=" + bootProperties.get(Attribute.PASSWORD_ATTR) +
             ";default-schema=" + SnappyStoreHiveCatalog.HIVE_METASTORE() +
-            ";disable-streaming=true;default-persistent=true;internal-connection=true";
+            getCommonJDBCSuffix();
         /*
         metadataConf.setVar(HiveConf.ConfVars.METASTORE_CONNECTION_USER_NAME,
             bootProperties.get("user").toString());

--- a/core/src/main/scala/org/apache/spark/sql/execution/columnar/ExternalStoreUtils.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/columnar/ExternalStoreUtils.scala
@@ -684,7 +684,11 @@ object ExternalStoreUtils {
     region.getUserAttribute.asInstanceOf[GemFireContainer] match {
       case null =>
         throw new IllegalStateException(s"Table $schema.$table not found in containers")
-      case c => c.fetchHiveMetaData(false)
+      case c => c.fetchHiveMetaData(false) match {
+        case null =>
+          throw new IllegalStateException(s"Table $schema.$table not found in hive metadata")
+        case m => m
+      }
     }
   }
 

--- a/core/src/main/scala/org/apache/spark/sql/execution/columnar/impl/ColumnDelta.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/columnar/impl/ColumnDelta.scala
@@ -84,7 +84,11 @@ final class ColumnDelta extends ColumnFormatValue with Delta {
         val tableColumnIndex = ColumnDelta.tableColumnIndex(columnIndex)
         val encoder = new ColumnDeltaEncoder(ColumnDelta.deltaHierarchyDepth(columnIndex))
         val schema = region.getUserAttribute.asInstanceOf[GemFireContainer]
-            .fetchHiveMetaData(false).schema.asInstanceOf[StructType]
+            .fetchHiveMetaData(false) match {
+          case null => throw new IllegalStateException(
+            s"Table for region ${region.getFullPath} not found in hive metadata")
+          case m => m.schema.asInstanceOf[StructType]
+        }
         val oldColumnValue = oldValue.asInstanceOf[ColumnFormatValue].getValueRetain(
           decompress = true, compress = false)
         val existingBuffer = oldColumnValue.getBuffer

--- a/core/src/main/scala/org/apache/spark/sql/hive/HiveClientUtil.scala
+++ b/core/src/main/scala/org/apache/spark/sql/hive/HiveClientUtil.scala
@@ -280,7 +280,7 @@ private class HiveClientUtil(sparkContext: SparkContext) extends Logging {
     SnappyContext.getClusterMode(sparkContext) match {
       case SnappyEmbeddedMode(_, _) | LocalMode(_, _) =>
         (ExternalStoreUtils.defaultStoreURL(Some(sparkContext)) +
-            ";disable-streaming=true;default-persistent=true;skip-constraint-checks=true;",
+            SnappyHiveCatalog.getCommonJDBCSuffix + ";skip-constraint-checks=true",
             Constant.JDBC_EMBEDDED_DRIVER)
       case ThinClientConnectorMode(_, url) =>
         (url + ";route-query=false;skip-constraint-checks=true;", Constant.JDBC_CLIENT_DRIVER)

--- a/examples/build.gradle
+++ b/examples/build.gradle
@@ -64,7 +64,7 @@ task productExamples(dependsOn: 'jar') { doLast {
 } }
 
 scalaTest {
-  dependsOn ':cleanScalaTest'
+  dependsOn ':cleanScalaTest', ':product'
   doFirst {
     // cleanup files since scalatest plugin does not honour workingDir yet
     cleanIntermediateFiles(project.path)

--- a/examples/quickstart/scripts/Quickstart.scala
+++ b/examples/quickstart/scripts/Quickstart.scala
@@ -30,7 +30,7 @@ import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.internal.SQLConf
 
 //Benchmark function that will execute a function and returns time taken to execute that function
-def benchmark(name: String, times: Int = 10, warmups: Int = 6)(f: => Unit) : Double = {
+def benchmark(name: String, times: Int = 5, warmups: Int = 3)(f: => Unit) : Double = {
   for (i <- 1 to warmups) {
     f
   }


### PR DESCRIPTION
## Changes proposed in this pull request

- explicitly changed the DDL of row buffer regions to use the new delta diskstore
- update store link which gets the store changes for this including metastore regions
  going into the datadictionary diskstore (when default-schema for a connection is
  SNAPPY_HIVE_METASTORE)

## Patch testing

precheckin

## ReleaseNotes.txt changes

Can mention the separate diskstores used for metastore and delta regions. In particular
the datadictionary on locators now contains all the metadata.

## Other PRs 

https://github.com/SnappyDataInc/snappy-store/pull/349