### PR TITLE
Fix for SNAP-2434 in parser

### DIFF
--- a/cluster/src/test/scala/org/apache/spark/sql/MiscTest.scala
+++ b/cluster/src/test/scala/org/apache/spark/sql/MiscTest.scala
@@ -58,17 +58,20 @@ class MiscTest extends SnappyFunSuite with Logging {
   }
 
   test("SNAP-2434") {
-    val sqlstr = s"select app.test.* from app.test"
-    try {
-      snc
-      snc.sql(sqlstr)
-      fail(s"this should have given TableNotFoundException")
-    } catch {
-      case tnfe: TableNotFoundException =>
-      case ae: AnalysisException => if (!ae.getMessage().contains("Table or view not found")) {
-        throw ae
+    snc
+    val sqlstrs = Seq(s"select app.test.* from app.test",
+      s"select test.* from test", s"select * from test")
+    sqlstrs.foreach(sqlstr =>
+      try {
+        snc.sql(sqlstr)
+        fail(s"this should have given TableNotFoundException")
+      } catch {
+        case tnfe: TableNotFoundException =>
+        case ae: AnalysisException => if (!ae.getMessage().contains("Table or view not found")) {
+          throw ae
+        }
+        case t: Throwable => fail(s"unexpected exception $t")
       }
-      case t: Throwable => fail(s"unexpected exception $t")
-    }
+    )
   }
 }

--- a/core/src/main/scala/org/apache/spark/sql/SnappyParser.scala
+++ b/core/src/main/scala/org/apache/spark/sql/SnappyParser.scala
@@ -880,12 +880,14 @@ class SnappyParser(session: SnappySession)
             }
           }
         ) |
-        '.' ~ ws ~ (
-            (identifier ~ '.' ~ ws).* ~ '*' ~ ws ~> ((i1: String, rest: Any) =>
-              UnresolvedStar(Option(i1 +: rest.asInstanceOf[Seq[String]]))) |
-            identifier. +('.' ~ ws) ~> ((i1: String, rest: Any) =>
-              UnresolvedAttribute(i1 +: rest.asInstanceOf[Seq[String]]))
-        ) |
+        ('.' ~ ws ~ identifier. +('.' ~ ws) ~ ('.' ~ '*' ~ push(true) ~ ws).? ~> {
+          (i1: String, rest: Any, s: Any) =>
+            if (s.asInstanceOf[Option[Boolean]].isDefined) {
+              UnresolvedStar(Option(i1 +: rest.asInstanceOf[Seq[String]]))
+            } else {
+              UnresolvedAttribute(i1 +: rest.asInstanceOf[Seq[String]])
+            }
+        })|
         MATCH ~> UnresolvedAttribute.quoted _
     ) |
     literal | paramLiteralQuestionMark |

--- a/core/src/main/scala/org/apache/spark/sql/SnappyParser.scala
+++ b/core/src/main/scala/org/apache/spark/sql/SnappyParser.scala
@@ -888,7 +888,7 @@ class SnappyParser(session: SnappySession)
               UnresolvedAttribute(i1 +: rest.asInstanceOf[Seq[String]])
             }
         } | '*' ~ ws ~> { (i1: String) =>
-             UnresolvedStar(Some(i1 +: Nil))
+             UnresolvedStar(Some(Seq(i1)))
         }) |
         MATCH ~> UnresolvedAttribute.quoted _
     ) |

--- a/core/src/main/scala/org/apache/spark/sql/SnappyParser.scala
+++ b/core/src/main/scala/org/apache/spark/sql/SnappyParser.scala
@@ -880,14 +880,16 @@ class SnappyParser(session: SnappySession)
             }
           }
         ) |
-        ('.' ~ ws ~ identifier. +('.' ~ ws) ~ ('.' ~ '*' ~ push(true) ~ ws).? ~> {
+        '.' ~ (identifier. +('.' ~ ws) ~ ('.' ~ '*' ~ push(true) ~ ws).? ~> {
           (i1: String, rest: Any, s: Any) =>
             if (s.asInstanceOf[Option[Boolean]].isDefined) {
               UnresolvedStar(Option(i1 +: rest.asInstanceOf[Seq[String]]))
             } else {
               UnresolvedAttribute(i1 +: rest.asInstanceOf[Seq[String]])
             }
-        })|
+        } | '*' ~ ws ~> { (i1: String) =>
+             UnresolvedStar(Some(i1 +: Nil))
+        }) |
         MATCH ~> UnresolvedAttribute.quoted _
     ) |
     literal | paramLiteralQuestionMark |

--- a/core/src/main/scala/org/apache/spark/sql/SnappyParser.scala
+++ b/core/src/main/scala/org/apache/spark/sql/SnappyParser.scala
@@ -881,10 +881,10 @@ class SnappyParser(session: SnappySession)
           }
         ) |
         '.' ~ ws ~ (
-            identifier. +('.' ~ ws) ~> ((i1: String, rest: Any) =>
-              UnresolvedAttribute(i1 +: rest.asInstanceOf[Seq[String]])) |
             (identifier ~ '.' ~ ws).* ~ '*' ~ ws ~> ((i1: String, rest: Any) =>
-              UnresolvedStar(Option(i1 +: rest.asInstanceOf[Seq[String]])))
+              UnresolvedStar(Option(i1 +: rest.asInstanceOf[Seq[String]]))) |
+            identifier. +('.' ~ ws) ~> ((i1: String, rest: Any) =>
+              UnresolvedAttribute(i1 +: rest.asInstanceOf[Seq[String]]))
         ) |
         MATCH ~> UnresolvedAttribute.quoted _
     ) |


### PR DESCRIPTION
## Changes proposed in this pull request

select test.* from test -- works
but
select app.test.* throws exception - in snappy

Minor fix in parser to handle the above syntax too.

## Patch testing

Unit test added.

## ReleaseNotes.txt changes

No.

## Other PRs 

None.