### PR TITLE
Ent-29 Make sure that snapshotTxIdForRead is reset properly

### DIFF
--- a/core/src/main/scala/io/snappydata/impl/SmartConnectorRDDHelper.scala
+++ b/core/src/main/scala/io/snappydata/impl/SmartConnectorRDDHelper.scala
@@ -43,9 +43,9 @@ final class SmartConnectorRDDHelper {
 
   private var useLocatorURL: Boolean = _
 
-  def prepareScan(conn: Connection, columnTable: String, projection: Array[Int],
+  def prepareScan(conn: Connection, txId: String, columnTable: String, projection: Array[Int],
       serializedFilters: Array[Byte], partition: SmartExecutorBucketPartition,
-      relDestroyVersion: Int): (PreparedStatement, ResultSet, String) = {
+      relDestroyVersion: Int): (PreparedStatement, ResultSet) = {
     val pstmt = conn.prepareStatement("call sys.COLUMN_TABLE_SCAN(?, ?, ?)")
     pstmt.setString(1, columnTable)
     pstmt.setString(2, projection.mkString(","))
@@ -54,10 +54,6 @@ final class SmartConnectorRDDHelper {
       pstmt.setBlob(3, new HarmonySerialBlob(serializedFilters))
     } else {
       pstmt.setNull(3, java.sql.Types.BLOB)
-    }
-    val txId = SmartConnectorRDDHelper.snapshotTxIdForRead.get() match {
-      case "" => null
-      case id => id
     }
     pstmt match {
       case clientStmt: ClientPreparedStatement =>
@@ -74,7 +70,7 @@ final class SmartConnectorRDDHelper {
     }
 
     val rs = pstmt.executeQuery()
-    (pstmt, rs, txId)
+    (pstmt, rs)
   }
 
   def getConnection(connectionProperties: ConnectionProperties,

--- a/core/src/main/scala/org/apache/spark/sql/execution/columnar/impl/JDBCSourceAsColumnarStore.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/columnar/impl/JDBCSourceAsColumnarStore.scala
@@ -774,32 +774,40 @@ final class SmartConnectorColumnRDD(
     val conn: Connection = helper.getConnection(connProperties, part)
     logDebug(s"Scan for $tableName, Partition index = ${part.index}, bucketId = ${part.bucketId}")
     val partitionId = part.bucketId
-    // fetch all the column blobs pushing down the filters
-    val (statement, rs, txId) = helper.prepareScan(conn, tableName, projection,
-      serializedFilters, part, relDestroyVersion)
-    val itr = new ColumnBatchIteratorOnRS(conn, projection, statement, rs,
-      context, partitionId)
+    val txId = SmartConnectorRDDHelper.snapshotTxIdForRead.get() match {
+      case "" => null
+      case id => id
+    }
+    var itr: Iterator[ByteBuffer] = null
+    try {
+      // fetch all the column blobs pushing down the filters
+      val (statement, rs) = helper.prepareScan(conn, txId,
+        tableName, projection,
+        serializedFilters, part, relDestroyVersion)
+      itr = new ColumnBatchIteratorOnRS(conn, projection, statement, rs,
+        context, partitionId)
+    } finally {
+      if (context ne null) {
+        context.addTaskCompletionListener { _ =>
+          logDebug(s"The txid going to be committed is $txId " + tableName)
 
-    if (context ne null) {
-      context.addTaskCompletionListener { _ =>
-        logDebug(s"The txid going to be committed is $txId " + tableName)
-
-        // if ((txId ne null) && !txId.equals("null")) {
-        val ps = conn.prepareStatement(s"call sys.COMMIT_SNAPSHOT_TXID(?,?)")
-        ps.setString(1, if (txId ne null) txId else "")
-        ps.setString(2, if (delayRollover) tableName else "")
-        ps.executeUpdate()
-        logDebug(s"The txid being committed is $txId")
-        ps.close()
-        SmartConnectorRDDHelper.snapshotTxIdForRead.set(null)
-        logDebug(s"closed connection for task from listener $partitionId")
-        try {
-          conn.close()
-          logDebug("closed connection for task " + context.partitionId())
-        } catch {
-          case NonFatal(e) => logWarning("Exception closing connection", e)
+          // if ((txId ne null) && !txId.equals("null")) {
+          val ps = conn.prepareStatement(s"call sys.COMMIT_SNAPSHOT_TXID(?,?)")
+          ps.setString(1, if (txId ne null) txId else "")
+          ps.setString(2, if (delayRollover) tableName else "")
+          ps.executeUpdate()
+          logDebug(s"The txid being committed is $txId")
+          ps.close()
+          SmartConnectorRDDHelper.snapshotTxIdForRead.set(null)
+          logDebug(s"closed connection for task from listener $partitionId")
+          try {
+            conn.close()
+            logDebug("closed connection for task " + context.partitionId())
+          } catch {
+            case NonFatal(e) => logWarning("Exception closing connection", e)
+          }
+          // }
         }
-        // }
       }
     }
     itr


### PR DESCRIPTION
## Changes proposed in this pull request

In SmartConnectorColumnRDD#compute, moved the code to attach task completion listener into a finally block. This is because when call to helper.prepareScan throws an exception, the listener was not getting attached and therefore snapshotTxIdForRead was never set to null even after the task is complete. This resulted in invalid (old) txId getting used in subsequent tasks.

## Patch testing
Ran the mentioned hydra test in bug 10 times. 
Ran SplitCluster* dunit tests
Precheckin to be run

## ReleaseNotes.txt changes

## Other PRs 

