### PR TITLE
[SNAP-2381] global lock to serialize concurrent puts

### DIFF
--- a/core/src/main/scala/org/apache/spark/sql/SnappySession.scala
+++ b/core/src/main/scala/org/apache/spark/sql/SnappySession.scala
@@ -27,8 +27,9 @@ import scala.concurrent.Future
 import scala.language.implicitConversions
 import scala.reflect.runtime.universe.{TypeTag, typeOf}
 import scala.util.control.NonFatal
+
 import com.gemstone.gemfire.internal.GemFireVersion
-import com.gemstone.gemfire.internal.cache.GemFireCacheImpl
+import com.gemstone.gemfire.internal.cache.{GemFireCacheImpl, PartitionedRegion}
 import com.gemstone.gemfire.internal.shared.{ClientResolverUtils, FinalizeHolder, FinalizeObject}
 import com.google.common.cache.{Cache, CacheBuilder}
 import com.pivotal.gemfirexd.internal.GemFireXDVersion
@@ -37,9 +38,11 @@ import com.pivotal.gemfirexd.internal.iapi.{types => stypes}
 import com.pivotal.gemfirexd.internal.shared.common.{SharedUtils, StoredFormatIds}
 import io.snappydata.collection.ObjectObjectHashMap
 import io.snappydata.{Constant, Property, SnappyDataFunctions, SnappyTableStatsProviderService}
+
 import org.apache.spark.annotation.{DeveloperApi, Experimental}
 import org.apache.spark.rdd.RDD
 import org.apache.spark.scheduler.{SparkListener, SparkListenerApplicationEnd}
+import org.apache.spark.sql.SnappySession.CACHED_PUTINTO_UPDATE_PLAN
 import org.apache.spark.sql.catalyst.analysis.{EliminateSubqueryAliases, NoSuchTableException}
 import org.apache.spark.sql.catalyst.encoders._
 import org.apache.spark.sql.catalyst.expressions.aggregate.AggregateExpression
