### PR TITLE
Snap 2398

### DIFF
--- a/core/src/main/scala/org/apache/spark/sql/SmartConnectorHelper.scala
+++ b/core/src/main/scala/org/apache/spark/sql/SmartConnectorHelper.scala
@@ -16,7 +16,9 @@
  */
 package org.apache.spark.sql
 
-import java.io.{ByteArrayInputStream, ByteArrayOutputStream, ObjectInputStream, ObjectOutputStream}
+import java.io._
+import java.net.URI
+import java.nio.file.{Files, Paths}
 import java.sql.{CallableStatement, Connection, SQLException}
 
 import com.pivotal.gemfirexd.Attribute
@@ -24,13 +26,12 @@ import com.pivotal.gemfirexd.internal.shared.common.reference.SQLState
 import io.snappydata.Constant
 import io.snappydata.impl.SmartConnectorRDDHelper
 import org.apache.hadoop.hive.ql.metadata.Table
-
 import org.apache.spark.sql.catalyst.expressions.SortDirection
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.apache.spark.sql.execution.datasources.jdbc.{JDBCOptions, JdbcUtils}
 import org.apache.spark.sql.hive.{ExternalTableType, QualifiedTableName, RelationInfo, SnappyStoreHiveCatalog}
 import org.apache.spark.sql.types.{StructField, StructType}
