### PR TITLE
Fix for SNAP-1931, SNAP-1932 and SNAP-1906

### DIFF
--- a/core/src/main/scala/org/apache/spark/sql/SnappySession.scala
+++ b/core/src/main/scala/org/apache/spark/sql/SnappySession.scala
@@ -1945,7 +1945,7 @@ object SnappySession extends Logging {
       session.sparkContext.listenerBus.post(SparkListenerSQLPlanExecutionStart(
         executionId, CachedDataFrame.queryStringShortForm(sqlText),
         sqlText, df.queryExecution.toString,
-        CachedDataFrame.queryPlanInfo(executedPlan, allLiterals),
+        CachedDataFrame.queryPlanInfo(executedPlan, allLiterals, null),
         start))
       f
     } finally {

--- a/core/src/main/scala/org/apache/spark/sql/catalyst/expressions/ParamLiteral.scala
+++ b/core/src/main/scala/org/apache/spark/sql/catalyst/expressions/ParamLiteral.scala
@@ -189,11 +189,11 @@ final class ParamLiteral(override val value: Any, _dataType: DataType, val pos: 
     ev.copy(initCode, isNullLocal, valueLocal)
   }
 
-  var currentValue: Any = value
+  private[sql] var currentValue: Any = value
 
   override def toString: String = currentValue match {
     case null => "null"
-    case binary: Array[Byte] => s"0x" + DatatypeConverter.printHexBinary(binary)
+    case binary: Array[Byte] => "0x" + DatatypeConverter.printHexBinary(binary)
     case other => other.toString
   }
 }

--- a/core/src/main/scala/org/apache/spark/sql/catalyst/expressions/ParamLiteral.scala
+++ b/core/src/main/scala/org/apache/spark/sql/catalyst/expressions/ParamLiteral.scala
@@ -18,13 +18,12 @@
 package org.apache.spark.sql.catalyst.expressions
 
 import java.util.Objects
+import javax.xml.bind.DatatypeConverter
 
 import scala.collection.mutable.ArrayBuffer
-
 import com.esotericsoftware.kryo.io.{Input, Output}
 import com.esotericsoftware.kryo.{Kryo, KryoSerializable}
 import com.gemstone.gemfire.internal.shared.ClientResolverUtils
-
 import org.apache.spark.memory.{MemoryConsumer, MemoryMode, TaskMemoryManager}
 import org.apache.spark.serializer.StructTypeSerializer
 import org.apache.spark.sql.catalyst.CatalystTypeConverters._
@@ -188,6 +187,14 @@ final class ParamLiteral(override val value: Any, _dataType: DataType, val pos: 
         """.stripMargin)
     }
     ev.copy(initCode, isNullLocal, valueLocal)
+  }
+
+  var currentValue: Any = value
+
+  override def toString: String = currentValue match {
+    case null => "null"
+    case binary: Array[Byte] => s"0x" + DatatypeConverter.printHexBinary(binary)
+    case other => other.toString
   }
 }
 

--- a/core/src/main/scala/org/apache/spark/sql/execution/ExistingPlans.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/ExistingPlans.scala
@@ -221,7 +221,7 @@ case class ExecutePlan(child: SparkPlan, preAction: () => Unit = () => ())
         (callSite.shortForm, callSite.longForm,
             PartitionedPhysicalScan.getSparkPlanInfo(child))
       case key => (CachedDataFrame.queryStringShortForm(key.sqlText), key.sqlText,
-          CachedDataFrame.queryPlanInfo(child, session.getAllLiterals(key)))
+          CachedDataFrame.queryPlanInfo(child, session.getAllLiterals(key), null))
     }
     val sc = session.sparkContext
     val oldExecutionId = sc.getLocalProperty(SQLExecution.EXECUTION_ID_KEY)


### PR DESCRIPTION
Fixes the issue of incomplete plan info in UI due to plan caching changes.
This also addresses SNAP-1931 and SNAP-1906

## Changes proposed in this pull request

Chose an inexpensive way of substituting just the current value in the ParamLiteral nodes in the plan and overriding the toString() method to use the currentValue instead of the constant value field.
Expensive transformation has been avoided for every run. Instead used once per cacheddataframe to just collect all the paralliteral nodes. The Spark metrics get properly reflected. Previously due to transformstion these fields were getting null and hence the problem. 

## Patch testing

Manual testing

## ReleaseNotes.txt changes

None.

## Other PRs 

No.