### PR TITLE
taking creds from globalSparkContext to shutdown the store

### DIFF
--- a/cluster/src/test/scala/org/apache/spark/sql/store/BugTest.scala
+++ b/cluster/src/test/scala/org/apache/spark/sql/store/BugTest.scala
@@ -31,8 +31,9 @@ class BugTest extends SnappyFunSuite with BeforeAndAfterAll {
   private val sysUser = "gemfire10"
 
   override def beforeAll(): Unit = {
-   this.stopAll()
+    this.stopAll()
   }
+  
   protected override def newSparkConf(addOn: (SparkConf) => SparkConf): SparkConf = {
     val ldapProperties = SecurityTestUtils.startLdapServerAndGetBootProperties(0, 0, sysUser,
       getClass.getResource("/auth.ldif").getPath)
@@ -70,10 +71,7 @@ class BugTest extends SnappyFunSuite with BeforeAndAfterAll {
     }
     System.clearProperty(Constant.STORE_PROPERTY_PREFIX + Attribute.USERNAME_ATTR)
     System.clearProperty(Constant.STORE_PROPERTY_PREFIX + Attribute.PASSWORD_ATTR)
-  //  System.setProperty(Attribute.AUTH_PROVIDER, "NONE")
-  //  System.setProperty(Constant.STORE_PROPERTY_PREFIX + Attribute.AUTH_PROVIDER, "NONE")
     System.setProperty("gemfirexd.authentication.required", "false")
-
   }
 
   test("Bug SNAP-2255 connection pool exhaustion") {
@@ -83,7 +81,6 @@ class BugTest extends SnappyFunSuite with BeforeAndAfterAll {
     val snc1 = snc.newSession()
     snc1.snappySession.conf.set(Attribute.USERNAME_ATTR, user1)
     snc1.snappySession.conf.set(Attribute.PASSWORD_ATTR, user1)
-
 
     snc1.sql(s"create table test (id  integer," +
         s" name STRING) using column")
@@ -102,6 +99,5 @@ class BugTest extends SnappyFunSuite with BeforeAndAfterAll {
       val rs = snc2.sql(s"select * from $user1.test").collect()
       assertEquals(1, rs.length)
     }
-
   }
 }

--- a/cluster/src/test/scala/org/apache/spark/sql/store/BugTest.scala
+++ b/cluster/src/test/scala/org/apache/spark/sql/store/BugTest.scala
@@ -20,11 +20,9 @@ import java.util.Properties
 
 import com.pivotal.gemfirexd.Attribute
 import com.pivotal.gemfirexd.security.{LdapTestServer, SecurityTestUtils}
+import io.snappydata.util.TestUtils
 import io.snappydata.{Constant, PlanTest, SnappyFunSuite}
 import org.scalatest.BeforeAndAfterAll
-
-
-
 import org.junit.Assert.{assertEquals, assertFalse, assertTrue}
 
 import org.apache.spark.SparkConf
@@ -32,6 +30,9 @@ import org.apache.spark.SparkConf
 class BugTest extends SnappyFunSuite with BeforeAndAfterAll {
   private val sysUser = "gemfire10"
 
+  override def beforeAll(): Unit = {
+   this.stopAll()
+  }
   protected override def newSparkConf(addOn: (SparkConf) => SparkConf): SparkConf = {
     val ldapProperties = SecurityTestUtils.startLdapServerAndGetBootProperties(0, 0, sysUser,
       getClass.getResource("/auth.ldif").getPath)
@@ -56,6 +57,7 @@ class BugTest extends SnappyFunSuite with BeforeAndAfterAll {
   }
 
   override def afterAll(): Unit = {
+    this.stopAll()
     val ldapServer = LdapTestServer.getInstance()
     if (ldapServer.isServerStarted) {
       ldapServer.stopService()
@@ -63,13 +65,18 @@ class BugTest extends SnappyFunSuite with BeforeAndAfterAll {
     import com.pivotal.gemfirexd.Property.{AUTH_LDAP_SERVER, AUTH_LDAP_SEARCH_BASE}
     for (k <- List(Attribute.AUTH_PROVIDER, AUTH_LDAP_SERVER, AUTH_LDAP_SEARCH_BASE)) {
       System.clearProperty(k)
+      System.clearProperty("gemfirexd." + k)
+      System.clearProperty(Constant.STORE_PROPERTY_PREFIX  + k)
     }
     System.clearProperty(Constant.STORE_PROPERTY_PREFIX + Attribute.USERNAME_ATTR)
     System.clearProperty(Constant.STORE_PROPERTY_PREFIX + Attribute.PASSWORD_ATTR)
-    super.afterAll()
+  //  System.setProperty(Attribute.AUTH_PROVIDER, "NONE")
+  //  System.setProperty(Constant.STORE_PROPERTY_PREFIX + Attribute.AUTH_PROVIDER, "NONE")
+    System.setProperty("gemfirexd.authentication.required", "false")
+
   }
 
-  test("Bug SNAP-2255 connection pool exhaustion ") {
+  test("Bug SNAP-2255 connection pool exhaustion") {
     val user1 = "gemfire1"
     val user2 = "gemfire2"
 

--- a/core/src/main/scala/io/snappydata/util/ServiceUtils.scala
+++ b/core/src/main/scala/io/snappydata/util/ServiceUtils.scala
@@ -109,8 +109,8 @@ object ServiceUtils {
     }
   }
 
-  def invokeStopFabricServer(sc: SparkContext): Unit = {
-    ServerManager.getServerInstance.stop(null)
+  def invokeStopFabricServer(sc: SparkContext, shutDownCreds: Properties = null): Unit = {
+    ServerManager.getServerInstance.stop(shutDownCreds)
   }
 
   def getAllLocators(sc: SparkContext): scala.collection.Map[DistributedMember, String] = {

--- a/core/src/main/scala/org/apache/spark/sql/SnappyContext.scala
+++ b/core/src/main/scala/org/apache/spark/sql/SnappyContext.scala
@@ -27,6 +27,7 @@ import scala.reflect.runtime.universe.TypeTag
 
 import com.gemstone.gemfire.distributed.internal.MembershipListener
 import com.gemstone.gemfire.distributed.internal.membership.InternalDistributedMember
+import com.pivotal.gemfirexd.Attribute
 import com.pivotal.gemfirexd.internal.engine.Misc
 import com.pivotal.gemfirexd.internal.shared.common.SharedUtils
 import io.snappydata.util.ServiceUtils
@@ -1150,7 +1151,17 @@ object SnappyContext extends Logging {
       // clear current hive catalog connection
       Hive.closeCurrent()
       if (ExternalStoreUtils.isLocalMode(sc)) {
-        ServiceUtils.invokeStopFabricServer(sc)
+        val user = sc.getConf.get(Constant.STORE_PROPERTY_PREFIX + Attribute.USERNAME_ATTR, "")
+        val props = if (!user.isEmpty) {
+          val prps = new java.util.Properties();
+          val pass = sc.getConf.get(Constant.STORE_PROPERTY_PREFIX + Attribute.PASSWORD_ATTR, "")
+          prps.put(com.pivotal.gemfirexd.Attribute.USERNAME_ATTR, user)
+          prps.put(com.pivotal.gemfirexd.Attribute.PASSWORD_ATTR, pass)
+          prps
+        } else {
+          null
+        }
+        ServiceUtils.invokeStopFabricServer(sc, props)
       }
 
       // clear static objects on the driver

--- a/core/src/main/scala/org/apache/spark/sql/SnappyContext.scala
+++ b/core/src/main/scala/org/apache/spark/sql/SnappyContext.scala
@@ -1151,15 +1151,14 @@ object SnappyContext extends Logging {
       // clear current hive catalog connection
       Hive.closeCurrent()
       if (ExternalStoreUtils.isLocalMode(sc)) {
-        val user = sc.getConf.get(Constant.STORE_PROPERTY_PREFIX + Attribute.USERNAME_ATTR, "")
-        val props = if (!user.isEmpty) {
-          val prps = new java.util.Properties();
-          val pass = sc.getConf.get(Constant.STORE_PROPERTY_PREFIX + Attribute.PASSWORD_ATTR, "")
-          prps.put(com.pivotal.gemfirexd.Attribute.USERNAME_ATTR, user)
-          prps.put(com.pivotal.gemfirexd.Attribute.PASSWORD_ATTR, pass)
-          prps
-        } else {
-          null
+        val props = sc.conf.getOption(Constant.STORE_PROPERTY_PREFIX +
+            Attribute.USERNAME_ATTR) match {
+          case Some(user) => val prps = new java.util.Properties();
+            val pass = sc.conf.get(Constant.STORE_PROPERTY_PREFIX + Attribute.PASSWORD_ATTR, "")
+            prps.put(com.pivotal.gemfirexd.Attribute.USERNAME_ATTR, user)
+            prps.put(com.pivotal.gemfirexd.Attribute.PASSWORD_ATTR, pass)
+            prps
+          case None => null
         }
         ServiceUtils.invokeStopFabricServer(sc, props)
       }


### PR DESCRIPTION
Precheckin tests fail as once a secured system is created in a test, it is not possible to shutdown the system using sparkContext.stop as creds are not passed.
Change is to retrieve creds from globalSparkContext ( assuming this is the context created during boot) & passing it to Utils for shutdown.
This fixes the failure of BugTest when run in the suite.


(Fill in the details about how this patch was tested)

## ReleaseNotes.txt changes

(Does this change require an entry in ReleaseNotes.txt? If yes, has it been added to it?)

## Other PRs 

(Does this change require changes in other projects- store, spark, spark-jobserver, aqp? Add the links of PR of the other subprojects that are related to this change)
