### PR TITLE
Code changes for ENT-21:

### DIFF
--- a/cluster/src/main/scala/io/snappydata/ToolsCallbackImpl.scala
+++ b/cluster/src/main/scala/io/snappydata/ToolsCallbackImpl.scala
@@ -25,17 +25,47 @@ import com.pivotal.gemfirexd.internal.engine.Misc
 import com.pivotal.gemfirexd.internal.engine.distributed.utils.GemFireXDUtils
 import io.snappydata.cluster.ExecutorInitiator
 import io.snappydata.impl.LeadImpl
+
 import org.apache.spark.executor.SnappyExecutor
-import org.apache.spark.{SparkContext, SparkFiles}
+import org.apache.spark.{Logging, SparkCallbacks, SparkContext, SparkFiles}
 import org.apache.spark.sql.catalyst.expressions.Expression
 import org.apache.spark.sql.catalyst.plans.physical.{HashPartitioning, Partitioning}
-import org.apache.spark.ui.SnappyDashboardTab
+import org.apache.spark.sql.execution.columnar.ExternalStoreUtils
+import org.apache.spark.sql.execution.ui.SQLTab
+import org.apache.spark.ui.{JettyUtils, SnappyDashboardTab}
 import org.apache.spark.util.{SnappyUtils, Utils}
 
-object ToolsCallbackImpl extends ToolsCallback {
+object ToolsCallbackImpl extends ToolsCallback with Logging {
 
   override def updateUI(sc: SparkContext): Unit = {
-    SnappyUtils.getSparkUI(sc).foreach(new SnappyDashboardTab(_))
+
+    SnappyUtils.getSparkUI(sc).foreach(ui => {
+      // Create Snappy Dashboard and SQL tabs.
+      // Set SnappyData authenticator SecurityHandler.
+      SparkCallbacks.getAuthenticatorForJettyServer match {
+        case Some(_) =>
+          // Set JettyUtils.skipHandlerStart for adding dashboard and sql security handlers
+          JettyUtils.skipHandlerStart.set(true)
+          // Creating SQL and Dashboard UI tabs
+          new SQLTab(ExternalStoreUtils.getSQLListener.get(), ui)
+          new SnappyDashboardTab(ui)
+          // Set security handlers
+          ui.getHandlers.foreach { h =>
+            if (!h.isStarted) {
+              h.setSecurityHandler(JettyUtils.basicAuthenticationHandler())
+              h.start()
+            }
+          }
+          // Unset JettyUtils.skipHandlerStart
+          JettyUtils.skipHandlerStart.set(false)
+        case None => logDebug("Not setting auth handler")
+          // Creating SQL and Dashboard UI tabs
+          new SQLTab(ExternalStoreUtils.getSQLListener.get(), ui)
+          new SnappyDashboardTab(ui)
+      }
+    })
+
+
   }
 
   override def removeAddedJar(sc: SparkContext, jarName: String): Unit =

--- a/core/src/main/java/org/apache/spark/sql/hive/SnappySharedState.java
+++ b/core/src/main/java/org/apache/spark/sql/hive/SnappySharedState.java
@@ -73,10 +73,12 @@ public final class SnappySharedState extends SharedState {
       SnappySQLListener listener = new SnappySQLListener(sc.conf());
       if (ExternalStoreUtils.getSQLListener().compareAndSet(null, listener)) {
         sc.addSparkListener(listener);
+        /*
         scala.Option<SparkUI> ui = sc.ui();
         if (ui.isDefined()) {
           new SQLTab(listener, ui.get());
         }
+        */
       }
       return ExternalStoreUtils.getSQLListener().get();
     } else {


### PR DESCRIPTION
## Changes proposed in this pull request

Issue: SnappyData Dashboard and SQL tabs are visible even if Cluster is started with authentication enabled. Changes proposed to fix this issue are as follows.
 - Set security handlers to all ServletContextHandlers which are created as a part of Dashboard, SQL tabs and Auto-refresh feature web services.
 - Moved SQL tab creation from _SnappySharedState:createListenerAndUI_ to _ToolsCallbackImpl:updateUI_.

## Patch testing

 - Tested Manually with/without Authentication (LDAP)

## ReleaseNotes.txt changes

 - NA

## Other PRs 

 Spark: https://github.com/SnappyDataInc/spark/pull/118
