### PR TITLE
[SNAP-2192] delay rollover in column updates to pre-commit

### DIFF
--- a/cluster/src/dunit/scala/io/snappydata/cluster/SplitSnappyClusterDUnitTest.scala
+++ b/cluster/src/dunit/scala/io/snappydata/cluster/SplitSnappyClusterDUnitTest.scala
@@ -266,6 +266,7 @@ class SplitSnappyClusterDUnitTest(s: String)
       ColumnUpdateDeleteTests.testSNAP1925(session)
       ColumnUpdateDeleteTests.testSNAP1926(session)
       ColumnUpdateDeleteTests.testConcurrentOps(session)
+      ColumnUpdateDeleteTests.testSNAP2124(session, checkPruning = true)
     } finally {
       StoreUtils.TEST_RANDOM_BUCKETID_ASSIGNMENT = false
     }

--- a/cluster/src/main/scala/org/apache/spark/scheduler/cluster/SnappyEmbeddedModeClusterManager.scala
+++ b/cluster/src/main/scala/org/apache/spark/scheduler/cluster/SnappyEmbeddedModeClusterManager.scala
@@ -50,7 +50,6 @@ class SnappyEmbeddedModeClusterManager extends ExternalClusterManager {
           (split(0).trim, split(1).trim)
         }
         else if (locator.isEmpty ||
-            locator == "" ||
             locator == "null" ||
             !ServiceUtils.LOCATOR_URL_PATTERN.matcher(locator).matches()
         ) {

--- a/cluster/src/test/scala/org/apache/spark/sql/store/ColumnUpdateDeleteTest.scala
+++ b/cluster/src/test/scala/org/apache/spark/sql/store/ColumnUpdateDeleteTest.scala
@@ -75,7 +75,7 @@ class ColumnUpdateDeleteTest extends ColumnTablesTestBase {
   }
 
   test("SNAP-2124 update missed") {
-    ColumnUpdateDeleteTests.testSNAP2124(this.snc.snappySession)
+    ColumnUpdateDeleteTests.testSNAP2124(this.snc.snappySession, checkPruning = true)
   }
 
   ignore("test update for all types") {

--- a/core/src/dunit/scala/io/snappydata/cluster/SplitClusterDUnitTestBase.scala
+++ b/core/src/dunit/scala/io/snappydata/cluster/SplitClusterDUnitTestBase.scala
@@ -173,6 +173,7 @@ trait SplitClusterDUnitTestBase extends Logging {
         ColumnUpdateDeleteTests.testSNAP1925(session)
         ColumnUpdateDeleteTests.testSNAP1926(session)
         ColumnUpdateDeleteTests.testConcurrentOps(session)
+        ColumnUpdateDeleteTests.testSNAP2124(session, checkPruning = false)
       }
     })
   }