@@ -396,11 +399,53 @@ class SnappySession(_sc: SparkContext) extends SparkSession(_sc) {
   private[sql] def getHashVar(ctx: CodegenContext,
       keyVars: Seq[String]): Option[String] = getContextObject(ctx, "H", keyVars)
 
-  private[sql] def clearContext(): Unit = synchronized {
-    getContextObject[LogicalPlan](SnappySession.CACHED_PUTINTO_UPDATE_PLAN).
-        foreach { cachedPlan =>
-          sharedState.cacheManager.uncacheQuery(this, cachedPlan, blocking = true)
+  private[sql] def cachePutInto(plan: Option[LogicalPlan], table: String): Boolean = {
+    // first acquire the global lock for putInto
+    val lock = PartitionedRegion.getRegionLock("PUTINTO_" + table, GemFireCacheImpl.getExisting)
+    lock.lock()
+    var hasUpdates = false
+    try {
+      val cachedPlan = plan match {
+        case Some(updateSubQuery) =>
+          val joinDS = new Dataset(this, updateSubQuery, RowEncoder(updateSubQuery.schema))
+          joinDS.persist()
+          if (joinDS.count() > 0) {
+            hasUpdates = true
+            plan
+          } else {
+            joinDS.unpersist(blocking = true)
+            None
+          }
+        case None =>
+          // assume that there are updates
+          hasUpdates = true
+          None
+      }
+      if (hasUpdates) {
+        // Adding to context after the count operation, as count will clear the context object.
+        addContextObject[(Option[LogicalPlan], PartitionedRegion.RegionLock)](
+          CACHED_PUTINTO_UPDATE_PLAN, cachedPlan -> lock)
+      }
+      hasUpdates
+    } finally {
+      // release lock immediately if no updates are to be done
+      if (!hasUpdates) lock.unlock()
+    }
+  }
+
+  private[sql] def clearPutInto(): Unit = {
+    contextObjects.remove(CACHED_PUTINTO_UPDATE_PLAN) match {
+      case null =>
+      case (cachedPlan: Option[LogicalPlan], lock: PartitionedRegion.RegionLock) =>
+        lock.unlock()
+        if (cachedPlan.isDefined) {
+          sharedState.cacheManager.uncacheQuery(this, cachedPlan.get, blocking = true)
         }
+    }
+  }
+
+  private[sql] def clearContext(): Unit = synchronized {
+    clearPutInto()
     contextObjects.clear()
     planCaching = Property.PlanCaching.get(sessionState.conf)
   }

--- a/core/src/main/scala/org/apache/spark/sql/execution/columnar/ColumnPutIntoExec.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/columnar/ColumnPutIntoExec.scala
@@ -17,6 +17,7 @@
 package org.apache.spark.sql.execution.columnar
 
 import org.apache.spark.rdd.RDD
+import org.apache.spark.sql.SnappySession
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeReference, UnsafeRow}
 import org.apache.spark.sql.execution.{BinaryExecNode, SparkPlan}
@@ -39,6 +40,14 @@ case class ColumnPutIntoExec(insertPlan: SparkPlan,
   }
 
   override def executeCollect(): Array[InternalRow] = {
+    try {
+      collectResults()
+    } finally {
+      sqlContext.sparkSession.asInstanceOf[SnappySession].clearPutInto()
+    }
+  }
+
+  private def collectResults(): Array[InternalRow] = {
     // First update the rows which are present in the table
     val u = updatePlan.executeCollect().map(_.getLong(0)).toSeq.foldLeft(0L)(_ + _)
     // Then insert the rows which are not there in the table

--- a/core/src/main/scala/org/apache/spark/sql/internal/ColumnTableBulkOps.scala
+++ b/core/src/main/scala/org/apache/spark/sql/internal/ColumnTableBulkOps.scala
@@ -73,19 +73,9 @@ object ColumnTableBulkOps {
         val analyzedUpdate = updateDS.queryExecution.analyzed.asInstanceOf[Update]
         updateSubQuery = analyzedUpdate.child
 
-        val (doInsertJoin, isCached) = if (subQuery.statistics.sizeInBytes <= cacheSize) {
-          val joinDS = new Dataset(sparkSession,
-            updateSubQuery, RowEncoder(updateSubQuery.schema))
-          joinDS.cache()
-          (joinDS.count() > 0, true)
-        } else (true, false)
-
-        // Adding to context after the count operation, as count will clear the context object.
-        if (isCached) {
-          sparkSession.asInstanceOf[SnappySession].
-              addContextObject(SnappySession.CACHED_PUTINTO_UPDATE_PLAN, updateSubQuery)
-        }
-
+        val doInsertJoin = sparkSession.asInstanceOf[SnappySession].cachePutInto(
+          if (subQuery.statistics.sizeInBytes <= cacheSize) Some(updateSubQuery) else None,
+          mutable.table)
         val insertChild = if (doInsertJoin) {
           Join(subQuery, updateSubQuery, LeftAnti, condition)
         } else subQuery

--- a/core/src/main/scala/org/apache/spark/sql/sources/interfaces.scala
+++ b/core/src/main/scala/org/apache/spark/sql/sources/interfaces.scala
@@ -72,6 +72,8 @@ trait RowPutRelation extends DestroyRelation {
 
 trait BulkPutRelation extends DestroyRelation {
 
+  def table: String
+
   def getPutKeys: Option[Seq[String]]
 
   /**
@@ -306,14 +308,16 @@ trait IndexableRelation {
 
 @DeveloperApi
 trait AlterableRelation {
+
   /**
-    * Alter's table schema by adding or dropping a provided column
-    * @param tableIdent
-    * @param isAddColumn
-    * @param column
-    */
+   * Alter's table schema by adding or dropping a provided column
+   *
+   * @param tableIdent  Table identifier
+   * @param isAddColumn True if column is to be added else it is to be dropped
+   * @param column      Column to be added or dropped
+   */
   def alterTable(tableIdent: QualifiedTableName,
-                 isAddColumn: Boolean, column: StructField): Unit
+      isAddColumn: Boolean, column: StructField): Unit
 }
 
 /**


### PR DESCRIPTION
## Changes proposed in this pull request

- global lock in putInto execution to serialize concurrent puts
- added lock to session context and clear in putInto plan's executeCollect

## Patch testing

new unit test to be added

## ReleaseNotes.txt changes

NA

## Other PRs 

NA