### PR TITLE
Change to let 'lead' with warnings

### DIFF
--- a/core/src/main/scala/org/apache/spark/sql/SnappyDDLParser.scala
+++ b/core/src/main/scala/org/apache/spark/sql/SnappyDDLParser.scala
@@ -810,7 +810,7 @@ case class DeployJarCommand(
         logWarning(s"Following jars are unavailable" +
             s" for deployment during restart: ${unavailableUris.deep.mkString(",")}")
       }
-      val uris = jars.map(j => sc.env.rpcEnv.fileServer.addFile(new File(j)))
+      val uris = availableUris.map(j => sc.env.rpcEnv.fileServer.addFile(new File(j)))
       SnappySession.addJarURIs(uris)
       Utils.mapExecutors[Unit](sparkSession.sparkContext, () => {
         ToolsCallbackInit.toolsCallback.addURIsToExecutorClassLoader(uris)

--- a/core/src/main/scala/org/apache/spark/sql/SnappySession.scala
+++ b/core/src/main/scala/org/apache/spark/sql/SnappySession.scala
@@ -108,11 +108,11 @@ class SnappySession(_sc: SparkContext) extends SparkSession(_sc) {
             val coordinate = cmdFields(0)
             val repos = if (cmdFields(1).isEmpty) None else Some(cmdFields(1))
             val cache = if (cmdFields(2).isEmpty) None else Some(cmdFields(2))
-            DeployCommand(coordinate, null, repos, cache).run(self)
+            DeployCommand(coordinate, null, repos, cache, true).run(self)
           }
           else {
             // Jars we have
-            DeployJarCommand(null, cmdFields(0)).run(self)
+            DeployJarCommand(null, cmdFields(0), true).run(self)
           }
         })
        }

--- a/core/src/main/scala/org/apache/spark/sql/hive/HiveClientUtil.scala
+++ b/core/src/main/scala/org/apache/spark/sql/hive/HiveClientUtil.scala
@@ -315,11 +315,11 @@ object HiveClientUtil {
               val repos = if (cmdFields(1).isEmpty) None else Some(cmdFields(1))
               val cache = if (cmdFields(2).isEmpty) None else Some(cmdFields(2))
               val session = SparkSession.builder().getOrCreate()
-              DeployCommand(coordinate, null, repos, cache).run(session)
+              DeployCommand(coordinate, null, repos, cache, true).run(session)
             }
             else {
               // Jars we have
-              DeployJarCommand(null, cmdFields(0))
+              DeployJarCommand(null, cmdFields(0), true)
             }
           })
         }

--- a/core/src/main/scala/org/apache/spark/sql/sources/StoreStrategy.scala
+++ b/core/src/main/scala/org/apache/spark/sql/sources/StoreStrategy.scala
@@ -90,9 +90,9 @@ object StoreStrategy extends Strategy {
 
     case SetSchema(schemaName) => ExecutedCommandExec(SetSchemaCommand(schemaName)) :: Nil
 
-    case d@DeployCommand(_, _, _, _) => ExecutedCommandExec(d) :: Nil
+    case d@DeployCommand(_, _, _, _, _) => ExecutedCommandExec(d) :: Nil
 
-    case d@DeployJarCommand(_, _) => ExecutedCommandExec(d) :: Nil
+    case d@DeployJarCommand(_, _, _) => ExecutedCommandExec(d) :: Nil
 
     case d@UnDeployCommand(_) => ExecutedCommandExec(d) :: Nil
 


### PR DESCRIPTION


## Changes proposed in this pull request

if deployed jars/coordinates not present during restart do not stop lead from coming up. Start and spit out warnings in logs.

## Patch testing

Manual

## ReleaseNotes.txt changes

None

## Other PRs 

No
