### PR TITLE
[SNAP-2347] Fix for row tables getting dropped.

### DIFF
--- a/core/src/main/scala/org/apache/spark/sql/execution/columnar/JDBCAppendableRelation.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/columnar/JDBCAppendableRelation.scala
@@ -66,6 +66,7 @@ abstract case class JDBCAppendableRelation(
   override val needConversion: Boolean = false
 
   var tableExists: Boolean = _
+  var tableCreated : Boolean = _
 
   protected final val connProperties: ConnectionProperties =
     externalStore.connProperties

--- a/core/src/main/scala/org/apache/spark/sql/execution/columnar/JDBCAppendableRelation.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/columnar/JDBCAppendableRelation.scala
@@ -66,6 +66,7 @@ abstract case class JDBCAppendableRelation(
   override val needConversion: Boolean = false
 
   var tableExists: Boolean = _
+
   var tableCreated : Boolean = _
 
   protected final val connProperties: ConnectionProperties =

--- a/core/src/main/scala/org/apache/spark/sql/execution/columnar/impl/ColumnFormatRelation.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/columnar/impl/ColumnFormatRelation.scala
@@ -446,6 +446,9 @@ abstract class BaseColumnFormatRelation(
             pass.asInstanceOf[String])
         }
         JdbcExtendedUtils.executeUpdate(sql, conn)
+        // setting table created to true here as cleanup
+        // in case of failed creation does a exists check.
+        tableCreated = true
         dialect match {
           case d: JdbcExtendedDialect => d.initializeTable(tableName,
             sqlContext.conf.caseSensitiveAnalysis, conn)
@@ -882,7 +885,7 @@ final class DefaultSource extends SchemaRelationProvider
       success = true
       relation
     } finally {
-      if (!success && !relation.tableExists) {
+      if (!success && relation.tableCreated) {
         // destroy the relation
         relation.destroy(ifExists = true)
       }

--- a/core/src/main/scala/org/apache/spark/sql/execution/row/RowFormatRelation.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/row/RowFormatRelation.scala
@@ -24,7 +24,7 @@ import com.pivotal.gemfirexd.internal.engine.Misc
 import com.pivotal.gemfirexd.internal.engine.ddl.catalog.GfxdSystemProcedures
 import com.pivotal.gemfirexd.internal.engine.ddl.resolver.GfxdPartitionByExpressionResolver
 
-import org.apache.spark.Partition
+import org.apache.spark.{Logging, Partition}
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql._
 import org.apache.spark.sql.catalyst.expressions.{And, Ascending, Attribute, Descending, EqualTo, Expression, In, SortDirection}
@@ -310,7 +310,7 @@ class RowFormatRelation(
   }
 }
 
-final class DefaultSource extends MutableRelationProvider with DataSourceRegister {
+final class DefaultSource extends MutableRelationProvider with DataSourceRegister with Logging {
 
   override def shortName(): String = SnappyParserConsts.ROW_SOURCE
 
@@ -335,6 +335,7 @@ final class DefaultSource extends MutableRelationProvider with DataSourceRegiste
 
     StoreUtils.validateConnProps(parameters)
     var success = false
+    var resolvedName = ""
     val relation = new RowFormatRelation(connProperties,
       tableName,
       getClass.getCanonicalName,
@@ -345,14 +346,15 @@ final class DefaultSource extends MutableRelationProvider with DataSourceRegiste
       tableOptions,
       sqlContext)
     try {
-      relation.createTable(mode)
-
+      logInfo(s"Trying to create table $tableName")
+      resolvedName = relation.createTable(mode)
+      logInfo(s"Succesfully created the table $tableName")
       val catalog = sqlContext.sparkSession.asInstanceOf[SnappySession].sessionCatalog
       catalog.registerDataSourceTable(
         catalog.newQualifiedTableName(tableName), None, Array.empty[String],
         classOf[execution.row.DefaultSource].getCanonicalName,
         tableOptions, Some(relation))
-      
+      logInfo(s"Registered the table $tableName in catalog")
       data match {
         case Some(plan) =>
           relation.insert(Dataset.ofRows(sqlContext.sparkSession, plan),
@@ -362,8 +364,9 @@ final class DefaultSource extends MutableRelationProvider with DataSourceRegiste
       success = true
       relation
     } finally {
-      if (!success && !relation.tableExists) {
+      if (!success && !relation.tableExists && !resolvedName.isEmpty) {
         // destroy the relation
+        logInfo(s"Failed in creating the table $tableName hence destroying")
         relation.destroy(ifExists = true)
       }
     }

--- a/core/src/main/scala/org/apache/spark/sql/execution/row/RowFormatRelation.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/row/RowFormatRelation.scala
@@ -347,7 +347,7 @@ final class DefaultSource extends MutableRelationProvider with DataSourceRegiste
     try {
       logDebug(s"Trying to create table $tableName")
       relation.createTable(mode)
-      logDebug(s"Succesfully created the table $tableName")
+      logDebug(s"Successfully created the table $tableName")
       val catalog = sqlContext.sparkSession.asInstanceOf[SnappySession].sessionCatalog
       catalog.registerDataSourceTable(
         catalog.newQualifiedTableName(tableName), None, Array.empty[String],

--- a/core/src/main/scala/org/apache/spark/sql/execution/row/RowFormatRelation.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/row/RowFormatRelation.scala
@@ -335,7 +335,6 @@ final class DefaultSource extends MutableRelationProvider with DataSourceRegiste
 
     StoreUtils.validateConnProps(parameters)
     var success = false
-    var resolvedName = ""
     val relation = new RowFormatRelation(connProperties,
       tableName,
       getClass.getCanonicalName,
@@ -347,7 +346,7 @@ final class DefaultSource extends MutableRelationProvider with DataSourceRegiste
       sqlContext)
     try {
       logDebug(s"Trying to create table $tableName")
-      resolvedName = relation.createTable(mode)
+      relation.createTable(mode)
       logDebug(s"Succesfully created the table $tableName")
       val catalog = sqlContext.sparkSession.asInstanceOf[SnappySession].sessionCatalog
       catalog.registerDataSourceTable(
@@ -364,7 +363,7 @@ final class DefaultSource extends MutableRelationProvider with DataSourceRegiste
       success = true
       relation
     } finally {
-      if (!success && !relation.tableExists && !resolvedName.isEmpty) {
+      if (!success && relation.tableCreated) {
         // destroy the relation
         logDebug(s"Failed in creating the table $tableName hence destroying")
         relation.destroy(ifExists = true)

--- a/core/src/main/scala/org/apache/spark/sql/execution/row/RowFormatRelation.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/row/RowFormatRelation.scala
@@ -346,15 +346,15 @@ final class DefaultSource extends MutableRelationProvider with DataSourceRegiste
       tableOptions,
       sqlContext)
     try {
-      logInfo(s"Trying to create table $tableName")
+      logDebug(s"Trying to create table $tableName")
       resolvedName = relation.createTable(mode)
-      logInfo(s"Succesfully created the table $tableName")
+      logDebug(s"Succesfully created the table $tableName")
       val catalog = sqlContext.sparkSession.asInstanceOf[SnappySession].sessionCatalog
       catalog.registerDataSourceTable(
         catalog.newQualifiedTableName(tableName), None, Array.empty[String],
         classOf[execution.row.DefaultSource].getCanonicalName,
         tableOptions, Some(relation))
-      logInfo(s"Registered the table $tableName in catalog")
+      logDebug(s"Registered the table $tableName in catalog")
       data match {
         case Some(plan) =>
           relation.insert(Dataset.ofRows(sqlContext.sparkSession, plan),
@@ -366,7 +366,7 @@ final class DefaultSource extends MutableRelationProvider with DataSourceRegiste
     } finally {
       if (!success && !relation.tableExists && !resolvedName.isEmpty) {
         // destroy the relation
-        logInfo(s"Failed in creating the table $tableName hence destroying")
+        logDebug(s"Failed in creating the table $tableName hence destroying")
         relation.destroy(ifExists = true)
       }
     }

--- a/core/src/main/scala/org/apache/spark/sql/row/JDBCMutableRelation.scala
+++ b/core/src/main/scala/org/apache/spark/sql/row/JDBCMutableRelation.scala
@@ -87,6 +87,8 @@ case class JDBCMutableRelation(
 
   var tableExists: Boolean = _
 
+  var tableCreated : Boolean = false
+
   final lazy val schemaFields: Map[String, StructField] =
     Utils.schemaFields(schema)
 
@@ -152,6 +154,7 @@ case class JDBCMutableRelation(
             pass.asInstanceOf[String])
         }
         JdbcExtendedUtils.executeUpdate(sql, conn)
+        tableCreated = true
         dialect match {
           case d: JdbcExtendedDialect => d.initializeTable(table,
             sqlContext.conf.caseSensitiveAnalysis, conn)

--- a/core/src/main/scala/org/apache/spark/sql/sources/interfaces.scala
+++ b/core/src/main/scala/org/apache/spark/sql/sources/interfaces.scala
@@ -263,6 +263,12 @@ trait DestroyRelation {
   def tableExists: Boolean
 
   /**
+    * Return true if table is created by the relation. This will be used to check
+    * while destroying the table incase of a failure while creating the table
+    */
+  def tableCreated: Boolean
+
+  /**
    * Truncate the table represented by this relation.
    */
   def truncate(): Unit

--- a/core/src/main/scala/org/apache/spark/sql/streaming/StreamBaseRelation.scala
+++ b/core/src/main/scala/org/apache/spark/sql/streaming/StreamBaseRelation.scala
@@ -44,6 +44,8 @@ abstract class StreamBaseRelation(opts: Map[String, String])
 
   var tableExists: Boolean = _
 
+  var tableCreated: Boolean = _
+
   override def addDependent(dependent: DependentRelation,
       catalog: SnappyStoreHiveCatalog): Boolean =
     DependencyCatalog.addDependent(tableName, dependent.name)

--- a/core/src/main/scala/org/apache/spark/sql/streaming/StreamBaseRelation.scala
+++ b/core/src/main/scala/org/apache/spark/sql/streaming/StreamBaseRelation.scala
@@ -44,7 +44,7 @@ abstract class StreamBaseRelation(opts: Map[String, String])
 
   var tableExists: Boolean = _
 
-  var tableCreated: Boolean = _
+  override def tableCreated: Boolean = !tableExists
 
   override def addDependent(dependent: DependentRelation,
       catalog: SnappyStoreHiveCatalog): Boolean =


### PR DESCRIPTION
## Changes proposed in this pull request
There was a small window when the connection is lost to the JDBC source JDBCMutable relation might drop the table, thinking of a failed initialization. 

## Patch testing

pre-checkin

## ReleaseNotes.txt changes

NA

## Other PRs 
Na
