### PR TITLE
[SNAP-2399] Added a check for boot time manager.

### DIFF
--- a/cluster/src/main/scala/org/apache/spark/memory/SnappyUnifiedMemoryManager.scala
+++ b/cluster/src/main/scala/org/apache/spark/memory/SnappyUnifiedMemoryManager.scala
@@ -621,6 +621,12 @@ class SnappyUnifiedMemoryManager private[memory](
       } else {
         storagePool.acquireMemory(blockId, numBytes)
       }
+
+      // Case where boot time memory is insufficient to recover database
+      if ( !enoughMemory && bootManager) {
+        return false
+      }
+
       if (!enoughMemory) {
 
         // return immediately for OFF_HEAP with shouldEvict=false


### PR DESCRIPTION
## Changes proposed in this pull request

If boot time UMM cannot find any memory, its best to return from that place. This means the system itself is configured with very low memory, which is not capable of handling overhead for keys & region structures. 

## Patch testing

precheckin

## ReleaseNotes.txt changes

NA

## Other PRs 

(Does this change require changes in other projects- store, spark, spark-jobserver, aqp? Add the links of PR of the other subprojects that are related to this change)