-import org.apache.spark.{Logging, Partition}
+import org.apache.spark.{Logging, Partition, SparkContext}
 
 class SmartConnectorHelper(snappySession: SnappySession) extends Logging {
 
@@ -46,6 +47,7 @@ class SmartConnectorHelper(snappySession: SnappySession) extends Logging {
   private val createUDFString = "call sys.CREATE_SNAPPY_UDF(?, ?, ?, ?)"
   private val dropUDFString = "call sys.DROP_SNAPPY_UDF(?, ?)"
   private val alterTableStmtString = "call sys.ALTER_SNAPPY_TABLE(?, ?, ?, ?, ?)"
+  private val getJarsStmtString = "call sys.GET_DEPLOYED_JARS(?)"
   private var getMetaDataStmt: CallableStatement = _
   private var createSnappyTblStmt: CallableStatement = _
   private var dropSnappyTblStmt: CallableStatement = _
@@ -54,15 +56,16 @@ class SmartConnectorHelper(snappySession: SnappySession) extends Logging {
   private var createUDFStmt: CallableStatement = _
   private var dropUDFStmt: CallableStatement = _
   private var alterTableStmt: CallableStatement = _
+  private var getJarsStmt: CallableStatement = _
 
   clusterMode match {
-    case ThinClientConnectorMode(_, url) =>
+    case ThinClientConnectorMode(sc, url) =>
       connectionURL = url
-      initializeConnection()
+      initializeConnection(sc)
     case _ =>
   }
 
-  def initializeConnection(): Unit = {
+  def initializeConnection(sc: SparkContext): Unit = {
     val jdbcOptions = new JDBCOptions(connectionURL + getSecurePart + ";route-query=false;", "",
       Map("driver" -> Constant.JDBC_CLIENT_DRIVER))
     conn = JdbcUtils.createConnectionFactory(jdbcOptions)()
@@ -74,6 +77,10 @@ class SmartConnectorHelper(snappySession: SnappySession) extends Logging {
     createUDFStmt = conn.prepareCall(createUDFString)
     dropUDFStmt = conn.prepareCall(dropUDFString)
     alterTableStmt = conn.prepareCall(alterTableStmtString)
+    getJarsStmt = conn.prepareCall(getJarsStmtString)
+    if (sc != null) {
+      executeGetJarsStmt(sc)
+    }
   }
 
   private def getSecurePart: String = {
@@ -97,7 +104,7 @@ class SmartConnectorHelper(snappySession: SnappySession) extends Logging {
         // attempt to create a new connection if connection
         // is closed
         conn.close()
-        initializeConnection()
+        initializeConnection(null)
         function
     }
   }
@@ -165,6 +172,30 @@ class SmartConnectorHelper(snappySession: SnappySession) extends Logging {
     alterTableStmt.setString(4, column.dataType.simpleString)
     alterTableStmt.setBoolean(5, column.nullable)
     alterTableStmt.execute()
+  }
+
+  private def executeGetJarsStmt(sc: SparkContext): Unit = {
+    getJarsStmt.registerOutParameter(1, java.sql.Types.VARCHAR)
+    getJarsStmt.execute()
+    val jarsString = getJarsStmt.getString(1)
+    if (jarsString != null && jarsString.nonEmpty) {
+      // comma separated list of file urls will be obtained
+      jarsString.split(",").foreach(f => {
+        val jarpath = f.substring(5)
+        if (Files.isReadable(Paths.get(jarpath))) {
+          try {
+            sc.addJar(jarpath)
+          } catch {
+            // warn
+            case ex: Exception => logWarning(s"could not add path $jarpath to SparkContext", ex)
+          }
+        } else {
+          // May be the smart connector app does not care about the deployed jars or
+          // the path is not readable so just log warning
+          logWarning(s"could not add path $jarpath to SparkContext as the file is not readable")
+        }
+      })
+    }
   }
 
   private def executeDropTableStmt(tableIdent: QualifiedTableName,

--- a/core/src/main/scala/org/apache/spark/sql/SnappyDDLParser.scala
+++ b/core/src/main/scala/org/apache/spark/sql/SnappyDDLParser.scala
@@ -24,41 +24,14 @@ import java.nio.file.{Files, Paths}
 import java.util.Map.Entry
 import java.util.function.Consumer
 
-<<<<<<< HEAD
-import com.gemstone.gemfire.SystemFailure
-import com.pivotal.gemfirexd.internal.engine.Misc
-||||||| merged common ancestors
-import scala.util.Try
-=======
 import scala.collection.mutable.ArrayBuffer
 import scala.util.Try
->>>>>>> master
-
-<<<<<<< HEAD
-import scala.util.Try
-||||||| merged common ancestors
-=======
 import com.gemstone.gemfire.SystemFailure
->>>>>>> master
+import com.pivotal.gemfirexd.internal.engine.Misc
 import io.snappydata.Constant
-<<<<<<< HEAD
-import org.apache.spark.TaskContext
-import org.apache.spark.deploy.SparkSubmitUtils
-||||||| merged common ancestors
-
-import org.apache.spark.TaskContext
-import org.apache.spark.deploy.SparkSubmitUtils
-=======
->>>>>>> master
 import org.parboiled2._
 import shapeless.{::, HNil}
-<<<<<<< HEAD
-||||||| merged common ancestors
-
-=======
-
 import org.apache.spark.deploy.SparkSubmitUtils
->>>>>>> master
 import org.apache.spark.sql.catalyst.catalog.{FunctionResource, FunctionResourceType}
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.plans.QueryPlan
@@ -74,16 +47,6 @@ import org.apache.spark.sql.streaming.StreamPlanProvider
 import org.apache.spark.sql.types._
 import org.apache.spark.sql.{SnappyParserConsts => Consts}
 import org.apache.spark.streaming._
-<<<<<<< HEAD
-
-import scala.collection.mutable.ArrayBuffer
-import org.apache.spark.sql.internal.MarkerForCreateTableAsSelect
-||||||| merged common ancestors
-import scala.collection.mutable.ArrayBuffer
-
-import org.apache.spark.sql.internal.MarkerForCreateTableAsSelect
-=======
->>>>>>> master
 
 abstract class SnappyDDLParser(session: SparkSession)
     extends SnappyBaseParser(session) {
@@ -801,16 +764,12 @@ case class SetSchema(schemaName: String) extends Command
 
 case class SnappyStreamingActions(action: Int, batchInterval: Option[Duration]) extends Command
 
-/**
- * Returns a list of jar files that are added to resources.
- * If jar files are provided, return the ones that are added to resources.
- */
 case class DeployCommand(
-    coordinates: String,
-    alias: String,
-    repos: Option[String],
-    jarCache: Option[String],
-    restart: Boolean) extends RunnableCommand {
+  coordinates: String,
+  alias: String,
+  repos: Option[String],
+  jarCache: Option[String],
+  restart: Boolean) extends RunnableCommand {
 
   override def run(sparkSession: SparkSession): Seq[Row] = {
     try {
@@ -853,11 +812,12 @@ case class DeployCommand(
         }
     }
   }
+}
 
 case class DeployJarCommand(
-    alias: String,
-    paths: String,
-    restart: Boolean) extends RunnableCommand {
+  alias: String,
+  paths: String,
+  restart: Boolean) extends RunnableCommand {
 
   override def run(sparkSession: SparkSession): Seq[Row] = {
     if (paths.nonEmpty) {

--- a/core/src/main/scala/org/apache/spark/sql/execution/columnar/impl/StoreCallbacksImpl.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/columnar/impl/StoreCallbacksImpl.scala
@@ -21,7 +21,6 @@ import java.util.Collections
 
 import scala.collection.JavaConverters._
 import scala.collection.mutable.ArrayBuffer
-
 import com.gemstone.gemfire.cache.{EntryDestroyedException, RegionDestroyedException}
 import com.gemstone.gemfire.internal.cache.lru.LRUEntry
 import com.gemstone.gemfire.internal.cache.persistence.query.CloseableIterator
@@ -41,7 +40,6 @@ import com.pivotal.gemfirexd.internal.impl.jdbc.EmbedConnection
 import com.pivotal.gemfirexd.internal.shared.common.reference.SQLState
 import com.pivotal.gemfirexd.internal.snappy.LeadNodeSmartConnectorOpContext
 import io.snappydata.SnappyTableStatsProviderService
-
 import org.apache.spark.memory.{MemoryManagerCallback, MemoryMode}
 import org.apache.spark.serializer.KryoSerializerPool
 import org.apache.spark.sql._
@@ -50,7 +48,7 @@ import org.apache.spark.sql.catalyst.expressions.codegen.{CodeAndComment, CodeFo
 import org.apache.spark.sql.catalyst.expressions.{AttributeReference, Expression, Literal, SortDirection, TokenLiteral, UnsafeRow}
 import org.apache.spark.sql.catalyst.parser.CatalystSqlParser
 import org.apache.spark.sql.catalyst.{CatalystTypeConverters, FunctionIdentifier, expressions}
-import org.apache.spark.sql.collection.Utils
+import org.apache.spark.sql.collection.{ToolsCallbackInit, Utils}
 import org.apache.spark.sql.execution.ConnectionPool
 import org.apache.spark.sql.execution.columnar.encoding.ColumnStatsSchema
 import org.apache.spark.sql.execution.columnar.{ColumnBatchCreator, ColumnBatchIterator, ColumnTableScan, ExternalStore, ExternalStoreUtils}
@@ -60,6 +58,8 @@ import org.apache.spark.sql.store.{CodeGeneration, StoreHashFunction}
 import org.apache.spark.sql.types._
 import org.apache.spark.unsafe.types.UTF8String
 import org.apache.spark.{Logging, SparkContext}
+
+import java.net.URLClassLoader
 
 object StoreCallbacksImpl extends StoreCallbacks with Logging with Serializable {
 
@@ -621,6 +621,9 @@ object StoreCallbacksImpl extends StoreCallbacks with Logging with Serializable 
   override def clearConnectionPools(): Unit = {
     ConnectionPool.clear()
   }
+
+  override def getLeadClassLoader() : URLClassLoader =
+    ToolsCallbackInit.toolsCallback.getLeadClassLoader()
 }
 
 trait StoreCallback extends Serializable {


### PR DESCRIPTION
## Changes proposed in this pull request

Smart Connector can use deployed jars now as long as path is visible on the driver node of the spark cluster.
Added a flag to fail if required when deployed jars are for some reason not available.
By default it just logs a warning.

## Patch testing

Manual testing

## ReleaseNotes.txt changes

Documentation of deploy jar should cover this.

## Other PRs 

https://github.com/SnappyDataInc/snappy-store/pull/403
