### PR TITLE
[SNAP-2306] Streaming query stop

### DIFF
--- a/cluster/src/main/scala/org/apache/spark/sql/SnappySessionFactory.scala
+++ b/cluster/src/main/scala/org/apache/spark/sql/SnappySessionFactory.scala
@@ -79,8 +79,11 @@ object SnappySessionFactory {
 
       override def isValidJob(job: SparkJobBase): Boolean = job.isInstanceOf[SnappySQLJob]
 
+      // Calling this method from JobKill.
       override def stop(): Unit = {
-        // not stopping anything here because SQLContext doesn't have one.
+        // Stopping all StreamingQueries started by the session.
+        // If it's a normal job there won't be any streaming query and it will be a no -op.
+        this.sessionState.streamingQueryManager.active.foreach(q => q.stop())
       }
 
       // Callback added to provide our classloader to load job classes.


### PR DESCRIPTION
## Changes proposed in this pull request

Added StreamingQuery.stop on job server session.stop() method call. This will be called from JobManagerActor's JobKill.

## Patch testing

precheckin

## ReleaseNotes.txt changes

## Other PRs 
https://github.com/SnappyDataInc/spark-jobserver/pull/19
