### PR TITLE
Added Fix to query with optional n argument

### DIFF
--- a/core/src/main/scala/org/apache/spark/sql/SnappyParser.scala
+++ b/core/src/main/scala/org/apache/spark/sql/SnappyParser.scala
@@ -719,7 +719,14 @@ class SnappyParser(session: SnappySession)
   }
 
   protected final def fetchExpression: Rule1[Expression] = rule {
-    FETCH ~ FIRST ~ expressionNoTokens ~ ((ROW|ROWS) ~ ONLY) ~> ((f: Expression) => f)
+    FETCH ~ FIRST ~ push(tokenize) ~ TOKENIZE_END ~ integral.? ~ ((ROW | ROWS) ~ ONLY) ~>
+      ((tokenized: Boolean, f: Any) => {
+        tokenize = tokenized
+        f.asInstanceOf[Option[String]] match {
+          case None => Literal(1)
+          case Some(s) => Literal(s.toInt)
+        }
+      })
   }
 
   protected final def distributeBy: Rule1[LogicalPlan => LogicalPlan] = rule {


### PR DESCRIPTION
In "fetch first n row only" it was expecting to pass 'n' number of first rows.
Now we made n as a optional field, if n didn't pass then it will fetch first 1 row.

## Changes proposed in this pull request

(Fill in the changes here)

## Patch testing

(Fill in the details about how this patch was tested)

## ReleaseNotes.txt changes

(Does this change require an entry in ReleaseNotes.txt? If yes, has it been added to it?)

## Other PRs 

(Does this change require changes in other projects- store, spark, spark-jobserver, aqp? Add the links of PR of the other subprojects that are related to this change)
