### PR TITLE
Don't close connection early

### DIFF
--- a/core/src/main/scala/org/apache/spark/sql/execution/SecurityUtils.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/SecurityUtils.scala
@@ -73,6 +73,7 @@ object SecurityUtils {
           // Since it is a pooled connection, the  underlying embed connection
           // should not be closed, instead pooled connection should be closed,
           // so that connection pool is not exhausted
+          pooledConnection.commit()
           pooledConnection.close()
         }
       }

--- a/core/src/main/scala/org/apache/spark/sql/execution/columnar/ColumnBatch.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/columnar/ColumnBatch.scala
@@ -85,7 +85,6 @@ abstract class ResultSetIterator[A](conn: Connection,
 
   def close() {
     // if (!hasNextValue) return
-    try {
       try {
         if (rs ne null) {
           // GfxdConnectionWrapper.restoreContextStack(stmt, rs)
@@ -111,15 +110,7 @@ abstract class ResultSetIterator[A](conn: Connection,
         case NonFatal(e) => logWarning("Exception closing statement", e)
       }
       hasNextValue = false
-    } finally {
-      try {
-        if (closeConnectionOnResultsClose && conn != null) {
-          conn.close()
-        }
-      } catch {
-        case _: Throwable =>
-      }
-    }
+
   }
 }
 
@@ -323,7 +314,7 @@ final class ColumnBatchIterator(region: LocalRegion, val batch: ColumnBatch,
 final class ColumnBatchIteratorOnRS(conn: Connection,
     projection: Array[Int], stmt: Statement, rs: ResultSet,
     context: TaskContext, partitionId: Int)
-    extends ResultSetIterator[ByteBuffer](conn, stmt, rs, context, false) {
+    extends ResultSetIterator[ByteBuffer](conn, stmt, rs, context) {
   private var currentUUID: Long = _
   // upto three deltas for each column and a deleted mask
   private val totalColumns = (projection.length * (ColumnDelta.MAX_DEPTH + 1)) + 1


### PR DESCRIPTION
  Make sure that connection is closed when task completes so that
  tx is also committed.

## Changes proposed in this pull request

Problem with closing connection early was that, same embedded connection can be used for other task which will use txState associated with previous task.

We make sure that conn is not closed until tx is also committed. All this is done till the end of task.

## Patch testing

Ran precheckin and hydra tests.

## ReleaseNotes.txt changes

(Does this change require an entry in ReleaseNotes.txt? If yes, has it been added to it?)

## Other PRs 

(Does this change require changes in other projects- store, spark, spark-jobserver, aqp? Add the links of PR of the other subprojects that are related to this change)
