### PR TITLE
[SNAP-2363] Query on view fails.

### DIFF
--- a/core/src/main/scala/org/apache/spark/sql/SnappyParser.scala
+++ b/core/src/main/scala/org/apache/spark/sql/SnappyParser.scala
@@ -1113,9 +1113,10 @@ class SnappyParser(session: SnappySession)
         (DISABLE_TOKENIZE ~ (dmlOperation | ddl | set | cache | uncache | desc | deployPackages))
   }
 
-  final def parse[T](sqlText: String, parseRule: => Try[T]): T = session.synchronized {
+  final def parse[T](sqlText: String, parseRule: => Try[T],
+      clearExecutionData: Boolean = false): T = session.synchronized {
     session.clearQueryData()
-    session.sessionState.clearExecutionData()
+    if (clearExecutionData) session.sessionState.clearExecutionData()
     caseSensitive = session.sessionState.conf.caseSensitiveAnalysis
     parseSQL(sqlText, parseRule)
   }

--- a/core/src/main/scala/org/apache/spark/sql/SnappySession.scala
+++ b/core/src/main/scala/org/apache/spark/sql/SnappySession.scala
@@ -213,7 +213,7 @@ class SnappySession(_sc: SparkContext) extends SparkSession(_sc) {
   }
 
   final def prepareSQL(sqlText: String): LogicalPlan = {
-    val logical = sessionState.sqlParser.parsePlan(sqlText)
+    val logical = sessionState.sqlParser.parsePlan(sqlText, clearExecutionData = true)
     SparkSession.setActiveSession(this)
     sessionState.analyzerPrepare.execute(logical)
   }
@@ -2067,7 +2067,7 @@ object SnappySession extends Logging {
 
   def sqlPlan(session: SnappySession, sqlText: String): CachedDataFrame = {
     val parser = session.sessionState.sqlParser
-    val parsed = parser.parsePlan(sqlText)
+    val parsed = parser.parsePlan(sqlText, clearExecutionData = true)
     val planCaching = session.planCaching
     val plan = if (planCaching) session.sessionState.preCacheRules.execute(parsed) else parsed
     val paramLiterals = parser.sqlParser.getAllLiterals

--- a/core/src/main/scala/org/apache/spark/sql/SnappySqlParser.scala
+++ b/core/src/main/scala/org/apache/spark/sql/SnappySqlParser.scala
@@ -48,4 +48,8 @@ class SnappySqlParser(session: SnappySession) extends AbstractSqlParser {
   override def parsePlan(sqlText: String): LogicalPlan = {
     sqlParser.parse(sqlText, sqlParser.sql.run())
   }
+
+  def parsePlan(sqlText: String, clearExecutionData: Boolean): LogicalPlan = {
+    sqlParser.parse(sqlText, sqlParser.sql.run(), clearExecutionData)
+  }
 }


### PR DESCRIPTION
Code generation exception is not leading to fallback to Spark plan. 

## Changes proposed in this pull request
This is because of presence of view which leads to a parse call from within Catalog.lookupRelation and clears the SnappySession context objects (so ExecutionKey required to retry is not found by CodegenSparkFallback).

This is to fix the spark fall back plan if code gen fails for SnappyData.
## Patch testing
precheckin 

## ReleaseNotes.txt changes

## Other PRs 
The actual fix for query failure on complex view will be with SNAP-2346
