### PR TITLE
[AQP-292] evaluate grouping keys explicitly if aggregates are using them

### DIFF
--- a/core/src/main/scala/org/apache/spark/sql/execution/ObjectHashMapAccessor.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/ObjectHashMapAccessor.scala
@@ -715,7 +715,7 @@ case class ObjectHashMapAccessor(@transient session: SnappySession,
    * Generate code to lookup the map or insert a new key, value if not found.
    */
   def generateMapGetOrInsert(objVar: String, valueInitVars: Seq[ExprCode],
-      valueInitCode: String, input: Seq[ExprCode],
+      valueInitCode: String, input: Seq[ExprCode], evalKeys: Seq[Boolean],
       dictArrayVar: String, dictArrayInitVar: String): String = {
     val hashVar = Array(ctx.freshName("hash"))
     val valueInit = valueInitCode + '\n' + generateUpdate(objVar, Nil,
@@ -728,14 +728,21 @@ case class ObjectHashMapAccessor(@transient session: SnappySession,
     dictionaryKey match {
       case Some(dictKey) =>
         val keyVars = getExpressionVars(keyExpressions, input)
+        // materialize the key code explicitly if required by update expressions later (AQP-292:
+        //   it can no longer access the code since keyVars has emptied the key codes in input)
+        val evalKeyCode = if (evalKeys.isEmpty) ""
+        else evaluateVariables(keyVars.indices.collect {
+          case i if evalKeys(i) => keyVars(i)
+        })
         val keyVar = keyVars.head
         s"""
+          $evalKeyCode
           $className $objVar;
           ${DictionaryOptimizedMapAccessor.dictionaryArrayGetOrInsert(ctx,
             keyExpressions, keyVar, dictKey, dictArrayVar, objVar, valueInit,
             continueOnNull = false, this)} else {
             // evaluate the key expressions
-            ${if (keyVar.code.isEmpty) "" else keyVar.code.trim}
+            ${evaluateVariables(keyVars)}
             // evaluate hash code of the lookup key
             ${generateHashCode(hashVar, keyVars, keyExpressions, register = false)}
             ${mapLookupCode(keyVars)}

--- a/core/src/test/scala/org/apache/spark/sql/store/RowTableTest.scala
+++ b/core/src/test/scala/org/apache/spark/sql/store/RowTableTest.scala
@@ -685,15 +685,14 @@ class RowTableTest
   test("Test Long Datatype for Row table - SNAP-1722") {
     // Also test long varchar to see if its not breaking the previous implementation
     snc.sql("create table table1 (col1  long, col2 Long,col3 short,col4  TINYINT, col5 " +
-      "BYTE, col6 SMALLINT)" +
+      "BYTE, col6 SMALLINT, primary key (col1, col2))" +
       " using row options( partition_by 'col1,col2', buckets '8')")
-    for(i <- 1 to 1000){
-      snc.sql(s"insert into table1 values($i,${i+1},1,1,1,1)")
+    for (i <- 1 to 100) {
+      snc.sql(s"insert into table1 values($i,${i + 1},1,1,1,1)")
     }
     val cnt = snc.sql("select * from table1").count
     snc.sql("drop table table1")
-    assert(cnt == 1000,s"Expceted count is 1000 but actual count is $cnt")
-
+    assert(cnt == 100, s"Expected count is 100 but actual count is $cnt")
   }
 
   test("create table without explicit schema (SNAP-2047)") {
@@ -702,8 +701,8 @@ class RowTableTest
 
     session.createExternalTable("staging_airline", "parquet", Map("path" -> hfile))
     session.sql("create table airline using row options(partition_by 'FlightNum') " +
-        "AS (SELECT * FROM staging_airline limit 100000)")
-    assert(session.table("airline").count() === 100000)
+        "AS (SELECT * FROM staging_airline limit 20000)")
+    assert(session.table("airline").count() === 20000)
 
     session.sql("drop table airline")
   }


### PR DESCRIPTION
For the case of dictionary optimized aggregate, the grouping key is not materialized rather
only the dictionary index is made use of (except for first insert in map for a key where
    the full key is looked up separately). This caused trouble for the case when one of the
aggregate expressions uses the grouping key e.g. select id, count(id) from table group by id
because the key code would not be materialized.

It caused the compilation of snappy aggregate plan to fail which would fallback to spark
aggregation correctly. For some reason the fallback plan would sometimes fail with
a ClassCastException.

This change does not address the ClassCastException itself rather only fixes the snappydata
hash aggregation plan so that fallback spark plan is not used. Former may need to be tracked
separately in AQP JIRA.

## Changes proposed in this pull request

- search for referred grouping keys in aggregate expressions
- send the matching indexes to ObjectHashMapAccessor generation and explicitly
  materialize them for dictionary optimized aggregate case
- added a test for above that checks for presence of snappy aggregation plan

## Patch testing

precheckin

## ReleaseNotes.txt changes

NA

## Other PRs 

NA