### PR TITLE
[SNAP-2204] search through aliases (e.g. for VIEWs) for colocated join keys

### DIFF
--- a/cluster/src/dunit/scala/io/snappydata/cluster/ClusterManagerTestBase.scala
+++ b/cluster/src/dunit/scala/io/snappydata/cluster/ClusterManagerTestBase.scala
@@ -70,8 +70,8 @@ abstract class ClusterManagerTestBase(s: String)
   bootProps.setProperty("critical-heap-percentage", "95")
 
   // reduce startup time
-  sysProps.setProperty("p2p.discoveryTimeout", "1000")
-  sysProps.setProperty("p2p.joinTimeout", "2000")
+  // sysProps.setProperty("p2p.discoveryTimeout", "1000")
+  // sysProps.setProperty("p2p.joinTimeout", "2000")
   sysProps.setProperty("p2p.minJoinTries", "1")
 
   // spark memory fill to detect any uninitialized memory accesses

--- a/core/src/main/scala/org/apache/spark/sql/SnappySession.scala
+++ b/core/src/main/scala/org/apache/spark/sql/SnappySession.scala
@@ -2280,7 +2280,7 @@ object SnappySession extends Logging {
         Utils.mapExecutors(sc, (_, _) => {
           CodeGeneration.clearAllCache()
           Iterator.empty
-        })
+        }).count()
       }
     }
   }

--- a/core/src/main/scala/org/apache/spark/sql/SnappyStrategies.scala
+++ b/core/src/main/scala/org/apache/spark/sql/SnappyStrategies.scala
@@ -16,6 +16,7 @@
  */
 package org.apache.spark.sql
 
+import scala.annotation.tailrec
 import scala.util.control.NonFatal
 
 import io.snappydata.Property
