### PR TITLE
added a method to identify if the table is internal column batch table

### DIFF
--- a/core/src/main/scala/org/apache/spark/sql/execution/columnar/impl/StoreCallbacksImpl.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/columnar/impl/StoreCallbacksImpl.scala
@@ -34,7 +34,7 @@ import com.pivotal.gemfirexd.internal.iapi.sql.conn.LanguageConnectionContext
 import com.pivotal.gemfirexd.internal.iapi.store.access.TransactionController
 import com.pivotal.gemfirexd.internal.impl.jdbc.EmbedConnection
 import com.pivotal.gemfirexd.internal.snappy.LeadNodeSmartConnectorOpContext
-import io.snappydata.SnappyTableStatsProviderService
+import io.snappydata.{Constant, SnappyTableStatsProviderService}
 
 import org.apache.spark.memory.{MemoryManagerCallback, MemoryMode}
 import org.apache.spark.sql._
@@ -183,6 +183,10 @@ object StoreCallbacksImpl extends StoreCallbacks with Logging with Serializable 
     list.addAll(c)
     list
   }
+
+  override def isInternalBatchTable(tableName: String): Boolean =
+    tableName.startsWith(Constant.SHADOW_SCHEMA_NAME_WITH_SEPARATOR)
+
 
   override def performConnectorOp(ctx: Object): Unit = {
 

--- a/core/src/main/scala/org/apache/spark/sql/execution/columnar/impl/StoreCallbacksImpl.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/columnar/impl/StoreCallbacksImpl.scala
@@ -184,10 +184,6 @@ object StoreCallbacksImpl extends StoreCallbacks with Logging with Serializable 
     list
   }
 
-  override def isInternalBatchTable(tableName: String): Boolean =
-    tableName.startsWith(Constant.SHADOW_SCHEMA_NAME_WITH_SEPARATOR)
-
-
   override def performConnectorOp(ctx: Object): Unit = {
 
     val context = ctx.asInstanceOf[LeadNodeSmartConnectorOpContext]


### PR DESCRIPTION
Pls refer to bug
[ENT-22](https://snappydata.atlassian.net/browse/ENT-22)

Added a method in the Callback to determine if the table is internal column batch storing table.
Linked PR request
[SnappyStore](https://github.com/SnappyDataInc/snappy-store/pull/376)
## Patch testing

(Fill in the details about how this patch was tested)

## ReleaseNotes.txt changes

(Does this change require an entry in ReleaseNotes.txt? If yes, has it been added to it?)

## Other PRs 

(Does this change require changes in other projects- store, spark, spark-jobserver, aqp? Add the links of PR of the other subprojects that are related to this change)
