### PR TITLE
[SNAP-2088] fixes for queries with filters on columns with nulls

### DIFF
--- a/cluster/src/dunit/scala/io/snappydata/cluster/SplitSnappyClusterDUnitTest.scala
+++ b/cluster/src/dunit/scala/io/snappydata/cluster/SplitSnappyClusterDUnitTest.scala
@@ -622,9 +622,11 @@ object SplitSnappyClusterDUnitTest
     // get those from embedded side
     var expectedRowCount = 10000000
     def waitForStats: Boolean = {
-      val stats = SnappyTableStatsProviderService.getService.
-          getAggregatedStatsOnDemand._1("APP.SNAPPYTABLE")
-      stats.getRowCount == expectedRowCount
+      SnappyTableStatsProviderService.getService.
+          getAggregatedStatsOnDemand._1.get("APP.SNAPPYTABLE") match {
+        case Some(stats) => stats.getRowCount == expectedRowCount
+        case _ => false
+      }
     }
     ClusterManagerTestBase.waitForCriterion(waitForStats,
       s"Expected stats row count to be $expectedRowCount", 30000, 500, throwOnTimeout = true)

--- a/cluster/src/dunit/scala/io/snappydata/externalstore/ColumnTableDUnitTest.scala
+++ b/cluster/src/dunit/scala/io/snappydata/externalstore/ColumnTableDUnitTest.scala
@@ -34,13 +34,15 @@ import org.apache.spark.sql.{Row, SaveMode, SnappyContext}
 /**
  * Some basic column table tests.
  */
