### PR TITLE
[SNAP-2186] Fixed offheap size for PR

### DIFF
--- a/cluster/src/test/scala/org/apache/spark/sql/execution/DataGenerator.scala
+++ b/cluster/src/test/scala/org/apache/spark/sql/execution/DataGenerator.scala
@@ -59,4 +59,37 @@ object DataGenerator {
         throw new UnsupportedOperationException(s"Unexpected data type $other")
     }
   }
+
+  def generateDataFrameWithUnique(sc: SparkSession,
+      schema: StructType,
+      uniqueRange : (Long, Long),
+      uniqueFields : Seq[String]): DataFrame = {
+    val rows = schema.fields.zipWithIndex.map { case (f, i) =>
+      randomValueWithUnique(f.dataType, i , uniqueFields.contains(f.name), uniqueRange)
+    }
+    val range = uniqueRange._2 - uniqueRange._1
+    sc.range(range).selectExpr(rows: _*)
+  }
+
+  def randomValueWithUnique(fieldType: DataType, index: Int,
+      isUnique: Boolean, uniqueRange : (Long, Long)): String = {
+    val lowerRangeVal = uniqueRange._1
+    fieldType match {
+      case IntegerType =>
+        if (isUnique) s"(id + ${lowerRangeVal}) as intval$index"
+        else s"id as intval$index"
+      case ByteType => if (isUnique) s"cast((id + $lowerRangeVal) as byte) as byteval$index"
+      else s"cast(id as byte) as byteval$index"
+      case LongType =>
+        if (isUnique) s"cast((id + $lowerRangeVal) as long) as longval$index"
+        else s"cast(id as long) as longval$index"
+      case _: DecimalType => s"cast ((rand() * 100.0) as decimal(28, 10) as decval$index"
+      case DoubleType => s"cast(id as double) as doubleval$index"
+      case TimestampType => s"((id % 2) + 2014) as timeval$index"
+      case BooleanType => s"((id % 2) == 0) as boolval$index"
+      case StringType => s"cast(id as string) as strval$index"
+      case other: DataType =>
+        throw new UnsupportedOperationException(s"Unexpected data type $other")
+    }
+  }
 }

--- a/core/src/main/scala/io/snappydata/SnappyTableStatsProviderService.scala
+++ b/core/src/main/scala/io/snappydata/SnappyTableStatsProviderService.scala
@@ -142,9 +142,9 @@ object SnappyEmbeddedTableStatsProviderService extends TableStatsProviderService
         val id = memMap.get("id").toString
 
         var memberStats: MemberStatistics = {
-          if(dssUUID != null && membersInfo.contains(dssUUID.toString)) {
+          if (dssUUID != null && membersInfo.contains(dssUUID.toString)) {
             membersInfo(dssUUID.toString)
-          } else if(membersInfo.contains(id)) {
+          } else if (membersInfo.contains(id)) {
             membersInfo(id)
           } else {
             null
@@ -257,18 +257,20 @@ object SnappyEmbeddedTableStatsProviderService extends TableStatsProviderService
             // TODO: this should use a transactional iterator to get a consistent
             // snapshot (also pass the same transaction to getNumColumnsInTable
             //   for reading value and delete count)
-            val itr = new pr.PRLocalScanIterator(true /* primaryOnly */ , null /* no TX */ ,
+            val itr = new pr.PRLocalScanIterator(false /* primaryOnly */ , null /* no TX */ ,
               null /* not required since includeValues is false */ ,
               createRemoteIterator, false /* forUpdate */ , false /* includeValues */)
             // using direct region operations
             while (itr.hasNext) {
               val re = itr.next().asInstanceOf[AbstractRegionEntry]
               val key = re.getRawKey.asInstanceOf[ColumnFormatKey]
-              if (numColumnsInTable < 0) {
-                numColumnsInTable = key.getNumColumnsInTable(table)
+              if (itr.getHostedBucketRegion.getBucketAdvisor.isPrimary) {
+                if (numColumnsInTable < 0) {
+                  numColumnsInTable = key.getNumColumnsInTable(table)
+                }
+                rowsInColumnBatch += key.getColumnBatchRowCount(itr, re,
+                  numColumnsInTable)
               }
-              rowsInColumnBatch += key.getColumnBatchRowCount(itr, re,
-                numColumnsInTable)
               re._getValue() match {
                 case v: ColumnFormatValue => offHeapSize += v.getOffHeapSizeInBytes
                 case _ =>

--- a/core/src/main/scala/io/snappydata/SnappyTableStatsProviderService.scala
+++ b/core/src/main/scala/io/snappydata/SnappyTableStatsProviderService.scala
@@ -264,11 +264,12 @@ object SnappyEmbeddedTableStatsProviderService extends TableStatsProviderService
             while (itr.hasNext) {
               val re = itr.next().asInstanceOf[AbstractRegionEntry]
               val key = re.getRawKey.asInstanceOf[ColumnFormatKey]
-              if (itr.getHostedBucketRegion.getBucketAdvisor.isPrimary) {
+              val bucketRegion = itr.getHostedBucketRegion
+              if (bucketRegion.getBucketAdvisor.isPrimary) {
                 if (numColumnsInTable < 0) {
                   numColumnsInTable = key.getNumColumnsInTable(table)
                 }
-                rowsInColumnBatch += key.getColumnBatchRowCount(itr, re,
+                rowsInColumnBatch += key.getColumnBatchRowCount(bucketRegion, re,
                   numColumnsInTable)
               }
               re._getValue() match {

--- a/core/src/main/scala/org/apache/spark/sql/execution/columnar/impl/ColumnFormatEntry.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/columnar/impl/ColumnFormatEntry.scala
@@ -111,9 +111,9 @@ final class ColumnFormatKey(private[columnar] var uuid: Long,
     GemFireXDUtils.getGemFireContainer(bufferTable, true).getNumColumns - 1
   }
 
-  override def getColumnBatchRowCount(itr: PREntriesIterator[_],
+  override def getColumnBatchRowCount(bucketRegion: BucketRegion,
       re: AbstractRegionEntry, numColumnsInTable: Int): Int = {
-    val currentBucketRegion = itr.getHostedBucketRegion
+    val currentBucketRegion = bucketRegion.getHostedBucketRegion
     if ((columnIndex == ColumnFormatEntry.STATROW_COL_INDEX ||
         columnIndex == ColumnFormatEntry.DELTA_STATROW_COL_INDEX ||
         columnIndex == ColumnFormatEntry.DELETE_MASK_COL_INDEX) &&


### PR DESCRIPTION
## Changes proposed in this pull request
a) While determining the off heap size of a PR the iterator only considered primary buckets.
Changed it to iterate over secondary buckets as well. 
b) Also added a utility method in DataGenerator to generate unique values based on a range.
Some formatting changes.
## Patch testing
Manual testing. Pre checkin pending. 

## ReleaseNotes.txt changes
NA
## Other PRs 
NA
