### PR TITLE
Fix for bug snap-2255. Closing the connection so as to return the poo…

### DIFF
--- a/cluster/src/test/scala/org/apache/spark/sql/store/BugTest.scala
+++ b/cluster/src/test/scala/org/apache/spark/sql/store/BugTest.scala
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2017 SnappyData, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License. You
+ * may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License. See accompanying
+ * LICENSE file.
+ */
+package org.apache.spark.sql.store
+
+import java.util.Properties
+
+import com.pivotal.gemfirexd.Attribute
+import com.pivotal.gemfirexd.security.{LdapTestServer, SecurityTestUtils}
+import io.snappydata.{Constant, PlanTest, SnappyFunSuite}
+import org.scalatest.BeforeAndAfterAll
+
+
+
+import org.junit.Assert.{assertEquals, assertFalse, assertTrue}
+
+import org.apache.spark.SparkConf
+
+class BugTest extends SnappyFunSuite with BeforeAndAfterAll {
+  private val sysUser = "gemfire10"
+
+  protected override def newSparkConf(addOn: (SparkConf) => SparkConf): SparkConf = {
+    val ldapProperties = SecurityTestUtils.startLdapServerAndGetBootProperties(0, 0, sysUser,
+      getClass.getResource("/auth.ldif").getPath)
+    import com.pivotal.gemfirexd.Property.{AUTH_LDAP_SERVER, AUTH_LDAP_SEARCH_BASE}
+    for (k <- List(Attribute.AUTH_PROVIDER, AUTH_LDAP_SERVER, AUTH_LDAP_SEARCH_BASE)) {
+      System.setProperty(k, ldapProperties.getProperty(k))
+    }
+    System.setProperty(Constant.STORE_PROPERTY_PREFIX + Attribute.USERNAME_ATTR, sysUser)
+    System.setProperty(Constant.STORE_PROPERTY_PREFIX + Attribute.PASSWORD_ATTR, sysUser)
+    val conf = new org.apache.spark.SparkConf()
+        .setAppName("BugTest")
+        .setMaster("local[3]")
+        .set(Attribute.AUTH_PROVIDER, ldapProperties.getProperty(Attribute.AUTH_PROVIDER))
+        .set(Constant.STORE_PROPERTY_PREFIX + Attribute.USERNAME_ATTR, sysUser)
+        .set(Constant.STORE_PROPERTY_PREFIX + Attribute.PASSWORD_ATTR, sysUser)
+
+    if (addOn != null) {
+      addOn(conf)
+    } else {
+      conf
+    }
+  }
+
+  override def afterAll(): Unit = {
+    val ldapServer = LdapTestServer.getInstance()
+    if (ldapServer.isServerStarted) {
+      ldapServer.stopService()
+    }
+    import com.pivotal.gemfirexd.Property.{AUTH_LDAP_SERVER, AUTH_LDAP_SEARCH_BASE}
+    for (k <- List(Attribute.AUTH_PROVIDER, AUTH_LDAP_SERVER, AUTH_LDAP_SEARCH_BASE)) {
+      System.clearProperty(k)
+    }
+    System.clearProperty(Constant.STORE_PROPERTY_PREFIX + Attribute.USERNAME_ATTR)
+    System.clearProperty(Constant.STORE_PROPERTY_PREFIX + Attribute.PASSWORD_ATTR)
+    super.afterAll()
+  }
+
+  test("Bug SNAP-2255 connection pool exhaustion ") {
+    val user1 = "gemfire1"
+    val user2 = "gemfire2"
+
+    val snc1 = snc.newSession()
+    snc1.snappySession.conf.set(Attribute.USERNAME_ATTR, user1)
+    snc1.snappySession.conf.set(Attribute.PASSWORD_ATTR, user1)
+
+
+    snc1.sql(s"create table test (id  integer," +
+        s" name STRING) using column")
+    snc1.sql("insert into test values (1, 'name1')")
+    snc1.sql(s"GRANT select ON TABLE  test TO  $user2")
+
+    // TODO : Use the actual connection pool limit
+    val limit = 500
+
+    for (i <- 1 to limit) {
+      val snc2 = snc.newSession()
+      snc2.snappySession.conf.set(Attribute.USERNAME_ATTR, user2)
+      snc2.snappySession.conf.set(Attribute.PASSWORD_ATTR, user2)
+
+
+      val rs = snc2.sql(s"select * from $user1.test").collect()
+      assertEquals(1, rs.length)
+    }
+
+  }
+}

--- a/core/src/main/scala/org/apache/spark/sql/execution/columnar/ColumnBatch.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/columnar/ColumnBatch.scala
@@ -85,30 +85,40 @@ abstract class ResultSetIterator[A](conn: Connection,
   def close() {
     // if (!hasNextValue) return
     try {
-      if (rs ne null) {
-        // GfxdConnectionWrapper.restoreContextStack(stmt, rs)
-        // rs.lightWeightClose()
-        rs.close()
-      }
-    } catch {
-      case NonFatal(e) => logWarning("Exception closing resultSet", e)
-    }
-    try {
-      if (stmt ne null) {
-        stmt.getConnection match {
-          case embedConn: EmbedConnection =>
-            val lcc = embedConn.getLanguageConnection
-            if (lcc ne null) {
-              lcc.clearExecuteLocally()
-            }
-          case _ =>
+      try {
+        if (rs ne null) {
+          // GfxdConnectionWrapper.restoreContextStack(stmt, rs)
+          // rs.lightWeightClose()
+          rs.close()
         }
-        stmt.close()
+      } catch {
+        case NonFatal(e) => logWarning("Exception closing resultSet", e)
       }
-    } catch {
-      case NonFatal(e) => logWarning("Exception closing statement", e)
+      try {
+        if (stmt ne null) {
+          stmt.getConnection match {
+            case embedConn: EmbedConnection =>
+              val lcc = embedConn.getLanguageConnection
+              if (lcc ne null) {
+                lcc.clearExecuteLocally()
+              }
+            case _ =>
+          }
+          stmt.close()
+        }
+      } catch {
+        case NonFatal(e) => logWarning("Exception closing statement", e)
+      }
+      hasNextValue = false
+    } finally {
+      try {
+        if (conn != null) {
+          conn.close()
+        }
+      } catch {
+        case _: Throwable =>
+      }
     }
-    hasNextValue = false
   }
 }
 


### PR DESCRIPTION
…led connection back to pool
Pls refer to bug SNAP-2255
[SNAP-2255](https://jira.snappydata.io/browse/SNAP-2255)
Returning the PooledConnection to the pool by closing it , leaving the underlying EmbedConnection intact. Without this the system becomes unusable after certain number of queries.
I have modified the code in the ColumnBatch , though I have not tried to reproduce the error from that code path.
Added bug test

(Fill in the details about how this patch was tested)

## ReleaseNotes.txt changes

(Does this change require an entry in ReleaseNotes.txt? If yes, has it been added to it?)

## Other PRs 
[Corresponding PR in Store](https://github.com/SnappyDataInc/snappy-store/pull/377)
(Does this change require changes in other projects- store, spark, spark-jobserver, aqp? Add the links of PR of the other subprojects that are related to this change)
