### PR TITLE
Parser performance improvements

### DIFF
--- a/cluster/src/main/scala/io/snappydata/gemxd/SparkSQLExecuteImpl.scala
+++ b/cluster/src/main/scala/io/snappydata/gemxd/SparkSQLExecuteImpl.scala
@@ -90,14 +90,14 @@ class SparkSQLExecuteImpl(val sql: String,
   // check for query hint to serialize complex types as JSON strings
   private[this] val complexTypeAsJson = session.getPreviousQueryHints.get(
     QueryHint.ComplexTypeAsJson.toString) match {
-    case None => true
-    case Some(v) => Misc.parseBoolean(v)
+    case null => true
+    case v => Misc.parseBoolean(v)
   }
 
   private val (allAsClob, columnsAsClob) = session.getPreviousQueryHints.get(
     QueryHint.ColumnsAsClob.toString) match {
-    case None => (false, Set.empty[String])
-    case Some(v) => Utils.parseColumnsAsClob(v)
+    case null => (false, Set.empty[String])
+    case v => Utils.parseColumnsAsClob(v)
   }
 
   override def packRows(msg: LeadNodeExecutorMsg,

--- a/cluster/src/test/scala/org/apache/spark/sql/execution/benchmark/MapTest.scala
+++ b/cluster/src/test/scala/org/apache/spark/sql/execution/benchmark/MapTest.scala
@@ -627,7 +627,7 @@ class MapTest extends SnappyFunSuite {
     benchmark.run()
   }
 
-  ignore("compare small map gets") {
+  test("compare small map gets") {
     val numEntries = 20
     val numLoops = 1000000
     val numIterations = 10
@@ -636,8 +636,10 @@ class MapTest extends SnappyFunSuite {
     val omap2 = new java.util.HashMap[String, String](numEntries)
     var imap3: Map[String, String] = null
     val omap3 = new scala.collection.mutable.HashMap[String, String]()
-    val omap4 = new Object2ObjectOpenHashMap[String, String](numEntries)
-    val omap5 = ObjectObjectHashMap.withExpectedSize[String, String](numEntries)
+    val omap4 = new java.util.concurrent.ConcurrentHashMap[String, String](32, 0.7f, 1)
+    val omap5 = new scala.collection.concurrent.TrieMap[String, String]
+    val omap6 = new Object2ObjectOpenHashMap[String, String](numEntries)
+    val omap7 = ObjectObjectHashMap.withExpectedSize[String, String](numEntries)
 
     val rnd = new XORShiftRandom()
     val data = Array.fill(numEntries)(s"str${rnd.nextInt(100)}")
@@ -696,7 +698,7 @@ class MapTest extends SnappyFunSuite {
         loop += 1
       }
     })
-    benchmark.addCase("FastUtil Map", numIterations,
+    benchmark.addCase("Java ConcurrentHashMap", numIterations,
       () => data.foreach(d => omap4.put(d, d)), omap4.clear)(_ => {
       var loop = 0
       while (loop < numLoops) {
@@ -708,13 +710,37 @@ class MapTest extends SnappyFunSuite {
         loop += 1
       }
     })
-    benchmark.addCase("Koloboke Map", numIterations,
+    benchmark.addCase("Scala TrieMap", numIterations,
       () => data.foreach(d => omap5.put(d, d)), omap5.clear)(_ => {
       var loop = 0
       while (loop < numLoops) {
         var i = 0
         while (i < numEntries) {
-          assert(data(i) == omap5.get(data(i)))
+          assert(data(i) == omap5(data(i)))
+          i += 1
+        }
+        loop += 1
+      }
+    })
+    benchmark.addCase("FastUtil Map", numIterations,
+      () => data.foreach(d => omap6.put(d, d)), omap6.clear)(_ => {
+      var loop = 0
+      while (loop < numLoops) {
+        var i = 0
+        while (i < numEntries) {
+          assert(data(i) == omap6.get(data(i)))
+          i += 1
+        }
+        loop += 1
+      }
+    })
+    benchmark.addCase("Koloboke Map", numIterations,
+      () => data.foreach(d => omap7.put(d, d)), omap7.clear)(_ => {
+      var loop = 0
+      while (loop < numLoops) {
+        var i = 0
+        while (i < numEntries) {
+          assert(data(i) == omap7.get(data(i)))
           i += 1
         }
         loop += 1

--- a/cluster/src/test/scala/org/apache/spark/sql/execution/benchmark/MapTest.scala
+++ b/cluster/src/test/scala/org/apache/spark/sql/execution/benchmark/MapTest.scala
@@ -627,7 +627,7 @@ class MapTest extends SnappyFunSuite {
     benchmark.run()
   }
 
-  test("compare small map gets") {
+  ignore("compare small map gets") {
     val numEntries = 20
     val numLoops = 1000000
     val numIterations = 10

--- a/core/src/main/scala/io/snappydata/Literals.scala
+++ b/core/src/main/scala/io/snappydata/Literals.scala
@@ -19,7 +19,9 @@ package io.snappydata
 import scala.reflect.ClassTag
 
 import com.gemstone.gemfire.internal.shared.SystemProperties
+import io.snappydata.collection.ObjectObjectHashMap
 
+import org.apache.spark.sql.collection.Utils
 import org.apache.spark.sql.execution.columnar.ExternalStoreUtils
 import org.apache.spark.sql.internal.{AltName, SQLAltName, SQLConfigEntry}
 import org.apache.spark.sql.store.CompressionCodecId
@@ -137,8 +139,8 @@ object Constant {
   // @TODO check whether function like named_struct, ntile etc. can ever
   // come in the where clause of a query. Right now Tokenization is done
   // for constants in where clause only.
-  val FOLDABLE_FUNCTIONS: Map[String, Seq[Int]] = Map("ROUND" -> Seq(1),
-    "BROUND" -> Seq(1), "PERCENTILE" -> Seq(1), "STACK" -> Seq(0),
+  val FOLDABLE_FUNCTIONS: ObjectObjectHashMap[String, Seq[Int]] = Utils.toOpenHashMap(Map(
+    "ROUND" -> Seq(1), "BROUND" -> Seq(1), "PERCENTILE" -> Seq(1), "STACK" -> Seq(0),
     "NTILE" -> Seq(0), "STR_TO_MAP" -> Seq(1, 2), "NAMED_STRUCT" -> Seq(-1),
     "REFLECT" -> Seq(0, 1), "JAVA_METHOD" -> Seq(0, 1), "XPATH" -> Seq(1),
     "XPATH_BOOLEAN" -> Seq(1), "XPATH_DOUBLE" -> Seq(1),
@@ -150,7 +152,7 @@ object Constant {
     "TO_UNIX_TIMESTAMP" -> Seq(1), "FROM_UNIX_TIMESTAMP" -> Seq(1),
     "TO_UTC_TIMESTAMP" -> Seq(1), "FROM_UTC_TIMESTAMP" -> Seq(1),
     "TRUNC" -> Seq(1), "NEXT_DAY" -> Seq(1),
-    "LIKE" -> Seq(1), "RLIKE" -> Seq(1))
+    "LIKE" -> Seq(1), "RLIKE" -> Seq(1)))
 }
 
 /**
@@ -285,6 +287,10 @@ object Property extends Enumeration {
   val Tokenize: SQLValue[Boolean] = SQLVal[Boolean](
     s"${Constant.PROPERTY_PREFIX}sql.tokenize",
     "Property to enable/disable tokenization", Some(true))
+
+  val ParserTraceError: SQLValue[Boolean] = SQLVal[Boolean](
+    s"${Constant.PROPERTY_PREFIX}sql.parser.traceError",
+    "Property to enable detailed rule tracing for parse errors", Some(false))
 
   val EnableExperimentalFeatures = SQLVal[Boolean](
     s"${Constant.PROPERTY_PREFIX}enable-experimental-features",

--- a/core/src/main/scala/org/apache/spark/sql/CachedDataFrame.scala
+++ b/core/src/main/scala/org/apache/spark/sql/CachedDataFrame.scala
@@ -59,7 +59,7 @@ class CachedDataFrame(session: SparkSession, queryExecution: QueryExecution,
     val rddId: Int, val hasLocalCollectProcessing: Boolean,
     val allLiterals: Array[LiteralValue] = Array.empty,
     val allbcplans: mutable.Map[SparkPlan, ArrayBuffer[Any]] = mutable.Map.empty,
-    val queryHints: Map[String, String] = Map.empty,
+    val queryHints: java.util.Map[String, String] = java.util.Collections.emptyMap(),
     var planProcessingTime: Long = 0,
     var currentExecutionId: Option[Long] = None)
     extends Dataset[Row](session, queryExecution, encoder) with Logging {
@@ -69,7 +69,7 @@ class CachedDataFrame(session: SparkSession, queryExecution: QueryExecution,
       cachedRDD: RDD[InternalRow], shuffleDependencies: Array[Int],
       rddId: Int, hasLocalCollectProcessing: Boolean,
       allLiterals: Array[LiteralValue],
-      queryHints: Map[String, String],
+      queryHints: java.util.Map[String, String],
       planProcessingTime: Long, currentExecutionId: Option[Long]) = {
     // scalastyle:on
     this(ds.sparkSession, ds.queryExecution, ds.exprEnc, queryString, cachedRDD,

--- a/core/src/main/scala/org/apache/spark/sql/SnappyBaseParser.scala
+++ b/core/src/main/scala/org/apache/spark/sql/SnappyBaseParser.scala
@@ -294,7 +294,7 @@ object SnappyParserConsts {
   final val exponent: CharPredicate = CharPredicate('e', 'E')
   final val numeric: CharPredicate = CharPredicate.Digit ++
       CharPredicate('.')
-  final val numericSuffix: CharPredicate = CharPredicate('D', 'L')
+  final val numericSuffix: CharPredicate = CharPredicate('D', 'd', 'F', 'f', 'L', 'l')
   final val plural: CharPredicate = CharPredicate('s', 'S')
 
   final val reservedKeywords: OpenHashSet[String] = new OpenHashSet[String]

--- a/core/src/main/scala/org/apache/spark/sql/SnappyBaseParser.scala
+++ b/core/src/main/scala/org/apache/spark/sql/SnappyBaseParser.scala
@@ -16,11 +16,11 @@
  */
 package org.apache.spark.sql
 
-import scala.collection.concurrent.TrieMap
-import scala.collection.mutable
+import java.util.concurrent.ConcurrentHashMap
 
 import com.gemstone.gemfire.internal.shared.SystemProperties
 import io.snappydata.Constant
+import io.snappydata.collection.OpenHashSet
 import org.parboiled2._
 
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
@@ -36,7 +36,8 @@ abstract class SnappyBaseParser(session: SparkSession) extends Parser {
 
   protected var caseSensitive: Boolean = session.sessionState.conf.caseSensitiveAnalysis
 
-  private[sql] final val queryHints: TrieMap[String, String] = TrieMap.empty
+  private[sql] final val queryHints: ConcurrentHashMap[String, String] =
+    new ConcurrentHashMap[String, String](4, 0.7f, 1)
 
   protected def reset(): Unit = queryHints.clear()
 
@@ -48,7 +49,7 @@ abstract class SnappyBaseParser(session: SparkSession) extends Parser {
     '+' ~ (Consts.whitespace.* ~ capture(CharPredicate.Alpha ~
         Consts.identifier.*) ~ Consts.whitespace.* ~
         '(' ~ capture(noneOf(Consts.hintValueEnd).*) ~ ')' ~>
-        ((k: String, v: String) => queryHints += (k -> v.trim): Unit)). + ~
+        ((k: String, v: String) => queryHints.put(k, v.trim): Unit)). + ~
         commentBody |
     commentBody
   }
@@ -57,7 +58,7 @@ abstract class SnappyBaseParser(session: SparkSession) extends Parser {
     '+' ~ (Consts.space.* ~ capture(CharPredicate.Alpha ~
         Consts.identifier.*) ~ Consts.space.* ~
         '(' ~ capture(noneOf(Consts.lineHintEnd).*) ~ ')' ~>
-        ((k: String, v: String) => queryHints += (k -> v.trim): Unit)). + ~
+        ((k: String, v: String) => queryHints.put(k, v.trim): Unit)). + ~
         noneOf(Consts.lineCommentEnd).* |
     noneOf(Consts.lineCommentEnd).*
   }
@@ -73,7 +74,7 @@ abstract class SnappyBaseParser(session: SparkSession) extends Parser {
 
   /** All recognized delimiters including whitespace. */
   final def delimiter: Rule0 = rule {
-    quiet(&(Consts.delimiters)) ~ ws | EOI
+    quiet((Consts.whitespace ~ ws) | &(Consts.delimiters)) | EOI
   }
 
   protected final def commaSep: Rule0 = rule {
@@ -121,7 +122,7 @@ abstract class SnappyBaseParser(session: SparkSession) extends Parser {
   protected def start: Rule1[LogicalPlan]
 
   protected final def identifier: Rule1[String] = rule {
-    atomic(capture( Consts.alphaUnderscore ~ Consts.identifier.*)) ~
+    atomic(capture(Consts.alphaUnderscore ~ Consts.identifier.*)) ~
         delimiter ~> { (s: String) =>
       val ucase = Utils.toUpperCase(s)
       test(!Consts.reservedKeywords.contains(ucase)) ~
@@ -279,7 +280,7 @@ object SnappyParserConsts {
   final val space: CharPredicate = CharPredicate(' ', '\t')
   final val whitespace: CharPredicate = CharPredicate(
     ' ', '\t', '\n', '\r', '\f')
-  final val delimiters: CharPredicate = whitespace ++ CharPredicate('@', '*',
+  final val delimiters: CharPredicate = CharPredicate('@', '*',
     '+', '-', '<', '=', '!', '>', '/', '(', ')', ',', ';', '%', '{', '}', ':',
     '[', ']', '.', '&', '|', '^', '~', '#')
   final val lineCommentEnd: String = "\n\r\f" + EOI
@@ -296,9 +297,9 @@ object SnappyParserConsts {
   final val numericSuffix: CharPredicate = CharPredicate('D', 'L')
   final val plural: CharPredicate = CharPredicate('s', 'S')
 
-  final val reservedKeywords: mutable.Set[String] = mutable.Set[String]()
+  final val reservedKeywords: OpenHashSet[String] = new OpenHashSet[String]
 
-  final val allKeywords: mutable.Set[String] = mutable.Set[String]()
+  final val allKeywords: OpenHashSet[String] = new OpenHashSet[String]
 
   final val optimizableLikePattern: java.util.regex.Pattern =
     java.util.regex.Pattern.compile("%?[^_%]*[^_%\\\\]%?")
@@ -312,8 +313,8 @@ object SnappyParserConsts {
    */
   private[sql] def reservedKeyword(s: String): Keyword = {
     val k = new Keyword(s)
-    reservedKeywords += k.upper
-    allKeywords += k.upper
+    reservedKeywords.add(k.upper)
+    allKeywords.add(k.upper)
     k
   }
 
@@ -328,7 +329,7 @@ object SnappyParserConsts {
    */
   private[sql] def nonReservedKeyword(s: String): Keyword = {
     val k = new Keyword(s)
-    allKeywords += k.upper
+    allKeywords.add(k.upper)
     k
   }
 

--- a/core/src/main/scala/org/apache/spark/sql/SnappyBaseParser.scala
+++ b/core/src/main/scala/org/apache/spark/sql/SnappyBaseParser.scala
@@ -440,7 +440,6 @@ object SnappyParserConsts {
   final val REFRESH: Keyword = nonReservedKeyword("refresh")
   final val REGEXP: Keyword = nonReservedKeyword("regexp")
   final val REPLACE: Keyword = nonReservedKeyword("replace")
-  final val RETURNS: Keyword = nonReservedKeyword("returns")
   final val RLIKE: Keyword = nonReservedKeyword("rlike")
   final val SEMI: Keyword = nonReservedKeyword("semi")
   final val SHOW: Keyword = nonReservedKeyword("show")
@@ -521,4 +520,8 @@ object SnappyParserConsts {
   final val BEHAVIOR: Keyword = nonReservedKeyword("behavior")
   final val SAMPLE: Keyword = nonReservedKeyword("sample")
   final val TOPK: Keyword = nonReservedKeyword("topk")
+
+  // keywords that are neither reserved nor non-reserved and can be freely
+  // used as named strictIdentifier
+  final val RETURNS: Keyword = new Keyword("returns")
 }

--- a/core/src/main/scala/org/apache/spark/sql/SnappySession.scala
+++ b/core/src/main/scala/org/apache/spark/sql/SnappySession.scala
@@ -17,10 +17,10 @@
 package org.apache.spark.sql
 
 import java.sql.SQLException
+import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.atomic.AtomicInteger
 
 import scala.collection.JavaConverters._
-import scala.collection.concurrent.TrieMap
 import scala.collection.mutable
 import scala.collection.mutable.ArrayBuffer
 import scala.language.implicitConversions
@@ -39,6 +39,7 @@ import com.pivotal.gemfirexd.internal.GemFireXDVersion
 import com.pivotal.gemfirexd.internal.iapi.sql.ParameterValueSet
 import com.pivotal.gemfirexd.internal.iapi.types.SQLDecimal
 import com.pivotal.gemfirexd.internal.shared.common.{SharedUtils, StoredFormatIds}
+import io.snappydata.collection.ObjectObjectHashMap
 import io.snappydata.{Constant, Property, SnappyDataFunctions, SnappyTableStatsProviderService}
 
 import org.apache.spark.annotation.{DeveloperApi, Experimental}
@@ -209,12 +210,13 @@ class SnappySession(_sc: SparkContext) extends SparkSession(_sc) {
   }
 
   @transient
-  private[sql] val queryHints: TrieMap[String, String] = TrieMap.empty
+  private[sql] val queryHints = new ConcurrentHashMap[String, String](16, 0.7f, 1)
 
-  def getPreviousQueryHints: Map[String, String] = Utils.immutableMap(queryHints)
+  def getPreviousQueryHints: java.util.Map[String, String] =
+    java.util.Collections.unmodifiableMap(queryHints)
 
   @transient
-  private val contextObjects: TrieMap[Any, Any] = TrieMap.empty
+  private val contextObjects = new ConcurrentHashMap[Any, Any](16, 0.7f, 1)
 
   @transient
   private[sql] var currentKey: SnappySession.CachedKey = _
@@ -222,11 +224,14 @@ class SnappySession(_sc: SparkContext) extends SparkSession(_sc) {
   @transient
   private[sql] var planCaching: Boolean = Property.PlanCaching.get(sessionState.conf)
 
+  @transient
+  private[sql] var wholeStageEnabled: Boolean = sessionState.conf.wholeStageEnabled
+
   /**
    * Get a previously registered context object using [[addContextObject]].
    */
   private[sql] def getContextObject[T](key: Any): Option[T] = {
-    contextObjects.get(key).asInstanceOf[Option[T]]
+    Option(contextObjects.get(key).asInstanceOf[T])
   }
 
   /**
@@ -2051,7 +2056,13 @@ object SnappySession extends Logging {
 
     // collect the query hints
     val queryHints = session.synchronized {
-      val hints = session.queryHints.toMap
+      val numHints = session.queryHints.size()
+      val hints = if (numHints == 0) java.util.Collections.emptyMap[String, String]()
+      else {
+        val m = ObjectObjectHashMap.withExpectedSize[String, String](numHints)
+        m.putAll(session.queryHints)
+        m
+      }
       session.clearQueryData()
       hints
     }
@@ -2062,11 +2073,11 @@ object SnappySession extends Logging {
     // if this has in-memory caching then don't cache since plan can change
     // dynamically after caching due to unpersist etc. Also do not cache
     // if snappy tables are no there
-    if (executedPlan.find(t => t match {
+    if (executedPlan.find {
       case imse : InMemoryTableScanExec => true
       case dsc: DataSourceScanExec => !dsc.relation.isInstanceOf[DependentRelation]
       case _ => false
-    }).isDefined) {
+    }.isDefined) {
       throw new EntryExistsException("uncached plan", cdf)
     }
     cdf
@@ -2224,7 +2235,7 @@ object SnappySession extends Logging {
     // set the query hints as would be set at the end of un-cached sql()
     session.synchronized {
       session.queryHints.clear()
-      session.queryHints ++= cachedDF.queryHints
+      session.queryHints.putAll(cachedDF.queryHints)
     }
     cachedDF
   }

--- a/core/src/main/scala/org/apache/spark/sql/collection/Utils.scala
+++ b/core/src/main/scala/org/apache/spark/sql/collection/Utils.scala
@@ -32,6 +32,7 @@ import com.esotericsoftware.kryo.io.{Input, Output}
 import com.esotericsoftware.kryo.{Kryo, KryoSerializable}
 import com.gemstone.gemfire.internal.shared.unsafe.UnsafeHolder
 import com.pivotal.gemfirexd.internal.engine.jdbc.GemFireXDRuntimeException
+import io.snappydata.collection.ObjectObjectHashMap
 import io.snappydata.{Constant, ToolsCallback}
 import org.apache.commons.math3.distribution.NormalDistribution
 
@@ -357,18 +358,6 @@ object Utils {
   final def isLoner(sc: SparkContext): Boolean =
     (sc ne null) && sc.schedulerBackend.isInstanceOf[LocalSchedulerBackend]
 
-  def toLowerCase(k: String): String = {
-    var index = 0
-    val len = k.length
-    while (index < len) {
-      if (Character.isUpperCase(k.charAt(index))) {
-        return k.toLowerCase(java.util.Locale.ENGLISH)
-      }
-      index += 1
-    }
-    k
-  }
-
   def parseColumnsAsClob(s: String): (Boolean, Set[String]) = {
     if (s.trim.equals("*")) {
       (true, Set.empty[String])
@@ -389,17 +378,9 @@ object Utils {
     false
   }
 
-  def toUpperCase(k: String): String = {
-    var index = 0
-    val len = k.length
-    while (index < len) {
-      if (Character.isLowerCase(k.charAt(index))) {
-        return k.toUpperCase(java.util.Locale.ENGLISH)
-      }
-      index += 1
-    }
-    k
-  }
+  def toLowerCase(k: String): String = k.toLowerCase(java.util.Locale.ENGLISH)
+
+  def toUpperCase(k: String): String = k.toUpperCase(java.util.Locale.ENGLISH)
 
   /**
    * Utility function to return a metadata for a StructField of StringType, to ensure that the
@@ -631,6 +612,12 @@ object Utils {
     override def foreach[U](f: ((A, B)) => U): Unit = map.foreach(f)
 
     override def get(key: A): Option[B] = map.get(key)
+  }
+
+  def toOpenHashMap[K, V](map: scala.collection.Map[K, V]): ObjectObjectHashMap[K, V] = {
+    val m = ObjectObjectHashMap.withExpectedSize[K, V](map.size)
+    map.foreach(p => m.put(p._1, p._2))
+    m
   }
 
   def createScalaConverter(dataType: DataType): Any => Any =

--- a/core/src/main/scala/org/apache/spark/sql/internal/SnappySessionState.scala
+++ b/core/src/main/scala/org/apache/spark/sql/internal/SnappySessionState.scala
@@ -503,29 +503,32 @@ class SnappyConf(@transient val session: SnappySession)
 
     case Property.PlanCaching.name =>
       value match {
-        case Some(boolval) =>
-          if (boolval.toString.toBoolean) {
+        case Some(boolVal) =>
+          if (boolVal.toString.toBoolean) {
             session.clearPlanCache()
           }
-          session.planCaching = boolval.toString.toBoolean
-        case None =>
+          session.planCaching = boolVal.toString.toBoolean
+        case None => session.planCaching = Property.PlanCaching.defaultValue.get
       }
 
     case Property.PlanCachingAll.name =>
       value match {
-        case Some(boolval) =>
-          val clearCache = !boolval.toString.toBoolean
+        case Some(boolVal) =>
+          val clearCache = !boolVal.toString.toBoolean
           if (clearCache) SnappySession.getPlanCache.asMap().clear()
         case None =>
       }
 
     case Property.Tokenize.name =>
       value match {
-        case Some(boolval) =>
-          SnappySession.tokenize = boolval.toString.toBoolean
-        case None =>
+        case Some(boolVal) => SnappySession.tokenize = boolVal.toString.toBoolean
+        case None => SnappySession.tokenize = Property.Tokenize.defaultValue.get
       }
 
+    case SQLConf.WHOLESTAGE_CODEGEN_ENABLED.key => value match {
+      case Some(b) => session.wholeStageEnabled = b.toString.toBoolean
+      case None => session.wholeStageEnabled = SQLConf.WHOLESTAGE_CODEGEN_ENABLED.defaultValue.get
+    }
     case _ => // ignore others
   }
 

--- a/core/src/main/scala/org/apache/spark/sql/sources/SnappyOptimizations.scala
+++ b/core/src/main/scala/org/apache/spark/sql/sources/SnappyOptimizations.scala
@@ -17,6 +17,7 @@
 
 package org.apache.spark.sql.sources
 
+import scala.collection.JavaConverters._
 import io.snappydata.QueryHint._
 import org.apache.spark.sql.SnappySession
 import org.apache.spark.sql.catalyst.expressions.{AttributeReference, Expression, PredicateHelper}
@@ -38,9 +39,10 @@ import scala.collection.mutable.ArrayBuffer
  * Replace table with index hint
  */
 case class ResolveQueryHints(snappySession: SnappySession) extends Rule[LogicalPlan] {
-  lazy val catalog = snappySession.sessionState.catalog
 
-  lazy val analyzer = snappySession.sessionState.analyzer
+  private def catalog = snappySession.sessionState.catalog
+
+  private def analyzer = snappySession.sessionState.analyzer
 
   override def apply(plan: LogicalPlan): LogicalPlan = {
 
@@ -69,9 +71,11 @@ case class ResolveQueryHints(snappySession: SnappySession) extends Rule[LogicalP
 
   }
 
-  private def getIndexHints = {
+  private def getIndexHints: mutable.Map[String, Option[LogicalPlan]] = {
     val indexHint = Index
-    snappySession.queryHints.collect {
+    val hints = snappySession.queryHints
+    if (hints.isEmpty) mutable.Map.empty
+    else hints.asScala.collect {
       case (hint, value) if hint.startsWith(indexHint) =>
         val tableOrAlias = hint.substring(indexHint.length)
         val key = catalog.lookupRelationOption(
@@ -473,7 +477,8 @@ case class ResolveIndex(implicit val snappySession: SnappySession) extends Rule[
     if (!enabled) {
       return plan
     }
-    if (snappySession.queryHints.exists {
+    val hints = snappySession.queryHints
+    if (!hints.isEmpty && hints.asScala.exists {
       case (hint, _) => hint.startsWith(Index) &&
           !joinOrderHints.contains(ContinueOptimizations)
     } || Entity.hasUnresolvedReferences(plan)) {

--- a/core/src/main/scala/org/apache/spark/sql/sources/subrules.scala
+++ b/core/src/main/scala/org/apache/spark/sql/sources/subrules.scala
@@ -17,7 +17,6 @@
 
 package org.apache.spark.sql.sources
 
-import io.snappydata.JOS
 import io.snappydata.QueryHint._
 
 import org.apache.spark.sql.SnappySession
@@ -82,10 +81,10 @@ object JoinOrderStrategy {
 
   def getJoinOrderHints(implicit snappySession: SnappySession): Seq[JoinOrderStrategy] = {
     snappySession.queryHints.get(JoinOrder) match {
-      case Some(hints) =>
+      case null => defaultSeq
+      case hints =>
         parse(hints.split(",")) ++
             Some(ApplyRest) // alert!! must be last rule and shouldn't be skipped.
-      case None => defaultSeq
     }
   }
 


### PR DESCRIPTION
Some parser performance improvements to recover the regression over 0.9 release.
Also optimized and enhanced numeric/decimal literal handling.

## Changes proposed in this pull request

- moved paramLiteral/literal rule below the identifier one in primary; this was changed as part
  of parser fixes to avoid treating INTERVAL literal as identifier (d015588) but cause perf trouble due to:
  - rejecting identifier rule in case of mismatch is fast most of the time since it has to only
    check against [a-z_] pattern which is done using a bitset check but rejecting literals
    requires running through many rules that are ORed and parser has to check and
    reject each one of those
  - moreover, if tokenization is enabled then the rule has to do double the work of
    first rejecting paramLiteral and then rejecting literal in non-match cases
  - identifiers are overall more common
- two changes to correct above:
  - broke out the intervalLiteral rule from inside literal and check it independently first
    before identifier but remaining ones are moved back to be below identifier
  - combined paramLiteral and literal into a single "paramOrLiteral" rule that will check
    for tokenize inside the body and return ParamLiteral or Literal accordingly

above was major factor for the perf degradation by 20-30% over 0.9 in ColumnTableTest.compare parser performance

- allow for float literals using F/f suffix; also allow lower-case for double/long suffix d/l
- avoid creating higher precision DecimalType because it will lead to casts on other side
  of comparison if column type is narrower, for example (the tag creation is no longer
    a problem since its lazy and not used in Spark any more)
- changed wholeStageEnabled to be a var in SnappySession updated like other properties
  instead of TOKENIZE_BEGIN having to read it from conf every time
- change FOLDABLE_FUNCTIONS map to be a koloboke one which is >2X faster than scala immutable map
- changed keywords maps to be OpenHashSets rather than scala mutable hashsets
- replace scala TrieMaps with java ConcurrentHashMaps in parser/session
  since former are quite a bit slower
- reset PlanCaching/Tokenization properties back to defaults in case they are unset
  (for None match) instead of no change
- added a "snappydata.sql.parser.traceError" proper to print detailed parser backtracking
  traces in case of a parse error
- mark RETURNS as neither reserved, nor non-reserved;
  fixes failure in TokenizationTest.SNAP-2031 tpcds that uses "returns" as a named alias
  without AS as per the changes to remove optional AS with identifier that fix ambiguities
  for cases like "SELECT ... FROM (SELECT ...) table where" (with table as just identifier and
  not strictidentifier the parser can easily confuse between this and when there is no alias)


## Patch testing

precheckin

## ReleaseNotes.txt changes

NA

## Other PRs 

NA