### PR TITLE
[SNAP-2212] re-evaluate check condition for all values of a key in joins

### DIFF
--- a/core/src/main/scala/org/apache/spark/sql/execution/ObjectHashMapAccessor.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/ObjectHashMapAccessor.scala
@@ -763,7 +763,7 @@ case class ObjectHashMapAccessor(@transient session: SnappySession,
   // scalastyle:off
   def generateMapLookup(entryVar: String, localValueVar: String,
       keyIsUnique: String, numRows: String, nullMaskVars: Array[String],
-      initCode: String, checkCond: (Option[ExprCode], String),
+      initCode: String, checkCond: (Option[ExprCode], String, Option[Expression]),
       streamKeys: Seq[Expression], streamKeyVars: Seq[ExprCode],
       streamOutput: Seq[Attribute], buildKeyVars: Seq[ExprCode],
       buildVars: Seq[ExprCode], input: Seq[ExprCode],
@@ -918,17 +918,17 @@ case class ObjectHashMapAccessor(@transient session: SnappySession,
     //    is always evaluated) -- see the evaluateRequiredVariables call in
     // base CodegenSupport.consume
     val checkCondition = checkCond._1
-    val inputCodes = if (checkCondition.isDefined) {
-      // evaluate all of input
-      evaluateVariables(input) + '\n' + checkCond._2
-    } else buildSide match {
+    val (checkCode, usedInputs) = if (checkCondition.isDefined) {
+      // add any additional inputs used by check condition
+      (checkCond._2, cParent.usedInputs ++ checkCond._3.get.references)
+    } else ("", cParent.usedInputs)
+    val inputCodes = buildSide match {
       case BuildRight =>
         // input streamed plan is on left
-        evaluateRequiredVariables(consumer.output, input, cParent.usedInputs)
+        evaluateRequiredVariables(consumer.output, input, usedInputs)
       case BuildLeft =>
         // input streamed plan is on right
-        evaluateRequiredVariables(consumer.output.takeRight(input.size),
-          input, cParent.usedInputs)
+        evaluateRequiredVariables(consumer.output.takeRight(input.size), input, usedInputs)
     }
 
     // Code fragments for different join types.
@@ -938,29 +938,29 @@ case class ObjectHashMapAccessor(@transient session: SnappySession,
     // will be the common parent's consume call.
     val entryConsume = joinType match {
       case Inner => genInnerJoinCodes(entryVar, mapKeyCodes, checkCondition,
-        numRows, getConsumeResultCode(numRows, resultVars),
+        checkCode, numRows, getConsumeResultCode(numRows, resultVars),
         keyIsUnique, declareLocalVars, moveNextValue, inputCodes)
 
       case LeftOuter | RightOuter =>
         // instantiate code for buildVars before calling getConsumeResultCode
         val buildInitCode = evaluateVariables(buildVars)
         genOuterJoinCodes(entryVar, buildVars, buildInitCode, mapKeyCodes,
-          checkCondition, numRows, getConsumeResultCode(numRows, resultVars),
+          checkCondition, checkCode, numRows, getConsumeResultCode(numRows, resultVars),
           keyIsUnique, declareLocalVars, moveNextValue, inputCodes)
 
       case LeftSemi => genSemiJoinCodes(entryVar, mapKeyCodes, checkCondition,
-        numRows, getConsumeResultCode(numRows, input),
+        checkCode, numRows, getConsumeResultCode(numRows, input),
         keyIsUnique, declareLocalVars, moveNextValue, inputCodes)
 
       case LeftAnti => genAntiJoinCodes(entryVar, mapKeyCodes, checkCondition,
-        numRows, getConsumeResultCode(numRows, input),
+        checkCode, numRows, getConsumeResultCode(numRows, input),
         keyIsUnique, declareLocalVars, moveNextValue, inputCodes)
 
       case _: ExistenceJoin =>
         // declare and add the exists variable to resultVars
         val existsVar = ctx.freshName("exists")
         genExistenceJoinCodes(entryVar, existsVar, mapKeyCodes,
-          checkCondition, numRows, getConsumeResultCode(numRows,
+          checkCondition, checkCode, numRows, getConsumeResultCode(numRows,
             input :+ ExprCode("", "false", existsVar)), keyIsUnique,
           declareLocalVars, moveNextValue, inputCodes)
 
@@ -1045,7 +1045,7 @@ case class ObjectHashMapAccessor(@transient session: SnappySession,
   }
 
   private def genInnerJoinCodes(entryVar: String, mapKeyCodes: String,
-      checkCondition: Option[ExprCode], numRows: String,
+      checkCondition: Option[ExprCode], checkCode: String, numRows: String,
       consumeResult: String, keyIsUnique: String, declareLocalVars: String,
       moveNextValue: String, inputCodes: String): String = {
 
@@ -1065,6 +1065,7 @@ case class ObjectHashMapAccessor(@transient session: SnappySession,
       $mapKeyCodes
       $inputCodes
       while (true) {
+        $checkCode
         do { // single iteration loop meant for breaking out with "continue"
           $consumeCode
         } while (false);
@@ -1080,7 +1081,7 @@ case class ObjectHashMapAccessor(@transient session: SnappySession,
   // scalastyle:off
   private def genOuterJoinCodes(entryVar: String, buildVars: Seq[ExprCode],
       buildInitCode: String, mapKeyCodes: String,
-      checkCondition: Option[ExprCode], numRows: String,
+      checkCondition: Option[ExprCode], checkCode: String, numRows: String,
       consumeResult: String, keyIsUnique: String, declareLocalVars: String,
       moveNextValue: String, inputCodes: String): String = {
   // scalastyle:on
@@ -1115,6 +1116,7 @@ case class ObjectHashMapAccessor(@transient session: SnappySession,
       $mapKeyCodes
       $inputCodes
       while (true) {
+        $checkCode
         do { // single iteration loop meant for breaking out with "continue"
           $consumeCode
         } while (false);
@@ -1128,7 +1130,7 @@ case class ObjectHashMapAccessor(@transient session: SnappySession,
   }
 
   private def genSemiJoinCodes(entryVar: String, mapKeyCodes: String,
-      checkCondition: Option[ExprCode], numRows: String,
+      checkCondition: Option[ExprCode], checkCode: String, numRows: String,
       consumeResult: String, keyIsUnique: String, declareLocalVars: String,
       moveNextValue: String, inputCodes: String): String = checkCondition match {
 
@@ -1145,9 +1147,10 @@ case class ObjectHashMapAccessor(@transient session: SnappySession,
         $declareLocalVars
 
         $mapKeyCodes
+        $inputCodes
         $breakLoop: while (true) {
+          $checkCode
           do { // single iteration loop meant for breaking out with "continue"
-            $inputCodes
             ${ev.code}
             // consume only one result
             if (!${ev.isNull} && ${ev.value}) {
@@ -1165,7 +1168,7 @@ case class ObjectHashMapAccessor(@transient session: SnappySession,
   }
 
   private def genAntiJoinCodes(entryVar: String, mapKeyCodes: String,
-      checkCondition: Option[ExprCode], numRows: String,
+      checkCondition: Option[ExprCode], checkCode: String, numRows: String,
       consumeResult: String, keyIsUnique: String, declareLocalVars: String,
       moveNextValue: String, inputCodes: String): String = checkCondition match {
 
@@ -1186,6 +1189,7 @@ case class ObjectHashMapAccessor(@transient session: SnappySession,
         boolean $matched = false;
         if ($entryVar != null) {
           $breakLoop: while (true) {
+            $checkCode
             do { // single iteration loop meant for breaking out with "continue"
               // fail if condition matches for any row
               ${ev.code}
@@ -1208,10 +1212,12 @@ case class ObjectHashMapAccessor(@transient session: SnappySession,
         $consumeResult"""
   }
 
+  // scalastyle:off
   private def genExistenceJoinCodes(entryVar: String, existsVar: String,
-      mapKeyCodes: String, checkCondition: Option[ExprCode], numRows: String,
-      consumeResult: String, keyIsUnique: String, declareLocalVars: String,
+      mapKeyCodes: String, checkCondition: Option[ExprCode], checkCode: String,
+      numRows: String, consumeResult: String, keyIsUnique: String, declareLocalVars: String,
       moveNextValue: String, inputCodes: String): String = checkCondition match {
+    // scalastyle:on
 
     case None =>
       // only one match needed, so no value iteration
@@ -1228,6 +1234,7 @@ case class ObjectHashMapAccessor(@transient session: SnappySession,
         boolean $existsVar = false;
         if ($entryVar != null) {
           $breakLoop: while (true) {
+            $checkCode
             do { // single iteration loop meant for breaking out with "continue"
               ${ev.code}
               if (!${ev.isNull} && ${ev.value}) {
@@ -1347,19 +1354,10 @@ case class ObjectHashMapAccessor(@transient session: SnappySession,
 
   private def hashSingleLong(colVar: String, nullVar: String,
       hashVar: String): String = {
-    val longVar = ctx.freshName("longVar")
     if (nullVar.isEmpty || nullVar == "false") {
-      s"""
-        final long $longVar = $colVar;
-        $hashVar = $hashingClass.fastHashInt(
-          (int)($longVar ^ ($longVar >>> 32)));
-      """
+      s"$hashVar = $hashingClass.fastHashLong($colVar);\n"
     } else {
-      s"""
-        final long $longVar;
-        $hashVar = ($nullVar) ? -1 : $hashingClass.fastHashInt(
-          (int)(($longVar = ($colVar)) ^ ($longVar >>> 32)));
-      """
+      s"$hashVar = ($nullVar) ? -1 : $hashingClass.fastHashLong($colVar);\n"
     }
   }
 

--- a/core/src/main/scala/org/apache/spark/sql/execution/joins/HashJoinExec.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/joins/HashJoinExec.scala
@@ -562,17 +562,17 @@ case class HashJoinExec(leftKeys: Seq[Expression],
    */
   private def getJoinCondition(ctx: CodegenContext,
       input: Seq[ExprCode],
-      buildVars: Seq[ExprCode]): (Option[ExprCode], String) = condition match {
+      buildVars: Seq[ExprCode]): (Option[ExprCode], String, Option[Expression]) = condition match {
     case Some(expr) =>
-      // evaluate the variables from build side that used by condition
+      // evaluate the variables from build side used by condition
       val eval = evaluateRequiredVariables(buildPlan.output, buildVars,
         expr.references)
       // filter the output via condition
       ctx.currentVars = input.map(_.copy(code = "")) ++ buildVars
       val ev = BindReferences.bindReference(expr,
         streamedPlan.output ++ buildPlan.output).genCode(ctx)
-      (Some(ev), eval)
-    case None => (None, "")
+      (Some(ev), eval, condition)
+    case None => (None, "", None)
   }
 }
 


### PR DESCRIPTION
Issue is due to the extra check condition in join being evaluated only once
for a key on build side which may be incorrect if the key has multiple values in the map
(similar to SNAP-1885 but for anti-join)

## Changes proposed in this pull request

- pass the code for check condition separately to all join types and evaluate it inside
  the loop over all values for a key
- also optimized the input evaluation for check condition to avoid evaluating
  all the input (that will unnecessarily read all columns of a table, for example) rather
  evaluate only the condition's Expresion references
- changed the fix in SNAP-1885 to move back inputCodes (which is stream-side columns that
    won't change) outside the loop while only the separated out checkCode is re-evaluated

## Patch testing

NA

## ReleaseNotes.txt changes

NA

## Other PRs 

NA