### PR TITLE
[SNAP-1283] LATERAL VIEW support in SnappyParser

### DIFF
--- a/cluster/src/test/scala/io/snappydata/QueryTest.scala
+++ b/cluster/src/test/scala/io/snappydata/QueryTest.scala
@@ -270,10 +270,11 @@ class QueryTest extends SnappyFunSuite {
       "select count(*), city from $t group by city",
       "select count(*), city from $t where country like 'country_1%' group by city",
       "select count(*), city, collect_list(airport_id), collect_list(name), " +
-          "collect_list(country) from (select * from $t order by airport_id) as t group by city",
+          "collect_list(country) from (select * from $t order by airport_id, name, country) " +
+          "as t group by city order by city",
       "select count(*), city, collect_list(airport_id), collect_list(name), " +
           "collect_list(country) from (select * from $t where country like 'country_1%' " +
-          "  order by airport_id) as t group by city"
+          "  order by airport_id, name, country) as t group by city order by city"
     )
 
     // To validate the results against queries directly on data disabling snappy aggregation.

--- a/cluster/src/test/scala/io/snappydata/QueryTest.scala
+++ b/cluster/src/test/scala/io/snappydata/QueryTest.scala
@@ -19,7 +19,6 @@ package io.snappydata
 
 import scala.collection.JavaConverters._
 
-import org.apache.spark.sql.QueryTest.checkAnswer
 import org.apache.spark.sql.execution.benchmark.ColumnCacheBenchmark
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.{AnalysisException, Row, SnappyContext, SnappySession, SparkSession}
@@ -287,8 +286,8 @@ class QueryTest extends SnappyFunSuite {
     }
 
     for (((r1, r2), e) <- results.zip(expectedResults)) {
-      org.apache.spark.sql.QueryTest.checkAnswer(r1, e)
-      org.apache.spark.sql.QueryTest.checkAnswer(r2, e)
+      checkAnswer(r1, e)
+      checkAnswer(r2, e)
     }
 
     // fire updates and check again
@@ -302,8 +301,8 @@ class QueryTest extends SnappyFunSuite {
     }
 
     for (((r1, r2), e) <- results.zip(expectedResults)) {
-      org.apache.spark.sql.QueryTest.checkAnswer(r1, e)
-      org.apache.spark.sql.QueryTest.checkAnswer(r2, e)
+      checkAnswer(r1, e)
+      checkAnswer(r2, e)
     }
   }
 }

--- a/cluster/src/test/scala/org/apache/spark/sql/execution/benchmark/ColumnCacheBenchmark.scala
+++ b/cluster/src/test/scala/org/apache/spark/sql/execution/benchmark/ColumnCacheBenchmark.scala
@@ -40,7 +40,6 @@ import com.gemstone.gemfire.internal.cache.GemFireCacheImpl
 import io.snappydata.SnappyFunSuite
 
 import org.apache.spark.SparkConf
-import org.apache.spark.memory.SnappyUnifiedMemoryManager
 import org.apache.spark.sql._
 import org.apache.spark.sql.execution.benchmark.ColumnCacheBenchmark.addCaseWithCleanup
 import org.apache.spark.sql.internal.SQLConf
@@ -62,22 +61,8 @@ class ColumnCacheBenchmark extends SnappyFunSuite {
   }
 
   override protected def newSparkConf(
-      addOn: SparkConf => SparkConf = null): SparkConf = {
-    val conf = new SparkConf()
-        .setIfMissing("spark.master", s"local[$cores]")
-        .setAppName("microbenchmark")
-    conf.set("snappydata.store.critical-heap-percentage", "95")
-    if (SnappySession.isEnterpriseEdition) {
-      conf.set("snappydata.store.memory-size", "1200m")
-    }
-    conf.set("spark.memory.manager", classOf[SnappyUnifiedMemoryManager].getName)
-    conf.set("spark.serializer", "org.apache.spark.serializer.PooledKryoSerializer")
-    conf.set("spark.closure.serializer", "org.apache.spark.serializer.PooledKryoSerializer")
-    if (addOn != null) {
-      addOn(conf)
-    }
-    conf
-  }
+      addOn: SparkConf => SparkConf = null): SparkConf =
+    TAQTest.newSparkConf(addOn)
 
   private lazy val sparkSession = new SparkSession(sc)
   private lazy val snappySession = snc.snappySession

