### PR TITLE
Fix for SNAP-2440. 

### DIFF
--- a/cluster/src/test/scala/org/apache/spark/sql/MiscTest.scala
+++ b/cluster/src/test/scala/org/apache/spark/sql/MiscTest.scala
@@ -94,22 +94,24 @@ class MiscTest extends SnappyFunSuite with Logging {
     snc.sql(s"insert into test values (1, 2), (4, 5), (6, 7)")
     val sqlstrs = Seq(s"select app.test.* from app.test",
       s"select app.test.col1, app.test.col2 from app.test",
-      s"select app.test.col1 from test",
       s"select col1, col2 from app.test",
       s"select * from app.test",
       s"select test.* from test")
-    sqlstrs.foreach(sqlstr => snc.sql(sqlstr).collect().size === 3)
+    sqlstrs.foreach(sqlstr => {
+      val res = snc.sql(sqlstr).collect()
+      assert(res.size === 3)
+      assert(res(0).get(0) != res(0).get(1))
+    })
 
-    //    val badsqls = Seq(s"select apppp.test.* from app.test",
-    //      s"select app.test.col99, app.test.col2 from app.test",
-    //      s"select testt.* from app.test",
-    //      s"select test.*.* from test")
-    //    badsqls.foreach(sqlstr =>
-    //      try {
-    //        snc.sql(sqlstr)
-    //        fail(s"expected analysis exception for $sqlstr")
-    //      } catch {
-    //        case ae: AnalysisException => // expected ... ignore
-    //      })
+    val badsqls = Seq(s"select apppp.test.* from app.test",
+      s"select app.test.col99, app.test.col2 from app.test",
+      s"select testt.* from app.test")
+    badsqls.foreach(sqlstr =>
+      try {
+        snc.sql(sqlstr)
+        fail(s"expected analysis exception for $sqlstr")
+      } catch {
+        case ae: AnalysisException => // expected ... ignore
+      })
   }
 }

--- a/cluster/src/test/scala/org/apache/spark/sql/MiscTest.scala
+++ b/cluster/src/test/scala/org/apache/spark/sql/MiscTest.scala
@@ -88,4 +88,28 @@ class MiscTest extends SnappyFunSuite with Logging {
       snc.sql(s"set schema app")
     }
   }
+
+  test("SNAP-2440") {
+    snc.sql(s"create table test(col1 int not null, col2 int not null) using column options()")
+    snc.sql(s"insert into test values (1, 2), (4, 5), (6, 7)")
+    val sqlstrs = Seq(s"select app.test.* from app.test",
+      s"select app.test.col1, app.test.col2 from app.test",
+      s"select app.test.col1 from test",
+      s"select col1, col2 from app.test",
+      s"select * from app.test",
+      s"select test.* from test")
+    sqlstrs.foreach(sqlstr => snc.sql(sqlstr).collect().size === 3)
+
+    //    val badsqls = Seq(s"select apppp.test.* from app.test",
+    //      s"select app.test.col99, app.test.col2 from app.test",
+    //      s"select testt.* from app.test",
+    //      s"select test.*.* from test")
+    //    badsqls.foreach(sqlstr =>
+    //      try {
+    //        snc.sql(sqlstr)
+    //        fail(s"expected analysis exception for $sqlstr")
+    //      } catch {
+    //        case ae: AnalysisException => // expected ... ignore
+    //      })
+  }
 }

--- a/core/src/main/scala/org/apache/spark/sql/SnappySession.scala
+++ b/core/src/main/scala/org/apache/spark/sql/SnappySession.scala
@@ -244,8 +244,8 @@ class SnappySession(_sc: SparkContext) extends SparkSession(_sc) {
 
   val unresolvedStarRegex = """(cannot resolve ')(\w+).(\w+).*(' give input columns.*)""".r
   val unresolvedColRegex = """(cannot resolve '`)(\w+).(\w+).(\w+)(.*given input columns.*)""".r
-  
-  // Hack to fix SNAP-2340 ( TODO: Will return after 102 to see if a better fix is warranted )
+
+  // Hack to fix SNAP-2440 ( TODO: Will return after 102 to see if a better fix is warranted )
   private def reAnalyzeForUnresolvedAttribute(
     originalPlan: LogicalPlan, e: AnalysisException,
     retryCount: Int): Option[LogicalPlan] = {


### PR DESCRIPTION
Will revisit for a more decent fix if required after 102

## Changes proposed in this pull request

Do not do anything by default. I mean no extra analysis rule or new node type.
Instead just catch the Analysis exception and retry with new UnresolvedStar node or UnresolvedAttributeNode as the case may be with unqualified projection name.


## Patch testing

Added a unit test

## ReleaseNotes.txt changes

Yes.

## Other PRs 

No.
