### PR TITLE
[SNAP-2214][SNAP-2036] OOME after restart with heap, projection pushdown

### DIFF
--- a/core/src/main/scala/io/snappydata/functions.scala
+++ b/core/src/main/scala/io/snappydata/functions.scala
@@ -54,9 +54,10 @@ case class DSID() extends LeafExpression {
   }
 
   override def doGenCode(ctx: CodegenContext, ev: ExprCode): ExprCode = {
-    val idTerm = ctx.freshName("dsid")
-    ctx.addMutableState("UTF8String", idTerm, s"$idTerm=UTF8String" +
-      s".fromString(com.pivotal.gemfirexd.internal.engine.Misc.getMyId().getId());")
-    ev.copy(code = s"final ${ctx.javaType(dataType)} ${ev.value} = $idTerm;", isNull = "false")
+    ctx.addMutableState("UTF8String", ev.value, s"${ev.value} = UTF8String" +
+        ".fromString(com.pivotal.gemfirexd.internal.engine.Misc.getMyId().getId());")
+    ev.code = ""
+    ev.isNull = "false"
+    ev
   }
 }

--- a/core/src/main/scala/org/apache/spark/sql/execution/columnar/impl/ColumnFormatRelation.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/columnar/impl/ColumnFormatRelation.scala
@@ -160,7 +160,7 @@ abstract class BaseColumnFormatRelation(
     }
 
     // note: filters is expected to be already split by CNF.
-    // see PhysicalOperation#unapply
+    // see PhysicalScan#unapply
     super.scanTable(externalColumnTableName, requiredColumns, filters, prunePartitions)
   }
 

--- a/core/src/main/scala/org/apache/spark/sql/execution/datasources/StoreDataSourceStrategy.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/datasources/StoreDataSourceStrategy.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 SnappyData, Inc. All rights reserved.
+ * Copyright (c) 2018 SnappyData, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you
  * may not use this file except in compliance with the License. You
@@ -14,49 +14,68 @@
  * permissions and limitations under the License. See accompanying
  * LICENSE file.
  */
