### PR TITLE
Added a new script snappy-encrypt-password.sh

### DIFF
--- a/cluster/sbin/snappy-encrypt-password.sh
+++ b/cluster/sbin/snappy-encrypt-password.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+
+function absPath() {
+  perl -MCwd -le 'print Cwd::abs_path(shift)' "$1"
+}
+
+sbin="$(dirname "$(absPath "$0")")"
+
+if [ -z "$1" ]; then
+  echo "At least one user name must be provided"
+  echo "Usage: `basename $0` <user1> <user2> ..."
+  exit 1
+fi
+
+trap "stty echo; exit $?" EXIT
+
+# get the plain-text passwords for all specified users
+declare -A userPasswords
+for user in "$@"; do
+  echo -n "Enter password for $user: "
+  stty -echo
+  read passwd1
+  stty echo
+  echo
+  echo -n "Re-enter password for $user: "
+  stty -echo
+  read passwd2
+  stty echo
+  echo
+  if [ "${passwd1}" != "${passwd2}" ]; then
+    echo Passwords for $user do not match
+    exit 1
+  fi
+  userPasswords["${user}"]="${passwd1}"
+done
+
+# get locator host:port
+hostPort="$($sbin/snappy-locators.sh start -dump-server-info)"
+
+# check for no specified client-port which will default to 1527 as per product defaults
+clientPort=""
+case "${hostPort}" in
+  *:) clientPort="-client-port=1527"; hostPort="${hostPort}1527" ;;
+esac
+
+$sbin/snappy-locators.sh start -user=app -auth-provider=NONE -J-Dgemfirexd.thrift-default=false -log-level=warning "$clientPort"
+
+callStr=
+for user in ${!userPasswords[@]}; do
+  callStr="${callStr} call sys.encrypt_password('$user', '${userPasswords[$user]}', 'AES', 0);"
+done
+
+$sbin/../bin/snappy << EOF
+connect 'jdbc:snappydata:drda://$hostPort/;load-balance=false';
+$callStr
+EOF
+
+$sbin/snappy-locators.sh stop

--- a/cluster/sbin/snappy-leads.sh
+++ b/cluster/sbin/snappy-leads.sh
@@ -33,7 +33,7 @@ sbin="$(dirname "$(absPath "$0")")"
 
 # Launch the slaves
 if echo $@ | grep -qw start; then
-  "$sbin/snappy-nodes.sh" lead cd "$SNAPPY_HOME" \; "$sbin/snappy-lead.sh" $@ $LEAD_STARTUP_OPTIONS
+  "$sbin/snappy-nodes.sh" lead cd "$SNAPPY_HOME" \; "$sbin/snappy-lead.sh" "$@" $LEAD_STARTUP_OPTIONS
 else
-  "$sbin/snappy-nodes.sh" lead cd "$SNAPPY_HOME" \; "$sbin/snappy-lead.sh" $@
+  "$sbin/snappy-nodes.sh" lead cd "$SNAPPY_HOME" \; "$sbin/snappy-lead.sh" "$@"
 fi

--- a/cluster/sbin/snappy-locators.sh
+++ b/cluster/sbin/snappy-locators.sh
@@ -33,7 +33,7 @@ sbin="$(dirname "$(absPath "$0")")"
 
 # Launch the slaves
 if echo $@ | grep -qw start; then
-  "$sbin/snappy-nodes.sh" locator cd "$SNAPPY_HOME" \; "$sbin/snappy-locator.sh" $@ $LOCATOR_STARTUP_OPTIONS
+  "$sbin/snappy-nodes.sh" locator cd "$SNAPPY_HOME" \; "$sbin/snappy-locator.sh" "$@" $LOCATOR_STARTUP_OPTIONS
 else
-  "$sbin/snappy-nodes.sh" locator cd "$SNAPPY_HOME" \; "$sbin/snappy-locator.sh" $@
+  "$sbin/snappy-nodes.sh" locator cd "$SNAPPY_HOME" \; "$sbin/snappy-locator.sh" "$@"
 fi

--- a/cluster/sbin/snappy-servers.sh
+++ b/cluster/sbin/snappy-servers.sh
@@ -43,7 +43,7 @@ fi
 
 # Launch the slaves
 if echo $@ | grep -qw start; then
-  "$sbin/snappy-nodes.sh" server $BACKGROUND cd "$SNAPPY_HOME" \; "$sbin/snappy-server.sh"  $@ $SERVER_STARTUP_OPTIONS
+  "$sbin/snappy-nodes.sh" server $BACKGROUND cd "$SNAPPY_HOME" \; "$sbin/snappy-server.sh"  "$@" $SERVER_STARTUP_OPTIONS
 else
-  "$sbin/snappy-nodes.sh" server $BACKGROUND cd "$SNAPPY_HOME" \; "$sbin/snappy-server.sh"  $@
+  "$sbin/snappy-nodes.sh" server $BACKGROUND cd "$SNAPPY_HOME" \; "$sbin/snappy-server.sh"  "$@"
 fi


### PR DESCRIPTION
Added a new script snappy-encrypt-password.sh that accepts userIds, plaint text passwords and returns an encrypted passwords.

This scripts uses newly added proc SYS.ENCRYPT_PASSWORD(). This script starts a locator using user's conf file settings AuthProvider as none. The encryption key is stored in data dictionary.
Changes to other scripts to allow passing of command line args.

Changes done along with Sumedh.

## Patch testing
Manual tests
Security dunit tests

## ReleaseNotes.txt changes
Doc note to be added


## Other PRs 
Store side PR: https://github.com/SnappyDataInc/snappy-store/pull/419