@@ -78,119 +79,142 @@ private[sql] trait SnappyStrategies {
       Nil
     } else {
       plan match {
-        case ExtractEquiJoinKeys(joinType, leftKeys, rightKeys, condition,
-        left, right) if canBuildRight(joinType) && canLocalJoin(right) =>
-          makeLocalHashJoin(leftKeys, rightKeys, left, right, condition,
-            joinType, joins.BuildRight, replicatedTableJoin = true)
-        case ExtractEquiJoinKeys(joinType, leftKeys, rightKeys, condition,
-        left, right) if canBuildLeft(joinType) && canLocalJoin(left) =>
-          makeLocalHashJoin(leftKeys, rightKeys, left, right, condition,
-            joinType, joins.BuildLeft, replicatedTableJoin = true)
-
-        // check for collocated joins before going for broadcast
-        case ExtractEquiJoinKeys(joinType, leftKeys, rightKeys, condition, left, right)
-          if isCollocatedJoin(joinType, left, leftKeys, right, rightKeys) =>
-          val buildLeft = canBuildLeft(joinType) && canBuildLocalHashMap(left, conf)
-          if (buildLeft && left.statistics.sizeInBytes < right.statistics.sizeInBytes) {
+        case ExtractEquiJoinKeys(joinType, leftKeys, rightKeys, condition, left, right) =>
+          // check for hash join with replicated table first
+          if (canBuildRight(joinType) && canLocalJoin(right)) {
             makeLocalHashJoin(leftKeys, rightKeys, left, right, condition,
-              joinType, joins.BuildLeft, replicatedTableJoin = false)
-          } else if (canBuildRight(joinType) && canBuildLocalHashMap(right, conf)) {
+              joinType, joins.BuildRight, replicatedTableJoin = true)
+          } else if (canBuildLeft(joinType) && canLocalJoin(left)) {
             makeLocalHashJoin(leftKeys, rightKeys, left, right, condition,
-              joinType, joins.BuildRight, replicatedTableJoin = false)
-          } else if (buildLeft) {
-            makeLocalHashJoin(leftKeys, rightKeys, left, right, condition,
-              joinType, joins.BuildLeft, replicatedTableJoin = false)
-          } else if (RowOrdering.isOrderable(leftKeys)) {
-            joins.SortMergeJoinExec(leftKeys, rightKeys, joinType, condition,
-              planLater(left), planLater(right)) :: Nil
-          } else Nil
-
-        case ExtractEquiJoinKeys(joinType, leftKeys, rightKeys, condition, left, right)
-          if canBuildRight(joinType) && canBroadcast(right, conf) =>
-          if (skipBroadcastRight(joinType, left, right, conf)) {
+              joinType, joins.BuildLeft, replicatedTableJoin = true)
+          }
+          // check for collocated joins before going for broadcast
+          else if (isCollocatedJoin(joinType, left, leftKeys, right, rightKeys)) {
+            val buildLeft = canBuildLeft(joinType) && canBuildLocalHashMap(left, conf)
+            if (buildLeft && left.statistics.sizeInBytes < right.statistics.sizeInBytes) {
+              makeLocalHashJoin(leftKeys, rightKeys, left, right, condition,
+                joinType, joins.BuildLeft, replicatedTableJoin = false)
+            } else if (canBuildRight(joinType) && canBuildLocalHashMap(right, conf)) {
+              makeLocalHashJoin(leftKeys, rightKeys, left, right, condition,
+                joinType, joins.BuildRight, replicatedTableJoin = false)
+            } else if (buildLeft) {
+              makeLocalHashJoin(leftKeys, rightKeys, left, right, condition,
+                joinType, joins.BuildLeft, replicatedTableJoin = false)
+            } else if (RowOrdering.isOrderable(leftKeys)) {
+              joins.SortMergeJoinExec(leftKeys, rightKeys, joinType, condition,
+                planLater(left), planLater(right)) :: Nil
+            } else Nil
+          }
+          // broadcast joins preferred over exchange+local hash join or SMJ
+          else if (canBuildRight(joinType) && canBroadcast(right, conf)) {
+            if (skipBroadcastRight(joinType, left, right, conf)) {
+              Seq(joins.BroadcastHashJoinExec(leftKeys, rightKeys, joinType,
+                BuildLeft, condition, planLater(left), planLater(right)))
+            } else {
+              Seq(joins.BroadcastHashJoinExec(leftKeys, rightKeys, joinType,
+                BuildRight, condition, planLater(left), planLater(right)))
+            }
+          } else if (canBuildLeft(joinType) && canBroadcast(left, conf)) {
             Seq(joins.BroadcastHashJoinExec(leftKeys, rightKeys, joinType,
               BuildLeft, condition, planLater(left), planLater(right)))
-          } else {
-            Seq(joins.BroadcastHashJoinExec(leftKeys, rightKeys, joinType,
-              BuildRight, condition, planLater(left), planLater(right)))
           }
-        case ExtractEquiJoinKeys(joinType, leftKeys, rightKeys, condition, left, right)
-          if canBuildLeft(joinType) && canBroadcast(left, conf) =>
-          Seq(joins.BroadcastHashJoinExec(leftKeys, rightKeys, joinType,
-            BuildLeft, condition, planLater(left), planLater(right)))
-
-        case ExtractEquiJoinKeys(joinType, leftKeys, rightKeys, condition, left, right)
-          if canBuildRight(joinType) && canBuildLocalHashMap(right, conf) ||
-            !RowOrdering.isOrderable(leftKeys) =>
-          if (canBuildLeft(joinType) && canBuildLocalHashMap(left, conf) &&
-            left.statistics.sizeInBytes < right.statistics.sizeInBytes) {
+          // prefer local hash join after exchange over sort merge join if size is small enough
+          else if (canBuildRight(joinType) && canBuildLocalHashMap(right, conf) ||
+              !RowOrdering.isOrderable(leftKeys)) {
+            if (canBuildLeft(joinType) && canBuildLocalHashMap(left, conf) &&
+                left.statistics.sizeInBytes < right.statistics.sizeInBytes) {
+              makeLocalHashJoin(leftKeys, rightKeys, left, right, condition,
+                joinType, joins.BuildLeft, replicatedTableJoin = false)
+            } else {
+              makeLocalHashJoin(leftKeys, rightKeys, left, right, condition,
+                joinType, joins.BuildRight, replicatedTableJoin = false)
+            }
+          } else if (canBuildLeft(joinType) && canBuildLocalHashMap(left, conf) ||
+              !RowOrdering.isOrderable(leftKeys)) {
             makeLocalHashJoin(leftKeys, rightKeys, left, right, condition,
               joinType, joins.BuildLeft, replicatedTableJoin = false)
-          } else {
-            makeLocalHashJoin(leftKeys, rightKeys, left, right, condition,
-              joinType, joins.BuildRight, replicatedTableJoin = false)
-          }
-        case ExtractEquiJoinKeys(joinType, leftKeys, rightKeys, condition, left, right)
-          if canBuildLeft(joinType) && canBuildLocalHashMap(left, conf) ||
-            !RowOrdering.isOrderable(leftKeys) =>
-          makeLocalHashJoin(leftKeys, rightKeys, left, right, condition,
-            joinType, joins.BuildLeft, replicatedTableJoin = false)
+          } else Nil
 
         case _ => Nil
       }
     }
 
