### PR TITLE
Fix issues and disable TPCDSSuite from precheckin

### DIFF
--- a/cluster/src/test/scala/io/snappydata/benchmark/snappy/TPCDSSuite.scala
+++ b/cluster/src/test/scala/io/snappydata/benchmark/snappy/TPCDSSuite.scala
@@ -57,7 +57,11 @@ class TPCDSSuite extends SnappyFunSuite
       "q91", "q92", "q93", "q94", "q95", "q96", "q97", "q98", "q99")
   }
 
-  test("Test with Snappy") {
+  // Disabling the test run from precheckin as it takes around an hour.
+  // TODO : Add TPCDS tests to be run as a part of smokePerf bt which will run on a dedicated
+  // machine.
+
+  ignore("Test with Snappy") {
     val sc = new SparkContext(conf)
     TPCDSQuerySnappyBenchmark.snappy = new SnappySession(sc)
     val dataLocation = "/export/shared/QA_DATA/TPCDS/data"
@@ -68,7 +72,11 @@ class TPCDSSuite extends SnappyFunSuite
       queries = tpcdsQueries, true, s"$snappyRepo/spark/sql/core/src/test/resources/tpcds")
   }
 
-  test("Test with Spark") {
+  // Disabling the test run from precheckin as it takes around an hour.
+  // TODO : Add TPCDS tests to be run as a part of smokePerf bt which will run on a dedicated
+  // machine.
+
+  ignore("Test with Spark") {
     TPCDSQuerySnappyBenchmark.spark = SparkSession.builder.config(conf).getOrCreate()
     val dataLocation = "/export/shared/QA_DATA/TPCDS/data"
     val snappyHome = System.getenv("SNAPPY_HOME")

--- a/dtests/src/test/java/io/snappydata/hydra/startUp/nwTestWithAllServerHA_meanKill_clusterRestartWithRandomOrderForServerStartUp.conf
+++ b/dtests/src/test/java/io/snappydata/hydra/startUp/nwTestWithAllServerHA_meanKill_clusterRestartWithRandomOrderForServerStartUp.conf
@@ -3,14 +3,11 @@ up config with abruptly killing server members during the query execution and th
  cluster at the end.";
 hydra.Prms-testDescription = "
 This test starts the snappy cluster and spark cluster.
-Test then runs the spark App for creating and loading data in persistent column tables using
-northwind schema and data.
-It then executes the snappy job and sql script in parallel along with abruptly killing servers
-one by one during the ops are in progress and then randomizing the order of server startup config
- after stopping and before restarting the cluster.
+Test then runs the sql script for creating and loading data in persistent column tables using northwind schema and data.
+It then executes the snappy job, spark app and sql script in parallel along with abruptly killing servers one by one during the ops are in progress and then randomizing the order of server startup config after stopping and before restarting the cluster.
 Snappy job executes and validate the northwind queries on the tables created and loaded through split mode.
 sql script only executes the northwind queries on the tables created and loaded through split mode.
-At the last, test verifies that the cluster is restarted successfully";
+At the last, test verifies that the cluster is restarted successfully every time.";
 
 INCLUDE $JTESTS/io/snappydata/hydra/startUp/serverMeanKill.inc;
 INCLUDE $JTESTS/io/snappydata/hydra/startUp/clusterRestart.inc;


### PR DESCRIPTION
## Changes proposed in this pull request

- Fixed the data and checkout path issue
 - Disabling TPCDSSuite test run from precheckin as it takes around 2 hrs. Planning to add TPCDS tests to be run as a part of smokePerf bt which will run on a dedicated machine.
- Disabling the validation in TPCDSSuite for now as this requires the expected result files to be created using stock spark beforehand
- Modified test description in startUp test.


## Patch testing

Verified the changes by running TPCDSSuite.scala

## ReleaseNotes.txt changes

NA

## Other PRs 

No
