### PR TITLE
[SNAP-2217] fix thread-unsafe paths in stats service and other cleanups

### DIFF
--- a/cluster/src/dunit/scala/io/snappydata/cluster/SnappyTableStatsProviderDUnitTest.scala
+++ b/cluster/src/dunit/scala/io/snappydata/cluster/SnappyTableStatsProviderDUnitTest.scala
@@ -270,7 +270,7 @@ object SnappyTableStatsProviderDUnitTest {
   }
 
   def convertToSerializableForm(stat: SnappyRegionStats): RegionStat = {
-    RegionStat(stat.getRegionName, stat.getTotalSize, stat.getSizeInMemory,
+    RegionStat(stat.getTableName, stat.getTotalSize, stat.getSizeInMemory,
       stat.getRowCount, stat.isColumnTable, stat.isReplicatedTable)
   }
 
@@ -290,7 +290,7 @@ object SnappyTableStatsProviderDUnitTest {
     def actual = SnappyTableStatsProviderService.getService.
         getAggregatedStatsOnDemand._1(table)
 
-    assert(actual.getRegionName == expected.getRegionName)
+    assert(actual.getTableName == expected.getTableName)
     assert(actual.isColumnTable == expected.isColumnTable)
 
     ClusterManagerTestBase.waitForCriterion(actual.getSizeInMemory == expected.getSizeInMemory

--- a/cluster/src/main/scala/io/snappydata/impl/LeadImpl.scala
+++ b/cluster/src/main/scala/io/snappydata/impl/LeadImpl.scala
@@ -251,7 +251,7 @@ class LeadImpl extends ServerImpl with Lead
       }
 
       // start the service to gather table statistics
-      SnappyTableStatsProviderService.start(sc)
+      SnappyTableStatsProviderService.start(sc, url = null)
 
       // update the Spark UI to add the dashboard and other SnappyData pages
       ToolsCallbackInit.toolsCallback.updateUI(sc)

--- a/cluster/src/main/scala/org/apache/spark/ui/SnappyDashboardPage.scala
+++ b/cluster/src/main/scala/org/apache/spark/ui/SnappyDashboardPage.scala
@@ -1002,7 +1002,7 @@ private[ui] class SnappyDashboardPage (parent: SnappyDashboardTab)
     <tr>
       <td>
         <div style="width:100%; padding-left:10px;">
-          {tableDetails.getRegionName}
+          {tableDetails.getTableName}
         </div>
       </td>
       <td>

--- a/cluster/src/main/scala/org/apache/spark/ui/SnappyStatsPage.scala
+++ b/cluster/src/main/scala/org/apache/spark/ui/SnappyStatsPage.scala
@@ -55,8 +55,8 @@ private[ui] class SnappyStatsPage(parent: SnappyStatsTab)
   private def rowTable(stats: SnappyRegionStats) = {
     val columnTable = if (stats.isColumnTable) " COLUMN " else " ROW "
     <tr>
-      <td sorttable_customkey={stats.getRegionName}>
-        {stats.getRegionName}
+      <td sorttable_customkey={stats.getTableName}>
+        {stats.getTableName}
       </td>
       <td sorttable_customkey={columnTable}>
         {columnTable}

--- a/core/src/dunit/scala/io/snappydata/cluster/SplitClusterDUnitSecurityTest.scala
+++ b/core/src/dunit/scala/io/snappydata/cluster/SplitClusterDUnitSecurityTest.scala
@@ -138,11 +138,13 @@ class SplitClusterDUnitSecurityTest(s: String)
     val netPort2 = AvailablePortHelper.getRandomAvailableTCPPort
     val confDir = s"$snappyProductDir/conf"
     val compressionArg = this.compressionArg
+    val waitForInit = "-jobserver.waitForInitialization=true"
     val ldapConf = getLdapConf
     writeToFile(
       s"localhost  -peer-discovery-port=$port -client-port=$netPort $compressionArg $ldapConf",
       s"$confDir/locators")
-    writeToFile(s"localhost  -locators=localhost[$port] $ldapConf", s"$confDir/leads")
+    writeToFile(s"localhost  -locators=localhost[$port] $waitForInit $compressionArg $ldapConf",
+      s"$confDir/leads")
     writeToFile(
       s"""localhost  -locators=localhost[$port] -client-port=$netPort1 $compressionArg $ldapConf
           |localhost  -locators=localhost[$port] -client-port=$netPort2 $compressionArg $ldapConf
@@ -669,7 +671,7 @@ class SplitClusterDUnitSecurityTest(s: String)
       logInfo(consoleLog)
       val jobId = getJobId(consoleLog)
       assert(consoleLog.contains("STARTED"), "Job not started")
-      DistributedTestBase.waitForCriterion(getWaitCriterion(jobId), 30000, 500, true)
+      DistributedTestBase.waitForCriterion(getWaitCriterion(jobId), 60000, 500, true)
     }
 
     user2Conn = getConn(jdbcUser2, setSNC = true)

--- a/core/src/dunit/scala/io/snappydata/cluster/SplitClusterDUnitTest.scala
+++ b/core/src/dunit/scala/io/snappydata/cluster/SplitClusterDUnitTest.scala
@@ -85,17 +85,17 @@ class SplitClusterDUnitTest(s: String)
     // create locators, leads and servers files
     val port = SplitClusterDUnitTest.locatorPort
     val netPort = SplitClusterDUnitTest.locatorNetPort
-    val netPort1 = AvailablePortHelper.getRandomAvailableTCPPort
     val netPort2 = AvailablePortHelper.getRandomAvailableTCPPort
     val netPort3 = AvailablePortHelper.getRandomAvailableTCPPort
 
     logInfo(s"Starting snappy cluster in $snappyProductDir/work with locator client port $netPort")
 
     val compressionArg = this.compressionArg
+    val waitForInit = "-jobserver.waitForInitialization=true"
     val confDir = s"$snappyProductDir/conf"
     writeToFile(s"localhost  -peer-discovery-port=$port -client-port=$netPort",
       s"$confDir/locators")
-    writeToFile(s"localhost  -locators=localhost[$port] -client-port=$netPort1 $compressionArg",
+    writeToFile(s"localhost  -locators=localhost[$port] $waitForInit $compressionArg",
       s"$confDir/leads")
     writeToFile(
       s"""localhost  -locators=localhost[$port] -client-port=$netPort2 $compressionArg

--- a/core/src/main/scala/io/snappydata/SnappyThinConnectorTableStatsProvider.scala
+++ b/core/src/main/scala/io/snappydata/SnappyThinConnectorTableStatsProvider.scala
@@ -19,14 +19,13 @@
 
 package io.snappydata
 
-import java.sql.{CallableStatement, Connection}
+import java.sql.{Connection, PreparedStatement, ResultSet}
 import java.util.{Timer, TimerTask}
 
-import scala.collection.JavaConverters._
+import scala.collection.mutable.ArrayBuffer
 import scala.util.control.NonFatal
 
-import com.gemstone.gemfire.internal.ByteArrayDataInput
-import com.gemstone.gemfire.{CancelException, DataSerializer}
+import com.gemstone.gemfire.CancelException
 import com.pivotal.gemfirexd.Attribute
 import com.pivotal.gemfirexd.internal.engine.ui.{SnappyExternalTableStats, SnappyIndexStats, SnappyRegionStats}
 import io.snappydata.Constant._
@@ -37,7 +36,7 @@ import org.apache.spark.sql.execution.datasources.jdbc.{JDBCOptions, JdbcUtils}
 object SnappyThinConnectorTableStatsProvider extends TableStatsProviderService {
 
   private var conn: Connection = _
-  private var getStatsStmt: CallableStatement = _
+  private var getStatsStmt: PreparedStatement = _
   private var _url: String = _
 
   def initializeConnection(context: Option[SparkContext] = None): Unit = {
@@ -54,13 +53,7 @@ object SnappyThinConnectorTableStatsProvider extends TableStatsProviderService {
     val jdbcOptions = new JDBCOptions(_url + securePart + ";route-query=false;", "",
       Map("driver" -> Constant.JDBC_CLIENT_DRIVER))
     conn = JdbcUtils.createConnectionFactory(jdbcOptions)()
-    getStatsStmt = conn.prepareCall("call sys.GET_SNAPPY_TABLE_STATS(?)")
-    getStatsStmt.registerOutParameter(1, java.sql.Types.BLOB)
-  }
-
-  def start(sc: SparkContext): Unit = {
-    throw new IllegalStateException("This is expected to be called for " +
-        "Embedded cluster mode only")
+    getStatsStmt = conn.prepareStatement("select * from sys.SNAPPY_TABLE_STATS")
   }
 
   def start(sc: SparkContext, url: String): Unit = {
@@ -69,6 +62,7 @@ object SnappyThinConnectorTableStatsProvider extends TableStatsProviderService {
         if (!doRun) {
           _url = url
           initializeConnection(Some(sc))
+          // reduce default interval a bit
           val delay = sc.getConf.getLong(Constant.SPARK_SNAPPY_PREFIX +
               "calcTableSizeInterval", DEFAULT_CALC_TABLE_SIZE_SERVICE_INTERVAL)
           doRun = true
@@ -90,12 +84,21 @@ object SnappyThinConnectorTableStatsProvider extends TableStatsProviderService {
     }
   }
 
-  def executeStatsStmt(sc: Option[SparkContext] = None): Unit = {
+  private def executeStatsStmt(sc: Option[SparkContext] = None): ResultSet = {
     if (conn == null) initializeConnection(sc)
-    getStatsStmt.execute()
+    getStatsStmt.executeQuery()
   }
 
   private def closeConnection(): Unit = {
+    val stmt = this.getStatsStmt
+    if (stmt ne null) {
+      try {
+        stmt.close()
+      } catch {
+        case NonFatal(_) => // ignore
+      }
+      getStatsStmt = null
+    }
     val c = this.conn
     if (c ne null) {
       try {
@@ -108,23 +111,29 @@ object SnappyThinConnectorTableStatsProvider extends TableStatsProviderService {
   }
 
   override def getStatsFromAllServers(sc: Option[SparkContext] = None): (Seq[SnappyRegionStats],
-      Seq[SnappyIndexStats], Seq[SnappyExternalTableStats]) = {
+      Seq[SnappyIndexStats], Seq[SnappyExternalTableStats]) = synchronized {
     try {
-      executeStatsStmt(sc)
+      val resultSet = executeStatsStmt(sc)
+      val regionStats = new ArrayBuffer[SnappyRegionStats]
+      while (resultSet.next()) {
+        val tableName = resultSet.getString(1)
+        val isColumnTable = resultSet.getBoolean(2)
+        val isReplicatedTable = resultSet.getBoolean(3)
+        val rowCount = resultSet.getLong(4)
+        val sizeInMemory = resultSet.getLong(5)
+        val totalSize = resultSet.getLong(6)
+        regionStats += new SnappyRegionStats(tableName, totalSize, sizeInMemory, rowCount,
+          isColumnTable, isReplicatedTable)
+      }
+      (regionStats, Nil, Nil)
     } catch {
-      case e: Exception =>
+      case NonFatal(e) =>
         logWarning("Warning: unable to retrieve table stats " +
             "from SnappyData cluster due to " + e.toString)
         logDebug("Exception stack trace: ", e)
         closeConnection()
-        return (Nil, Nil, Nil)
+        (Nil, Nil, Nil)
     }
-    val value = getStatsStmt.getBlob(1)
-    val bdi: ByteArrayDataInput = new ByteArrayDataInput
-    bdi.initialize(value.getBytes(1, value.length().asInstanceOf[Int]), null)
-    val regionStats: java.util.List[SnappyRegionStats] =
-      DataSerializer.readObject(bdi).asInstanceOf[java.util.ArrayList[SnappyRegionStats]]
-    (regionStats.asScala, Nil, Nil)
   }
 
   override def stop(): Unit = {

--- a/core/src/main/scala/io/snappydata/SnappyThinConnectorTableStatsProvider.scala
+++ b/core/src/main/scala/io/snappydata/SnappyThinConnectorTableStatsProvider.scala
@@ -53,7 +53,7 @@ object SnappyThinConnectorTableStatsProvider extends TableStatsProviderService {
     val jdbcOptions = new JDBCOptions(_url + securePart + ";route-query=false;", "",
       Map("driver" -> Constant.JDBC_CLIENT_DRIVER))
     conn = JdbcUtils.createConnectionFactory(jdbcOptions)()
-    getStatsStmt = conn.prepareStatement("select * from sys.SNAPPY_TABLE_STATS")
+    getStatsStmt = conn.prepareStatement("select * from sys.TABLESTATS")
   }
 
   def start(sc: SparkContext, url: String): Unit = {

--- a/core/src/main/scala/io/snappydata/TableStatsProviderService.scala
+++ b/core/src/main/scala/io/snappydata/TableStatsProviderService.scala
@@ -17,18 +17,22 @@
 
 package io.snappydata
 
-import java.util.concurrent.atomic.AtomicReference
+import java.util.concurrent.{ConcurrentHashMap, TimeUnit}
+import javax.annotation.concurrent.GuardedBy
 
-import scala.collection.concurrent.TrieMap
+import scala.collection.JavaConverters._
 import scala.collection.mutable
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.duration.Duration
+import scala.concurrent.{Await, Future}
 import scala.language.implicitConversions
-import scala.util.control.Breaks._
+import scala.util.control.NonFatal
 
 import com.gemstone.gemfire.CancelException
 import com.pivotal.gemfirexd.internal.engine.ui.{SnappyExternalTableStats, SnappyIndexStats, SnappyRegionStats}
 
+import org.apache.spark.sql.SnappySession
 import org.apache.spark.sql.collection.Utils
-import org.apache.spark.sql.{SnappyContext, SnappySession}
 import org.apache.spark.{Logging, SparkContext}
 
 trait TableStatsProviderService extends Logging {
@@ -38,44 +42,16 @@ trait TableStatsProviderService extends Logging {
   private var externalTableSizeInfo = Map.empty[String, SnappyExternalTableStats]
   @volatile
   private var indexesInfo = Map.empty[String, SnappyIndexStats]
-  protected val membersInfo: TrieMap[String, mutable.Map[String, Any]] =
-    TrieMap.empty[String, mutable.Map[String, Any]]
+  protected val membersInfo: mutable.Map[String, mutable.Map[String, Any]] =
+    new ConcurrentHashMap[String, mutable.Map[String, Any]](8, 0.7f, 1).asScala
 
-  private val _snc: AtomicReference[SnappyContext] = new AtomicReference[SnappyContext]()
-
-  protected def snc: SnappyContext = {
-    val context = _snc.get()
-    if (context ne null) context
-    else if (doRun) {
-      val newContext = SnappyContext()
-      _snc.compareAndSet(null, newContext)
-      _snc.get()
-    } else null
-  }
-
-  var memberStatsUpdater: Option[Thread] = None
-
-  protected def getMemberStatsUpdater: Thread = synchronized {
-
-    if (memberStatsUpdater.isEmpty ||
-        memberStatsUpdater.get.getState == Thread.State.TERMINATED) {
-      memberStatsUpdater = {
-        val th = new Thread(new Runnable() {
-          def run() {
-            // update membersInfo
-            fillAggregatedMemberStatsOnDemand()
-          }
-        })
-        Option(th)
-      }
-    }
-    memberStatsUpdater.get
-  }
+  @GuardedBy("this")
+  protected var memberStatsFuture: Option[Future[Unit]] = None
+  protected val waitDuration = Duration(5000L, TimeUnit.MILLISECONDS)
 
   @volatile protected var doRun: Boolean = false
   @volatile private var running: Boolean = false
 
-  def start(sc: SparkContext): Unit
   def start(sc: SparkContext, url: String): Unit
 
   protected def aggregateStats(): Unit = synchronized {
@@ -123,60 +99,24 @@ trait TableStatsProviderService extends Logging {
   def fillAggregatedMemberStatsOnDemand(): Unit = {
   }
 
-  def getMembersStatsFromService: mutable.Map[String, mutable.Map[String, Any]] = {
-    membersInfo
-  }
-
   def getMembersStatsOnDemand: mutable.Map[String, mutable.Map[String, Any]] = {
-    // fillAggregatedMemberStatsOnDemand()
-    // membersInfo
-
-    var infoToBeReturned: mutable.Map[String, mutable.Map[String, Any]] =
-      TrieMap.empty[String, mutable.Map[String, Any]]
-    val prevMembersInfo = membersInfo.synchronized{membersInfo}
-    val waitTime: Int = 500
-
-    // get member stats updater thread
-    val msUpdater = getMemberStatsUpdater
-    if (!msUpdater.isAlive) {
-      // start updater thread to update members stats
-      msUpdater.start()
+    // wait for updated stats for sometime else return the previous information
+    val future = synchronized(memberStatsFuture match {
+      case Some(f) => f
+      case None =>
+        val f = Future(fillAggregatedMemberStatsOnDemand())
+        memberStatsFuture = Some(f)
+        f
+    })
+    try {
+      logDebug(s"Obtaining updated Members Statistics. Waiting for $waitDuration")
+      Await.result(future, waitDuration)
+      synchronized(memberStatsFuture = None)
+    } catch {
+      case NonFatal(_) => // ignore timeout exception and return current map
+        logWarning("Obtaining updated Members Statistics is taking longer than expected time.")
     }
-
-    val endTimeMillis = System.currentTimeMillis() + 5000
-    if (msUpdater.isAlive) {
-      breakable {
-        while (msUpdater.isAlive) {
-          if (System.currentTimeMillis() > endTimeMillis) {
-            logWarning("Obtaining updated Members Statistics is taking longer than expected time..")
-            // infoToBeReturned = prevMembersInfo
-            break
-          }
-          try {
-            // Wait
-            logDebug("Obtaining updated Members Statistics in progress.." +
-                "Waiting for " + waitTime + " ms")
-            Thread.sleep(waitTime)
-          } catch {
-            case e: InterruptedException => logWarning("InterruptedException", e)
-          }
-        }
-      }
-
-      if (msUpdater.getState == Thread.State.TERMINATED) {
-        // Thread is terminated so assigning updated member info
-        infoToBeReturned = membersInfo
-      } else {
-        // Thread is still running so assigning last updated member info
-        logWarning("Setting last updated member statistics snapshot..")
-        infoToBeReturned = prevMembersInfo
-      }
-    } else {
-      // Thread is terminated so assigning updated member info
-      infoToBeReturned = membersInfo
-    }
-
-    infoToBeReturned
+    membersInfo
   }
 
   def stop(): Unit = {
@@ -185,7 +125,6 @@ trait TableStatsProviderService extends Logging {
     synchronized {
       if (running) wait(10000)
     }
-    _snc.set(null)
   }
 
   def getIndexesStatsFromService: Map[String, SnappyIndexStats] = {
@@ -201,14 +140,9 @@ trait TableStatsProviderService extends Logging {
     indexesInfo
   }
 
-  def getTableSizeStats: Map[String, SnappyRegionStats] = {
-    // TODO: [SachinK] Below conditional check can be commented to avoid
-    // forced refresh of stats on every call (tableSizeInfo could be empty).
-    val tableSizes = this.tableSizeInfo
-    if (tableSizes.isEmpty) {
-      // force run
-      aggregateStats()
-    }
+  def refreshAndGetTableSizeStats: Map[String, SnappyRegionStats] = {
+    // force run
+    aggregateStats()
     tableSizeInfo
   }
 
@@ -229,8 +163,7 @@ trait TableStatsProviderService extends Logging {
 
   def getAggregatedStatsOnDemand: (Map[String, SnappyRegionStats],
       Map[String, SnappyIndexStats], Map[String, SnappyExternalTableStats]) = {
-    val snc = this.snc
-    if (snc eq null) return (Map.empty, Map.empty, Map.empty)
+    if (!doRun) return (Map.empty, Map.empty, Map.empty)
     val (tableStats, indexStats, externalTableStats) = getStatsFromAllServers()
 
     val aggregatedStats = scala.collection.mutable.Map[String, SnappyRegionStats]()
@@ -239,11 +172,11 @@ trait TableStatsProviderService extends Logging {
     if (!doRun) return (Map.empty, Map.empty, Map.empty)
     // val samples = getSampleTableList(snc)
     tableStats.foreach { stat =>
-      aggregatedStats.get(stat.getRegionName) match {
+      aggregatedStats.get(stat.getTableName) match {
         case Some(oldRecord) =>
-          aggregatedStats.put(stat.getRegionName, oldRecord.getCombinedStats(stat))
+          aggregatedStats.put(stat.getTableName, oldRecord.getCombinedStats(stat))
         case None =>
-          aggregatedStats.put(stat.getRegionName, stat)
+          aggregatedStats.put(stat.getTableName, stat)
       }
     }
 

--- a/core/src/main/scala/org/apache/spark/sql/execution/columnar/ExternalStoreUtils.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/columnar/ExternalStoreUtils.scala
@@ -223,9 +223,6 @@ object ExternalStoreUtils {
             url + ";route-query=false;internal-connection=true"
           case LocalMode(_, url) =>
             Constant.DEFAULT_EMBEDDED_URL + ";" + url + ";internal-connection=true"
-          case ExternalClusterMode(_, url) =>
-            throw new AnalysisException("Option 'url' not specified for cluster " +
-                url)
         }
     }
   }

--- a/core/src/main/scala/org/apache/spark/sql/execution/columnar/impl/StoreCallbacksImpl.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/columnar/impl/StoreCallbacksImpl.scala
@@ -178,7 +178,7 @@ object StoreCallbacksImpl extends StoreCallbacks with Logging with Serializable 
 
   def getSnappyTableStats: AnyRef = {
     val c = SnappyTableStatsProviderService.getService
-        .getTableSizeStats.values.asJavaCollection
+        .refreshAndGetTableSizeStats.values.asJavaCollection
     val list: java.util.List[SnappyRegionStats] = new java.util.ArrayList(c.size())
     list.addAll(c)
     list

--- a/core/src/main/scala/org/apache/spark/sql/hive/HiveClientUtil.scala
+++ b/core/src/main/scala/org/apache/spark/sql/hive/HiveClientUtil.scala
@@ -290,8 +290,6 @@ private class HiveClientUtil(sparkContext: SparkContext) extends Logging {
             Constant.JDBC_EMBEDDED_DRIVER)
       case ThinClientConnectorMode(_, url) =>
         (url + ";route-query=false;skip-constraint-checks=true;", Constant.JDBC_CLIENT_DRIVER)
-      case ExternalClusterMode(_, _) =>
-        (null, null)
     }
   }
 }


### PR DESCRIPTION
## Changes proposed in this pull request

- use the new VTI to query for stats from smart connector instead of procedure
  with serialized blob; also added sync blocks to correct thread-unsafe paths and
  recreate the statement in case of any exception due to node failures or otherwise
- also corrected thread-unsafe mutable maps that are value of member info map;
  changed to use java CHM consistently
- changed explicit thread creation in getMembersStatsOnDemand with a Future
  which is both cleaner and does not require starting thread every time
- the new VTI calls will force the stats to be updated else thin stats service can
  fall 2 times behind (due to delay in both that service and embedded service runs)
- removed obsolete and unused ExternalClusterMode (SNAP-1837)
- replaced two start methods in TableStatsProviderService with a single one
- added jobserver.waitForInitialization flag to split dunit tests that submit jobs
  and need that to be ready immediately after start to fix occasional failures

## Patch testing

precheckin and manual

## ReleaseNotes.txt changes

Add information on the new VTI in docs @shyjaprabhu 

## Other PRs 

https://github.com/SnappyDataInc/snappy-store/pull/369