--- a/cluster/src/test/scala/org/apache/spark/sql/execution/benchmark/TAQTest.scala
+++ b/cluster/src/test/scala/org/apache/spark/sql/execution/benchmark/TAQTest.scala
@@ -273,7 +273,7 @@ object TAQTest extends Logging with Assertions {
   }
 
   def newSparkConf(addOn: SparkConf => SparkConf = null): SparkConf = {
-    val cores = math.min(8, Runtime.getRuntime.availableProcessors())
+    val cores = math.min(16, Runtime.getRuntime.availableProcessors())
     val conf = new SparkConf()
         .setIfMissing("spark.master", s"local[$cores]")
         .setAppName("microbenchmark")

--- a/core/src/main/scala/org/apache/spark/sql/SnappyBaseParser.scala
+++ b/core/src/main/scala/org/apache/spark/sql/SnappyBaseParser.scala
@@ -481,11 +481,12 @@ object SnappyParserConsts {
   final val WEEK: Keyword = nonReservedKeyword("week")
   final val YEAR: Keyword = nonReservedKeyword("year")
 
-  // cube, rollup, grouping sets are not reserved
+  // cube, rollup, grouping sets etc are not reserved
   final val CUBE: Keyword = nonReservedKeyword("cube")
   final val ROLLUP: Keyword = nonReservedKeyword("rollup")
   final val GROUPING: Keyword = nonReservedKeyword("grouping")
   final val SETS: Keyword = nonReservedKeyword("sets")
+  final val LATERAL: Keyword = nonReservedKeyword("lateral")
 
   // datatypes are not reserved
   final val ARRAY: Keyword = nonReservedKeyword("array")

--- a/core/src/main/scala/org/apache/spark/sql/SnappyDDLParser.scala
+++ b/core/src/main/scala/org/apache/spark/sql/SnappyDDLParser.scala
@@ -183,11 +183,12 @@ abstract class SnappyDDLParser(session: SparkSession)
   final def WEEK: Rule0 = rule { intervalUnit(Consts.WEEK) }
   final def YEAR: Rule0 = rule { intervalUnit(Consts.YEAR) }
 
-  // cube, rollup, grouping sets
+  // cube, rollup, grouping sets etc
   final def CUBE: Rule0 = rule { keyword(Consts.CUBE) }
   final def ROLLUP: Rule0 = rule { keyword(Consts.ROLLUP) }
   final def GROUPING: Rule0 = rule { keyword(Consts.GROUPING) }
   final def SETS: Rule0 = rule { keyword(Consts.SETS) }
+  final def LATERAL: Rule0 = rule { keyword(Consts.LATERAL) }
 
   // DDLs, SET, SHOW etc
 

--- a/core/src/test/scala/io/snappydata/SnappyFunSuite.scala
+++ b/core/src/test/scala/io/snappydata/SnappyFunSuite.scala
@@ -28,7 +28,8 @@ import io.snappydata.util.TestUtils
 
 import org.apache.spark.sql.catalyst.expressions.{Alias, And, AttributeReference, EqualNullSafe, EqualTo, Exists, ExprId, Expression, ListQuery, PredicateHelper, PredicateSubquery, ScalarSubquery}
 import org.apache.spark.sql.catalyst.plans.logical.{Filter, Join, LogicalPlan, OneRowRelation, Sample}
-import org.apache.spark.sql.catalyst.util.sideBySide
+import org.apache.spark.sql.catalyst.util.{sideBySide, stackTraceToString}
+import org.apache.spark.sql.{AnalysisException, DataFrame, Dataset, QueryTest, Row}
 // scalastyle:off
 import org.scalatest.{BeforeAndAfterAll, FunSuite, Outcome, Retries}
 // scalastyle:on
@@ -194,6 +195,42 @@ abstract class SnappyFunSuite
     // scalastyle:off
     println(msg)
     // scalastyle:on
+  }
+
+  def checkAnswer(df: => DataFrame, expectedAnswer: Seq[Row]): Unit = {
+    val analyzedDF = try df catch {
+      case ae: AnalysisException =>
+        if (ae.plan.isDefined) {
+          fail(
+            s"""
+               |Failed to analyze query: $ae
+               |${ae.plan.get}
+               |
+               |${stackTraceToString(ae)}
+               |""".stripMargin)
+        } else {
+          throw ae
+        }
+    }
+
+    assertEmptyMissingInput(analyzedDF)
+
+    QueryTest.checkAnswer(analyzedDF, expectedAnswer) match {
+      case Some(errorMessage) => fail(errorMessage)
+      case None =>
+    }
+  }
+
+  /**
+   * Asserts that a given [[Dataset]] does not have missing inputs in all the analyzed plans.
+   */
+  def assertEmptyMissingInput(query: Dataset[_]): Unit = {
+    assert(query.queryExecution.analyzed.missingInput.isEmpty,
+      s"The analyzed logical plan has missing inputs:\n${query.queryExecution.analyzed}")
+    assert(query.queryExecution.optimizedPlan.missingInput.isEmpty,
+      s"The optimized logical plan has missing inputs:\n${query.queryExecution.optimizedPlan}")
+    assert(query.queryExecution.executedPlan.missingInput.isEmpty,
+      s"The physical plan has missing inputs:\n${query.queryExecution.executedPlan}")
   }
 }
 

--- a/core/src/test/scala/org/apache/spark/sql/execution/AggregationSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/execution/AggregationSuite.scala
@@ -18,20 +18,13 @@ package org.apache.spark.sql.execution
 
 import io.snappydata.{Property, SnappyFunSuite}
 
