### PR TITLE
[SNAP-1501] OVERFLOW=false disables eviction if EVICTION_BY is absent.

### DIFF
--- a/core/src/main/scala/org/apache/spark/sql/store/StoreUtils.scala
+++ b/core/src/main/scala/org/apache/spark/sql/store/StoreUtils.scala
@@ -414,7 +414,8 @@ object StoreUtils {
     parameters.remove(PARTITIONER).foreach(v =>
       sb.append(GEM_PARTITIONER).append('\'').append(v).append("' "))
 
-    val defaultEviction = s"$GEM_HEAPPERCENT $GEM_OVERFLOW"
+    val overflow = parameters.get(OVERFLOW).map((_.toBoolean)).getOrElse(true)
+    val defaultEviction = if (overflow) s"$GEM_HEAPPERCENT $GEM_OVERFLOW" else EMPTY_STRING
     sb.append(parameters.remove(EVICTION_BY).map(v => {
       if (v.contains(LRUCOUNT) && isShadowTable) {
         throw Utils.analysisException(
@@ -422,7 +423,7 @@ object StoreUtils {
       } else if (v.equalsIgnoreCase("NONE")) {
         EMPTY_STRING
       } else {
-        if (!parameters.get(OVERFLOW).map((_.toBoolean)).getOrElse(true)) {
+        if (!overflow) {
           throw Utils.analysisException("overflow 'FALSE' is not supported when eviction is " +
               "configured.")
         }

--- a/core/src/test/scala/org/apache/spark/sql/store/ColumnTableTest.scala
+++ b/core/src/test/scala/org/apache/spark/sql/store/ColumnTableTest.scala
@@ -759,6 +759,11 @@ class ColumnTableTest
     assert(region.getEvictionAttributes.getAlgorithm === EvictionAlgorithm.NONE)
     snc.sql("DROP TABLE IF EXISTS COLUMN_TEST_TABLE6")
 
+    snc.sql("CREATE TABLE COLUMN_TEST_TABLE6(OrderId INT ,ItemId INT) USING row options" +
+        " (OVERFLOW 'false')")
+    Misc.getRegionForTable("APP.COLUMN_TEST_TABLE6", true).asInstanceOf[DistributedRegion]
+    assert(region.getEvictionAttributes.getAlgorithm === EvictionAlgorithm.NONE)
+    snc.sql("DROP TABLE IF EXISTS COLUMN_TEST_TABLE6")
   }
 
   test("Test PR with Colocation") {

--- a/core/src/test/scala/org/apache/spark/sql/store/ColumnTableTest.scala
+++ b/core/src/test/scala/org/apache/spark/sql/store/ColumnTableTest.scala
@@ -636,18 +636,18 @@ class ColumnTableTest
     try {
       snc.sql("CREATE TABLE COLUMN_TEST_TABLE6(OrderId INT ,ItemId INT) USING column options" +
           " (PARTITION_BY 'OrderId', EVICTION_BY 'LRUMEMSIZE 200', OVERFLOW 'false')")
-      assert(false, "OVERFLOW option is not allowed")
+      assert(false, "OVERFLOW=false is not allowed when EVICTION_BY is specified")
     } catch {
-      case ae: AnalysisException => // Expected
+      case _: AnalysisException => // Expected
     }
     snc.sql("DROP TABLE IF EXISTS COLUMN_TEST_TABLE6")
 
     try {
       snc.sql("CREATE TABLE COLUMN_TEST_TABLE6(OrderId INT ,ItemId INT) USING row options" +
           " (PARTITION_BY 'OrderId', EVICTION_BY 'LRUMEMSIZE 200', OVERFLOW 'false')")
-      assert(false, "OVERFLOW option is not allowed")
+      assert(false, "OVERFLOW=false is not allowed when EVICTION_BY is specified")
     } catch {
-      case ae: AnalysisException => // Expected
+      case _: AnalysisException => // Expected
     }
     snc.sql("DROP TABLE IF EXISTS COLUMN_TEST_TABLE6")
 
@@ -676,8 +676,9 @@ class ColumnTableTest
     try {
       snc.sql("CREATE TABLE COLUMN_TEST_TABLE6(OrderId INT ,ItemId INT) USING column options" +
           " (PARTITION_BY 'OrderId', EVICTION_BY 'LRUCOUNT 200')")
+      assert(false, "EVICTION_BY=LRUCOUNT is not supported for column tables")
     } catch {
-      case ae: AnalysisException => // Expected
+      case _: AnalysisException => // Expected
     }
     snc.sql("DROP TABLE IF EXISTS COLUMN_TEST_TABLE6")
 
@@ -745,6 +746,19 @@ class ColumnTableTest
     assert(region.getEvictionAttributes.getAlgorithm ===
         EvictionAlgorithm.NONE)
     snc.sql("DROP TABLE IF EXISTS COLUMN_TEST_TABLE6")
+
+    snc.sql("CREATE TABLE COLUMN_TEST_TABLE6(OrderId INT ,ItemId INT) USING column options" +
+        " (PARTITION_BY 'OrderId', OVERFLOW 'false')")
+    region = Misc.getRegionForTable("APP.COLUMN_TEST_TABLE6", true).asInstanceOf[PartitionedRegion]
+    assert(region.getEvictionAttributes.getAlgorithm === EvictionAlgorithm.NONE)
+    snc.sql("DROP TABLE IF EXISTS COLUMN_TEST_TABLE6")
+
+    snc.sql("CREATE TABLE COLUMN_TEST_TABLE6(OrderId INT ,ItemId INT) USING row options" +
+        " (PARTITION_BY 'OrderId', OVERFLOW 'false')")
+    region = Misc.getRegionForTable("APP.COLUMN_TEST_TABLE6", true).asInstanceOf[PartitionedRegion]
+    assert(region.getEvictionAttributes.getAlgorithm === EvictionAlgorithm.NONE)
+    snc.sql("DROP TABLE IF EXISTS COLUMN_TEST_TABLE6")
+
   }
 
   test("Test PR with Colocation") {


### PR DESCRIPTION
## Changes proposed in this pull request
* OVERFLOW=false disables eviction if EVICTION_BY is absent.
* Updated test cases.

## Patch testing
unit tests.
precheckin running

## ReleaseNotes.txt changes
A note about OVERFLOW option is deprecated.

## Other PRs 
NA