### PR TITLE
Fixes for SNAP-2433:

### DIFF
--- a/core/src/main/scala/io/snappydata/SnappyTableStatsProviderService.scala
+++ b/core/src/main/scala/io/snappydata/SnappyTableStatsProviderService.scala
@@ -156,15 +156,11 @@ object SnappyEmbeddedTableStatsProviderService extends TableStatsProviderService
           memberStats = new MemberStatistics(memMap)
           if (dssUUID != null) {
             members.put(dssUUID.toString, memberStats)
-          } else if (id != null) {
-            members.put(id, memberStats)
           }
         } else {
           memberStats.updateMemberStatistics(memMap)
           if (dssUUID != null) {
             members.put(dssUUID.toString, memberStats)
-          } else if (id != null) {
-            members.put(id, memberStats)
           }
         }
 


### PR DESCRIPTION
## Changes proposed in this pull request
**Problem:** Same member node is listed twice, in the UI, with different status.
**Cause:** Multiple Disk Store UUIDs are found when same member is shuts down and comes back again. 
Also if Disk Store is not found, then members stats are first stored against its Id as key in stats map. Later after Disk store UUID is available the another entry with Disk store UUID is added for same node.
**Solution:**
  - Storing cluster members stats in map against their DiskStoreUUID(as key) only
    and removing members ID as key.

## Patch testing

 - Tested manually
 - Tested using Cluster Recovery BT.

## ReleaseNotes.txt changes

 - NA

## Other PRs 

 Store: https://github.com/SnappyDataInc/snappy-store/pull/415