+/*
+ * PhysicalScan taken from Spark's PhysicalOperation having license as below.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.spark.sql.execution.datasources
+
+import scala.collection.mutable
 
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.CatalystTypeConverters.convertToScala
-import org.apache.spark.sql.catalyst.expressions.{Alias, Attribute, AttributeReference, AttributeSet, DynamicReplacableConstant, EmptyRow, Expression, Literal, NamedExpression}
-import org.apache.spark.sql.catalyst.planning.PhysicalOperation
-import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
+import org.apache.spark.sql.catalyst.expressions.{Alias, Attribute, AttributeReference, AttributeSet, DynamicReplacableConstant, EmptyRow, Expression, Literal, NamedExpression, PredicateHelper}
+import org.apache.spark.sql.catalyst.plans.logical.{BroadcastHint, LogicalPlan, Project, Filter => LFilter}
 import org.apache.spark.sql.catalyst.plans.physical.UnknownPartitioning
-import org.apache.spark.sql.execution.{PartitionedDataSourceScan, RowDataSourceScanExec}
 import org.apache.spark.sql.catalyst.{CatalystTypeConverters, InternalRow, analysis, expressions}
+import org.apache.spark.sql.execution.{PartitionedDataSourceScan, RowDataSourceScanExec}
 import org.apache.spark.sql.sources.{BaseRelation, Filter, PrunedUnsafeFilteredScan}
 import org.apache.spark.sql.types.StringType
 import org.apache.spark.sql.{AnalysisException, Strategy, execution, sources}
 import org.apache.spark.unsafe.types.UTF8String
 
-import scala.collection.mutable
-
 /**
-  * This strategy makes a PartitionedPhysicalRDD out of a PrunedFilterScan based datasource.
-  * Mostly this is a copy of DataSourceStrategy of Spark. But it takes care of the underlying
-  * partitions of the datasource.
-  */
+ * This strategy makes a PartitionedPhysicalRDD out of a PrunedFilterScan based datasource.
+ * Mostly this is a copy of DataSourceStrategy of Spark. But it takes care of the underlying
+ * partitions of the datasource.
+ */
 private[sql] object StoreDataSourceStrategy extends Strategy {
 
   def apply(plan: LogicalPlan): Seq[execution.SparkPlan] = plan match {
-    case PhysicalOperation(projects, filters,
-    l@LogicalRelation(t: PartitionedDataSourceScan, _, _)) =>
-      pruneFilterProject(
-        l,
-        projects,
-        filters,
-        t.numBuckets,
-        t.partitionColumns,
-        (a, f) => t.buildUnsafeScan(a.map(_.name).toArray, f)) :: Nil
-    case PhysicalOperation(projects, filters,
-    l@LogicalRelation(t: PrunedUnsafeFilteredScan, _, _)) =>
-      pruneFilterProject(
-        l,
-        projects,
-        filters,
-        0,
-        Nil,
-        (a, f) => t.buildUnsafeScan(a.map(_.name).toArray, f)) :: Nil
+    case PhysicalScan(projects, filters, scan) => scan match {
+      case l@LogicalRelation(t: PartitionedDataSourceScan, _, _) =>
+        pruneFilterProject(
+          l,
+          projects,
+          filters,
+          t.numBuckets,
+          t.partitionColumns,
+          (a, f) => t.buildUnsafeScan(a.map(_.name).toArray, f)) :: Nil
+      case l@LogicalRelation(t: PrunedUnsafeFilteredScan, _, _) =>
+        pruneFilterProject(
+          l,
+          projects,
+          filters,
+          0,
+          Nil,
+          (a, f) => t.buildUnsafeScan(a.map(_.name).toArray, f)) :: Nil
+      case _ => Nil
+    }
     case _ => Nil
   }
 
@@ -172,7 +191,7 @@ private[sql] object StoreDataSourceStrategy extends Strategy {
           RowDataSourceScanExec(
             mappedProjects,
             scanBuilder(requestedColumns, candidatePredicates, pushedFilters)
-              ._1.asInstanceOf[RDD[InternalRow]],
+                ._1.asInstanceOf[RDD[InternalRow]],
             baseRelation, UnknownPartitioning(0), metadata,
             relation.catalogTable.map(_.identifier))
       }
@@ -202,7 +221,7 @@ private[sql] object StoreDataSourceStrategy extends Strategy {
           RowDataSourceScanExec(
             mappedProjects,
             scanBuilder(requestedColumns, candidatePredicates, pushedFilters)
-              ._1.asInstanceOf[RDD[InternalRow]],
+                ._1.asInstanceOf[RDD[InternalRow]],
             baseRelation, UnknownPartitioning(0), metadata,
             relation.catalogTable.map(_.identifier))
       }
@@ -344,5 +363,74 @@ private[sql] object StoreDataSourceStrategy extends Strategy {
     val (_, translatedFilters) = translated.unzip
 
     (unrecognizedPredicates ++ unhandledPredicates, translatedFilters)
+  }
+}
+
+/**
+ * Taken from Spark's PhysicalOperation with the difference that non-deterministic
+ * fields don't cause all columns of underlying table being projected.
+ */
+/**
+ * A pattern that matches any number of project or filter operations on top of another relational
+ * operator.  All filter operators are collected and their conditions are broken up and returned
+ * together with the top project operator.
+ * [[org.apache.spark.sql.catalyst.expressions.Alias Aliases]] are in-lined/substituted if
+ * necessary.
+ */
+object PhysicalScan extends PredicateHelper {
+  type ReturnType = (Seq[NamedExpression], Seq[Expression], LogicalPlan)
+
+  def unapply(plan: LogicalPlan): Option[ReturnType] = {
+    val (fields, filters, child, _) = collectProjectsAndFilters(plan)
+    Some((fields.getOrElse(child.output), filters.filter(_.deterministic), child))
+  }
+
+  /**
+   * Collects all projects and filters, in-lining/substituting aliases if necessary.
+   * Here are two examples for alias in-lining/substitution.
+   * Before:
+   * {{{
+   *   SELECT c1 FROM (SELECT key AS c1 FROM t1) t2 WHERE c1 > 10
+   *   SELECT c1 AS c2 FROM (SELECT key AS c1 FROM t1) t2 WHERE c1 > 10
+   * }}}
+   * After:
+   * {{{
+   *   SELECT key AS c1 FROM t1 WHERE key > 10
+   *   SELECT key AS c2 FROM t1 WHERE key > 10
+   * }}}
+   */
+  private def collectProjectsAndFilters(plan: LogicalPlan):
+  (Option[Seq[NamedExpression]], Seq[Expression], LogicalPlan, Map[Attribute, Expression]) =
+    plan match {
+      case Project(fields, child) =>
+        val (_, filters, other, aliases) = collectProjectsAndFilters(child)
+        val substitutedFields = fields.map(substitute(aliases)).asInstanceOf[Seq[NamedExpression]]
+        (Some(substitutedFields), filters, other, collectAliases(substitutedFields))
+
+      case LFilter(condition, child) =>
+        val (fields, filters, other, aliases) = collectProjectsAndFilters(child)
+        val substitutedCondition = substitute(aliases)(condition)
+        (fields, filters ++ splitConjunctivePredicates(substitutedCondition), other, aliases)
+
+      case BroadcastHint(child) => collectProjectsAndFilters(child)
+
+      case other => (None, Nil, other, Map.empty)
+    }
+
+  private def collectAliases(fields: Seq[Expression]): Map[Attribute, Expression] = fields.collect {
+    case a@Alias(child, _) => a.toAttribute -> child
+  }.toMap
+
+  private def substitute(aliases: Map[Attribute, Expression])(expr: Expression): Expression = {
+    expr.transform {
+      case a@Alias(ref: AttributeReference, name) =>
+        aliases.get(ref)
+            .map(Alias(_, name)(a.exprId, a.qualifier, isGenerated = a.isGenerated))
+            .getOrElse(a)
+
+      case a: AttributeReference =>
+        aliases.get(a)
+            .map(Alias(_, a.name)(a.exprId, a.qualifier, isGenerated = a.isGenerated)).getOrElse(a)
+    }
   }
 }

