### PR TITLE
Added a timeout for hive queries wait so that we can fail fast

### DIFF
--- a/core/src/main/java/io/snappydata/impl/SnappyHiveCatalog.java
+++ b/core/src/main/java/io/snappydata/impl/SnappyHiveCatalog.java
@@ -269,7 +269,8 @@ public class SnappyHiveCatalog implements ExternalCatalog {
 
   private <T> T handleFutureResult(Future<T> f) {
     try {
-      return f.get();
+      // Time out if it takes more than 30 seconds
+      return f.get(30, TimeUnit.SECONDS);
     } catch (ExecutionException e) {
       throw new RuntimeException(e.getCause());
     } catch (Exception e) {


### PR DESCRIPTION
This causes delay in shutdown etc. also even if hive query is failing due to cluster being down.

## Changes proposed in this pull request

Do not wait for more than 30 seconds for any hive query. Added a timeout.

## Patch testing

(Fill in the details about how this patch was tested)

## ReleaseNotes.txt changes

(Does this change require an entry in ReleaseNotes.txt? If yes, has it been added to it?)

## Other PRs 

(Does this change require changes in other projects- store, spark, spark-jobserver, aqp? Add the links of PR of the other subprojects that are related to this change)