-import org.apache.spark.sql.{DataFrame, QueryTest, Row, SnappySession, SparkSession}
+import org.apache.spark.sql.{Row, SnappySession, SparkSession}
 
 class AggregationSuite extends SnappyFunSuite {
 
-  private def checkAnswer(result: DataFrame, expected: Seq[Row]): Unit = {
-    QueryTest.checkAnswer(result, expected) match {
-      case Some(errMessage) => throw new RuntimeException(errMessage)
-      case None => // all good
-    }
-  }
-
   test("AVG plan failure for nullables") {
     val spark = new SparkSession(sc)
-    val snappy = new SnappySession(sc)
+    val snappy = snc.snappySession
     snappy.sql(s"set ${Property.ColumnBatchSize.name}=5000")
 
     val checkDF = spark.range(10000).selectExpr("id", "(id * 12) as k",
@@ -72,5 +65,19 @@ class AggregationSuite extends SnappyFunSuite {
     expectedAnswer = checkDF.join(symDF, "s").selectExpr("avg(k)").collect().toSeq
     result = snappy.sql(query)
     checkAnswer(result, expectedAnswer)
+  }
+
+  test("support for LATERAL VIEW in SnappyParser") {
+    val snappy = snc.snappySession
+    val json =
+      """{ "id": 1, "name": "A green door", "price": 12.50, "tags": ["home", "green"],
+        | "parts" : [ { "lock" : "One lock", "key" : "single key" },
+        | { "lock" : "2 lock", "key" : "2 key" } ] }""".stripMargin
+    val rdd = sc.makeRDD(Seq(json))
+    val ds = snappy.read.json(rdd)
+    ds.createOrReplaceTempView("json")
+    val res = snappy.sql("SELECT id, part.lock, part.key FROM json " +
+        "LATERAL VIEW explode(parts) partTable AS part")
+    checkAnswer(res, Seq(Row(1, "One lock", "single key"), Row(1, "2 lock", "2 key")))
   }
 }

--- a/core/src/test/scala/org/apache/spark/sql/store/CreateIndexTest.scala
+++ b/core/src/test/scala/org/apache/spark/sql/store/CreateIndexTest.scala
@@ -33,7 +33,7 @@ import org.apache.spark.sql.execution.datasources.LogicalRelation
 import org.apache.spark.sql.execution.joins.HashJoinExec
 import org.apache.spark.sql.execution.row.RowFormatRelation
 import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.{AnalysisException, DataFrame, QueryTest, Row, SaveMode, SnappyContext}
+import org.apache.spark.sql.{AnalysisException, DataFrame, Row, SaveMode, SnappyContext}
 
 class CreateIndexTest extends SnappyFunSuite with BeforeAndAfterEach {
   self =>
@@ -234,10 +234,10 @@ class CreateIndexTest extends SnappyFunSuite with BeforeAndAfterEach {
     val ds = snContext.createDataset(data)
     ds.write.insertInto(tableName)
 
-    QueryTest.checkAnswer(snContext.sql(s"select * from $tableName"), data)
-    QueryTest.checkAnswer(snContext.sql(
+    checkAnswer(snContext.sql(s"select * from $tableName"), data)
+    checkAnswer(snContext.sql(
       s"""select "value" from $tableName where `version`=111"""), Seq(Row("aaa")))
-    QueryTest.checkAnswer(snContext.sql(s"""select * from $tableName where "version" >= 555"""),
+    checkAnswer(snContext.sql(s"""select * from $tableName where "version" >= 555"""),
       Seq(Row(555, "ccc"), Row(666, "ccc")))
 
     snContext.sql("drop table " + tableName)
@@ -261,10 +261,10 @@ class CreateIndexTest extends SnappyFunSuite with BeforeAndAfterEach {
 
     ds.write.insertInto(tableName)
 
-    QueryTest.checkAnswer(snContext.table(tableName), data)
-    QueryTest.checkAnswer(snContext.table(tableName).filter($"version" === 111)
+    checkAnswer(snContext.table(tableName), data)
+    checkAnswer(snContext.table(tableName).filter($"version" === 111)
         .select($"value"), Seq(Row("aaa")))
-    QueryTest.checkAnswer(snContext.table(tableName).filter($"version" >= 555),
+    checkAnswer(snContext.table(tableName).filter($"version" >= 555),
       Seq(Row(555, "ccc"), Row(666, "ccc")))
 
     snContext.setConf(SQLConf.CASE_SENSITIVE, false)


### PR DESCRIPTION
## Changes proposed in this pull request

- SnappyParser.lateralView rule added used in relations rule
- added test using sample data/query mentioned on Slack by @Steve Felsheim
- moved common "checkAnswer" code to base SnappyFunSuite

## Patch testing

precheckin

## ReleaseNotes.txt changes

Support for LATERAL VIEW to be mentioned in docs.

## Other PRs 

NA