### PR TITLE
Fixes for SNAP-2071 and SNAP-2400 :

### DIFF
--- a/cluster/src/main/scala/org/apache/spark/status/api/v1/TableDetails.scala
+++ b/cluster/src/main/scala/org/apache/spark/status/api/v1/TableDetails.scala
@@ -24,8 +24,7 @@ object TableDetails {
 
   def getAllTablesInfo: Seq[TableSummary] = {
 
-    val (tableBuff, indexBuff, externalTableBuff) =
-      SnappyTableStatsProviderService.getService.getAggregatedStatsOnDemand
+    val tableBuff = SnappyTableStatsProviderService.getService.getAllTableStatsFromService
 
     tableBuff.mapValues(table =>{
       val storageModel = {
@@ -53,8 +52,8 @@ object TableDetails {
 
   def getAllExternalTablesInfo: Seq[ExternalTableSummary] = {
 
-    val (tableBuff, indexBuff, externalTableBuff) =
-      SnappyTableStatsProviderService.getService.getAggregatedStatsOnDemand
+    val externalTableBuff =
+      SnappyTableStatsProviderService.getService.getAllExternalTableStatsFromService
 
     externalTableBuff.mapValues(table => {
       new ExternalTableSummary(table.getTableName, table.getProvider,

--- a/core/src/main/scala/io/snappydata/TableStatsProviderService.scala
+++ b/core/src/main/scala/io/snappydata/TableStatsProviderService.scala
@@ -157,17 +157,38 @@ trait TableStatsProviderService extends Logging {
 
   def getTableStatsFromService(
       fullyQualifiedTableName: String): Option[SnappyRegionStats] = {
-    val tableSizes = this.tableSizeInfo
-    if (tableSizes.isEmpty || !tableSizes.contains(fullyQualifiedTableName)) {
+    if (this.tableSizeInfo.isEmpty
+        || !this.tableSizeInfo.contains(fullyQualifiedTableName)) {
       // force run
       aggregateStats()
     }
     tableSizeInfo.get(fullyQualifiedTableName)
   }
 
+  def getAllTableStatsFromService: Map[String, SnappyRegionStats] = {
+    if (this.tableSizeInfo.isEmpty) {
+      // force run
+      aggregateStats()
+    }
+    this.tableSizeInfo
+  }
+
   def getExternalTableStatsFromService(
       fullyQualifiedTableName: String): Option[SnappyExternalTableStats] = {
+    if (this.externalTableSizeInfo.isEmpty
+        || !this.externalTableSizeInfo.contains(fullyQualifiedTableName)) {
+      // force run
+      aggregateStats()
+    }
     externalTableSizeInfo.get(fullyQualifiedTableName)
+  }
+
+  def getAllExternalTableStatsFromService: Map[String, SnappyExternalTableStats] = {
+    if (this.externalTableSizeInfo.isEmpty) {
+      // force run
+      aggregateStats()
+    }
+    this.externalTableSizeInfo
   }
 
   def getAggregatedStatsOnDemand: (Map[String, SnappyRegionStats],


### PR DESCRIPTION
## Changes proposed in this pull request

  - Fetching table stats and external table stats from objects populated by SnappyTableStatsProviderService instead of calling getAggregatedStatsOnDemand of SnappyTableStatsProviderService.
  - Adding getAllTableStatsFromService and getAllExternalTableStatsFromService methods to fetch table stats and external stats.

## Patch testing

 - Tested manually and with the help of BT test

## ReleaseNotes.txt changes

 - None

## Other PRs 

 - Spark: https://github.com/SnappyDataInc/spark/pull/108