+    @tailrec def unAlias(e: Expression): Expression = e match {
+      case a: Alias => unAlias(a.child)
+      case _ => e
+    }
+
     private def getCollocatedPartitioning(joinType: JoinType,
         leftPlan: LogicalPlan, leftKeys: Seq[Expression],
         rightPlan: LogicalPlan, rightKeys: Seq[Expression],
-        checkBroadcastJoin: Boolean): (Seq[Expression], Seq[Int], Int) = {
+        checkBroadcastJoin: Boolean): (Seq[NamedExpression], Seq[Int], Int) = {
 
-      def getKeyOrder(joinKeys: Seq[Expression],
-          partitioning: Seq[Expression]): Seq[Int] = {
+      def getKeyOrder(plan: LogicalPlan, joinKeys: Seq[Expression],
+          partitioning: Seq[NamedExpression]): Seq[Int] = {
+        val part = partitioning.map(unAlias)
+        lazy val planExpressions = plan.expressions
         val keyOrder = joinKeys.map { k =>
-          val i = partitioning.indexWhere(_.semanticEquals(k))
-          if (i < 0) return Nil
-          i
+          val key = unAlias(k)
+          val i = part.indexWhere(_.semanticEquals(key))
+          if (i < 0) {
+            // search for any view aliases (SNAP-2204)
+            key match {
+              case ke: NamedExpression =>
+                val planKey = planExpressions.collectFirst {
+                  case a: Alias if ke.exprId == a.exprId => unAlias(a.child)
+                  case e: NamedExpression if (ke ne e) && ke.exprId == e.exprId => e
+                } match {
+                  case Some(e) => e
+                  case None => return Nil
+                }
+                val j = part.indexWhere(_.semanticEquals(planKey))
+                if (j < 0) return Nil
+                j
+
+              case _ => return Nil
+            }
+          } else i
         }
         keyOrder
       }
 
       def getCompatiblePartitioning(plan: LogicalPlan,
-          joinKeys: Seq[Expression]): (Seq[Expression], Seq[Int], Int) = plan match {
-        case PhysicalOperation(_, _, r@LogicalRelation(
-        scan: PartitionedDataSourceScan, _, _)) =>
-          // send back numPartitions=1 for replicated table since collocated
-          if (!scan.isPartitioned) return (Nil, Nil, 1)
+          joinKeys: Seq[Expression]): (Seq[NamedExpression], Seq[Int], Int) = plan match {
+        case PhysicalOperation(_, _, child) => child match {
+          case r@LogicalRelation(scan: PartitionedDataSourceScan, _, _) =>
+            // send back numPartitions=1 for replicated table since collocated
+            if (!scan.isPartitioned) return (Nil, Nil, 1)
 
-          // use case-insensitive resolution since partitioning columns during
-          // creation could be using the same as opposed to during scan
-          val partCols = scan.partitionColumns.map(colName =>
-            r.resolveQuoted(colName, analysis.caseInsensitiveResolution)
-                .getOrElse(throw new AnalysisException(
-                  s"""Cannot resolve column "$colName" among (${r.output})""")))
-          // check if join keys match (or are subset of) partitioning columns
-          val keyOrder = getKeyOrder(joinKeys, partCols)
-          if (keyOrder.nonEmpty) (partCols, keyOrder, scan.numBuckets)
-          // return partitioning in any case when checking for broadcast
-          else if (checkBroadcastJoin) (partCols, Nil, scan.numBuckets)
-          else (Nil, Nil, -1)
+            // use case-insensitive resolution since partitioning columns during
+            // creation could be using the same as opposed to during scan
+            val partCols = scan.partitionColumns.map(colName =>
+              r.resolveQuoted(colName, analysis.caseInsensitiveResolution)
+                  .getOrElse(throw new AnalysisException(
+                    s"""Cannot resolve column "$colName" among (${r.output})""")))
+            // check if join keys match (or are subset of) partitioning columns
+            val keyOrder = getKeyOrder(plan, joinKeys, partCols)
+            if (keyOrder.nonEmpty) (partCols, keyOrder, scan.numBuckets)
+            // return partitioning in any case when checking for broadcast
+            else if (checkBroadcastJoin) (partCols, Nil, scan.numBuckets)
+            else (Nil, Nil, -1)
 
-        case PhysicalOperation(_, _, ExtractEquiJoinKeys(jType, lKeys, rKeys,
-        _, left, right)) =>
-          // If join is a result of collocated join, then the result can
-          // also be a collocated join with other tables if compatible
-          // Also the result of a broadcast join will be partitioned
-          // on the other table, so allow collocation for the result.
-          // Below will return partitioning columns of the result but the key
-          // order of those in its join are not useful, rather need to determine
-          // the key order as passed to the method.
-          val (cols, _, numPartitions) = getCollocatedPartitioning(
-            jType, left, lKeys, right, rKeys, checkBroadcastJoin = true)
-          // check if the partitioning of the result is compatible with current
-          val keyOrder = getKeyOrder(joinKeys, cols)
-          if (keyOrder.nonEmpty) (cols, keyOrder, numPartitions)
-          else (Nil, Nil, -1)
+          case ExtractEquiJoinKeys(jType, lKeys, rKeys, _, left, right) =>
+            // If join is a result of collocated join, then the result can
+            // also be a collocated join with other tables if compatible
+            // Also the result of a broadcast join will be partitioned
+            // on the other table, so allow collocation for the result.
+            // Below will return partitioning columns of the result but the key
+            // order of those in its join are not useful, rather need to determine
+            // the key order as passed to the method.
+            val (cols, _, numPartitions) = getCollocatedPartitioning(
+              jType, left, lKeys, right, rKeys, checkBroadcastJoin = true)
+            // check if the partitioning of the result is compatible with current
+            val keyOrder = getKeyOrder(plan, joinKeys, cols)
+            if (keyOrder.nonEmpty) (cols, keyOrder, numPartitions)
+            else (Nil, Nil, -1)
 
+          case _ => (Nil, Nil, -1)
+        }
         case _ => (Nil, Nil, -1)
       }
 
@@ -292,15 +316,14 @@ private[sql] object JoinStrategy {
 
   def canLocalJoin(plan: LogicalPlan): Boolean = {
     plan match {
-      case PhysicalOperation(_, _, LogicalRelation(
-      t: PartitionedDataSourceScan, _, _)) => !t.isPartitioned
-      case PhysicalOperation(_, _, Join(left, right, _, _)) =>
-        // If join is a result of join of replicated tables, this
-        // join result should also be a local join with any other table
-        canLocalJoin(left) && canLocalJoin(right)
-      case PhysicalOperation(_, _, node) if node.children.size == 1 =>
-        canLocalJoin(node.children.head)
-
+      case PhysicalOperation(_, _, child) => child match {
+        case LogicalRelation(t: PartitionedDataSourceScan, _, _) => !t.isPartitioned
+        case Join(left, right, _, _) =>
+          // If join is a result of join of replicated tables, this
+          // join result should also be a local join with any other table
+          canLocalJoin(left) && canLocalJoin(right)
+        case node => if (node.children.size == 1) canLocalJoin(node.children.head) else false
+      }
       case _ => false
     }
   }


### PR DESCRIPTION
## Changes proposed in this pull request

Search the plan expressions to find any matching view aliases to determine the
underlying column for a join key. A physical plan for a query on join VIEW looks like:

```
Join Inner, (gen_attr_0#347 = gen_attr_2#349)
:- Project [ID#204 AS gen_attr_0#347]
:  +- Filter isnotnull(ID#204)
:     +- Relation[ID#204,ADDR#205] ColumnFormatRelation[APP.VIEWCOLTABLE]
+- Project [ID#248 AS gen_attr_2#349, ADDR#249 AS gen_attr_1#350]
   +- Filter isnotnull(ID#248)
      +- Relation[ID#248,ADDR#249] RowFormatRelation[APP.VIEWROWTABLE]
```

The underlying column is buried inside the Project alias while the join condition
is on generated attributes (gen_attr_0 and gen_attr_2).

Also changes to avoid multiple unapplies of ExtractEquiJoinKeys, PhysicalOperation rather
do it once and then match on the extracted children.

Added unit tests for above.

## Patch testing

precheckin

## ReleaseNotes.txt changes

NA

## Other PRs 

NA