### PR TITLE
[SNAP-2477] Adding an API to get table type for SnappyData tables.

### DIFF
--- a/core/src/main/scala/org/apache/spark/sql/hive/SnappyStoreHiveCatalog.scala
+++ b/core/src/main/scala/org/apache/spark/sql/hive/SnappyStoreHiveCatalog.scala
@@ -1069,6 +1069,24 @@ class SnappyStoreHiveCatalog(externalCatalog: SnappyExternalCatalog,
     }
   }
 
+    def getTableType(table: String): String = {
+        val tableIdent = this.newQualifiedTableName(table)
+        try {
+            val relation: LogicalRelation = getCachedHiveTable(tableIdent)
+            // println(relation)
+            val tableType: ExternalTableType = relation match {
+                case LogicalRelation(mutable: BaseRelation, _, _) =>
+                    snappySession.sessionCatalog.getTableType(mutable)
+                case _ => ExternalTableType.apply("None")
+            }
+            tableType.name
+        } catch {
+            case _: TableNotFoundException | _: NoSuchTableException =>
+                throw new Exception(s"Table '$table' not found")
+            case ex: Throwable => throw ex
+        }
+    }
+
   private def toUrl(resource: FunctionResource): URL = {
     val path = resource.uri
     val uri = new Path(path).toUri

--- a/core/src/main/scala/org/apache/spark/sql/hive/SnappyStoreHiveCatalog.scala
+++ b/core/src/main/scala/org/apache/spark/sql/hive/SnappyStoreHiveCatalog.scala
@@ -1068,15 +1068,14 @@ class SnappyStoreHiveCatalog(externalCatalog: SnappyExternalCatalog,
       case _ => ExternalTableType.External
     }
   }
-
+    /** API to get table type of a SnappyData table */
     def getTableType(table: String): String = {
         val tableIdent = this.newQualifiedTableName(table)
         try {
             val relation: LogicalRelation = getCachedHiveTable(tableIdent)
-            // println(relation)
             val tableType: ExternalTableType = relation match {
                 case LogicalRelation(mutable: BaseRelation, _, _) =>
-                    snappySession.sessionCatalog.getTableType(mutable)
+                    snappySession.sessionCatalog.getTableType(mutable) // get the table type for table
                 case _ => ExternalTableType.apply("None")
             }
             tableType.name

--- a/core/src/test/scala/org/apache/spark/sql/store/ColumnTableTest.scala
+++ b/core/src/test/scala/org/apache/spark/sql/store/ColumnTableTest.scala
@@ -1474,7 +1474,7 @@ class ColumnTableTest
         val res4 = session.sessionCatalog.getTableType("temp4")
         assert(res4 == "EXTERNAL")
 
-        Try(session.sessionCatalog.getKeyColumns("temp5")) match {
+        Try(session.sessionCatalog.getTableType("temp5")) match {
             case Success(df) => throw new AssertionError(
                 "Should not have succedded with incorrect options")
             case Failure(error) => // Do nothing

--- a/core/src/test/scala/org/apache/spark/sql/store/ColumnTableTest.scala
+++ b/core/src/test/scala/org/apache/spark/sql/store/ColumnTableTest.scala
@@ -1455,7 +1455,7 @@ class ColumnTableTest
         snc.sql(s"insert into t1 values(3,'test3')")
         val df = snc.sql("select * from t1")
         df.show
-        val tempPath = "/tmp/" + System.currentTimeMillis()
+        val tempPath = System.getProperty("user.dir") + System.currentTimeMillis()
 
         assert(df.count() == 3)
         df.write.option("header", "true").csv(tempPath)


### PR DESCRIPTION
## Changes proposed in this pull request

(Fill in the changes here)

## Patch testing

(Fill in the details about how this patch was tested)

## ReleaseNotes.txt changes

(Does this change require an entry in ReleaseNotes.txt? If yes, has it been added to it?)

## Other PRs 

(Does this change require changes in other projects- store, spark, spark-jobserver, aqp? Add the links of PR of the other subprojects that are related to this change)
