### PR TITLE
- Skip searching exceptions from hoststats files in smoke bt

### DIFF
--- a/dtests/src/test/scala/io/snappydata/hydra/SnappyHydraRunner.scala
+++ b/dtests/src/test/scala/io/snappydata/hydra/SnappyHydraRunner.scala
@@ -18,14 +18,13 @@ package io.snappydata.hydra
 
 import java.io.File
 
-import io.snappydata.SnappyTestRunner
-import org.apache.commons.io.FileUtils
-
 import scala.sys.process._
 
+import org.apache.commons.io.FileUtils
+
 /**
-  * Extending SnappyTestRunner. This class runs the snappy hydra smoke.bt and smokePerf.bt
-  */
+ * Extending SnappyTestRunner. This class runs the snappy hydra smoke.bt and smokePerf.bt
+ */
 class SnappyHydraRunner extends SnappyHydraTestRunner {
 
   override def afterAll(): Unit = {
@@ -56,6 +55,7 @@ class SnappyHydraRunner extends SnappyHydraTestRunner {
     catch {
       case r: java.lang.RuntimeException =>
         if (r.getMessage().contains("Nonzero exit value: 1")) {
+          // scalastyle:off println
           println("smoke bt run is successful.")
         }
         else {

--- a/dtests/src/test/scala/io/snappydata/hydra/SnappyHydraTestRunner.scala
+++ b/dtests/src/test/scala/io/snappydata/hydra/SnappyHydraTestRunner.scala
@@ -19,8 +19,9 @@ package io.snappydata.hydra
 import java.io.File
 
 import io.snappydata.SnappyTestRunner
-
 import scala.sys.process._
+
+import hydra.HostHelper
 
 /**
  * Class extending can mix match methods like searchExceptions
@@ -63,8 +64,10 @@ class SnappyHydraTestRunner extends SnappyTestRunner {
         "[[:space:]]*be[[:space:]]*instantiated" */
     val c21 = Seq("grep", "-v", "Failed to retrieve information for")
     val c22 = "grep -v abrt-watch-log"
+    val hostName = HostHelper.getLocalHost()
+    val c23 = s"grep -v hoststats_${hostName}.txt"
     val command1 = c1 #| c2 #| c3 #| c4 #| c5 #| c6 #| c7 #| c8 #| c12 #| c13 #| c14 #| c15 #|
-        c16 #| /* c17 #| */ c18 #| /* c19 #| c20 #| */ c21 #| c22
+        c16 #| /* c17 #| */ c18 #| /* c19 #| c20 #| */ c21 #| c22 #| c23
     // TODO : handle case where the logDir path is incorrect or doesn't exists
     try {
       val output1: String = command1.!!


### PR DESCRIPTION
## Changes proposed in this pull request

- Skip searching exceptions from hoststats files in smoke bt

## Patch testing

Verified the change by running smoke bt after creating a connectionException.txt file and kept it open in vi editor during the test run.

## ReleaseNotes.txt changes

NA

## Other PRs 

None