--- a/core/src/main/scala/org/apache/spark/sql/internal/SnappySessionState.scala
+++ b/core/src/main/scala/org/apache/spark/sql/internal/SnappySessionState.scala
@@ -34,7 +34,6 @@ import org.apache.spark.sql.catalyst.analysis.{Analyzer, EliminateSubqueryAliase
 import org.apache.spark.sql.catalyst.catalog.CatalogRelation
 import org.apache.spark.sql.catalyst.expressions.{EqualTo, _}
 import org.apache.spark.sql.catalyst.optimizer.{Optimizer, ReorderJoin}
-import org.apache.spark.sql.catalyst.planning.PhysicalOperation
 import org.apache.spark.sql.catalyst.plans.logical.{InsertIntoTable, Join, LogicalPlan, Project}
 import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.collection.Utils
@@ -206,7 +205,7 @@ class SnappySessionState(snappySession: SnappySession)
         case _: InsertIntoTable | _: TableMutationPlan =>
           // disable for inserts/puts to avoid exchanges
           snappySession.linkPartitionsToBuckets(flag = true)
-        case PhysicalOperation(_, _, LogicalRelation(_: IndexColumnFormatRelation, _, _)) =>
+        case LogicalRelation(_: IndexColumnFormatRelation, _, _) =>
           snappySession.linkPartitionsToBuckets(flag = true)
         case _ => // nothing for others
       }


### PR DESCRIPTION
Changes for SNAP-2214:

Issue of OOME was seen when testing for performance problem with spark_partition_id
function group by queries (SNAP-2036) which are used to see data distribution (perf is problem
  even in embedded especially if some data has overflowed to disk). The issue is that
decompression after recovery is not updating the UMM for the heap storage case. The reason
for this is that the "regionContext" and "diskId" are never set for a heap ColumnFormatValue so
it does not update the UMM for the region.

Changes for SNAP-2036:

All columns of a table get selected in the ColumnTableScan due to pushdown being skipped
entirely if there is a non-deterministic function (like spark_partition_id) anywhere.
This causes performance problem not only in smart connector (that pulls all columns
    unnecessarily) but also in embedded mode when some data is overflowed to disk
where it ends up read it from disk and decompressing even though they get projected
out later in the plan.

## Changes proposed in this pull request

SNAP-2214

- explicitly acquire memory from UMM in compression/decompression
- release this memory in finally block in ColumnFormatValue compress/decompress
- use isManagedDirect consistently for explicit accounting in acquire/release
  (though non-managed direct memory case should never arise here after cache is initialized)

SNAP-2036
- added a PhysicalScan class taking from Spark's PhysicalOperation to extract
  filters/projections for table scan operator
- this does not skip the projection/filter entirely for non-deterministic functions
  that was added in SPARK-10316 rather removes non-deterministic filters at the end
  which are what cause trouble (e.g. rand() gets injected twice in the plan)
- added unit test to SnappySQLQuerySuite adapting from the spark test using row table
- removed unnecessary local variable in DSID
- removed PhysicalOperation unapply in LinkPartitionsToBuckets for index relation
  because it is traversing down the entire plan in any case

## Patch testing

precheckin

## ReleaseNotes.txt changes

NA

## Other PRs 

https://github.com/SnappyDataInc/snappy-store/pull/367