### PR TITLE
[ENT-34] Avoid setting snappy user name.

### DIFF
--- a/core/src/main/scala/org/apache/spark/sql/execution/columnar/ExternalStoreUtils.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/columnar/ExternalStoreUtils.scala
@@ -334,7 +334,12 @@ object ExternalStoreUtils {
       hikariCP: Boolean): ConnectionProperties = {
     val (user, password) = getCredentials(session)
 
-    if (!user.isEmpty && !password.isEmpty) {
+    val isSnappy = dialect match {
+      case GemFireXDDialect | GemFireXDClientDialect => true
+      case _ => false
+    }
+
+    if (!user.isEmpty && !password.isEmpty && isSnappy) {
       def secureProps(props: Properties): Properties = {
         props.setProperty(ClientAttribute.USERNAME, user)
         props.setProperty(ClientAttribute.PASSWORD, password)


### PR DESCRIPTION
## Changes proposed in this pull request
Security code used to set snappy username in all pool connection obtained in the system.
Added a check to allow it only for snappy.

## Patch testing
precheckin
## ReleaseNotes.txt changes
NA
## Other PRs 

NA