+// noinspection ZeroIndexToHead
 class ColumnTableDUnitTest(s: String) extends ClusterManagerTestBase(s) {
 
-  val currenyLocatorPort = ClusterManagerTestBase.locPort
+  private val currentLocatorPort = ClusterManagerTestBase.locPort
 
   def testTableCreation(): Unit = {
     startSparkJob()
-    Array(vm0,vm1,vm2).foreach(_.invoke(classOf[ClusterManagerTestBase], "validateNoActiveSnapshotTX"))
+    Array(vm0, vm1, vm2).foreach(_.invoke(classOf[ClusterManagerTestBase],
+      "validateNoActiveSnapshotTX"))
   }
 
   def testTableCreationWithHA(): Unit = {
@@ -48,12 +50,12 @@ class ColumnTableDUnitTest(s: String) extends ClusterManagerTestBase(s) {
     val snc = SnappyContext(sc)
 
     createTable(snc, tableName, Map("BUCKETS" -> "1", "PERSISTENT" -> "async"))
-    verifyTableData(snc , tableName)
+    verifyTableData(snc, tableName)
 
     vm2.invoke(classOf[ClusterManagerTestBase], "stopAny")
 
     val props = bootProps
-    val port = currenyLocatorPort
+    val port = currentLocatorPort
 
     val restartServer = new SerializableRunnable() {
       override def run(): Unit = ClusterManagerTestBase.startSnappyServer(port, props)
@@ -61,39 +63,46 @@ class ColumnTableDUnitTest(s: String) extends ClusterManagerTestBase(s) {
 
     vm2.invoke(restartServer)
 
-    verifyTableData(snc , tableName)
+    verifyTableData(snc, tableName)
     dropTable(snc, tableName)
-    Array(vm0,vm1,vm2).foreach(_.invoke(classOf[ClusterManagerTestBase], "validateNoActiveSnapshotTX"))
+    Array(vm0, vm1, vm2).foreach(_.invoke(classOf[ClusterManagerTestBase],
+      "validateNoActiveSnapshotTX"))
   }
 
   def testCreateInsertAndDropOfTable(): Unit = {
     startSparkJob2()
-    Array(vm0,vm1,vm2).foreach(_.invoke(classOf[ClusterManagerTestBase], "validateNoActiveSnapshotTX"))
+    Array(vm0, vm1, vm2).foreach(_.invoke(classOf[ClusterManagerTestBase],
+      "validateNoActiveSnapshotTX"))
   }
 
   def testCreateInsertAndDropOfTableProjectionQuery(): Unit = {
     startSparkJob3()
-    Array(vm0,vm1,vm2).foreach(_.invoke(classOf[ClusterManagerTestBase], "validateNoActiveSnapshotTX"))
+    Array(vm0, vm1, vm2).foreach(_.invoke(classOf[ClusterManagerTestBase],
+      "validateNoActiveSnapshotTX"))
   }
 
   def testCreateInsertAndDropOfTableWithPartition(): Unit = {
     startSparkJob4()
-    Array(vm0,vm1,vm2).foreach(_.invoke(classOf[ClusterManagerTestBase], "validateNoActiveSnapshotTX"))
+    Array(vm0, vm1, vm2).foreach(_.invoke(classOf[ClusterManagerTestBase],
+      "validateNoActiveSnapshotTX"))
   }
 
   def testCreateInsertAPI(): Unit = {
     startSparkJob5()
-    Array(vm0,vm1,vm2).foreach(_.invoke(classOf[ClusterManagerTestBase], "validateNoActiveSnapshotTX"))
+    Array(vm0, vm1, vm2).foreach(_.invoke(classOf[ClusterManagerTestBase],
+      "validateNoActiveSnapshotTX"))
   }
 
   def testCreateAndSingleInsertAPI(): Unit = {
     startSparkJob6()
-    Array(vm0,vm1,vm2).foreach(_.invoke(classOf[ClusterManagerTestBase], "validateNoActiveSnapshotTX"))
+    Array(vm0, vm1, vm2).foreach(_.invoke(classOf[ClusterManagerTestBase],
+      "validateNoActiveSnapshotTX"))
   }
 
   def testCreateAndInsertCLOB(): Unit = {
     startSparkJob7()
-    Array(vm0,vm1,vm2).foreach(_.invoke(classOf[ClusterManagerTestBase], "validateNoActiveSnapshotTX"))
+    Array(vm0, vm1, vm2).foreach(_.invoke(classOf[ClusterManagerTestBase],
+      "validateNoActiveSnapshotTX"))
   }
 
 
@@ -109,7 +118,7 @@ class ColumnTableDUnitTest(s: String) extends ClusterManagerTestBase(s) {
       data = data :+ Seq.fill(3)(Random.nextInt)
     }
     val rdd = sc.parallelize(data, data.length).map(
-      s => new Data(s(0), s(1), s(2)))
+      s => Data(s(0), s(1), s(2)))
 
     val dataDF = snc.createDataFrame(rdd)
 
@@ -156,7 +165,7 @@ class ColumnTableDUnitTest(s: String) extends ClusterManagerTestBase(s) {
       data = data :+ Seq.fill(3)(Random.nextInt)
     }
     val rdd = sc.parallelize(data, 3).map(
-      s => new Data(s(0), s(1), s(2)))
+      s => Data(s(0), s(1), s(2)))
 
     val dataDF = snc.createDataFrame(rdd)
 
@@ -205,7 +214,7 @@ class ColumnTableDUnitTest(s: String) extends ClusterManagerTestBase(s) {
       data = data :+ Seq.fill(3)(Random.nextInt)
     }
     val rdd = sc.parallelize(data, 3).map(
-      s => new Data(s(0), s(1), s(2)))
+      s => Data(s(0), s(1), s(2)))
 
     val dataDF = snc.createDataFrame(rdd)
 
@@ -219,7 +228,7 @@ class ColumnTableDUnitTest(s: String) extends ClusterManagerTestBase(s) {
         val pr: PartitionedRegion =
           Misc.getRegionForTable("APP." + tName, true).asInstanceOf[PartitionedRegion]
         var buckets = Set.empty[Integer]
-        0 to (pr.getTotalNumberOfBuckets - 1) foreach { x =>
+        0 until pr.getTotalNumberOfBuckets foreach { x =>
           buckets = buckets + x
         }
         val iter = pr.getAppropriateLocalEntriesIterator(
@@ -250,7 +259,7 @@ class ColumnTableDUnitTest(s: String) extends ClusterManagerTestBase(s) {
     }
 
     dataDF.write.mode(SaveMode.Append).saveAsTable(tableName)
-    val totalCounts = Array(vm0, vm1, vm2).map(_.invoke(getTotalEntriesCount))
+    val totalCounts = Array(vm0, vm1, vm2).map(_.invoke(getTotalEntriesCount).asInstanceOf[Int])
     assert(totalCounts(0) == totalCounts(1))
     assert(totalCounts(0) == totalCounts(2))
 
@@ -263,10 +272,10 @@ class ColumnTableDUnitTest(s: String) extends ClusterManagerTestBase(s) {
     assert(r.length == 1008, s"Unexpected elements ${r.length}, expected=1008")
 
     snc.dropTable(tableName, ifExists = true)
-    Array(vm0,vm1,vm2).foreach(_.invoke(classOf[ClusterManagerTestBase], "validateNoActiveSnapshotTX"))
+    Array(vm0, vm1, vm2).foreach(_.invoke(classOf[ClusterManagerTestBase],
+      "validateNoActiveSnapshotTX"))
     getLogWriter.info("Successful")
   }
-
 
   private val tableName: String = "ColumnTable"
   private val tableNameWithPartition: String = "ColumnTablePartition"
@@ -285,7 +294,7 @@ class ColumnTableDUnitTest(s: String) extends ClusterManagerTestBase(s) {
       tableName: String = tableName,
       props: Map[String, String] = props): Unit = {
     val data = Seq(Seq(1, 2, 3), Seq(7, 8, 9), Seq(9, 2, 3), Seq(4, 2, 3), Seq(5, 6, 7))
-    val rdd = sc.parallelize(data, data.length).map(s => new Data(s(0), s(1), s(2)))
+    val rdd = sc.parallelize(data, data.length).map(s => Data(s(0), s(1), s(2)))
     val dataDF = snc.createDataFrame(rdd)
     snc.createTable(tableName, "column", dataDF.schema, props)
     dataDF.write.format("column").mode(SaveMode.Append).saveAsTable(tableName)
@@ -309,7 +318,7 @@ class ColumnTableDUnitTest(s: String) extends ClusterManagerTestBase(s) {
       data = data :+ Seq.fill(3)(Random.nextInt)
     }
 
-    val rdd = sc.parallelize(data, data.length).map(s => new Data(s(0), s(1), s(2)))
+    val rdd = sc.parallelize(data, data.length).map(s => Data(s(0), s(1), s(2)))
     val dataDF = snc.createDataFrame(rdd)
 
     snc.createTable(tableName, "column", dataDF.schema, props)
@@ -353,7 +362,7 @@ class ColumnTableDUnitTest(s: String) extends ClusterManagerTestBase(s) {
       data = data :+ Seq.fill(3)(Random.nextInt)
     }
 
-    val rdd = sc.parallelize(data, data.length).map(s => new Data(s(0), s(1), s(2)))
+    val rdd = sc.parallelize(data, data.length).map(s => Data(s(0), s(1), s(2)))
     val dataDF = snc.createDataFrame(rdd)
 
     dataDF.write.format("column").mode(SaveMode.Append)
@@ -369,7 +378,7 @@ class ColumnTableDUnitTest(s: String) extends ClusterManagerTestBase(s) {
       true).asInstanceOf[PartitionedRegion]
     val shadowRegion = Misc.getRegionForTable(
       "APP." +
-      ColumnFormatRelation.columnBatchTableName(tableNameWithPartition).toUpperCase(),
+          ColumnFormatRelation.columnBatchTableName(tableNameWithPartition).toUpperCase(),
       true).asInstanceOf[PartitionedRegion]
 
     println("startSparkJob3 " + region.size())
@@ -398,7 +407,7 @@ class ColumnTableDUnitTest(s: String) extends ClusterManagerTestBase(s) {
       data = data :+ Seq.fill(4)(Random.nextInt)
     }
 
-    val rdd = sc.parallelize(data, data.length).map(s => new PartitionData(s(0),
+    val rdd = sc.parallelize(data, data.length).map(s => PartitionData(s(0),
       s(1).toString, s(2).toString, s(3).toString))
     val dataDF = snc.createDataFrame(rdd)
 
@@ -423,7 +432,7 @@ class ColumnTableDUnitTest(s: String) extends ClusterManagerTestBase(s) {
       true).asInstanceOf[PartitionedRegion]
     val shadowRegion = Misc.getRegionForTable(
       "APP." +
-      ColumnFormatRelation.columnBatchTableName(tableNameWithPartition).toUpperCase(),
+          ColumnFormatRelation.columnBatchTableName(tableNameWithPartition).toUpperCase(),
       true).asInstanceOf[PartitionedRegion]
 
     println("startSparkJob4 " + region.size())
@@ -442,7 +451,7 @@ class ColumnTableDUnitTest(s: String) extends ClusterManagerTestBase(s) {
     1 to 1000 foreach { _ =>
       data = data :+ Seq.fill(4)(Random.nextInt)
     }
-    val rdd = sc.parallelize(data, 10).map(s => new PartitionDataInt(s(0),
+    val rdd = sc.parallelize(data, 10).map(s => PartitionDataInt(s(0),
       s(1), s(2), s(3)))
     val dataDF = snc.createDataFrame(rdd)
 
@@ -473,13 +482,13 @@ class ColumnTableDUnitTest(s: String) extends ClusterManagerTestBase(s) {
       true).asInstanceOf[PartitionedRegion]
     val shadowRegion = Misc.getRegionForTable(
       "APP." +
-      ColumnFormatRelation.columnBatchTableName(tableNameWithPartition).toUpperCase(),
+          ColumnFormatRelation.columnBatchTableName(tableNameWithPartition).toUpperCase(),
       true).asInstanceOf[PartitionedRegion]
 
     println("startSparkJob5 " + region.size())
     println("startSparkJob5 " + shadowRegion.size())
 
-    val regionSize = region.size() + (shadowRegion.size()/5) * 3
+    val regionSize = region.size() + (shadowRegion.size() / 5) * 3
     assert(1005 == regionSize, s"Unexpected size = $regionSize, expected = 1005")
     assert(shadowRegion.size() > 0)
 
@@ -512,7 +521,7 @@ class ColumnTableDUnitTest(s: String) extends ClusterManagerTestBase(s) {
     1 to 10000 foreach { _ =>
       data = data :+ Seq.fill(2)(Random.nextInt)
     }
-    val rdd = sc.parallelize(data, 50).map(s => new TData(s(0), s(1)))
+    val rdd = sc.parallelize(data, 50).map(s => TData(s(0), s(1)))
 
     val dataDF = snc.createDataFrame(rdd)
     dataDF.write.format("column").mode(SaveMode.Append)
@@ -526,8 +535,7 @@ class ColumnTableDUnitTest(s: String) extends ClusterManagerTestBase(s) {
     val region = Misc.getRegionForTable("APP.COLUMNTABLE4", true).
         asInstanceOf[PartitionedRegion]
     val shadowRegion = Misc.getRegionForTable(
-      "APP." +
-      ColumnFormatRelation.columnBatchTableName("COLUMNTABLE4").toUpperCase(),
+      "APP." + ColumnFormatRelation.columnBatchTableName("COLUMNTABLE4").toUpperCase(),
       true).asInstanceOf[PartitionedRegion]
 
     println("region.size() " + region.size())
@@ -572,7 +580,7 @@ class ColumnTableDUnitTest(s: String) extends ClusterManagerTestBase(s) {
     1 to 10000 foreach { _ =>
       data = data :+ Seq.fill(4)(Random.nextInt)
     }
-    val rdd = sc.parallelize(data, 50).map(s => new PartitionData(s(0),
+    val rdd = sc.parallelize(data, 50).map(s => PartitionData(s(0),
       s(1).toString, s(2).toString, s(3).toString))
 
     val dataDF = snc.createDataFrame(rdd)
@@ -642,9 +650,8 @@ class ColumnTableDUnitTest(s: String) extends ClusterManagerTestBase(s) {
 
     val hfile: String = getClass.getResource("/2015.parquet").getPath
     val airlineDataFrame = snc.read.load(hfile)
-    val start0 = System.currentTimeMillis
     airlineDataFrame.write.insertInto(s"airline")
-    assert(snc.sql("select count(*) from airline").count()>0)
+    assert(snc.sql("select count(*) from airline").count() > 0)
     snc.sql("drop table airline")
   }
 
@@ -652,8 +659,8 @@ class ColumnTableDUnitTest(s: String) extends ClusterManagerTestBase(s) {
     val snc = org.apache.spark.sql.SnappyContext(sc)
 
     snc.sql(s"create table t1 using com.databricks.spark.csv options(path " +
-      s"'${(getClass.getResource("/northwind/orders.csv").getPath)}', header 'true', " +
-      s"inferschema 'true', maxCharsPerColumn '4096')")
+        s"'${getClass.getResource("/northwind/orders.csv").getPath}', header 'true', " +
+        s"inferschema 'true', maxCharsPerColumn '4096')")
     snc.sql("select * from t1").printSchema()
     snc.sql("select * from t1").show
     val tempPath = "/tmp/" + System.currentTimeMillis()
@@ -663,8 +670,6 @@ class ColumnTableDUnitTest(s: String) extends ClusterManagerTestBase(s) {
     FileUtils.deleteDirectory(new File(tempPath))
   }
 
-
-
   def testSNAP1878(): Unit = {
     val snc = org.apache.spark.sql.SnappyContext(sc)
 
@@ -672,15 +677,15 @@ class ColumnTableDUnitTest(s: String) extends ClusterManagerTestBase(s) {
     snc.sql(s"insert into t1 values(1,'test1')")
     snc.sql(s"insert into t1 values(2,'test2')")
     snc.sql(s"insert into t1 values(3,'test3')")
-    val df=snc.sql("select * from t1")
+    val df = snc.sql("select * from t1")
     df.show
     val tempPath = "/tmp/" + System.currentTimeMillis()
 
-    assert(df.count()==3)
-    df.write.option("header","true").csv(tempPath)
-    snc.createExternalTable("TEST_EXTERNAL","csv",Map("path" -> tempPath,"header" -> "true"))
-    val dataDF=snc.sql("select * from TEST_EXTERNAL")
-    assert(dataDF.count==3)
+    assert(df.count() == 3)
+    df.write.option("header", "true").csv(tempPath)
+    snc.createExternalTable("TEST_EXTERNAL", "csv", Map("path" -> tempPath, "header" -> "true"))
+    val dataDF = snc.sql("select * from TEST_EXTERNAL")
+    assert(dataDF.count == 3)
     snc.sql("drop table if exists TEST_EXTERNAL")
     FileUtils.deleteDirectory(new File(tempPath))
   }
@@ -717,54 +722,6 @@ class ColumnTableDUnitTest(s: String) extends ClusterManagerTestBase(s) {
     snc.sql(s"select distinct city from $t1 where country like 'country_1%'").show
     snc.sql(s"select distinct city from $t2 where country like 'country_1%'").show
   }
-
-  // This will fail until part 2 of the fix for SNAP-2088 comes in.
-  def testSNAP2088_2(): Unit = {
-    val snc = org.apache.spark.sql.SnappyContext(sc)
-    val t1 = "snap2088"
-    val t2 = "snap2088_2"
-
-    snc.sql(s"create table $t1 (airport_id int, name string, city string, country string) " +
-        s"using column options (COLUMN_BATCH_SIZE '50')")
-    snc.sql(s"create table $t2 (airport_id int, name string, city string, country string) " +
-        s"using column options (COLUMN_BATCH_SIZE '5000')")
-
-    val data = snc.range(10000).selectExpr("cast ((rand() * 100000) as int)",
-      "concat('name_', cast((id % 20) as string))",
-      "case when id % 2 = 0 then null else concat('city_', cast((id % 10) as string)) end",
-      "concat('country_', cast((id % 3) as string))")
-    data.write.insertInto(t1)
-    data.write.insertInto(t2)
-
-    // Ensure some queries do not just throw exception.
-    snc.sql(s"select distinct city from $t1").show
-    snc.sql(s"select distinct city from $t2 order by city").show
-    snc.sql(s"select count(*) from $t1 group by city").show
-    snc.sql(s"select distinct city from $t1 where country like 'country_1%'").show
-    snc.sql(s"select distinct city from $t2 where country like 'country_1%'").show
-
-    // Validate the results too.
-    var df = snc.sql(s"select count(*) from $t1 where city is null")
-    var cnt = df.collect()(0).getLong(0)
-    assert(cnt == 5000, s"$cnt records found in $t1 with null city, expected 5000")
-
-    df = snc.sql(s"select count(*) from $t2 where city is null")
-    cnt = df.collect()(0).getLong(0)
-    assert(cnt == 5000, s"$cnt records found in $t2 with null city, expected 5000")
-
-    df = snc.sql(s"select count(*) from $t1 group by city")
-    df.collect().foreach(r => {
-      assert(r.getLong(0) == 1000, s"${r.getLong(0)} rows found, expected 1000 for $t1")
-    })
-    assert(df.collect().length == 6, s"${df.collect().length} cities found, expected 6")
-
-    snc.sql(s"select count(*) from $t2 group by city")
-    df.collect().foreach(r => {
-      assert(r.getLong(0) == 1000, s"${r.getLong(0)} rows found, expected 1000 for $t2")
-    })
-    assert(df.collect().length == 6, s"${df.collect().length} cities found, expected 6")
-  }
-
 }
 
 case class TData(Key1: Int, Value: Int)

--- a/cluster/src/main/scala/io/snappydata/impl/LeadImpl.scala
+++ b/cluster/src/main/scala/io/snappydata/impl/LeadImpl.scala
@@ -238,7 +238,7 @@ class LeadImpl extends ServerImpl with Lead
         jobServerConfig = getConfig(confFile)
         val bindAddress = jobServerConfig.getString("spark.jobserver.bind-address")
         val port = jobServerConfig.getInt("spark.jobserver.port")
-        startupString = s"job server on $bindAddress[$port]"
+        startupString = s"job server on: $bindAddress[$port]"
       }
       if (!jobServerWait) {
         // mark RUNNING (job server and zeppelin will continue to start in background)

--- a/cluster/src/test/scala/io/snappydata/QueryTest.scala
+++ b/cluster/src/test/scala/io/snappydata/QueryTest.scala
@@ -79,11 +79,11 @@ class QueryTest extends SnappyFunSuite {
 
     // SNAP-1482: check for engineering format numeric values
     var r = session.sql("select 2.1e-2").collect()
-    assert (r(0).getDouble(0) == 0.021)
+    assert(r(0).getDouble(0) == 0.021)
     r = session.sql("select 2.1e+2").collect()
-    assert (r(0).getDouble(0) == 210)
+    assert(r(0).getDouble(0) == 210)
     r = session.sql("select 2.1e2").collect()
-    assert (r(0).getDouble(0) == 210)
+    assert(r(0).getDouble(0) == 210)
 
     SparkSession.clearActiveSession()
     val spark = SparkSession.builder().getOrCreate()
@@ -239,5 +239,56 @@ class QueryTest extends SnappyFunSuite {
           |    )
           |) = 2""".stripMargin),
       Row(1) :: Row(1) :: Row(null) :: Row(null) :: Nil)
+  }
+
+  test("SNAP-2088 check for null handling with dictionary optimized joins and filters") {
+    val snc = this.snc
+    val t1 = "snap2088"
+    val t2 = "snap2088_2"
+
+    snc.sql(s"create table $t1 (airport_id int, name string, city string, country string) " +
+        s"using column options (COLUMN_BATCH_SIZE '50')")
+    snc.sql(s"create table $t2 (airport_id int, name string, city string, country string) " +
+        s"using column options (COLUMN_BATCH_SIZE '5000')")
+
+    val data = snc.range(10000).selectExpr("cast ((rand() * 100000) as int) as airport_id",
+      "concat('name_', cast((id % 20) as string)) as name",
+      "(case when id%2=0 then null else concat('city_', cast((id%10) as string)) end) as city",
+      "concat('country_', cast((id % 3) as string)) as country")
+    data.cache()
+    data.count()
+    data.createOrReplaceTempView("data")
+    data.write.insertInto(t1)
+    data.write.insertInto(t2)
+
+    // Some queries that either throw exception or give incorrect results as noted in SNAP-2088.
+    val queries = Array(
+      "select distinct city from $t",
+      "select distinct city from $t order by city",
+      "select distinct city from $t where country like 'country_1%'",
+      "select * from $t where city is null",
+      "select * from $t where city is null and country like 'country_1%'",
+      "select count(*), city from $t group by city",
+      "select count(*), city from $t where country like 'country_1%' group by city",
+      "select count(*), city, collect_list(airport_id), collect_list(name), " +
+          "collect_list(country) from (select * from $t order by airport_id) as t group by city",
+      "select count(*), city, collect_list(airport_id), collect_list(name), " +
+          "collect_list(country) from (select * from $t where country like 'country_1%' " +
+          "  order by airport_id) as t group by city"
+    )
+
+    // To validate the results against queries directly on data disabling snappy aggregation.
+    snc.sql("set snappydata.sql.hashAggregateSize=-1")
+    val expectedResults = queries.map(q => snc.sql(q.replace("$t", "data")).collect())
+
+    snc.sql("set snappydata.sql.hashAggregateSize=0")
+    val results = queries.map { q =>
+      snc.sql(q.replace("$t", t1)) -> snc.sql(q.replace("$t", t2))
+    }
+
+    for (((r1, r2), e) <- results.zip(expectedResults)) {
+      org.apache.spark.sql.QueryTest.checkAnswer(r1, e)
+      org.apache.spark.sql.QueryTest.checkAnswer(r2, e)
+    }
   }
 }

--- a/core/src/dunit/scala/io/snappydata/cluster/SplitClusterDUnitTest.scala
+++ b/core/src/dunit/scala/io/snappydata/cluster/SplitClusterDUnitTest.scala
@@ -643,7 +643,8 @@ object SplitClusterDUnitTest extends SplitClusterDUnitTestObject {
     var output = sparkShellCommand.!!
     logInfo(output)
     output = output.replaceAll("NoSuchObjectException", "NoSuchObject")
-    assert(!output.contains("Exception"), s"Some exception stacktrace seen on spark-shell console.")
+    assert(!output.contains("Exception"),
+      s"Some exception stacktrace seen on spark-shell console: $output")
 
     val conn = getConnection(locatorClientPort, props)
     val stmt = conn.createStatement()

--- a/core/src/main/scala/org/apache/spark/sql/execution/columnar/ColumnBatch.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/columnar/ColumnBatch.scala
@@ -219,9 +219,8 @@ final class ColumnBatchIterator(region: LocalRegion, val batch: ColumnBatch,
       val deltaPosition = ColumnDelta.deltaColumnIndex(columnIndex, 0)
       val delta1 = getColumnBuffer(deltaPosition, throwIfMissing = false)
       val delta2 = getColumnBuffer(deltaPosition - 1, throwIfMissing = false)
-      val delta3 = getColumnBuffer(deltaPosition - 2, throwIfMissing = false)
-      if ((delta1 ne null) || (delta2 ne null) || (delta3 ne null)) {
-        UpdatedColumnDecoder(decoder, field, delta1, delta2, delta3)
+      if ((delta1 ne null) || (delta2 ne null)) {
+        UpdatedColumnDecoder(decoder, field, delta1, delta2)
       } else null
     }
   }
@@ -387,9 +386,8 @@ final class ColumnBatchIteratorOnRS(conn: Connection,
     val deltaPosition = ColumnDelta.deltaColumnIndex(columnIndex, 0)
     val delta1 = buffers.get(deltaPosition)
     val delta2 = buffers.get(deltaPosition - 1)
-    val delta3 = buffers.get(deltaPosition - 2)
-    if ((delta1 ne null) || (delta2 ne null) || (delta3 ne null)) {
-      UpdatedColumnDecoder(decoder, field, delta1, delta2, delta3)
+    if ((delta1 ne null) || (delta2 ne null)) {
+      UpdatedColumnDecoder(decoder, field, delta1, delta2)
     } else null
   }
 

--- a/core/src/main/scala/org/apache/spark/sql/execution/columnar/ColumnTableScan.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/columnar/ColumnTableScan.scala
@@ -807,13 +807,12 @@ private[sql] final case class ColumnTableScan(
         val dictionaryIndex = if (attr.nullable) {
           ExprCode(
             s"""
-               |if ($decoder.isNullAt($buffer, $batchOrdinal)) {
-               |  $dictionaryIndexVar = $dictionaryVar.size();
-               |  $numNullsVar++;
-               |} else {
+               |${genIfNonNullCode(ctx, decoder, buffer, batchOrdinal, numNullsVar)} {
                |  $dictionaryIndexVar = $updateDecoder == null
                |    ? $decoder.readDictionaryIndex($buffer, $nonNullPosition)
                |    : $updateDecoder.readDictionaryIndex();
+               |} else {
+               |  $dictionaryIndexVar = $dictionaryVar.size();
                |}
                """.stripMargin, "false", dictionaryIndexVar)
         } else {
@@ -863,15 +862,16 @@ private[sql] final case class ColumnTableScan(
       val code =
         s"""
            |final $jt $col;
-           |final boolean $isNullVar;
+           |boolean $isNullVar = false;
            |if ($unchangedCode) {
-           |  if (($isNullVar = $decoder.isNullAt($buffer, $batchOrdinal))) {
+           |  ${genIfNonNullCode(ctx, decoder, buffer, batchOrdinal, numNullsVar)} {
+           |    $colAssign
+           |  } else {
            |    $col = $defaultValue;
-           |    $numNullsVar++;
-           |  } else $colAssign
+           |    $isNullVar = true;
+           |  }
            |} else if ($updateDecoder.readNotNull()) {
            |  $updatedAssign
-           |  $isNullVar = false;
            |} else {
            |  $col = $defaultValue;
            |  $isNullVar = true;
@@ -890,6 +890,31 @@ private[sql] final case class ColumnTableScan(
       }
       ExprCode(code, "false", col)
     }
+  }
+
+  private def genIfNonNullCode(ctx: CodegenContext, decoder: String,
+      buffer: String, batchOrdinal: String, numNullsVar: String): String = {
+    // nextNullPosition is not updated immediately rather when batchOrdinal
+    // goes just past because a column read code can be invoked multiple
+    // times for the same batchOrdinal like in SNAP-2118;
+    // check below crams in all the conditions in a single check to minimize code
+    // repetition of non-null assignment call that is normally inlined by JVM
+    // while moving this check in a separate method would be less performant because
+    // there are two variables that need to be returned (numNulls and isNull)
+    // and besides this piece of code should get inlined in any case or else
+    // it will be big performance hit for every column nullability check
+    val nextNullPosition = ctx.freshName("nextNullPosition")
+    s"""
+       |int $nextNullPosition = $decoder.getNextNullPosition();
+       |if ($batchOrdinal < $nextNullPosition ||
+       |    // check case when batchOrdinal has gone just past nextNullPosition
+       |    ($batchOrdinal == $nextNullPosition + 1 &&
+       |     $batchOrdinal < ($nextNullPosition = $decoder.findNextNullPosition(
+       |       $buffer, $nextNullPosition, $numNullsVar++))) ||
+       |    // check if batchOrdinal has moved ahead by more than one due to filters
+       |    ($batchOrdinal != $nextNullPosition && (($numNullsVar =
+       |       $decoder.numNulls($buffer, $batchOrdinal, $numNullsVar)) == 0 ||
+       |       $batchOrdinal != $decoder.getNextNullPosition())))""".stripMargin
   }
 }
 

--- a/core/src/main/scala/org/apache/spark/sql/execution/columnar/ColumnTableScan.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/columnar/ColumnTableScan.scala
@@ -899,8 +899,6 @@ private[sql] final case class ColumnTableScan(
     // times for the same batchOrdinal like in SNAP-2118;
     // check below crams in all the conditions in a single check to minimize code
     // repetition of non-null assignment call that is normally inlined by JVM
-    // while moving this check in a separate method would be less performant because
-    // there are two variables that need to be returned (numNulls and isNull)
     // and besides this piece of code should get inlined in any case or else
     // it will be big performance hit for every column nullability check
     val nextNullPosition = ctx.freshName("nextNullPosition")

--- a/core/src/main/scala/org/apache/spark/sql/execution/columnar/encoding/BitSet.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/columnar/encoding/BitSet.scala
@@ -128,6 +128,7 @@ object BitSet {
    */
   def cardinality(baseObject: AnyRef, baseAddress: Long,
       position: Int, sizeInWords: Int): Int = {
+    assert(position >= 0)
     val posNumWords = position >> 6
     var pos = 0
     val numBytesToCheck = if (sizeInWords > posNumWords) {

--- a/core/src/main/scala/org/apache/spark/sql/execution/columnar/encoding/ColumnDeltaDecoder.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/columnar/encoding/ColumnDeltaDecoder.scala
@@ -38,6 +38,7 @@ final class ColumnDeltaDecoder(buffer: ByteBuffer, field: StructField) {
 
   private var positionCursor: Long = _
   private var positionEndCursor: Long = _
+  private var wasNull: Boolean = _
   private var decoderPosition: Int = _
 
   private def initialize(columnBytes: AnyRef, cursor: Long): Long = {
@@ -64,115 +65,63 @@ final class ColumnDeltaDecoder(buffer: ByteBuffer, field: StructField) {
     }
   }
 
-  @inline def hasNulls: Boolean = realDecoder.hasNulls
-
   @inline def readNotNull: Boolean = {
-    val isNull = realDecoder.isNullAt(deltaBytes, decoderPosition)
-    decoderPosition += 1
-    !isNull
+    wasNull = realDecoder.isNullAt(deltaBytes, decoderPosition)
+    !wasNull
   }
 
   @inline private[encoding] def nextNonNullPosition(): Unit = nonNullPosition += 1
 
-  @inline def readBoolean: Boolean = {
-    val position = nonNullPosition
-    nonNullPosition = position + 1
-    realDecoder.readBoolean(deltaBytes, position)
-  }
+  @inline private[encoding] def nextPosition(): Unit = decoderPosition += 1
 
-  @inline def readByte: Byte = {
-    val position = nonNullPosition
-    nonNullPosition = position + 1
-    realDecoder.readByte(deltaBytes, position)
-  }
+  @inline def readBoolean: Boolean =
+    realDecoder.readBoolean(deltaBytes, nonNullPosition)
 
-  @inline def readShort: Short = {
-    val position = nonNullPosition
-    nonNullPosition = position + 1
-    realDecoder.readShort(deltaBytes, position)
-  }
+  @inline def readByte: Byte =
+    realDecoder.readByte(deltaBytes, nonNullPosition)
 
-  @inline def readInt: Int = {
-    val position = nonNullPosition
-    nonNullPosition = position + 1
-    realDecoder.readInt(deltaBytes, position)
-  }
+  @inline def readShort: Short =
+    realDecoder.readShort(deltaBytes, nonNullPosition)
 
-  @inline def readLong: Long = {
-    val position = nonNullPosition
-    nonNullPosition = position + 1
-    realDecoder.readLong(deltaBytes, position)
-  }
+  @inline def readInt: Int =
+    realDecoder.readInt(deltaBytes, nonNullPosition)
 
-  @inline def readFloat: Float = {
-    val position = nonNullPosition
-    nonNullPosition = position + 1
-    realDecoder.readFloat(deltaBytes, position)
-  }
+  @inline def readLong: Long =
+    realDecoder.readLong(deltaBytes, nonNullPosition)
 
-  @inline def readDouble: Double = {
-    val position = nonNullPosition
-    nonNullPosition = position + 1
-    realDecoder.readDouble(deltaBytes, position)
-  }
+  @inline def readFloat: Float =
+    realDecoder.readFloat(deltaBytes, nonNullPosition)
 
-  @inline def readDate: Int = {
-    val position = nonNullPosition
-    nonNullPosition = position + 1
-    realDecoder.readDate(deltaBytes, position)
-  }
+  @inline def readDouble: Double =
+    realDecoder.readDouble(deltaBytes, nonNullPosition)
 
-  @inline def readTimestamp: Long = {
-    val position = nonNullPosition
-    nonNullPosition = position + 1
-    realDecoder.readTimestamp(deltaBytes, position)
-  }
+  @inline def readDate: Int =
+    realDecoder.readDate(deltaBytes, nonNullPosition)
 
-  @inline def readLongDecimal(precision: Int, scale: Int): Decimal = {
-    val position = nonNullPosition
-    nonNullPosition = position + 1
-    realDecoder.readLongDecimal(deltaBytes, precision, scale, position)
-  }
+  @inline def readTimestamp: Long =
+    realDecoder.readTimestamp(deltaBytes, nonNullPosition)
 
-  @inline def readDecimal(precision: Int, scale: Int): Decimal = {
-    val position = nonNullPosition
-    nonNullPosition = position + 1
-    realDecoder.readDecimal(deltaBytes, precision, scale, position)
-  }
+  @inline def readLongDecimal(precision: Int, scale: Int): Decimal =
+    realDecoder.readLongDecimal(deltaBytes, precision, scale, nonNullPosition)
 
-  @inline def readUTF8String: UTF8String = {
-    val position = nonNullPosition
-    nonNullPosition = position + 1
-    realDecoder.readUTF8String(deltaBytes, position)
-  }
+  @inline def readDecimal(precision: Int, scale: Int): Decimal =
+    realDecoder.readDecimal(deltaBytes, precision, scale, nonNullPosition)
 
-  @inline def readInterval: CalendarInterval = {
-    val position = nonNullPosition
-    nonNullPosition = position + 1
-    realDecoder.readInterval(deltaBytes, position)
-  }
+  @inline def readUTF8String: UTF8String =
+    realDecoder.readUTF8String(deltaBytes, nonNullPosition)
 
-  @inline def readBinary: Array[Byte] = {
-    val position = nonNullPosition
-    nonNullPosition = position + 1
-    realDecoder.readBinary(deltaBytes, position)
-  }
+  @inline def readInterval: CalendarInterval =
+    realDecoder.readInterval(deltaBytes, nonNullPosition)
 
-  @inline def readArray: ArrayData = {
-    val position = nonNullPosition
-    nonNullPosition = position + 1
-    realDecoder.readArray(deltaBytes, position)
-  }
+  @inline def readBinary: Array[Byte] =
+    realDecoder.readBinary(deltaBytes, nonNullPosition)
 
-  @inline def readMap: MapData = {
-    val position = nonNullPosition
-    nonNullPosition = position + 1
-    realDecoder.readMap(deltaBytes, position)
-  }
+  @inline def readArray: ArrayData =
+    realDecoder.readArray(deltaBytes, nonNullPosition)
 
-  @inline def readStruct(numFields: Int): InternalRow = {
-    val position = nonNullPosition
-    nonNullPosition = position + 1
-    realDecoder.readStruct(deltaBytes, numFields, position)
-  }
+  @inline def readMap: MapData =
+    realDecoder.readMap(deltaBytes, nonNullPosition)
+
+  @inline def readStruct(numFields: Int): InternalRow =
+    realDecoder.readStruct(deltaBytes, numFields, nonNullPosition)
 }

--- a/core/src/main/scala/org/apache/spark/sql/execution/columnar/encoding/ColumnEncoding.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/columnar/encoding/ColumnEncoding.scala
@@ -90,6 +90,21 @@ abstract class ColumnDecoder(columnDataRef: AnyRef, startCursor: Long,
   protected[sql] def initializeCursor(columnBytes: AnyRef, cursor: Long,
       dataType: DataType): Long
 
+  /**
+   * Return the next position of a null value.
+   */
+  def getNextNullPosition: Int
+
+  /**
+   * Fetch next null position and return it as returned by [[getNextNullPosition]].
+   */
+  def findNextNullPosition(columnBytes: AnyRef, nextNullPosition: Int, num: Int): Int
+
+  /**
+   * Return the number of nulls till given ordinal given previous result.
+   */
+  def numNulls(columnBytes: AnyRef, ordinal: Int, num: Int): Int
+
   /** Absolute position null check for random access. */
   def isNullAt(columnBytes: AnyRef, position: Int): Boolean
 
@@ -782,10 +797,12 @@ object ColumnEncoding {
           s"for $dataType($field)$bytesStr")
     }
 
-    val numNullWords = readInt(columnBytes, cursor)
     val decoder = allDecoders(typeId)(columnBytes, cursor, field, initDelta, dataType,
-      // use NotNull version if field is marked so or no nulls in the batch
-      field.nullable && numNullWords != 0)
+      // use NotNull version if field is marked so
+      // don't use NotNull in case this batch has no nulls because switching
+      // between NotNull and Nullable decoders between batches causes JVM inlining
+      // to take a hit in many cases
+      field.nullable)
     if (decoder.typeId != typeId) {
       throw new IllegalStateException(s"typeId for $decoder = " +
           s"${decoder.typeId} does not match $typeId in global registration")
@@ -1011,6 +1028,13 @@ trait NotNullDecoder extends ColumnDecoder {
     startCursor + 4
   }
 
+  override final def getNextNullPosition: Int = Int.MaxValue
+
+  override final def findNextNullPosition(columnBytes: AnyRef, nextNullPosition: Int,
+      num: Int): Int = Int.MaxValue
+
+  override final def numNulls(columnBytes: AnyRef, ordinal: Int, num: Int): Int = 0
+
   override final def isNullAt(columnBytes: AnyRef, position: Int): Boolean = false
 }
 
@@ -1025,6 +1049,7 @@ trait NullableDecoder extends ColumnDecoder {
 
   private[this] final var dataCursor: Long = _
   private[this] final var numNullWords: Int = _
+  private[this] final var nextNullPosition: Int = _
 
   override protected[sql] final def hasNulls: Boolean = true
 
@@ -1035,13 +1060,52 @@ trait NullableDecoder extends ColumnDecoder {
     cursor += 4
     this.dataCursor = cursor
     // expect it to be a factor of 8
-    assert(numNullBytes > 0 && (numNullBytes & 0x7) == 0,
+    assert((numNullBytes & 0x7) == 0,
       s"Expected valid null values but got length = $numNullBytes")
-    // mark this case with a negative "nextPosition" that holds the number of words
     this.numNullWords = numNullBytes >>> 3
+    // initialize the first nextNullPosition
+    findNextNullPosition(columnBytes, -1, 0)
     // skip null bit set
     cursor += numNullBytes
     cursor
+  }
+
+  override final def getNextNullPosition: Int = nextNullPosition
+
+  override final def findNextNullPosition(columnBytes: AnyRef, nextNullPosition: Int,
+      num: Int): Int = {
+    this.nextNullPosition = BitSet.nextSetBit(columnBytes, dataCursor,
+      nextNullPosition + 1, numNullWords)
+    this.nextNullPosition
+  }
+
+  override final def numNulls(columnBytes: AnyRef, ordinal: Int, num: Int): Int = {
+    // find the next null after given ordinal and count the additional nulls till ordinal
+    val baseOffset = this.dataCursor
+    val numWords = this.numNullWords
+    val nextNull = this.nextNullPosition
+    // new nextNullPosition must be inclusive of current ordinal because generated
+    // code will check for nullability of ordinal separately
+    nextNullPosition = BitSet.nextSetBit(columnBytes, baseOffset, ordinal, numWords)
+    // find new number of nulls from the previous null position till ordinal
+    // (search has to be aligned to word boundary)
+    val searchWord = nextNull >>> 6 // a word holds 64 bits
+    // if word boundary is first word then faster to do full recount
+    if (searchWord == 0) {
+      // count excludes the ordinal itself since nextNullPosition above includes it
+      BitSet.cardinality(columnBytes, baseOffset, ordinal, numWords)
+    } else {
+      // address required by BitSet methods is in bytes
+      val searchOffset = baseOffset + (searchWord << 3)
+      val searchOffsetInWord = nextNull & 0x3f
+      // count from the word boundary
+      val countFrom = BitSet.cardinality(columnBytes, searchOffset,
+        // skipping "searchWord" words from start so ordinal, numWords adjusted accordingly
+        ordinal - (searchWord << 6), numWords - searchWord)
+      // reduce the number of nulls till the position within the word (excluding
+      //   searchOffsetInWord as the passed num does not include the previous nextNullPosition)
+      countFrom - BitSet.cardinality(columnBytes, searchOffset, searchOffsetInWord, 1) + num
+    }
   }
 
   override final def isNullAt(columnBytes: AnyRef, position: Int): Boolean = {

--- a/core/src/main/scala/org/apache/spark/sql/execution/row/ResultSetDecoder.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/row/ResultSetDecoder.scala
@@ -47,6 +47,15 @@ final class ResultSetDecoder(rs: ResultSetWithNull, columnPosition: Int)
   override protected[sql] def initializeCursor(columnBytes: AnyRef, cursor: Long,
       dataType: DataType): Long = 0L
 
+  override def getNextNullPosition: Int =
+    if (rs.isNull(columnPosition)) 0 else 1 /* 1 will never match */
+
+  override def findNextNullPosition(columnBytes: AnyRef, nextNullPosition: Int, num: Int): Int =
+    1 /* batch size is always 1 */
+
+  override def numNulls(columnBytes: AnyRef, ordinal: Int, num: Int): Int =
+    if (rs.isNull(columnPosition)) 1 else 0
+
   override def isNullAt(columnBytes: AnyRef, position: Int): Boolean =
     rs.isNull(columnPosition)
 

--- a/core/src/main/scala/org/apache/spark/sql/execution/row/UnsafeRowDecoder.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/row/UnsafeRowDecoder.scala
@@ -40,6 +40,15 @@ final class UnsafeRowDecoder(holder: UnsafeRowHolder, columnIndex: Int)
   override protected[sql] def initializeCursor(columnBytes: AnyRef, cursor: Long,
       dataType: DataType): Long = 0L
 
+  override def getNextNullPosition: Int =
+    if (holder.row.isNullAt(columnIndex)) 0 else 1 /* 1 will never match */
+
+  override def findNextNullPosition(columnBytes: AnyRef, nextNullPosition: Int, num: Int): Int =
+    1 /* batch size is always 1 */
+
+  override def numNulls(columnBytes: AnyRef, ordinal: Int, num: Int): Int =
+    if (holder.row.isNullAt(columnIndex)) 1 else 0
+
   override def isNullAt(columnBytes: AnyRef, position: Int): Boolean =
     holder.row.isNullAt(columnIndex)
 

--- a/core/src/test/scala/io/snappydata/gemxd/BasicStoreSuite.scala
+++ b/core/src/test/scala/io/snappydata/gemxd/BasicStoreSuite.scala
@@ -16,19 +16,20 @@
  */
 package io.snappydata.gemxd
 
-import java.sql.{Connection, PreparedStatement, ResultSet, Statement}
 import java.util.Properties
 
 import scala.util.control.NonFatal
 
 import com.pivotal.gemfirexd.TestUtil
+import com.pivotal.gemfirexd.internal.engine.Misc
 import io.snappydata.core.LocalSparkConf
 
-import org.apache.spark.sql.{Row, SaveMode, SnappyContext}
+import org.apache.spark.sql.{Row, SaveMode}
 
 class BasicStoreSuite(s: String) extends TestUtil(s) {
 
   override protected def tearDown(): Unit = {
+    if (Misc.getMemStoreBootingNoThrow == null) return
     val conn = TestUtil.getConnection("jdbc:snappydata:;", new Properties())
     try {
       conn.createStatement().execute("drop table if exists t1")


### PR DESCRIPTION
Brief overview of null handling in generated code and the new approach.

#### Pre SNAP-1936

The initial code for null handling in ColumnTableScan was simple one where there was always
sequential iteration over all the rows for all the projected columns. The generated code
maintained current cursor position of decoder that indicated the position of current non-null
value to be read while nullability check was done with a separate call to decoder.

#### Changes in SNAP-1936 and its weaknesses

This changed completely with #793 (SNAP-1936) that changed sequential cursors to random
ones to handle cases of high filtering where cursors of other columns (having no filter
conditions but being projected) need not be updated anymore for every row. It complicated
the nullability handling because now the code needs to determine "number of nulls till this
point" to enable decoder to read the non-null value and it was too inefficient to determine
this afresh in every iteration. The solution adopted there was to track "number of nulls till
now" and update that with a call to decoder which in turn will track the next null position
and only if current ordinal has jumped past it without touching it, it will recompute number
of nulls till current ordinal. Further to avoid two calls, one for number of nulls and other for
whether current value is null, it used a convention of returning negative number of nulls
to denote latter as true.

This approach had one remaining bug as in SNAP-2118 fixed in #929 (for non-nulls only) where
same ordinal could be read multiple times but nextNullPosition tracker would update
immediately on first read of an ordinal expecting that the next call would always be greater
than previous (so will give erroneous result for nullability if a call with same ordinal is made
again).

This was further muddied by changes in SNAP-1743 #905 that erroneously assumed that
nextNullPosition was only for determine nullability and missed the "number of nulls till this
point" functionality achieved by the same. The motivation for those changes was the
observation that scan performance over null columns was erratic with JVM sometimes
optimizing "nextNullPosition" code correctly and sometimes not while direct bitset read
was always optimized (and a bit faster even if both were optimized due to no writes). One
error in the thinking of SNAP-1936 in terms of performance was the design to do two things
in a single function call so added extra negation operations, while forgetting the fact that
we need the functions to be inlined in any case so two functions calls may have been just fine.

Just for comparison, Spark's ColumnVector creates arrays of values of full sizes with blanks
at null values so it never has to adjust the position as per the number of nulls. For nulls it
has a boolean array again of the full size. It is, of course, much slower because of extra writes
and is not a feasible approach in this implementation.

#### Approach in this PR

This PR avoids the pitfalls above and also brings performance back to pre-SNAP-1936 level
for all cases. The basic idea being similar to SNAP-1936 but with a few changes:

a) handling of multiple calls to same ordinal by updating the position only when ordinal goes
    past (and optimized handling when it has gone just past i.e. is +1)

b) inlined code segments in areas that are expected to be inlined to get decent performance

c) assume that an optimal nullable decoder will always use the approach of "nextNullPosition"
   tracking to enable inlining in generated code above, so the ColumnDecoder interface has
   added appropriate methods

Specifically note this code fragment in ColumnTableScan code generation:

```scala
    s"""
       |int $nextNullPosition = $decoder.getNextNullPosition();
       |if ($batchOrdinal < $nextNullPosition ||
       |    // check case when batchOrdinal has gone just past nextNullPosition
       |    ($batchOrdinal == $nextNullPosition + 1 &&
       |     $batchOrdinal < ($nextNullPosition = $decoder.findNextNullPosition(
       |       $buffer, $nextNullPosition, $numNullsVar++))) ||
       |    // check if batchOrdinal has moved ahead by more than one due to filters
       |    ($batchOrdinal != $nextNullPosition && (($numNullsVar =
       |       $decoder.numNulls($buffer, $batchOrdinal, $numNullsVar)) == 0 ||
       |       $batchOrdinal != $decoder.getNextNullPosition())))""".stripMargin
```

combines all the three conditions in a single if, preferring performance over code readability.
The first case is when ordinal has still not reached nextNullPosition (so no change in numNulls
till ordinal and current value is also not null). The second case is when ordinal has moved
just past nextNullPosition in which case update the nextNullPosition from nulls bitset
(and runLength in future) and check again. The last case is when ordinal has jumped much
past due to filters, and in that case calculate the new numNulls (the == 0 check is redudandant
but is the most performant way to do it inline given the lack of comma operator in java).

## Changes proposed in this pull request

- Added new methods in ColumnDecoder to take care of filters skipping nulls and making the
  running null count invalid:
  - getNextNullPosition: returns the next position that is null
  - findNextNullPosition: would search for and update the next null position beyond the
    provided on
  - numNulls: count the nulls from given position to given new one (old count also provided)
  These are supposed to be invoked by generated code tracking the number of nulls.
- Limit update delta handling to two deltas because more than two will never be used
  else hit on scan performance is high due to increasing number of cache lines
- Moved test for part2 of SNAP-2088 from ColumnTableDUnitTest to QueryTest.
  Fixed scalastyle errors in ColumnTableDUnitTest
- Added many more queries in QueryTest for SNAP-2088 with filters and checking
  full result set against Spark cache results
- initial corrections to update handling (still some work left here to complete)

## Patch testing

precheckin

## ReleaseNotes.txt changes

NA

## Other PRs 

NA