### PR TITLE
[SNAP-2175] handle no GemFireCache in smart connector mode

### DIFF
--- a/cluster/src/dunit/scala/io/snappydata/cluster/ClusterManagerTestBase.scala
+++ b/cluster/src/dunit/scala/io/snappydata/cluster/ClusterManagerTestBase.scala
@@ -76,6 +76,8 @@ abstract class ClusterManagerTestBase(s: String)
 
   // spark memory fill to detect any uninitialized memory accesses
   sysProps.setProperty("spark.memory.debugFill", "true")
+  // reduce minimum compression size so that it happens for all the values for testing
+  sysProps.setProperty(Constant.COMPRESSION_MIN_SIZE, "128")
 
   var host: Host = _
   var vm0: VM = _

--- a/cluster/src/dunit/scala/org/apache/spark/sql/TPCHDUnitTest.scala
+++ b/cluster/src/dunit/scala/org/apache/spark/sql/TPCHDUnitTest.scala
@@ -383,7 +383,7 @@ object TPCHUtils extends Logging {
             for ((expectedLine, actualLine) <- expectedLineSet zip actualLineSet) {
               if (!expectedLine.equals(actualLine)) {
                 resultOutputStream.println(s"For $query result mismatched observed")
-                resultOutputStream.println(s"Excpected : $expectedLine")
+                resultOutputStream.println(s"Expected  : $expectedLine")
                 resultOutputStream.println(s"Found     : $actualLine")
                 resultOutputStream.println(s"-------------------------------------")
               }
@@ -424,7 +424,7 @@ object TPCHUtils extends Logging {
         s"Query result match Observed. Look at Result_Snappy_Tokenization.out for detailed failure")
       if (resultOutputFile.count() != 0) {
         logWarning(
-          s"QUERY RESYLT MATCH OBSERVED. Look at Result_Snappy_Tokenization.out for detailed" +
+          s"QUERY RESULT MATCH OBSERVED. Look at Result_Snappy_Tokenization.out for detailed" +
               s" failure")
       }
     }

--- a/cluster/src/test/scala/io/snappydata/benchmark/snappy/TPCDSSuite.scala
+++ b/cluster/src/test/scala/io/snappydata/benchmark/snappy/TPCDSSuite.scala
@@ -115,7 +115,7 @@ class TPCDSSuite extends SnappyFunSuite
           for ((expectedLine, actualLine) <- expectedLineSet zip actualLineSet) {
             if (!expectedLine.equals(actualLine)) {
               resultOutputStream.println(s"For $query result mismatched observed")
-              resultOutputStream.println(s"Excpected : $expectedLine")
+              resultOutputStream.println(s"Expected  : $expectedLine")
               resultOutputStream.println(s"Found     : $actualLine")
               resultOutputStream.println(s"-------------------------------------")
             }

--- a/cluster/src/test/scala/io/snappydata/benchmark/snappy/tpch/DataValidationJob.scala
+++ b/cluster/src/test/scala/io/snappydata/benchmark/snappy/tpch/DataValidationJob.scala
@@ -74,7 +74,7 @@ object DataValidationJob extends SnappySQLJob {
             for ((expectedLine, actualLine) <- expectedLineSet zip actualLineSet) {
               if (!expectedLine.equals(actualLine)) {
                 resultOutputStream.println(s"For $query result mismatched observed")
-                resultOutputStream.println(s"Excpected : $expectedLine")
+                resultOutputStream.println(s"Expected  : $expectedLine")
                 resultOutputStream.println(s"Found     : $actualLine")
                 resultOutputStream.println(s"-------------------------------------")
               }

--- a/core/src/dunit/scala/io/snappydata/cluster/SplitClusterDUnitSecurityTest.scala
+++ b/core/src/dunit/scala/io/snappydata/cluster/SplitClusterDUnitSecurityTest.scala
@@ -29,6 +29,7 @@ import com.pivotal.gemfirexd.Property.{AUTH_LDAP_SEARCH_BASE, AUTH_LDAP_SERVER}
 import com.pivotal.gemfirexd.internal.engine.Misc
 import com.pivotal.gemfirexd.internal.engine.db.FabricDatabase
 import com.pivotal.gemfirexd.security.{LdapTestServer, SecurityTestUtils}
+import io.snappydata.Constant
 import io.snappydata.test.dunit.DistributedTestBase.WaitCriterion
 import io.snappydata.test.dunit.{AvailablePortHelper, DistributedTestBase, Host, SerializableRunnable, VM}
 import io.snappydata.util.TestUtils
@@ -56,6 +57,7 @@ class SplitClusterDUnitSecurityTest(s: String)
   bootProps.setProperty("log-level", "config")
   bootProps.setProperty("statistic-archive-file", "snappyStore.gfs")
   bootProps.setProperty("spark.executor.cores", TestUtils.defaultCores.toString)
+  System.setProperty(Constant.COMPRESSION_MIN_SIZE, compressionMinSize)
 
   var adminConn = null: Connection
   var user1Conn = null: Connection
@@ -135,13 +137,15 @@ class SplitClusterDUnitSecurityTest(s: String)
     val netPort1 = AvailablePortHelper.getRandomAvailableTCPPort
     val netPort2 = AvailablePortHelper.getRandomAvailableTCPPort
     val confDir = s"$snappyProductDir/conf"
+    val compressionArg = this.compressionArg
     val ldapConf = getLdapConf
-    writeToFile(s"localhost  -peer-discovery-port=$port -client-port=$netPort $ldapConf",
+    writeToFile(
+      s"localhost  -peer-discovery-port=$port -client-port=$netPort $compressionArg $ldapConf",
       s"$confDir/locators")
     writeToFile(s"localhost  -locators=localhost[$port] $ldapConf", s"$confDir/leads")
     writeToFile(
-      s"""localhost  -locators=localhost[$port] -client-port=$netPort1 $ldapConf
-          |localhost  -locators=localhost[$port] -client-port=$netPort2 $ldapConf
+      s"""localhost  -locators=localhost[$port] -client-port=$netPort1 $compressionArg $ldapConf
+          |localhost  -locators=localhost[$port] -client-port=$netPort2 $compressionArg $ldapConf
           |""".stripMargin, s"$confDir/servers")
     logInfo((snappyProductDir + "/sbin/snappy-start-all.sh").!!)
 

--- a/core/src/dunit/scala/io/snappydata/cluster/SplitClusterDUnitTest.scala
+++ b/core/src/dunit/scala/io/snappydata/cluster/SplitClusterDUnitTest.scala
@@ -52,6 +52,7 @@ class SplitClusterDUnitTest(s: String)
   bootProps.setProperty("log-level", "config")
   bootProps.setProperty("statistic-archive-file", "snappyStore.gfs")
   bootProps.setProperty("spark.executor.cores", TestUtils.defaultCores.toString)
+  System.setProperty(Constant.COMPRESSION_MIN_SIZE, compressionMinSize)
 
   private[this] var host: Host = _
   var vm0: VM = _
@@ -90,14 +91,15 @@ class SplitClusterDUnitTest(s: String)
 
     logInfo(s"Starting snappy cluster in $snappyProductDir/work with locator client port $netPort")
 
+    val compressionArg = this.compressionArg
     val confDir = s"$snappyProductDir/conf"
     writeToFile(s"localhost  -peer-discovery-port=$port -client-port=$netPort",
       s"$confDir/locators")
-    writeToFile(s"localhost  -locators=localhost[$port] -client-port=$netPort1",
+    writeToFile(s"localhost  -locators=localhost[$port] -client-port=$netPort1 $compressionArg",
       s"$confDir/leads")
     writeToFile(
-      s"""localhost  -locators=localhost[$port] -client-port=$netPort2
-          |localhost  -locators=localhost[$port] -client-port=$netPort3
+      s"""localhost  -locators=localhost[$port] -client-port=$netPort2 $compressionArg
+          |localhost  -locators=localhost[$port] -client-port=$netPort3 $compressionArg
           |""".stripMargin, s"$confDir/servers")
     (snappyProductDir + "/sbin/snappy-start-all.sh").!!
 

--- a/core/src/dunit/scala/io/snappydata/cluster/SplitClusterDUnitTestBase.scala
+++ b/core/src/dunit/scala/io/snappydata/cluster/SplitClusterDUnitTestBase.scala
@@ -26,14 +26,15 @@ import scala.util.Random
 
 import com.pivotal.gemfirexd.Attribute
 import com.pivotal.gemfirexd.internal.engine.Misc
-import io.snappydata.{ColumnUpdateDeleteTests, Constant}
 import io.snappydata.test.dunit.{SerializableRunnable, VM}
 import io.snappydata.test.util.TestException
 import io.snappydata.util.TestUtils
+import io.snappydata.{ColumnUpdateDeleteTests, Constant}
 import org.junit.Assert
 
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.collection.{Utils, WrappedInternalRow}
+import org.apache.spark.sql.store.StoreUtils
 import org.apache.spark.sql.types.Decimal
 import org.apache.spark.sql.{SnappyContext, ThinClientConnectorMode}
 import org.apache.spark.util.collection.OpenHashSet
@@ -54,6 +55,11 @@ trait SplitClusterDUnitTestBase extends Logging {
   def vm3: VM
 
   protected def startArgs: Array[AnyRef]
+
+  // reduce minimum compression size so that it happens for all the values for testing
+  protected def compressionMinSize = "128"
+
+  protected def compressionArg: String = s"-D${Constant.COMPRESSION_MIN_SIZE}=$compressionMinSize"
 
   protected def testObject: SplitClusterDUnitTestObject
 
@@ -168,12 +174,18 @@ trait SplitClusterDUnitTestBase extends Logging {
       override def run(): Unit = {
         val snc = testObject.getSnappyContextForConnector(netPort)
         val session = snc.snappySession
-        ColumnUpdateDeleteTests.testBasicUpdate(session)
-        ColumnUpdateDeleteTests.testBasicDelete(session)
-        ColumnUpdateDeleteTests.testSNAP1925(session)
-        ColumnUpdateDeleteTests.testSNAP1926(session)
-        ColumnUpdateDeleteTests.testConcurrentOps(session)
-        ColumnUpdateDeleteTests.testSNAP2124(session, checkPruning = false)
+        // using random bucket assignment for cases like SNAP-2175
+        StoreUtils.TEST_RANDOM_BUCKETID_ASSIGNMENT = true
+        try {
+          ColumnUpdateDeleteTests.testBasicUpdate(session)
+          ColumnUpdateDeleteTests.testBasicDelete(session)
+          ColumnUpdateDeleteTests.testSNAP1925(session)
+          ColumnUpdateDeleteTests.testSNAP1926(session)
+          ColumnUpdateDeleteTests.testConcurrentOps(session)
+          ColumnUpdateDeleteTests.testSNAP2124(session, checkPruning = false)
+        } finally {
+          StoreUtils.TEST_RANDOM_BUCKETID_ASSIGNMENT = false
+        }
       }
     })
   }

--- a/core/src/main/scala/io/snappydata/Literals.scala
+++ b/core/src/main/scala/io/snappydata/Literals.scala
@@ -102,6 +102,9 @@ object Constant {
   // should be started
   val ZEPPELIN_INTERPRETER_PORT = "zeppelin.interpreter.port"
 
+  // System property for minimum size of buffer to consider for compression.
+  val COMPRESSION_MIN_SIZE: String = PROPERTY_PREFIX + "compression.minSize"
+
   val CHAR_TYPE_BASE_PROP = "base"
 
   val CHAR_TYPE_SIZE_PROP = "size"

--- a/core/src/main/scala/io/snappydata/TableStatsProviderService.scala
+++ b/core/src/main/scala/io/snappydata/TableStatsProviderService.scala
@@ -265,7 +265,7 @@ trait TableStatsProviderService extends Logging {
           .getDataSourceTables(Seq(ExternalTableType.Sample)).map(_.toString())
     } catch {
       case tnfe: org.apache.spark.sql.TableNotFoundException =>
-        Seq.empty[String]
+        Nil
     }
   }
   */

--- a/core/src/main/scala/io/snappydata/impl/SparkConnectorRDDHelper.scala
+++ b/core/src/main/scala/io/snappydata/impl/SparkConnectorRDDHelper.scala
@@ -36,6 +36,7 @@ import org.apache.spark.sql.execution.columnar.impl.{ColumnDelta, ColumnFormatEn
 import org.apache.spark.sql.execution.datasources.jdbc.DriverRegistry
 import org.apache.spark.sql.row.GemFireXDClientDialect
 import org.apache.spark.sql.sources.ConnectionProperties
+import org.apache.spark.sql.store.StoreUtils
 import org.apache.spark.sql.types.StructType
 
 final class SparkConnectorRDDHelper {
@@ -151,7 +152,12 @@ object SparkConnectorRDDHelper {
     val numPartitions = bucketToServerList.length
     val partitions = new Array[Partition](numPartitions)
     for (p <- 0 until numPartitions) {
-      partitions(p) = new SmartExecutorBucketPartition(p, p, bucketToServerList(p))
+      if (StoreUtils.TEST_RANDOM_BUCKETID_ASSIGNMENT) {
+        partitions(p) = new SmartExecutorBucketPartition(p, p,
+          bucketToServerList(scala.util.Random.nextInt(numPartitions)))
+      } else {
+        partitions(p) = new SmartExecutorBucketPartition(p, p, bucketToServerList(p))
+      }
     }
     partitions
   }

--- a/core/src/main/scala/org/apache/spark/sql/SmartConnectorHelper.scala
+++ b/core/src/main/scala/org/apache/spark/sql/SmartConnectorHelper.scala
@@ -248,12 +248,12 @@ class SmartConnectorHelper(snappySession: SnappySession) extends Logging {
         val replicaToNodesInfo = getMetaDataStmt.getString(6)
         val allNetUrls = SparkConnectorRDDHelper.setReplicasToServerMappingInfo(replicaToNodesInfo)
         val partitions = SparkConnectorRDDHelper.getPartitions(allNetUrls)
-        (t, RelationInfo(1, isPartitioned = false, Seq.empty[String], indexCols, pkCols,
+        (t, RelationInfo(1, isPartitioned = false, Nil, indexCols, pkCols,
           partitions, embdClusterRelDestroyVersion))
       }
     } else {
       // external tables (with source as csv, parquet etc.)
-      (t, RelationInfo(1, isPartitioned = false, Seq.empty[String], Array.empty[String],
+      (t, RelationInfo(1, isPartitioned = false, Nil, Array.empty[String],
         Array.empty[String], Array.empty[Partition], embdClusterRelDestroyVersion))
     }
   }

--- a/core/src/main/scala/org/apache/spark/sql/SnappyBaseParser.scala
+++ b/core/src/main/scala/org/apache/spark/sql/SnappyBaseParser.scala
@@ -121,9 +121,12 @@ abstract class SnappyBaseParser(session: SparkSession) extends Parser {
 
   protected def start: Rule1[LogicalPlan]
 
+  protected final def unquotedIdentifier: Rule1[String] = rule {
+    atomic(capture(Consts.alphaUnderscore ~ Consts.identifier.*)) ~ delimiter
+  }
+
   protected final def identifier: Rule1[String] = rule {
-    atomic(capture(Consts.alphaUnderscore ~ Consts.identifier.*)) ~
-        delimiter ~> { (s: String) =>
+    unquotedIdentifier ~> { (s: String) =>
       val ucase = Utils.toUpperCase(s)
       test(!Consts.reservedKeywords.contains(ucase)) ~
           push(if (caseSensitive) s else ucase)
@@ -146,8 +149,7 @@ abstract class SnappyBaseParser(session: SparkSession) extends Parser {
    * interpreted as a strictIdentifier.
    */
   protected final def strictIdentifier: Rule1[String] = rule {
-    atomic(capture(CharPredicate.Alpha ~ Consts.identifier.*)) ~
-        delimiter ~> { (s: String) =>
+    unquotedIdentifier ~> { (s: String) =>
       val ucase = Utils.toUpperCase(s)
       test(!Consts.allKeywords.contains(ucase)) ~
           push(if (caseSensitive) s else ucase)

--- a/core/src/main/scala/org/apache/spark/sql/SnappyDDLParser.scala
+++ b/core/src/main/scala/org/apache/spark/sql/SnappyDDLParser.scala
@@ -330,7 +330,7 @@ abstract class SnappyDDLParser(session: SparkSession)
       }
       val userCols = cols.asInstanceOf[Option[Seq[(String, Option[String])]]] match {
         case Some(seq) => seq
-        case None => Seq.empty
+        case None => Nil
       }
       CreateViewCommand(
         name = table,
@@ -611,7 +611,9 @@ abstract class SnappyDDLParser(session: SparkSession)
   }
 
   protected final def qualifiedName: Rule1[String] = rule {
-    capture((Consts.identifier | '.').*) ~ delimiter
+    (unquotedIdentifier + ('.' ~ ws)) ~>
+        ((ids: Seq[String]) => ids.mkString(".")) |
+    quotedIdentifier
   }
 
   protected def column: Rule1[StructField] = rule {

--- a/core/src/main/scala/org/apache/spark/sql/SnappyParser.scala
+++ b/core/src/main/scala/org/apache/spark/sql/SnappyParser.scala
@@ -691,8 +691,8 @@ class SnappyParser(session: SnappySession) extends SnappyDDLParser(session) {
         commaSep)).? ~ ((ORDER | SORT) ~ BY ~ ordering).? ~ windowFrame.? ~ ')' ~
         ws ~> ((p: Any, o: Any, w: Any) =>
       WindowSpecDefinition(
-        p.asInstanceOf[Option[Seq[Expression]]].getOrElse(Seq.empty),
-        o.asInstanceOf[Option[Seq[SortOrder]]].getOrElse(Seq.empty),
+        p.asInstanceOf[Option[Seq[Expression]]].getOrElse(Nil),
+        o.asInstanceOf[Option[Seq[SortOrder]]].getOrElse(Nil),
         w.asInstanceOf[Option[SpecifiedWindowFrame]]
           .getOrElse(UnspecifiedFrame))) |
     identifier ~> WindowSpecReference
@@ -723,7 +723,7 @@ class SnappyParser(session: SnappySession) extends SnappyDDLParser(session) {
     '(' ~ ws ~ (expression + commaSep).? ~ ')' ~>
       ((e: Any) => e.asInstanceOf[Option[Vector[Expression]]] match {
         case Some(ve) => ve
-        case _ => Seq.empty
+        case _ => Nil
       })
   }
 
@@ -975,7 +975,7 @@ class SnappyParser(session: SnappySession) extends SnappyDDLParser(session) {
           val expressions = e.asInstanceOf[Seq[Expression]]
           val columnNames = cols.asInstanceOf[Option[Seq[String]]] match {
             case Some(s) => s.map(UnresolvedAttribute.apply)
-            case None => Seq.empty
+            case None => Nil
           }
           Generate(UnresolvedGenerator(functionName, expressions), join = true,
             outer = o.asInstanceOf[Option[Boolean]].isDefined, Some(tableName),
@@ -1011,7 +1011,7 @@ class SnappyParser(session: SnappySession) extends SnappyDDLParser(session) {
             case _ => base
           }
           val (updateColumns, updateExpressions) = updateExprs.unzip
-          Update(table, withFilter, Seq.empty, updateColumns, updateExpressions)
+          Update(table, withFilter, Nil, updateColumns, updateExpressions)
         })
   }
 
@@ -1024,7 +1024,7 @@ class SnappyParser(session: SnappySession) extends SnappyDDLParser(session) {
             case None => base
             case Some(w) => Filter(w.asInstanceOf[Expression], base)
           }
-          Delete(base, child, Seq.empty)
+          Delete(base, child, Nil)
         })
   }
 

--- a/core/src/main/scala/org/apache/spark/sql/SnappySession.scala
+++ b/core/src/main/scala/org/apache/spark/sql/SnappySession.scala
@@ -373,7 +373,7 @@ class SnappySession(_sc: SparkContext) extends SparkSession(_sc) {
     if (key != null && key.valid) {
       allLiterals = CachedPlanHelperExec.allLiterals(
         getContextObject[ArrayBuffer[ArrayBuffer[Any]]](
-          SnappyParserConsts.REFERENCES_KEY).getOrElse(Seq.empty)
+          SnappyParserConsts.REFERENCES_KEY).getOrElse(Nil)
       ).filter(!_.collectedForPlanCaching)
 
       allLiterals.foreach(_.collectedForPlanCaching = true)
@@ -2273,7 +2273,8 @@ object SnappySession extends Logging {
 
   def clearAllCache(onlyQueryPlanCache: Boolean = false): Unit = {
     val sc = SnappyContext.globalSparkContext
-    if (!SnappyTableStatsProviderService.suspendCacheInvalidation && (sc ne null)) {
+    if (!SnappyTableStatsProviderService.suspendCacheInvalidation &&
+        (sc ne null) && !sc.isStopped) {
       planCache.invalidateAll()
       if (!onlyQueryPlanCache) {
         CodeGeneration.clearAllCache()

--- a/core/src/main/scala/org/apache/spark/sql/collection/ReusableRow.scala
+++ b/core/src/main/scala/org/apache/spark/sql/collection/ReusableRow.scala
@@ -42,7 +42,7 @@ class ReusableRow(val values: Array[MutableValue])
         case _ => new MutableAny
       }.toArray)
 
-  def this() = this(Seq.empty)
+  def this() = this(Nil)
 
   override final def length: Int = values.length
 

--- a/core/src/main/scala/org/apache/spark/sql/collection/Utils.scala
+++ b/core/src/main/scala/org/apache/spark/sql/collection/Utils.scala
@@ -998,7 +998,7 @@ object ToolsCallbackInit extends Logging {
       tc
     } catch {
       case _: ClassNotFoundException =>
-        logWarning("toolsCallback couldn't be INITIALIZED." +
+        logWarning("ToolsCallback couldn't be INITIALIZED. " +
             "DriverURL won't get published to others.")
         null
     }

--- a/core/src/main/scala/org/apache/spark/sql/execution/ExistingPlans.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/ExistingPlans.scala
@@ -151,7 +151,7 @@ private[sql] object PartitionedPhysicalScan {
           columnScan.sqlContext.sessionState.analyzer.resolver(left.name, right.name)
 
         val rowBufferScan = RowTableScan(output, StructType.fromAttributes(
-          output), baseTableRDD, numBuckets, Seq.empty, Seq.empty, table, caseSensitive)
+          output), baseTableRDD, numBuckets, Nil, Nil, table, caseSensitive)
         val otherPartKeys = partitionColumns.map(_.transform {
           case a: AttributeReference => rowBufferScan.output.find(resolveCol(_, a)).getOrElse {
             throw new AnalysisException(s"RowBuffer output column $a not found in " +

--- a/core/src/main/scala/org/apache/spark/sql/execution/ObjectHashMapAccessor.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/ObjectHashMapAccessor.scala
@@ -286,7 +286,7 @@ case class ObjectHashMapAccessor(@transient session: SnappySession,
   override protected def doExecute(): RDD[InternalRow] =
     throw new UnsupportedOperationException("unexpected invocation")
 
-  override def inputRDDs(): Seq[RDD[InternalRow]] = Seq.empty
+  override def inputRDDs(): Seq[RDD[InternalRow]] = Nil
 
   override protected def doProduce(ctx: CodegenContext): String =
     throw new UnsupportedOperationException("unexpected invocation")

--- a/core/src/main/scala/org/apache/spark/sql/execution/columnar/ColumnBatch.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/columnar/ColumnBatch.scala
@@ -429,7 +429,7 @@ final class ColumnBatchIteratorOnRS(conn: Connection,
     // create a new map instead of clearing old one to help young gen GC
     colBuffers = IntObjectHashMap.withExpectedSize[ByteBuffer](totalColumns + 1)
     val statsBlob = rs.getBlob(4)
-    val statsBuffer = statsBlob match {
+    val statsBuffer = decompress(statsBlob match {
       case blob: BufferedBlob =>
         // the chunk can never be a ByteBufferReference in this case and
         // the internal buffer will now be owned by ColumnFormatValue
@@ -438,10 +438,10 @@ final class ColumnBatchIteratorOnRS(conn: Connection,
         chunk.chunk
       case blob => ByteBuffer.wrap(blob.getBytes(
         1, blob.length().asInstanceOf[Int]))
-    }
+    })
     statsBlob.free()
     // put the stats buffer to free on next() or close()
-    colBuffers.justPut(ColumnFormatEntry.DELTA_STATROW_COL_INDEX, decompress(statsBuffer))
+    colBuffers.justPut(ColumnFormatEntry.STATROW_COL_INDEX, statsBuffer)
     statsBuffer
   }
 

--- a/core/src/main/scala/org/apache/spark/sql/execution/columnar/ColumnBatchCreator.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/columnar/ColumnBatchCreator.scala
@@ -80,11 +80,11 @@ final class ColumnBatchCreator(
         // code does not (which is passed in the references separately)
         val gen = CodeGeneration.compileCode("COLUMN_TABLE.BATCH", schema.fields, () => {
           val tableScan = RowTableScan(schema.toAttributes, schema,
-            dataRDD = null, numBuckets = -1, partitionColumns = Seq.empty,
-            partitionColumnAliases = Seq.empty, baseRelation = null, caseSensitive = true)
+            dataRDD = null, numBuckets = -1, partitionColumns = Nil,
+            partitionColumnAliases = Nil, baseRelation = null, caseSensitive = true)
           // sending negative values for batch size and delta rows will create
           // only one column batch that will not be checked for size again
-          val insertPlan = ColumnInsertExec(tableScan, Seq.empty, Seq.empty,
+          val insertPlan = ColumnInsertExec(tableScan, Nil, Nil,
             numBuckets = -1, isPartitioned = false, None,
             (-bufferRegion.getColumnBatchSize, -1, compressionCodec), tableName,
             onExecutor = true, schema, store, useMemberVariables = false)
@@ -136,7 +136,7 @@ final class ColumnBatchCreator(
       val bufferPlan = CallbackColumnInsert(schema)
       // no puts into row buffer for now since it causes split of rows held
       // together and thus failures in ClosedFormAccuracySuite etc
-      val insertPlan = ColumnInsertExec(bufferPlan, Seq.empty, Seq.empty,
+      val insertPlan = ColumnInsertExec(bufferPlan, Nil, Nil,
         numBuckets = -1, isPartitioned = false, None, (columnBatchSize, -1, compressionCodec),
         tableName, onExecutor = true, schema, externalStore,
         useMemberVariables = true)

--- a/core/src/main/scala/org/apache/spark/sql/execution/columnar/ColumnTableScan.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/columnar/ColumnTableScan.scala
@@ -253,9 +253,7 @@ private[sql] final case class ColumnTableScan(
           // If the filter can't be resolved then we are missing required statistics.
           boundFilter.filter(_.resolved)
         }
-      } else {
-        Seq.empty[Expression]
-      }
+      } else Nil
     }
 
     val predicate = ExpressionCanonicalizer.execute(

--- a/core/src/main/scala/org/apache/spark/sql/execution/columnar/ExternalStore.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/columnar/ExternalStore.scala
@@ -19,14 +19,18 @@ package org.apache.spark.sql.execution.columnar
 import java.nio.ByteBuffer
 import java.sql.Connection
 
+import scala.util.control.NonFatal
+
+import com.pivotal.gemfirexd.internal.engine.distributed.utils.GemFireXDUtils
 import com.pivotal.gemfirexd.internal.impl.jdbc.EmbedConnection
 
+import org.apache.spark.Logging
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.sources.ConnectionProperties
 import org.apache.spark.sql.types.StructType
 
-trait ExternalStore extends Serializable {
+trait ExternalStore extends Serializable with Logging {
 
   final val columnPrefix = "COL_"
 
@@ -64,11 +68,22 @@ trait ExternalStore extends Serializable {
       if (closeOnSuccessOrFailure && !conn.isInstanceOf[EmbedConnection] && !conn.isClosed) {
         try {
           if (success) conn.commit()
-          else conn.rollback()
+          else handleRollback(conn.rollback)
         } finally {
           conn.close()
         }
       }
+    }
+  }
+
+  def handleRollback(rollback: () => Unit, finallyCode: () => Unit = null): Unit = {
+    try {
+      rollback()
+    } catch {
+      case NonFatal(e) =>
+        if (GemFireXDUtils.retryToBeDone(e)) logInfo(e.toString) else logWarning(e.toString, e)
+    } finally {
+      if (finallyCode ne null) finallyCode()
     }
   }
 }

--- a/core/src/main/scala/org/apache/spark/sql/execution/columnar/JDBCAppendableRelation.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/columnar/JDBCAppendableRelation.scala
@@ -141,7 +141,7 @@ abstract case class JDBCAppendableRelation(
 
   override def getInsertPlan(relation: LogicalRelation,
       child: SparkPlan): SparkPlan = {
-    new ColumnInsertExec(child, Seq.empty, Seq.empty, this, table)
+    new ColumnInsertExec(child, Nil, Nil, this, table)
   }
 
   override def insert(data: DataFrame, overwrite: Boolean): Unit = {

--- a/core/src/main/scala/org/apache/spark/sql/execution/columnar/impl/ColumnFormatEntry.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/columnar/impl/ColumnFormatEntry.scala
@@ -86,6 +86,8 @@ object ColumnFormatEntry {
   // table index mapping code depends on this being the smallest meta-column
   // (see ColumnDelta.tableColumnIndex and similar methods)
   val DELETE_MASK_COL_INDEX: Int = -3
+
+  private[columnar] val dummyStats = new DummyCachePerfStats
 }
 
 /**
@@ -428,7 +430,10 @@ class ColumnFormatValue extends SerializedDiskBuffer
 
   @inline private def getCachePerfStats(context: RegionEntryContext): CachePerfStats = {
     if (context ne null) context.getCachePerfStats
-    else GemFireCacheImpl.getExisting.getCachePerfStats
+    else {
+      val cache = GemFireCacheImpl.getInstance()
+      if (cache ne null) cache.getCachePerfStats else ColumnFormatEntry.dummyStats
+    }
   }
 
   private def decompressValue(buffer: ByteBuffer): ColumnFormatValue = {

--- a/core/src/main/scala/org/apache/spark/sql/execution/columnar/impl/JDBCSourceAsColumnarStore.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/columnar/impl/JDBCSourceAsColumnarStore.scala
@@ -588,12 +588,12 @@ class JDBCSourceAsColumnarStore(private var _connProperties: ConnectionPropertie
         tableName + ".COLUMN_TABLE.DECOMPRESS", schema.fields, () => {
           val schemaAttrs = schema.toAttributes
           val tableScan = ColumnTableScan(schemaAttrs, dataRDD = null,
-            otherRDDs = Seq.empty, numBuckets = -1,
-            partitionColumns = Seq.empty, partitionColumnAliases = Seq.empty,
-            baseRelation = null, schema, allFilters = Seq.empty, schemaAttrs,
+            otherRDDs = Nil, numBuckets = -1,
+            partitionColumns = Nil, partitionColumnAliases = Nil,
+            baseRelation = null, schema, allFilters = Nil, schemaAttrs,
             caseSensitive = true)
           val insertPlan = RowInsertExec(tableScan, putInto = true,
-            Seq.empty, Seq.empty, numBuckets = -1, isPartitioned = false, schema,
+            Nil, Nil, numBuckets = -1, isPartitioned = false, schema,
             None, onExecutor = true, tableName, connProperties)
           // now generate the code with the help of WholeStageCodegenExec
           // this is only used for local code generation while its RDD

--- a/core/src/main/scala/org/apache/spark/sql/execution/columnar/impl/JDBCSourceAsColumnarStore.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/columnar/impl/JDBCSourceAsColumnarStore.scala
@@ -17,7 +17,7 @@
 package org.apache.spark.sql.execution.columnar.impl
 
 import java.nio.ByteBuffer
-import java.sql.{Connection, ResultSet, Statement}
+import java.sql.{Connection, PreparedStatement, ResultSet, Statement}
 import java.util.Collections
 
 import scala.annotation.meta.param
@@ -54,14 +54,14 @@ import org.apache.spark.sql.store.{CodeGeneration, StoreUtils}
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.sql.{SnappyContext, SnappySession, SparkSession, ThinClientConnectorMode}
 import org.apache.spark.util.TaskCompletionListener
-import org.apache.spark.{Logging, Partition, TaskContext}
+import org.apache.spark.{Partition, TaskContext}
 
 /**
  * Column Store implementation for GemFireXD.
  */
 class JDBCSourceAsColumnarStore(private var _connProperties: ConnectionProperties,
     var numPartitions: Int, private var _tableName: String, var schema: StructType)
-    extends ExternalStore with KryoSerializable with Logging {
+    extends ExternalStore with KryoSerializable {
 
   self =>
 
@@ -184,7 +184,7 @@ class JDBCSourceAsColumnarStore(private var _connProperties: ConnectionPropertie
       } finally {
         try {
           if (!success && !conn.isClosed) {
-            conn.rollback()
+            handleRollback(conn.rollback)
           }
         } finally {
           conn.close()
@@ -202,18 +202,18 @@ class JDBCSourceAsColumnarStore(private var _connProperties: ConnectionPropertie
           case ConnectionType.Embedded =>
             Misc.getGemFireCache.getCacheTransactionManager.rollback()
           case _ =>
-            logDebug(s"Going to rollback $txId the transaction on server on wconn $conn ")
-            val ps = conn.prepareStatement(s"call sys.ROLLBACK_SNAPSHOT_TXID(?)")
-            ps.setString(1, if (txId ne null) txId else "")
-            try {
+            logDebug(s"Going to rollback transaction $txId on server using $conn")
+            var ps: PreparedStatement = null
+            handleRollback(() => {
+              ps = conn.prepareStatement(s"call sys.ROLLBACK_SNAPSHOT_TXID(?)")
+              ps.setString(1, if (txId ne null) txId else "")
               ps.executeUpdate()
-              logDebug(s"The txid being rolledback is $txId")
-            }
-            finally {
-              ps.close()
+              logDebug(s"The transaction ID being rolled back is $txId")
+            }, () => {
+              if (ps ne null) ps.close()
               SparkConnectorRDDHelper.snapshotTxIdForWrite.set(null)
               logDebug(s"Rolled back $txId the transaction on server ")
-            }
+            })
         }
       }
     }(conn)

--- a/core/src/main/scala/org/apache/spark/sql/execution/columnar/impl/StoreCallbacksImpl.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/columnar/impl/StoreCallbacksImpl.scala
@@ -101,9 +101,7 @@ object StoreCallbacksImpl extends StoreCallbacks with Logging with Serializable 
             val tables = Misc.getMemStore.getAllContainers.asScala.
                 map(x => (x.getSchemaName + "." + x.getTableName, x.fetchHiveMetaData(false)))
             catalogEntry.dependents.toSeq.map(x => tables.find(x == _._1).get._2)
-          } else {
-            Seq.empty
-          }
+          } else Nil
 
           val tableName = container.getQualifiedTableName
           // add weightage column for sample tables if required

--- a/core/src/main/scala/org/apache/spark/sql/execution/datasources/StoreDataSourceStrategy.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/datasources/StoreDataSourceStrategy.scala
@@ -55,7 +55,7 @@ private[sql] object StoreDataSourceStrategy extends Strategy {
         projects,
         filters,
         0,
-        Seq.empty[String],
+        Nil,
         (a, f) => t.buildUnsafeScan(a.map(_.name).toArray, f)) :: Nil
     case _ => Nil
   }
@@ -127,7 +127,7 @@ private[sql] object StoreDataSourceStrategy extends Strategy {
       joinedCols.map(j => projects.collect {
         case a@Alias(child, _) if child.semanticEquals(j) => a.toAttribute
       })
-    } else Seq.empty
+    } else Nil
     val metadata: Map[String, String] = if (numBuckets > 0) {
       Map.empty[String, String]
     } else {

--- a/core/src/main/scala/org/apache/spark/sql/execution/ddl.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/ddl.scala
@@ -43,7 +43,7 @@ private[sql] case class CreateMetastoreTableUsing(
     snc.createTable(snc.sessionState.catalog
         .newQualifiedTableName(tableIdent), provider, userSpecifiedSchema,
       schemaDDL, mode, snc.addBaseTableOption(baseTable, options), isBuiltIn)
-    Seq.empty
+    Nil
   }
 }
 
@@ -65,7 +65,7 @@ private[sql] case class CreateMetastoreTableUsingSelect(
     snc.createTable(catalog.newQualifiedTableName(tableIdent), provider,
       userSpecifiedSchema, schemaDDL, partitionColumns, mode,
       snc.addBaseTableOption(baseTable, options), query, isBuiltIn)
-    Seq.empty
+    Nil
   }
 }
 
@@ -87,7 +87,7 @@ private[sql] case class DropTableOrViewCommand(isView: Boolean, ifExists: Boolea
         "Cannot drop a view with DROP TABLE. Please use DROP VIEW instead")
     }
     snc.dropTable(qualifiedName, ifExists, resolveRelation = true)
-    Seq.empty
+    Nil
   }
 }
 
@@ -99,7 +99,7 @@ private[sql] case class TruncateManagedTableCommand(ifExists: Boolean,
     val catalog = snc.sessionState.catalog
     snc.truncateTable(catalog.newQualifiedTableName(tableIdent),
       ifExists, ignoreIfUnsupported = false)
-    Seq.empty
+    Nil
   }
 }
 
@@ -110,7 +110,7 @@ private[sql] case class AlterTableAddColumnCommand(tableIdent: TableIdentifier,
     val snc = session.asInstanceOf[SnappySession]
     val catalog = snc.sessionState.catalog
     snc.alterTable(catalog.newQualifiedTableName(tableIdent), isAddColumn = true, addColumn)
-    Seq.empty
+    Nil
   }
 }
 
@@ -134,7 +134,7 @@ private[sql] case class AlterTableDropColumnCommand(
       }
     val table = catalog.newQualifiedTableName(tableIdent)
     snc.alterTable(table, isAddColumn = false, structField)
-    Seq.empty
+    Nil
   }
 }
 
@@ -149,7 +149,7 @@ private[sql] case class CreateIndexCommand(indexName: TableIdentifier,
     val tableIdent = catalog.newQualifiedTableName(baseTable)
     val indexIdent = catalog.newQualifiedTableName(indexName)
     snc.createIndex(indexIdent, tableIdent, indexColumns, options)
-    Seq.empty
+    Nil
   }
 }
 
@@ -162,7 +162,7 @@ private[sql] case class DropIndexCommand(
     val catalog = snc.sessionState.catalog
     val indexIdent = catalog.newQualifiedTableName(indexName)
     snc.dropIndex(indexIdent, ifExists)
-    Seq.empty
+    Nil
   }
 }
 
@@ -170,7 +170,7 @@ private[sql] case class SetSchemaCommand(schemaName: String) extends RunnableCom
 
   override def run(sparkSession: SparkSession): Seq[Row] = {
     sparkSession.asInstanceOf[SnappySession].setSchema(schemaName)
-    Seq.empty[Row]
+    Nil
   }
 }
 
@@ -208,6 +208,6 @@ private[sql] case class SnappyStreamingActionsCommand(action: Int,
           // "There is no running Streaming Context to be stopped")
         }
     }
-    Seq.empty[Row]
+    Nil
   }
 }

--- a/core/src/main/scala/org/apache/spark/sql/execution/row/RowFormatRelation.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/row/RowFormatRelation.scala
@@ -182,7 +182,7 @@ class RowFormatRelation(
               .asInstanceOf[GfxdPartitionByExpressionResolver]
           val parColumn = resolver.getColumnNames
           (pr.getTotalNumberOfBuckets, true, parColumn.toSeq)
-        case _ => (1, false, Seq.empty[String])
+        case _ => (1, false, Nil)
       }
     }
   }

--- a/core/src/main/scala/org/apache/spark/sql/hive/ConnectorCatalog.scala
+++ b/core/src/main/scala/org/apache/spark/sql/hive/ConnectorCatalog.scala
@@ -231,7 +231,7 @@ trait ConnectorCatalog extends SnappyStoreHiveCatalog {
 
 case class RelationInfo(numBuckets: Int = 1,
     isPartitioned: Boolean = false,
-    partitioningCols: Seq[String] = Seq.empty,
+    partitioningCols: Seq[String] = Nil,
     indexCols: Array[String] = Array.empty,
     pkCols: Array[String] = Array.empty,
     partitions: Array[org.apache.spark.Partition] = Array.empty,

--- a/core/src/main/scala/org/apache/spark/sql/hive/SnappyStoreHiveCatalog.scala
+++ b/core/src/main/scala/org/apache/spark/sql/hive/SnappyStoreHiveCatalog.scala
@@ -226,7 +226,7 @@ class SnappyStoreHiveCatalog(externalCatalog: SnappyExternalCatalog,
         }
 
         (LogicalRelation(relation, catalogTable = Some(table)), table, RelationInfo(
-          0, isPartitioned = false, Seq.empty, Array.empty, Array.empty, Array.empty, -1))
+          0, isPartitioned = false, Nil, Array.empty, Array.empty, Array.empty, -1))
       }
     }
 
@@ -644,7 +644,7 @@ class SnappyStoreHiveCatalog(externalCatalog: SnappyExternalCatalog,
             schema
           case None => relation match {
             case Some(r) => r.schema
-            case _ => StructType(Seq.empty)
+            case _ => StructType(Nil)
           }
         }
         val schemaJsonString = tableSchema.json
@@ -1105,7 +1105,7 @@ object SnappyStoreHiveCatalog {
       Seq[(LogicalPlan, String)]] = CacheBuilder.newBuilder().maximumSize(1).build(
     new CacheLoader[QualifiedTableName, Seq[(LogicalPlan, String)]]() {
       override def load(in: QualifiedTableName): Seq[(LogicalPlan, String)] = {
-        Seq.empty
+        Nil
       }
     })
 

--- a/core/src/main/scala/org/apache/spark/sql/internal/ColumnTableBulkOps.scala
+++ b/core/src/main/scala/org/apache/spark/sql/internal/ColumnTableBulkOps.scala
@@ -18,7 +18,7 @@ package org.apache.spark.sql.internal
 
 import io.snappydata.Property
 
-import org.apache.spark.sql.catalyst.encoders.{ExpressionEncoder, RowEncoder}
+import org.apache.spark.sql.catalyst.encoders.RowEncoder
 import org.apache.spark.sql.catalyst.expressions.{And, Attribute, AttributeReference, EqualTo, Expression}
 import org.apache.spark.sql.catalyst.plans.logical.{BinaryNode, Join, LogicalPlan, OverwriteOptions, Project}
 import org.apache.spark.sql.catalyst.plans.{Inner, LeftAnti}
@@ -26,7 +26,7 @@ import org.apache.spark.sql.collection.Utils
 import org.apache.spark.sql.execution.datasources.LogicalRelation
 import org.apache.spark.sql.sources._
 import org.apache.spark.sql.types.{DataType, LongType}
-import org.apache.spark.sql.{AnalysisException, Dataset, Row, SnappyContext, SnappySession, SparkSession}
+import org.apache.spark.sql.{AnalysisException, Dataset, SnappySession, SparkSession}
 
 /**
   * Helper object for PutInto operations for column tables.
@@ -60,9 +60,9 @@ object ColumnTableBulkOps {
     var transFormedPlan: LogicalPlan = originalPlan
 
     table.collectFirst {
-      case LogicalRelation(mutable: BulkPutRelation, _, _) => {
+      case LogicalRelation(mutable: BulkPutRelation, _, _) =>
         val putKeys = mutable.getPutKeys()
-        if (!putKeys.isDefined) {
+        if (putKeys.isEmpty) {
           throw new AnalysisException(
             s"PutInto in a column table requires key column(s) but got empty string")
         }
@@ -93,14 +93,13 @@ object ColumnTableBulkOps {
 
         val insertPlan = new Insert(table, Map.empty[String,
             Option[String]], Project(subQuery.output, insertChild),
-          OverwriteOptions(false), ifNotExists = false)
+          OverwriteOptions(enabled = false), ifNotExists = false)
 
         val updateExpressions = insertChild.output.filterNot(a => keyColumns.contains(a.name))
-        val updatePlan = Update(table, updateSubQuery, Seq.empty,
+        val updatePlan = Update(table, updateSubQuery, Nil,
           updateColumns, updateExpressions)
 
         transFormedPlan = PutIntoColumnTable(table, insertPlan, updatePlan)
-      }
       case _ => // Do nothing, original putInto plan is enough
     }
     transFormedPlan
@@ -130,15 +129,13 @@ object ColumnTableBulkOps {
       }
     }
     val joinPairs = leftKeys.zip(rightKeys)
-    val newCondition = (joinPairs.map(EqualTo.tupled)).reduceOption(And)
+    val newCondition = joinPairs.map(EqualTo.tupled).reduceOption(And)
     newCondition
   }
 
   def getKeyColumns(table: LogicalPlan): Seq[String] = {
     table.collectFirst {
-      case lr@LogicalRelation(mutable: MutableRelation, _, _) =>
-        val ks = mutable.getKeyColumns
-        ks
+      case LogicalRelation(mutable: MutableRelation, _, _) => mutable.getKeyColumns
     }.getOrElse(throw new AnalysisException(
       s"Update/Delete requires a MutableRelation but got $table"))
 
@@ -151,16 +148,15 @@ object ColumnTableBulkOps {
     var transFormedPlan: LogicalPlan = originalPlan
 
     table.collectFirst {
-      case LogicalRelation(mutable: BulkPutRelation, _, _) => {
+      case LogicalRelation(mutable: BulkPutRelation, _, _) =>
         val putKeys = mutable.getPutKeys()
-        if (!putKeys.isDefined) {
+        if (putKeys.isEmpty) {
           throw new AnalysisException(
             s"DeleteFrom in a column table requires key column(s) but got empty string")
         }
         val condition = prepareCondition(sparkSession, table, subQuery, putKeys.get)
         val exists = Join(subQuery, table, Inner, condition)
-        transFormedPlan = Delete(table, exists, Seq.empty[Attribute])
-      }
+        transFormedPlan = Delete(table, exists, Nil)
       case _ => // Do nothing, original DeleteFromTable plan is enough
     }
     transFormedPlan

--- a/core/src/main/scala/org/apache/spark/sql/internal/SnappySessionState.scala
+++ b/core/src/main/scala/org/apache/spark/sql/internal/SnappySessionState.scala
@@ -259,7 +259,7 @@ class SnappySessionState(snappySession: SnappySession)
             // if this is a row table, then fallback to direct execution
             mutable match {
               case _: UpdatableRelation if currentKey ne null =>
-                return (Seq.empty, DMLExternalTable(catalog.newQualifiedTableName(
+                return (Nil, DMLExternalTable(catalog.newQualifiedTableName(
                   mutable.table), lr, currentKey.sqlText), lr)
               case _ =>
                 throw new AnalysisException(

--- a/core/src/main/scala/org/apache/spark/sql/row/JDBCMutableRelation.scala
+++ b/core/src/main/scala/org/apache/spark/sql/row/JDBCMutableRelation.scala
@@ -90,9 +90,9 @@ case class JDBCMutableRelation(
   final lazy val schemaFields: Map[String, StructField] =
     Utils.schemaFields(schema)
 
-  def partitionColumns: Seq[String] = Seq.empty
+  def partitionColumns: Seq[String] = Nil
 
-  def partitionExpressions(relation: LogicalRelation): Seq[Expression] = Seq.empty
+  def partitionExpressions(relation: LogicalRelation): Seq[Expression] = Nil
 
   def numBuckets: Int = -1
 

--- a/core/src/main/scala/org/apache/spark/sql/sources/DependencyCatalog.scala
+++ b/core/src/main/scala/org/apache/spark/sql/sources/DependencyCatalog.scala
@@ -89,7 +89,7 @@ object DependencyCatalog {
     val sync = lock.readLock()
     sync.lock()
     try {
-      parentToDependentsMap.get(tableName).map(_.toSeq).getOrElse(Seq.empty)
+      parentToDependentsMap.get(tableName).map(_.toSeq).getOrElse(Nil)
     } finally {
       sync.unlock()
     }

--- a/core/src/main/scala/org/apache/spark/sql/sources/RuleUtils.scala
+++ b/core/src/main/scala/org/apache/spark/sql/sources/RuleUtils.scala
@@ -96,7 +96,7 @@ object RuleUtils extends PredicateHelper {
       var currentReachablePaths = replicatedReachablePaths
       val newChains = source.flatMap { rep1 =>
         val (otherSide, remainingPaths) = currentReachablePaths.foldLeft(
-          (Seq.empty[LogicalPlan], currentReachablePaths)) {
+          (Nil.asInstanceOf[Seq[LogicalPlan]], currentReachablePaths)) {
           case ((otherKey, current), plan) =>
             plan match {
               case l :: r :: o if o.isEmpty & (l == rep1) =>
@@ -214,7 +214,7 @@ object RuleUtils extends PredicateHelper {
               predicates
             case SubqueryAlias(alias, _, _) if alias.equals(t) =>
               predicates
-            case _ => Seq.empty
+            case _ => Nil
           }
       } if filterCols.nonEmpty
 
@@ -363,7 +363,7 @@ object HasColocatedEntities {
             Replacement(subquery, SubqueryAlias(alias, rightPlan, None))
         }
         ((leftRelation.get, rightRelation.get),
-            ReplacementSet(ArrayBuffer(leftReplacement, rightReplacement), Seq.empty))
+            ReplacementSet(ArrayBuffer(leftReplacement, rightReplacement), Nil))
       }
     }
 
@@ -457,7 +457,7 @@ case class ReplacementSet(chain: ArrayBuffer[Replacement],
         flatMap(_.permutations).filter(hasJoinConditions)).filter(_.nonEmpty)
 
     if(feasibleJoinPlan.isEmpty) {
-      Seq.empty
+      Nil
     } else {
       val all = feasibleJoinPlan.sortBy { jo =>
         estimateSize(jo)

--- a/core/src/main/scala/org/apache/spark/sql/sources/SnappyOptimizations.scala
+++ b/core/src/main/scala/org/apache/spark/sql/sources/SnappyOptimizations.scala
@@ -187,7 +187,7 @@ case class ResolveIndex(implicit val snappySession: SnappySession) extends Rule[
         .getOrElse(Replacement(r, r)))
 
     val replicatesWithColocated = ReplacementSet(replicates.map(r => Replacement(r, r, false)) ++
-        (if (colocationGroups.nonEmpty) colocationGroups.head.chain else Seq.empty), conditions)
+        (if (colocationGroups.nonEmpty) colocationGroups.head.chain else Nil), conditions)
 
     val replicatesWithNonColocatedHavingFilters = nonColocatedWithFilters.map(nc =>
       ReplacementSet(replicates.map(r => Replacement(r, r)) ++ Some(nc), conditions)).sorted
@@ -202,7 +202,7 @@ case class ResolveIndex(implicit val snappySession: SnappySession) extends Rule[
       r.mappedConditions(conditions)
     }
 
-    var curPlan = CompletePlan(null, Seq.empty)
+    var curPlan = CompletePlan(null, Nil)
 
     // there are no Non-Colocated tables of lesser cost than colocation chain in consideration.
     if (smallerNC == -1) {
@@ -348,7 +348,7 @@ case class ResolveIndex(implicit val snappySession: SnappySession) extends Rule[
         val joinKeys = joinConditions.flatMap {
           case (leftA: AttributeReference, rightA: AttributeReference) =>
             Seq((leftA.name, rightA.name))
-          case _ => Seq.empty[(String, String)]
+          case _ => Nil
         }
 
         val hasJoinKeys = Function.tupled[INDEX_RELATION, INDEX_RELATION, Boolean] {

--- a/core/src/main/scala/org/apache/spark/sql/sources/StoreStrategy.scala
+++ b/core/src/main/scala/org/apache/spark/sql/sources/StoreStrategy.scala
@@ -223,7 +223,7 @@ private[sql] case class DeleteFromTable(
 
   override def children: Seq[LogicalPlan] = table :: child :: Nil
 
-  override def output: Seq[Attribute] = Seq.empty
+  override def output: Seq[Attribute] = Nil
 
   override lazy val resolved: Boolean = childrenResolved &&
       child.output.zip(table.output).forall {

--- a/core/src/main/scala/org/apache/spark/sql/store/CompressionUtils.scala
+++ b/core/src/main/scala/org/apache/spark/sql/store/CompressionUtils.scala
@@ -19,9 +19,10 @@ package org.apache.spark.sql.store
 
 import java.nio.{ByteBuffer, ByteOrder}
 
-import com.gemstone.gemfire.internal.shared.BufferAllocator
 import com.gemstone.gemfire.internal.shared.unsafe.UnsafeHolder
+import com.gemstone.gemfire.internal.shared.{BufferAllocator, SystemProperties}
 import com.ning.compress.lzf.{LZFDecoder, LZFEncoder}
+import io.snappydata.Constant
 import net.jpountz.lz4.LZ4Factory
 import org.xerial.snappy.Snappy
 
@@ -45,7 +46,8 @@ object CompressionUtils {
   private[this] val COMPRESSION_HEADER_SIZE = 8
   private[this] val MIN_COMPRESSION_RATIO = 0.75
   /** minimum size of buffer that will be considered for compression */
-  private[sql] val MIN_COMPRESSION_SIZE = 2048
+  private[sql] val MIN_COMPRESSION_SIZE =
+    SystemProperties.getServerInstance.getInteger(Constant.COMPRESSION_MIN_SIZE, 2048)
 
   private def writeCompressionHeader(codecId: Int,
       uncompressedLen: Int, buffer: ByteBuffer): Unit = {

--- a/core/src/main/scala/org/apache/spark/sql/store/StoreUtils.scala
+++ b/core/src/main/scala/org/apache/spark/sql/store/StoreUtils.scala
@@ -133,7 +133,7 @@ object StoreUtils {
       val primary = region.getOrCreateNodeForBucketWrite(bucketId, null).canonicalString()
       SnappyContext.getBlockId(primary) match {
         case Some(b) => Seq(Utils.getHostExecutorId(b.blockId))
-        case None => Seq.empty
+        case None => Nil
       }
     } else {
       var prependPrimary = preferPrimaries
@@ -496,7 +496,7 @@ object StoreUtils {
       parameters: mutable.Map[String, String]): Seq[String] = {
     parameters.get(PARTITION_BY).map(v => {
       v.split(",").toSeq.map(a => a.trim)
-    }).getOrElse(Seq.empty[String])
+    }).getOrElse(Nil)
   }
 
   def getColumnUpdateDeleteOrdering(batchIdColumn: Attribute): SortOrder = {

--- a/core/src/main/scala/org/apache/spark/sql/streaming/StreamBaseRelation.scala
+++ b/core/src/main/scala/org/apache/spark/sql/streaming/StreamBaseRelation.scala
@@ -82,7 +82,7 @@ abstract class StreamBaseRelation(opts: Map[String, String])
       // search for existing dependents in the catalog (these may still not
       //   have been initialized e.g. after recovery, so add explicitly)
       val catalog = context.snappySession.sessionState.catalog
-      val initDependents = catalog.getDataSourceTables(Seq.empty,
+      val initDependents = catalog.getDataSourceTables(Nil,
         Some(tableName)).map(_.toString())
       (stream, initDependents)
     })

--- a/dtests/src/test/java/io/snappydata/hydra/cluster/startDualModeCluster_smoke.bt
+++ b/dtests/src/test/java/io/snappydata/hydra/cluster/startDualModeCluster_smoke.bt
@@ -1,5 +1,5 @@
 io/snappydata/hydra/cluster/startDualModeCluster.conf
   A=snappyStore snappyStoreHosts=3 snappyStoreVMsPerHost=1 snappyStoreThreadsPerVM=1
-  B=lead leadHosts=1 leadVMsPerHost=1 leadThreadsPerVM=1
+  B=lead leadHosts=1 leadVMsPerHost=1 leadThreadsPerVM=2
   C=locator locatorHosts=1 locatorVMsPerHost=1 locatorThreadsPerVM=1
   D=worker workerHosts=1 workerVMsPerHost=1 workerThreadsPerVM=1

--- a/dtests/src/test/java/io/snappydata/hydra/cluster/startDualModeCluster_smoke.bt
+++ b/dtests/src/test/java/io/snappydata/hydra/cluster/startDualModeCluster_smoke.bt
@@ -1,0 +1,5 @@
+io/snappydata/hydra/cluster/startDualModeCluster.conf
+  A=snappyStore snappyStoreHosts=3 snappyStoreVMsPerHost=1 snappyStoreThreadsPerVM=1
+  B=lead leadHosts=1 leadVMsPerHost=1 leadThreadsPerVM=1
+  C=locator locatorHosts=1 locatorVMsPerHost=1 locatorThreadsPerVM=1
+  D=worker workerHosts=1 workerVMsPerHost=1 workerThreadsPerVM=1

--- a/dtests/src/test/java/io/snappydata/hydra/smoke.sh
+++ b/dtests/src/test/java/io/snappydata/hydra/smoke.sh
@@ -42,7 +42,7 @@ shift
 
 #java -ea -cp $SNAPPYDATA_SOURCE_DIR/cluster/build-artifacts/scala-2.11/libs/snappydata-cluster_2.11-1.0.0-tests.jar io.snappydata.benchmark.snappy.TPCHPerfComparer $resultDir
 
-$SNAPPYDATA_SOURCE_DIR/store/tests/core/src/main/java/bin/sample-runbt.sh $resultDir $SNAPPYDATA_SOURCE_DIR  -r 1  -d false io/snappydata/hydra/cluster/startDualModeCluster.bt
+$SNAPPYDATA_SOURCE_DIR/store/tests/core/src/main/java/bin/sample-runbt.sh $resultDir $SNAPPYDATA_SOURCE_DIR  -r 1  -d false io/snappydata/hydra/cluster/startDualModeCluster_smoke.bt
 sleep 30;
 
 $SNAPPYDATA_SOURCE_DIR/store/tests/core/src/main/java/bin/sample-runbt.sh $resultDir $SNAPPYDATA_SOURCE_DIR  -r 1  -d false io/snappydata/hydra/smoke.bt

--- a/dtests/src/test/scala/io/snappydata/hydra/SnappyHydraRunner.scala
+++ b/dtests/src/test/scala/io/snappydata/hydra/SnappyHydraRunner.scala
@@ -65,15 +65,16 @@ class SnappyHydraRunner extends SnappyTestRunner {
     val c14 = "grep -v java.lang.reflect.InvocationTargetException"
     val c15 = "grep -v org.apache.spark.storage.ShuffleBlockFetcherIterator." +
         "throwFetchFailedException"
-    /*val c16 = "grep \'status:[:space]stopping\'[:space]-e[:space]\'java.lang" +
-        ".IllegalStateException\'"*/
+    /* val c16 = "grep \'status:[:space]stopping\'[:space]-e[:space]\'java.lang" +
+        ".IllegalStateException\'" */
     val c17 = "grep -v com.gemstone.gemfire.distributed.LockServiceDestroyedException"
-    /*val c18 = "grep GemFireIOException:[:space]Current[:space]operations[:space]did[:space]not" +
+    /* val c18 = "grep GemFireIOException:[:space]Current[:space]operations[:space]did[:space]not" +
         "[:space]distribute[:space]within"
     val c19 = "grep SparkException:[:space]External[:space]scheduler[:space]cannot[:space]be" +
-        "[:space]instantiated"*/
+        "[:space]instantiated" */
+    val c20 = Seq("grep", "-v", "Failed to retrieve information for")
     val command1 = c1 #| c2 #| c3 #| c4 #| c5 #| c6 #| c7 #| c8 #| c12 #| c13 #| c14 #| c15 #|
-        /*c16 #|*/ c17 /*#| c18 #| c19*/
+        /* c16 #| */ c17 /* #| c18 #| c19 */ #| c20
     // TODO : handle case where the logDir path is incorrect or doesn't exists
     try {
       val output1: String = command1.!!


### PR DESCRIPTION
Issue was due to compression when sending buffer in smart connector mode to remote node
(for some reason workers not colocated?). Gets CachePerfStats but fails with no cache then
tries to rollback which again fails because previous send over the socket was a partial one.

In current tests remote put should not have happened but is happening occasionally which
is another issue that may need to be tracked.

## Changes proposed in this pull request

- stats being used for compression/decompression are not available in smart connector mode
  so use dummy stats for the same; it will also cause no exceptions if cache is going down
  which is fine
- added a ExternalStore.handleRollback to avoid throwing exceptions in rollback
  else it hides the main exception
- handle occasional failures in smoke tests due to NPE in stats provider during table drop;
  since hive client does not take a DD lock (deliberately) so it can throw runtime exceptions
  if reading a table metadata while being dropped
- added cluster with single locator/lead for smoke tests

## Patch testing

precheckin

## ReleaseNotes.txt changes

NA

## Other PRs 

https://github.com/SnappyDataInc/snappy-store/pull/366