### PR TITLE
[SNAP-2127] use separate delta disk-stores for row buffer regions

### DIFF
--- a/cluster/src/dunit/scala/io/snappydata/cluster/DDLRoutingDUnitTest.scala
+++ b/cluster/src/dunit/scala/io/snappydata/cluster/DDLRoutingDUnitTest.scala
@@ -18,8 +18,9 @@ package io.snappydata.cluster
 
 import java.sql.{Connection, DriverManager, SQLException}
 
-import com.pivotal.gemfirexd.internal.engine.Misc
+import com.pivotal.gemfirexd.internal.engine.{GfxdConstants, Misc}
 import io.snappydata.test.dunit.{AvailablePortHelper, SerializableRunnable}
+
 import org.apache.spark.sql.SnappyContext
 import org.apache.spark.sql.collection.Utils
 
@@ -133,7 +134,8 @@ class DDLRoutingDUnitTest(val s: String) extends ClusterManagerTestBase(s) {
           s"USING column $options")
     } catch {
       case sqle: SQLException => if (sqle.getSQLState != "38000" ||
-          !sqle.getMessage.contains("Disk store D1 not found")) {
+          (!sqle.getMessage.contains("Disk store D1 not found") && !sqle.getMessage.contains(
+            s"Disk store D1${GfxdConstants.SNAPPY_DELTA_DISKSTORE_SUFFIX} not found"))) {
         throw sqle
       }
     }

--- a/core/src/main/scala/io/snappydata/impl/SparkConnectorRDDHelper.scala
+++ b/core/src/main/scala/io/snappydata/impl/SparkConnectorRDDHelper.scala
@@ -186,7 +186,7 @@ object SparkConnectorRDDHelper {
           val netUrls = new ArrayBuffer[(String, String)](1)
           netUrls += host -> netUrl
           allNetUrls(bid) = netUrls
-          if (!availableNetUrls.contains(host)) {
+          if (!availableNetUrls.containsKey(host)) {
             availableNetUrls.put(host, netUrl)
           }
         } else {

--- a/core/src/main/scala/org/apache/spark/sql/store/StoreUtils.scala
+++ b/core/src/main/scala/org/apache/spark/sql/store/StoreUtils.scala
@@ -476,10 +476,15 @@ object StoreUtils {
 
     // delta buffer regions will use delta store
     if (!isRowTable && !isShadowTable) {
-      if (parameters.remove(DISKSTORE).isDefined && !isPersistent) {
-        throw Utils.analysisException(s"Option '$DISKSTORE' requires '$PERSISTENCE' option")
+      parameters.remove(DISKSTORE) match {
+        case Some(v) =>
+          if (!isPersistent) {
+            throw Utils.analysisException(s"Option '$DISKSTORE' requires '$PERSISTENCE' option")
+          }
+          sb.append(s"'$v${GfxdConstants.SNAPPY_DELTA_DISKSTORE_SUFFIX}' ")
+        case None =>
+          if (isPersistent) sb.append(s"'${GfxdConstants.SNAPPY_DEFAULT_DELTA_DISKSTORE}' ")
       }
-      if (isPersistent) sb.append(s"'${GfxdConstants.SNAPPY_DELTA_DISKSTORE_NAME}' ")
     } else {
       parameters.remove(DISKSTORE).foreach { v =>
         if (isPersistent) sb.append(s"'$v' ")

--- a/core/src/main/scala/org/apache/spark/sql/store/StoreUtils.scala
+++ b/core/src/main/scala/org/apache/spark/sql/store/StoreUtils.scala
@@ -481,7 +481,11 @@ object StoreUtils {
           if (!isPersistent) {
             throw Utils.analysisException(s"Option '$DISKSTORE' requires '$PERSISTENCE' option")
           }
-          sb.append(s"'$v${GfxdConstants.SNAPPY_DELTA_DISKSTORE_SUFFIX}' ")
+          if (v == GfxdConstants.GFXD_DEFAULT_DISKSTORE_NAME) {
+            sb.append(s"'${GfxdConstants.SNAPPY_DEFAULT_DELTA_DISKSTORE}' ")
+          } else {
+            sb.append(s"'$v${GfxdConstants.SNAPPY_DELTA_DISKSTORE_SUFFIX}' ")
+          }
         case None =>
           if (isPersistent) sb.append(s"'${GfxdConstants.SNAPPY_DEFAULT_DELTA_DISKSTORE}' ")
       }


### PR DESCRIPTION
Follow up PR for SNAP-2121 as per review comments

## Changes proposed in this pull request

- if a disk-store has been defined for a column table, then use the corresponding
  delta disk-store instead of a global one
- update store link for the store layer changes

## Patch testing

precheckin

## ReleaseNotes.txt changes

Note the new implicit delta disk stores in the docs.

## Other PRs 

https://github.com/SnappyDataInc/snappy-store/pull/350