--- a/core/src/main/scala/io/snappydata/impl/SparkConnectorRDDHelper.scala
+++ b/core/src/main/scala/io/snappydata/impl/SparkConnectorRDDHelper.scala
@@ -79,7 +79,7 @@ final class SparkConnectorRDDHelper {
     val partition = split.asInstanceOf[SmartExecutorBucketPartition]
     val statement = conn.createStatement()
     val txId = SparkConnectorRDDHelper.snapshotTxIdForRead.get() match {
-      case "null" => null
+      case "" => null
       case id => id
     }
     statement match {

--- a/core/src/main/scala/org/apache/spark/sql/execution/columnar/ColumnExec.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/columnar/ColumnExec.scala
@@ -35,6 +35,8 @@ trait ColumnExec extends RowExec {
 
   override def resolvedName: String = externalStore.tableName
 
+  protected def delayRollover: Boolean = false
+
   override protected def connectionCodes(ctx: CodegenContext): (String, String, String) = {
     val connectionClass = classOf[Connection].getName
     val externalStoreTerm = ctx.addReferenceObj("externalStore", externalStore)
@@ -49,7 +51,7 @@ trait ColumnExec extends RowExec {
 
     val initCode =
       s"""
-         |$taskListener = new $listenerClass(($storeClass)$externalStoreTerm);
+         |$taskListener = new $listenerClass(($storeClass)$externalStoreTerm, $delayRollover);
          |$connTerm = $taskListener.getConn();
          |if ($getContext() != null) {
          |   $getContext().addTaskCompletionListener($taskListener);

--- a/core/src/main/scala/org/apache/spark/sql/execution/columnar/ColumnInsertExec.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/columnar/ColumnInsertExec.scala
@@ -663,14 +663,14 @@ case class ColumnInsertExec(child: SparkPlan, partitionColumns: Seq[String],
     ctx.addNewFunction(beginSnapshotTx,
       s"""
          |private final Object[] $beginSnapshotTx() {
-         |  return $externalStoreTerm.beginTx();
+         |  return $externalStoreTerm.beginTx(false);
          |}
       """.stripMargin)
     commitSnapshotTx = ctx.freshName("commitSnapshotTx")
     ctx.addNewFunction(commitSnapshotTx,
       s"""
          |private final void $commitSnapshotTx(String $txId, scala.Option $conn) {
-         |  $externalStoreTerm.commitTx($txId, $conn);
+         |  $externalStoreTerm.commitTx($txId, false, $conn);
          |}
       """.stripMargin)
     rollbackSnapshotTx = ctx.freshName("rollbackSnapshotTx")
@@ -812,14 +812,14 @@ case class ColumnInsertExec(child: SparkPlan, partitionColumns: Seq[String],
     ctx.addNewFunction(beginSnapshotTx,
       s"""
          |private final Object[] $beginSnapshotTx() {
-         |  return $externalStoreTerm.beginTx();
+         |  return $externalStoreTerm.beginTx(false);
          |}
       """.stripMargin)
     commitSnapshotTx = ctx.freshName("commitSnapshotTx")
     ctx.addNewFunction(commitSnapshotTx,
       s"""
          |private final void $commitSnapshotTx(String $txId, scala.Option $conn) {
-         |  $externalStoreTerm.commitTx($txId, $conn);
+         |  $externalStoreTerm.commitTx($txId, false, $conn);
          |}
       """.stripMargin)
     rollbackSnapshotTx = ctx.freshName("rollbackSnapshotTx")

--- a/core/src/main/scala/org/apache/spark/sql/execution/columnar/ColumnUpdateExec.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/columnar/ColumnUpdateExec.scala
@@ -90,6 +90,8 @@ case class ColumnUpdateExec(child: SparkPlan, columnTable: String,
   @transient private var updateMetric: String = _
   @transient protected var txId: String = _
 
+  override protected def delayRollover: Boolean = true
+
   override protected def doProduce(ctx: CodegenContext): String = {
 
     val sql = new StringBuilder

--- a/core/src/main/scala/org/apache/spark/sql/execution/columnar/ExternalStore.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/columnar/ExternalStore.scala
@@ -42,7 +42,7 @@ trait ExternalStore extends Serializable {
 
   def getColumnBatchRDD(tableName: String, rowBuffer: String, requiredColumns: Array[String],
       projection: Array[Int], fullScan: Boolean, prunePartitions: => Int,
-      session: SparkSession, schema: StructType): RDD[Any]
+      session: SparkSession, schema: StructType, delayRollover: Boolean): RDD[Any]
 
   def getConnectedExternalStore(tableName: String,
       onExecutor: Boolean): ConnectedExternalStore

--- a/core/src/main/scala/org/apache/spark/sql/execution/columnar/ExternalStoreUtils.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/columnar/ExternalStoreUtils.scala
@@ -144,7 +144,7 @@ object ExternalStoreUtils {
       addProperty(props, "testOnBorrow", "true")
       // embedded validation check is cheap
       if (isEmbedded) addProperty(props, "validationInterval", "0")
-      else addProperty(props, "validationInterval", "5000")
+      else addProperty(props, "validationInterval", "10000")
     }
     props.toMap
   }

--- a/core/src/main/scala/org/apache/spark/sql/execution/columnar/JDBCAppendableRelation.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/columnar/JDBCAppendableRelation.scala
@@ -75,6 +75,8 @@ abstract case class JDBCAppendableRelation(
 
   val resolvedName: String = table
 
+  protected var delayRollover = false
+
   def numBuckets: Int = -1
 
   def isPartitioned: Boolean = true
@@ -133,7 +135,7 @@ abstract case class JDBCAppendableRelation(
     readLock {
       externalStore.getColumnBatchRDD(tableName, rowBuffer = table,
         requestedColumns, projection, (filters eq null) || filters.length == 0,
-        prunePartitions, sqlContext.sparkSession, schema)
+        prunePartitions, sqlContext.sparkSession, schema, delayRollover)
     }
   }
 

--- a/core/src/main/scala/org/apache/spark/sql/execution/columnar/impl/ColumnFormatRelation.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/columnar/impl/ColumnFormatRelation.scala
@@ -22,6 +22,7 @@ import scala.util.control.NonFatal
 
 import com.gemstone.gemfire.internal.cache.{ExternalTableMetaData, PartitionedRegion}
 import com.pivotal.gemfirexd.internal.engine.Misc
+import com.pivotal.gemfirexd.internal.engine.ddl.catalog.GfxdSystemProcedures
 import com.pivotal.gemfirexd.internal.engine.store.GemFireContainer
 import io.snappydata.Constant
 
@@ -214,7 +215,7 @@ abstract class BaseColumnFormatRelation(
           Array.empty[Filter],
           // use same partitions as the column store (SNAP-1083)
           partitionEvaluator,
-          commitTx = false)
+          commitTx = false, delayRollover)
       case _ =>
         new SmartConnectorRowRDD(
           session,
@@ -226,8 +227,7 @@ abstract class BaseColumnFormatRelation(
           // use same partitions as the column store (SNAP-1083)
           partitionEvaluator,
           relInfo.embdClusterRelDestroyVersion,
-          _commitTx = false
-        )
+          _commitTx = false, delayRollover)
     }
   }
 
@@ -486,10 +486,10 @@ abstract class BaseColumnFormatRelation(
       case SnappyEmbeddedMode(_, _) | LocalMode(_, _) =>
         // force flush all the buckets into the column store
         Utils.mapExecutors(sqlContext, () => {
-          ColumnFormatRelation.flushLocalBuckets(resolvedName)
+          GfxdSystemProcedures.flushLocalBuckets(resolvedName, true)
           Iterator.empty
         }).count()
-        ColumnFormatRelation.flushLocalBuckets(resolvedName)
+        GfxdSystemProcedures.flushLocalBuckets(resolvedName, true)
       case _ =>
     }
   }
@@ -529,9 +529,11 @@ class ColumnFormatRelation(
     }
     val cr = relation.relation.asInstanceOf[ColumnFormatRelation]
     val schema = StructType(cr.schema ++ ColumnDelta.mutableKeyFields)
-    relation.copy(relation = new ColumnFormatRelation(cr.table, cr.provider,
+    val newRelation = new ColumnFormatRelation(cr.table, cr.provider,
       cr.mode, schema, cr.schemaExtensions, cr.ddlExtensionForShadowTable,
-      cr.origOptions, cr.externalStore, cr.partitioningColumns, cr.sqlContext),
+      cr.origOptions, cr.externalStore, cr.partitioningColumns, cr.sqlContext)
+    newRelation.delayRollover = true
+    relation.copy(relation = newRelation,
       expectedOutputAttributes = Some(relation.output ++ ColumnDelta.mutableKeyAttributes))
   }
 
@@ -718,9 +720,11 @@ class IndexColumnFormatRelation(
       keyColumns: Seq[String]): LogicalRelation = {
     val cr = relation.relation.asInstanceOf[IndexColumnFormatRelation]
     val schema = StructType(cr.schema ++ ColumnDelta.mutableKeyFields)
-    relation.copy(relation = new IndexColumnFormatRelation(cr.table, cr.provider,
+    val newRelation = new IndexColumnFormatRelation(cr.table, cr.provider,
       cr.mode, schema, cr.schemaExtensions, cr.ddlExtensionForShadowTable, cr.origOptions,
-      cr.externalStore, cr.partitioningColumns, cr.sqlContext, baseTableName),
+      cr.externalStore, cr.partitioningColumns, cr.sqlContext, baseTableName)
+    newRelation.delayRollover = true
+    relation.copy(relation = newRelation,
       expectedOutputAttributes = Some(relation.output ++ ColumnDelta.mutableKeyAttributes))
   }
 
@@ -739,23 +743,6 @@ class IndexColumnFormatRelation(
 object ColumnFormatRelation extends Logging with StoreCallback {
 
   type IndexUpdateStruct = ((PreparedStatement, InternalRow) => Int, PreparedStatement)
-
-  // register the call backs with the JDBCSource so that
-  // bucket region can insert into the column table
-
-  def flushLocalBuckets(resolvedName: String): Unit = {
-    val pr = Misc.getRegionForTable(resolvedName, false)
-        .asInstanceOf[PartitionedRegion]
-    if (pr != null) {
-      val ds = pr.getDataStore
-      if (ds != null) {
-        val itr = ds.getAllLocalPrimaryBucketRegions.iterator()
-        while (itr.hasNext) {
-          itr.next().createAndInsertColumnBatch(true)
-        }
-      }
-    }
-  }
 
   final def columnBatchTableName(table: String): String = {
     val schemaDot = table.indexOf('.')

--- a/core/src/main/scala/org/apache/spark/sql/execution/columnar/impl/JDBCSourceAsColumnarStore.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/columnar/impl/JDBCSourceAsColumnarStore.scala
@@ -27,10 +27,12 @@ import scala.util.control.NonFatal
 
 import com.esotericsoftware.kryo.io.{Input, Output}
 import com.esotericsoftware.kryo.{Kryo, KryoSerializable}
+import com.gemstone.gemfire.cache.IsolationLevel
 import com.gemstone.gemfire.internal.cache.{BucketRegion, CachePerfStats, GemFireCacheImpl, LocalRegion, PartitionedRegion, TXManagerImpl}
 import com.gemstone.gemfire.internal.shared.unsafe.UnsafeHolder
 import com.gemstone.gemfire.internal.shared.{BufferAllocator, SystemProperties}
 import com.pivotal.gemfirexd.internal.engine.Misc
+import com.pivotal.gemfirexd.internal.engine.ddl.catalog.GfxdSystemProcedures
 import com.pivotal.gemfirexd.internal.iapi.services.context.ContextService
 import com.pivotal.gemfirexd.internal.impl.jdbc.{EmbedConnection, EmbedConnectionContext}
 import io.snappydata.impl.SparkConnectorRDDHelper
@@ -104,7 +106,7 @@ class JDBCSourceAsColumnarStore(private var _connProperties: ConnectionPropertie
   }
 
   // begin should decide the connection which will be used by insert/commit/rollback
-  def beginTx(): Array[_ <: Object] = {
+  def beginTx(delayRollover: Boolean): Array[_ <: Object] = {
     val conn = self.getConnection(tableName, onExecutor = true)
 
     assert(!conn.isClosed)
@@ -116,7 +118,9 @@ class JDBCSourceAsColumnarStore(private var _connProperties: ConnectionPropertie
             if (context == null ||
                 (context.getSnapshotTXState == null && context.getTXState == null)) {
               val txMgr = Misc.getGemFireCache.getCacheTransactionManager
-              txMgr.begin(com.gemstone.gemfire.cache.IsolationLevel.SNAPSHOT, null)
+              val tx = txMgr.beginTX(TXManagerImpl.getOrCreateTXContext(),
+                IsolationLevel.SNAPSHOT, null, null)
+              tx.setColumnRolloverDisabled(delayRollover)
               Array(conn, txMgr.getTransactionId.stringFormat())
             } else {
               Array(conn, null)
@@ -125,10 +129,11 @@ class JDBCSourceAsColumnarStore(private var _connProperties: ConnectionPropertie
             val txId = SparkConnectorRDDHelper.snapshotTxIdForWrite.get
             if (txId == null) {
               logDebug(s"Going to start the transaction on server on conn $conn ")
-              val startAndGetSnapshotTXId = conn.prepareCall(s"call sys.START_SNAPSHOT_TXID (?)")
-              startAndGetSnapshotTXId.registerOutParameter(1, java.sql.Types.VARCHAR)
+              val startAndGetSnapshotTXId = conn.prepareCall(s"call sys.START_SNAPSHOT_TXID(?,?)")
+              startAndGetSnapshotTXId.setBoolean(1, delayRollover)
+              startAndGetSnapshotTXId.registerOutParameter(2, java.sql.Types.VARCHAR)
               startAndGetSnapshotTXId.execute()
-              val txid: String = startAndGetSnapshotTXId.getString(1)
+              val txid = startAndGetSnapshotTXId.getString(2)
               startAndGetSnapshotTXId.close()
               SparkConnectorRDDHelper.snapshotTxIdForWrite.set(txid)
               logDebug(s"The snapshot tx id is $txid and tablename is $tableName")
@@ -136,7 +141,7 @@ class JDBCSourceAsColumnarStore(private var _connProperties: ConnectionPropertie
             } else {
               logDebug(s"Going to use the transaction $txId on server on conn $conn ")
               // it should always be not null.
-              if (!txId.equals("null")) {
+              if (!txId.isEmpty) {
                 val statement = conn.createStatement()
                 statement.execute(
                   s"call sys.USE_SNAPSHOT_TXID('$txId')")
@@ -148,18 +153,23 @@ class JDBCSourceAsColumnarStore(private var _connProperties: ConnectionPropertie
     }(Some(conn))
   }
 
-  def commitTx(txId: String, conn: Option[Connection]): Unit = {
+  def commitTx(txId: String, delayRollover: Boolean, conn: Option[Connection]): Unit = {
     tryExecute(tableName, closeOnSuccessOrFailure = false, onExecutor = true)(conn => {
       var success = false
       try {
         connectionType match {
           case ConnectionType.Embedded =>
+            // if rollover was marked as delayed, then do the rollover before commit
+            if (delayRollover) {
+              GfxdSystemProcedures.flushLocalBuckets(tableName, false)
+            }
             // if(SparkConnectorRDDHelper.snapshotTxIdForRead.get)
             Misc.getGemFireCache.getCacheTransactionManager.commit()
           case _ =>
             logDebug(s"Going to commit $txId the transaction on server conn is $conn")
-            val ps = conn.prepareStatement(s"call sys.COMMIT_SNAPSHOT_TXID(?)")
-            ps.setString(1, if (txId == null) "null" else txId)
+            val ps = conn.prepareStatement(s"call sys.COMMIT_SNAPSHOT_TXID(?,?)")
+            ps.setString(1, if (txId ne null) txId else "")
+            ps.setString(2, if (delayRollover) tableName else "")
             try {
               ps.executeUpdate()
               logDebug(s"The txid being committed is $txId")
@@ -194,7 +204,7 @@ class JDBCSourceAsColumnarStore(private var _connProperties: ConnectionPropertie
           case _ =>
             logDebug(s"Going to rollback $txId the transaction on server on wconn $conn ")
             val ps = conn.prepareStatement(s"call sys.ROLLBACK_SNAPSHOT_TXID(?)")
-            ps.setString(1, if (txId == null) "null" else txId)
+            ps.setString(1, if (txId ne null) txId else "")
             try {
               ps.executeUpdate()
               logDebug(s"The txid being rolledback is $txId")
@@ -509,7 +519,8 @@ class JDBCSourceAsColumnarStore(private var _connProperties: ConnectionPropertie
       fullScan: Boolean,
       prunePartitions: => Int,
       session: SparkSession,
-      schema: StructType): RDD[Any] = {
+      schema: StructType,
+      delayRollover: Boolean): RDD[Any] = {
     val snappySession = session.asInstanceOf[SnappySession]
     connectionType match {
       case ConnectionType.Embedded =>
@@ -535,7 +546,8 @@ class JDBCSourceAsColumnarStore(private var _connProperties: ConnectionPropertie
           tableName, requiredColumns, ConnectionProperties(connProperties.url,
             connProperties.driver, connProperties.dialect, poolProps,
             connProperties.connProps, connProperties.executorConnProps,
-            connProperties.hikariCP), schema, this, parts, embdClusterRelDestroyVersion)
+            connProperties.hikariCP),
+          schema, this, parts, embdClusterRelDestroyVersion, delayRollover)
     }
   }
 
@@ -769,7 +781,8 @@ final class SmartConnectorColumnRDD(
     private var schema: StructType,
     @transient private val store: ExternalStore,
     private val parts: Array[Partition],
-    private var relDestroyVersion: Int = -1)
+    private var relDestroyVersion: Int,
+    private var delayRollover: Boolean)
     extends RDDKryo[Any](session.sparkContext, Nil)
         with KryoSerializable {
 
@@ -792,8 +805,9 @@ final class SmartConnectorColumnRDD(
         logDebug(s"The txid going to be committed is $txId " + tableName)
 
         // if ((txId ne null) && !txId.equals("null")) {
-        val ps = conn.prepareStatement(s"call sys.COMMIT_SNAPSHOT_TXID(?)")
-        ps.setString(1, if (txId eq null) "null" else txId)
+        val ps = conn.prepareStatement(s"call sys.COMMIT_SNAPSHOT_TXID(?,?)")
+        ps.setString(1, if (txId ne null) txId else "")
+        ps.setString(2, if (delayRollover) tableName else "")
         ps.executeUpdate()
         logDebug(s"The txid being committed is $txId")
         ps.close()
@@ -829,6 +843,7 @@ final class SmartConnectorColumnRDD(
     ConnectionPropertiesSerializer.write(kryo, output, connProperties)
     StructTypeSerializer.write(kryo, output, schema)
     output.writeVarInt(relDestroyVersion, false)
+    output.writeBoolean(delayRollover)
   }
 
   override def read(kryo: Kryo, input: Input): Unit = {
@@ -840,6 +855,7 @@ final class SmartConnectorColumnRDD(
     connProperties = ConnectionPropertiesSerializer.read(kryo, input)
     schema = StructTypeSerializer.read(kryo, input, c = null)
     relDestroyVersion = input.readVarInt(false)
+    delayRollover = input.readBoolean()
   }
 }
 
@@ -850,11 +866,11 @@ class SmartConnectorRowRDD(_session: SnappySession,
     _connProperties: ConnectionProperties,
     _filters: Array[Filter] = Array.empty[Filter],
     _partEval: () => Array[Partition] = () => Array.empty[Partition],
-    _relDestroyVersion: Int = -1,
-    _commitTx: Boolean)
+    _relDestroyVersion: Int,
+    _commitTx: Boolean, _delayRollover: Boolean)
     extends RowFormatScanRDD(_session, _tableName, _isPartitioned, _columns,
       pushProjections = true, useResultSet = true, _connProperties,
-    _filters, _partEval, _commitTx) {
+    _filters, _partEval, _commitTx, _delayRollover) {
 
 
   override def commitTxBeforeTaskCompletion(conn: Option[Connection],
@@ -863,8 +879,9 @@ class SmartConnectorRowRDD(_session: SnappySession,
       val txId = SparkConnectorRDDHelper.snapshotTxIdForRead.get
       logDebug(s"The txid going to be committed is $txId " + tableName)
       // if ((txId ne null) && !txId.equals("null")) {
-        val ps = conn.get.prepareStatement(s"call sys.COMMIT_SNAPSHOT_TXID(?)")
-        ps.setString(1, if (txId == null) "null" else txId)
+        val ps = conn.get.prepareStatement(s"call sys.COMMIT_SNAPSHOT_TXID(?,?)")
+        ps.setString(1, if (txId ne null) txId else "")
+        ps.setString(2, if (delayRollover) tableName else "")
         ps.executeUpdate()
         logDebug(s"The txid being committed is $txId")
         ps.close()
@@ -932,7 +949,7 @@ class SmartConnectorRowRDD(_session: SnappySession,
     if (thriftConn ne null) {
       stmt.asInstanceOf[ClientPreparedStatement].setSnapshotTransactionId(txId)
     } else if (txId != null) {
-      if (!txId.equals("null")) {
+      if (!txId.isEmpty) {
         statement.execute(
           s"call sys.USE_SNAPSHOT_TXID('$txId')")
       }
@@ -941,8 +958,9 @@ class SmartConnectorRowRDD(_session: SnappySession,
     val rs = stmt.executeQuery()
 
     // get the txid which was used to take the snapshot.
-    if (!_commitTx) {
-      val getSnapshotTXId = conn.prepareStatement("values sys.GET_SNAPSHOT_TXID()")
+    if (!commitTx) {
+      val getSnapshotTXId = conn.prepareStatement("values sys.GET_SNAPSHOT_TXID(?)")
+      getSnapshotTXId.setBoolean(1, delayRollover)
       val rs = getSnapshotTXId.executeQuery()
       rs.next()
       val txId = rs.getString(1)
@@ -972,8 +990,9 @@ class SmartConnectorRowRDD(_session: SnappySession,
 
 }
 
-class SnapshotConnectionListener(store: JDBCSourceAsColumnarStore) extends TaskCompletionListener {
-  val connAndTxId: Array[_ <: Object] = store.beginTx()
+class SnapshotConnectionListener(store: JDBCSourceAsColumnarStore,
+    delayRollover: Boolean) extends TaskCompletionListener {
+  val connAndTxId: Array[_ <: Object] = store.beginTx(delayRollover)
   var isSuccess = false
 
   override def onTaskCompletion(context: TaskContext): Unit = {
@@ -981,7 +1000,7 @@ class SnapshotConnectionListener(store: JDBCSourceAsColumnarStore) extends TaskC
     val conn = connAndTxId(0).asInstanceOf[Connection]
     if (connAndTxId(1) != null) {
       if (success()) {
-        store.commitTx(txId, Some(conn))
+        store.commitTx(txId, delayRollover, Some(conn))
       }
       else {
         store.rollbackTx(txId, Some(conn))

--- a/core/src/main/scala/org/apache/spark/sql/execution/columnar/impl/RemoteEntriesIterator.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/columnar/impl/RemoteEntriesIterator.scala
@@ -24,7 +24,7 @@ import com.gemstone.gemfire.internal.cache.{NonLocalRegionEntry, PartitionedRegi
 import com.pivotal.gemfirexd.internal.engine.distributed.GfxdListResultCollector.ListResultCollectorValue
 import com.pivotal.gemfirexd.internal.engine.distributed.message.GetAllExecutorMessage
 import com.pivotal.gemfirexd.internal.engine.sql.execute.GemFireResultSet
-import io.snappydata.collection.LongObjectHashMap
+import io.snappydata.collection.IntObjectHashMap
 
 import org.apache.spark.sql.execution.columnar.impl.ColumnFormatEntry.{DELETE_MASK_COL_INDEX, STATROW_COL_INDEX}
 
@@ -67,7 +67,7 @@ final class RemoteEntriesIterator(bucketId: Int, projection: Array[Int],
   }
 
   private var currentStatsKey: ColumnFormatKey = _
-  private val currentValueMap = LongObjectHashMap.withExpectedSize[AnyRef](8)
+  private val currentValueMap = IntObjectHashMap.withExpectedSize[AnyRef](8)
 
   private def fetchUsingGetAll(keys: Array[AnyRef]): Seq[(AnyRef, AnyRef)] = {
     val msg = new GetAllExecutorMessage(pr, keys, null, null, null, null,
@@ -76,7 +76,6 @@ final class RemoteEntriesIterator(bucketId: Int, projection: Array[Int],
     allMemberResults.flatMap { case v: ListResultCollectorValue =>
       msg.getKeysPerMember(v.memberID).asScala.zip(
         v.resultOfSingleExecution.asInstanceOf[java.util.List[AnyRef]].asScala)
-
     }
   }
 

--- a/core/src/main/scala/org/apache/spark/sql/execution/row/RowFormatRelation.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/row/RowFormatRelation.scala
@@ -145,8 +145,7 @@ class RowFormatRelation(
           useResultSet = false,
           connProperties,
           handledFilters,
-          commitTx = true
-        )
+          commitTx = true, delayRollover = false)
 
       case _ =>
         new SmartConnectorRowRDD(
@@ -158,8 +157,7 @@ class RowFormatRelation(
           handledFilters,
           _partEval = () => relInfo.partitions,
           relInfo.embdClusterRelDestroyVersion,
-          _commitTx = true
-        )
+          _commitTx = true, _delayRollover = false)
     }
     (rdd, Nil)
   }

--- a/core/src/main/scala/org/apache/spark/sql/execution/row/RowFormatScanRDD.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/row/RowFormatScanRDD.scala
@@ -229,9 +229,11 @@ class RowFormatScanRDD(@transient val session: SnappySession,
     rs.pushStatementContext(lcc, true)
     */
     // set the delayRollover flag on current transaction
-    val tx = TXManagerImpl.getCurrentTXState
-    if (tx ne null) {
-      tx.getProxy.setColumnRolloverDisabled(delayRollover)
+    if (delayRollover) {
+      val tx = TXManagerImpl.getCurrentTXState
+      if (tx ne null) {
+        tx.getProxy.setColumnRolloverDisabled(true)
+      }
     }
     (conn, stmt, rs)
   }

--- a/core/src/test/java/io/snappydata/TestClass.java
+++ b/core/src/test/java/io/snappydata/TestClass.java
@@ -1,0 +1,110 @@
+package io.snappydata;
+
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.function.Supplier;
+
+import com.gemstone.gemfire.DataSerializable;
+import com.gemstone.gemfire.internal.shared.ClientResolverUtils;
+import org.apache.spark.unsafe.Platform;
+import org.apache.spark.unsafe.hash.Murmur3_x86_32;
+
+public class TestClass {
+
+  private final HashMap<String, Supplier<DataSerializable>> registeredTypes =
+      new HashMap<>();
+
+  private void register(String key, Supplier<DataSerializable> f) {
+    registeredTypes.put(key, f);
+  }
+
+  private void invoke(String key) throws IOException, ClassNotFoundException {
+    DataSerializable v = registeredTypes.get(key).get();
+    v.fromData(null);
+    System.out.println(v);
+  }
+
+  public static void main(String[] args) throws Exception {
+    /*
+    TestClass test = new TestClass();
+    System.out.println("Registering");
+    test.register("T1", T1::new);
+    System.out.println("Registering Child");
+    test.register("Child", T1.Child::new);
+    System.out.println("Invoking");
+    test.invoke("T1");
+    System.out.println("Invoking");
+    test.invoke("T1");
+    System.out.println("Invoking Child");
+    test.invoke("Child");
+    System.out.println("Invoking Child");
+    test.invoke("Child");
+    */
+    byte[] bytes = ClientResolverUtils.class.getName().getBytes(StandardCharsets.UTF_8);
+    final int warmups = 100;
+    final int measure = 1000;
+
+    long total = 0;
+    for (int i = 0; i < warmups; i++) {
+      total += ClientResolverUtils.addBytesToHash(bytes, 42);
+    }
+    System.out.println("1: Total=" + total);
+
+    total = 0;
+    long start = System.nanoTime();
+    for (int i = 0; i < measure; i++) {
+      total += ClientResolverUtils.addBytesToHash(bytes, 42);
+    }
+    long end = System.nanoTime();
+    System.out.println("1: Time taken = " + (end - start) + "ns, total=" + total);
+
+    total = 0;
+    for (int i = 0; i < warmups; i++) {
+      total += Murmur3_x86_32.hashUnsafeBytes(bytes, Platform.BYTE_ARRAY_OFFSET,
+          bytes.length, 42);
+    }
+    System.out.println("2: Total=" + total);
+
+    total = 0;
+    start = System.nanoTime();
+    for (int i = 0; i < measure; i++) {
+      total += Murmur3_x86_32.hashUnsafeBytes(bytes, Platform.BYTE_ARRAY_OFFSET,
+          bytes.length, 42);
+    }
+    end = System.nanoTime();
+    System.out.println("2: Time taken = " + (end - start) + "ns, total=" + total);
+  }
+}
+
+final class T1 implements DataSerializable {
+
+  static {
+    System.out.println("T1.cinit");
+  }
+
+  static final class Child implements DataSerializable {
+
+    static {
+      System.out.println("Child.cinit");
+    }
+
+    @Override
+    public void toData(DataOutput out) throws IOException {
+    }
+
+    @Override
+    public void fromData(DataInput in) throws IOException, ClassNotFoundException {
+    }
+  }
+
+  @Override
+  public void toData(DataOutput out) throws IOException {
+  }
+
+  @Override
+  public void fromData(DataInput in) throws IOException, ClassNotFoundException {
+  }
+}

--- a/core/src/test/scala/io/snappydata/ColumnUpdateDeleteTests.scala
+++ b/core/src/test/scala/io/snappydata/ColumnUpdateDeleteTests.scala
@@ -524,7 +524,7 @@ object ColumnUpdateDeleteTests extends Assertions with Logging {
     assert(res.length === 0)
   }
 
-  def testSNAP2124(session: SnappySession): Unit = {
+  def testSNAP2124(session: SnappySession, checkPruning: Boolean): Unit = {
     val filePath = getClass.getResource("/sample_records.json").getPath
     session.sql("CREATE TABLE domaindata (cntno_l string,cntno_m string," +
         "day1 string,day2 string,day3 string,day4 string,day5 string," +
@@ -538,8 +538,13 @@ object ColumnUpdateDeleteTests extends Assertions with Logging {
     SnappyFunSuite.checkAnswer(ds, Seq(Row("['cbcinewsemail.com']", "[]")))
 
     ds = session.sql("UPDATE domaindata SET ds = '[''cbcin.com'']', dr = '[]' WHERE id = 40")
-    // below checks both the result and partition pruning (only one row)
-    SnappyFunSuite.checkAnswer(ds, Seq(Row(1)))
+    if (checkPruning) {
+      // below checks both the result and partition pruning (only one row)
+      SnappyFunSuite.checkAnswer(ds, Seq(Row(1)))
+    } else {
+      // check the result but expect no pruning (missing in smart connector)
+      SnappyFunSuite.checkAnswer(ds, Row(1) :: (1 until 40).map(_ => Row(0)).toList)
+    }
 
     ds = session.sql("select ds, dr from domaindata where id = 40")
     SnappyFunSuite.checkAnswer(ds, Seq(Row("['cbcin.com']", "[]")))


### PR DESCRIPTION
## Changes proposed in this pull request

- added "delayRollover" flag to scan RDDs and SnapshotConnectionListener in updates
  to disable rollover during operation and do it explicitly, if required, just before commit
- flag is passed through two routes:
  - ColumnUpdateExec overrides delayRollover which is passed to SnapshotConnectionListener;
    this is the case where update starts its own transaction due to intermediate shuffle
  - flag passed to row/column scan RDDs during construction (via Relation instance) which
    is the case where there is no shuffle and scan started transaction is used
  though issue is only for second case above, still delayRollover has been added to both
- added testOnBorrow flag to tomcat pool (hikari has it by default) to clean failed connections
- use empty string TXId for no TX instead of "null" string
- enabled test for SNAP-2124 to dunit tests too (disable pruning check in split mode where
    pruning with smart connector is still missing)

## Patch testing

precheckin

## ReleaseNotes.txt changes

NA

## Other PRs 

https://github.com/SnappyDataInc/snappy-store/pull/362