### PR TITLE
[SNAP-2348] Invalid decompress call on stats row.

### DIFF
--- a/cluster/src/test/scala/org/apache/spark/sql/execution/DataGenerator.scala
+++ b/cluster/src/test/scala/org/apache/spark/sql/execution/DataGenerator.scala
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2017 SnappyData, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License. You
+ * may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License. See accompanying
+ * LICENSE file.
+ */
+package org.apache.spark.sql.execution
+
+import org.apache.spark.sql.types._
+import org.apache.spark.sql.{DataFrame, SparkSession}
+
+/**
+  * Utility to generate data given a schema. This is a very primitive version.
+  * Can be enhanced to cater to joins/group by etc.
+  */
+object DataGenerator {
+
+  val numVals = 100
+  val numTypes = 100
+  val numRoles = 100
+  val numGroups = 100
+  val numNames = 1000
+  val numIds = 5000
+
+  val numIters = 10
+
+  val numElems1 = 12 * numVals * numIds
+  val numElems2 = 4 * numIds
+  val numElems3 = numTypes * numTypes
+
+  def generateDataFrame(sc: SparkSession, schema: StructType, numRows: Long): DataFrame = {
+    val rows = schema.fields.zipWithIndex.map { case (f, i) =>
+      randomValue(f.dataType, i)
+    }
+    sc.range(numRows).selectExpr(rows: _*)
+  }
+
+  def randomValue(fieldType: DataType, index: Int): String = {
+    fieldType match {
+      case IntegerType => s"(id % $numIds) as intval$index"
+      case ByteType => s"cast((id % $numTypes) as byte) as byteval$index"
+      case LongType => s"cast((id % $numTypes) as long) as longval$index"
+      case _: DecimalType => s"cast ((rand() * 100.0) as decimal(28, 10) as decval$index"
+      case DoubleType => s"cast((id % $numTypes) as double) as doubleval$index"
+      case TimestampType => s"((id % 2) + 2014) as timeval$index"
+      case BooleanType => s"((id % 2) == 0) as boolval$index"
+      case StringType => s"cast((id % $numNames) as string) as strval$index"
+      case other: DataType =>
+        throw new UnsupportedOperationException(s"Unexpected data type $other")
+    }
+  }
+}

--- a/core/src/main/scala/org/apache/spark/sql/execution/columnar/ColumnTableScan.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/columnar/ColumnTableScan.scala
@@ -863,8 +863,7 @@ object ColumnTableScan extends Logging {
         StartsWithForStats(stats.upperBound, stats.lowerBound, pattern)
 
       case IsNull(a: Attribute) => statsFor(a).nullCount > 0
-      case IsNotNull(a: Attribute) => statsFor(a).nullCount >= 0 &&
-          numBatchRows > statsFor(a).nullCount
+      case IsNotNull(a: Attribute) => numBatchRows > statsFor(a).nullCount
     }
 
     // This code is picked up from InMemoryTableScanExec

--- a/core/src/main/scala/org/apache/spark/sql/execution/columnar/ColumnTableScan.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/columnar/ColumnTableScan.scala
@@ -863,7 +863,8 @@ object ColumnTableScan extends Logging {
         StartsWithForStats(stats.upperBound, stats.lowerBound, pattern)
 
       case IsNull(a: Attribute) => statsFor(a).nullCount > 0
-      case IsNotNull(a: Attribute) => numBatchRows > statsFor(a).nullCount
+      case IsNotNull(a: Attribute) => statsFor(a).nullCount >= 0 &&
+          numBatchRows > statsFor(a).nullCount
     }
 
     // This code is picked up from InMemoryTableScanExec

--- a/core/src/main/scala/org/apache/spark/sql/execution/columnar/ColumnUpdateExec.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/columnar/ColumnUpdateExec.scala
@@ -264,7 +264,7 @@ case class ColumnUpdateExec(child: SparkPlan, columnTable: String,
           val nullcountExpr = ExprCode(s"final int $nullCount = -1;", "false", nullCount)
           // write null for unchanged columns (by this update)
           (ColumnStatsSchema(field.name, field.dataType,
-            nullCountNullable = false).schema, allNullsExprs :+ nullcountExpr)
+            nullCountNullable = true).schema, allNullsExprs :+ nullcountExpr)
         case u => ColumnWriter.genCodeColumnStats(ctx, field,
           s"$deltaEncoders[$u].getRealEncoder()", nullCountNullable = true)
       }

--- a/core/src/main/scala/org/apache/spark/sql/execution/columnar/ColumnUpdateExec.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/columnar/ColumnUpdateExec.scala
@@ -246,6 +246,7 @@ case class ColumnUpdateExec(child: SparkPlan, columnTable: String,
     // Columns that have not been updated will write nulls for all three stats
     // columns so this costs 3 bits per non-updated column (worst case of say
     // 100 column table will be ~38 bytes).
+
     // New Code : Stats rows are written as UnsafeRow. Unsafe row irrespective
     // of nullability keeps nullbits.
     // So if 100 columns are  there stats row will contain 100 * 3 and UnsafeRow will contain
@@ -253,18 +254,23 @@ case class ColumnUpdateExec(child: SparkPlan, columnTable: String,
     // as null does not really saves much.
 
     // These nullbits are set based on platform endianness. SD ColumnFormatValue
-    // assumes LITTLE_ENDIAN bytes.
+    // assumes LITTLE_ENDIAN bytes. However, Unsafe row itself does not force any endianness
+    // and picks up from the platform. Hence a lower byte of the bit set  can be represented as
+    // [11111110]. The 0th bit is for batch count which can never be null.
+    // This causes SD ColumnFormatValue to understand stats row as a compressed byte
+    // array( as first int is 1, hence -1 which after taking a negative
+    // equals to 1 i.e LZ4 compression codec id ).
+    // Hence setting each 3rd bit( null count stats) with not null flag. This will never cause
+    // the word to be read as negative number.
     val allNullsExprs = Seq(ExprCode("", "true", ""),
-      ExprCode("", "true", ""))
+      ExprCode("", "true", ""), ExprCode("", "false", "-1"))
     val (statsSchema, stats) = tableSchema.indices.map { i =>
       val field = tableSchema(i)
       tableToUpdateIndex.get(i) match {
         case null =>
-          val nullCount = ctx.freshName("nullCount")
-          val nullcountExpr = ExprCode(s"final int $nullCount = -1;", "false", nullCount)
-          // write null for unchanged columns (by this update)
+             // write null for unchanged columns apart from null count field (by this update)
           (ColumnStatsSchema(field.name, field.dataType,
-            nullCountNullable = true).schema, allNullsExprs :+ nullcountExpr)
+            nullCountNullable = true).schema, allNullsExprs)
         case u => ColumnWriter.genCodeColumnStats(ctx, field,
           s"$deltaEncoders[$u].getRealEncoder()", nullCountNullable = true)
       }

--- a/core/src/main/scala/org/apache/spark/sql/store/CompressionCodecId.scala
+++ b/core/src/main/scala/org/apache/spark/sql/store/CompressionCodecId.scala
@@ -43,7 +43,8 @@ object CompressionCodecId extends Enumeration {
    * in rare cases if first integer is a negative value. However it should never be match
    * with the IDs here because negative of codecId which is written are -1, -2, -3 resolve
    * to 0xfffffff... which should never happen since nullCount fields are non-nullable
-   * in the UnsafeRow created, so bitset cannot have 'ff' kind of patterns.
+   * (for not updated columns we keep -1 in null count)
+    * in the UnsafeRow created, so bitset cannot have 'ff' kind of patterns.
    */
   def isCompressed(codec: Int): Boolean = codec > 0 && codec <= MAX_ID
 


### PR DESCRIPTION
Even if delta stats rows are not compressed ColumnFormatValue considered it as a compressed value and tries to decompress.

## Changes proposed in this pull request
Stats rows are written as UnsafeRow. Unsafe row irrespective of nullability keeps nullbits.
So if 100 columns are  there stats row will contain 100 * 3 and UnsafeRow will contain
300 nullbits plus bits required for 8 bytes word allignment. Hence setting unused columns
as null does not really saves much.

These nullbits are set based on platform endianness. SD ColumnFormatValue
assumes LITTLE_ENDIAN bytes. However, Unsafe row itself does not force any endianness
and picks up from the platform. Hence a lower byte of the bit set  can be represented as
[11111110]. The 0th bit is for batch count which can never be null.
This causes SD ColumnFormatValue to understand stats row as a compressed byte
array( as first int is 1, hence -1 which after taking a negative
equals to 1 i.e LZ4 compression codec id ).
Hence setting each 3rd bit( null count stats) with not null flag. This will never cause
the word to be read as negative number.

## Patch testing

pre-checkin pending.

## ReleaseNotes.txt changes

(Does this change require an entry in ReleaseNotes.txt? If yes, has it been added to it?)

## Other PRs 

NA
