### PR TITLE
fixing the policy test failures after the new restrictTableCreation f…

### DIFF
--- a/cluster/src/main/scala/io/snappydata/ToolsCallbackImpl.scala
+++ b/cluster/src/main/scala/io/snappydata/ToolsCallbackImpl.scala
@@ -189,6 +189,7 @@ object ToolsCallbackImpl extends ToolsCallback with Logging {
             }
           }
           PrivilegeInfo.checkOwnership(currentUser, sd, sd, dd)
+          sd.getAuthorizationId;
         } finally {
           if (contextSet) conn.getTR.restoreContextStack()
         }

--- a/cluster/src/main/scala/io/snappydata/ToolsCallbackImpl.scala
+++ b/cluster/src/main/scala/io/snappydata/ToolsCallbackImpl.scala
@@ -166,7 +166,7 @@ object ToolsCallbackImpl extends ToolsCallback with Logging {
     ret
   }
 
-  override def checkSchemaPermission(schema: String, currentUser: String): Unit = {
+  override def checkSchemaPermission(schema: String, currentUser: String): String = {
     val ms = Misc.getMemStoreBootingNoThrow
     if (ms != null) {
       var conn: EmbedConnection = null
@@ -181,7 +181,7 @@ object ToolsCallbackImpl extends ToolsCallback with Logging {
             schema, conn.getLanguageConnection.getTransactionExecute, false)
           if (sd == null) {
             if (schema.equals(currentUser)) {
-              if (ms.tableCreationAllowed()) return
+              if (ms.tableCreationAllowed()) return currentUser
               throw StandardException.newException(SQLState.AUTH_NO_ACCESS_NOT_OWNER,
                 schema, schema)
             } else {
@@ -192,7 +192,9 @@ object ToolsCallbackImpl extends ToolsCallback with Logging {
         } finally {
           if (contextSet) conn.getTR.restoreContextStack()
         }
+      } else {
+        currentUser
       }
-    }
+    } else currentUser
   }
 }

--- a/cluster/src/test/scala/org/apache/spark/sql/policy/AlterTableRowLevelSecurityEnableTest.scala
+++ b/cluster/src/test/scala/org/apache/spark/sql/policy/AlterTableRowLevelSecurityEnableTest.scala
@@ -50,16 +50,8 @@ class AlterTableRowLevelSecurityEnableTest extends SnappyFunSuite
   val rowTableName: String = s"${tableOwner}.$rowTable"
 
   var ownerContext: SnappyContext = _
-  var allowCreateTableFlag: Boolean = _
+
   override def beforeAll(): Unit = {
-    val ms = Misc.getMemStoreBootingNoThrow
-    if (ms != null) {
-      allowCreateTableFlag = ms.tableCreationAllowed
-    }
-    if (!allowCreateTableFlag) {
-      this.stopAll()
-      System.setProperty("snappydata.RESTRICT_TABLE_CREATION", "false")
-    }
     super.beforeAll()
 
     val seq = for (i <- 0 until numElements) yield {
@@ -86,11 +78,6 @@ class AlterTableRowLevelSecurityEnableTest extends SnappyFunSuite
   override def afterAll(): Unit = {
     ownerContext.dropTable(colTableName, true)
     ownerContext.dropTable(rowTableName, true)
-    val ms = Misc.getMemStoreBootingNoThrow
-    if (allowCreateTableFlag != ms.tableCreationAllowed()) {
-      this.stopAll()
-      System.setProperty("snappydata.RESTRICT_TABLE_CREATION", allowCreateTableFlag.toString)
-    }
     super.afterAll()
   }
 

--- a/cluster/src/test/scala/org/apache/spark/sql/policy/AlterTableRowLevelSecurityEnableTest.scala
+++ b/cluster/src/test/scala/org/apache/spark/sql/policy/AlterTableRowLevelSecurityEnableTest.scala
@@ -50,6 +50,8 @@ class AlterTableRowLevelSecurityEnableTest extends SnappyFunSuite
   var ownerContext: SnappyContext = _
 
   override def beforeAll(): Unit = {
+    this.stopAll()
+    System.setProperty("snappydata.RESTRICT_TABLE_CREATION", "false")
     super.beforeAll()
 
     val seq = for (i <- 0 until numElements) yield {
@@ -77,6 +79,7 @@ class AlterTableRowLevelSecurityEnableTest extends SnappyFunSuite
     ownerContext.dropTable(colTableName, true)
     ownerContext.dropTable(rowTableName, true)
     super.afterAll()
+    System.clearProperty("snappydata.RESTRICT_TABLE_CREATION")
 
   }
 

--- a/cluster/src/test/scala/org/apache/spark/sql/policy/PolicyJdbcClientTest.scala
+++ b/cluster/src/test/scala/org/apache/spark/sql/policy/PolicyJdbcClientTest.scala
@@ -45,6 +45,8 @@ class PolicyJdbcClientTest extends SnappyFunSuite
   var ownerContext: SnappyContext = _
 
   override def beforeAll(): Unit = {
+    this.stopAll()
+    System.setProperty("snappydata.RESTRICT_TABLE_CREATION", "false")
     super.beforeAll()
     val seq = for (i <- 0 until numElements) yield {
       (s"name_$i", i)
@@ -79,6 +81,7 @@ class PolicyJdbcClientTest extends SnappyFunSuite
     ownerContext.dropTable(rowTableName, true)
     TestUtil.stopNetServer()
     super.afterAll()
+    System.clearProperty("snappydata.RESTRICT_TABLE_CREATION")
 
   }
 

--- a/cluster/src/test/scala/org/apache/spark/sql/policy/PolicyJdbcClientTest.scala
+++ b/cluster/src/test/scala/org/apache/spark/sql/policy/PolicyJdbcClientTest.scala
@@ -43,16 +43,7 @@ class PolicyJdbcClientTest extends SnappyFunSuite
   val colTableName: String = s"$tableOwner.ColumnTable"
   val rowTableName: String = s"${tableOwner}.RowTable"
   var ownerContext: SnappyContext = _
-  var allowCreateTableFlag: Boolean = _
   override def beforeAll(): Unit = {
-    val ms = Misc.getMemStoreBootingNoThrow
-    if (ms != null) {
-      allowCreateTableFlag = ms.tableCreationAllowed
-    }
-    if (!allowCreateTableFlag) {
-      this.stopAll()
-      System.setProperty("snappydata.RESTRICT_TABLE_CREATION", "false")
-    }
     super.beforeAll()
     val seq = for (i <- 0 until numElements) yield {
       (s"name_$i", i)
@@ -85,11 +76,6 @@ class PolicyJdbcClientTest extends SnappyFunSuite
   override def afterAll(): Unit = {
     ownerContext.dropTable(colTableName, true)
     ownerContext.dropTable(rowTableName, true)
-    val ms = Misc.getMemStoreBootingNoThrow
-    if (allowCreateTableFlag != ms.tableCreationAllowed()) {
-      this.stopAll()
-      System.setProperty("snappydata.RESTRICT_TABLE_CREATION", allowCreateTableFlag.toString)
-    }
     TestUtil.stopNetServer()
     super.afterAll()
   }

--- a/cluster/src/test/scala/org/apache/spark/sql/policy/PolicyTest.scala
+++ b/cluster/src/test/scala/org/apache/spark/sql/policy/PolicyTest.scala
@@ -41,7 +41,7 @@ class PolicyTest extends SnappyFunSuite
   val colTableName: String = s"$tableOwner.ColumnTable"
   val rowTableName: String = s"${tableOwner}.RowTable"
   var ownerContext: SnappyContext = _
-  var allowCreateTableFlag: Boolean = _
+
   protected override def newSparkConf(addOn: (SparkConf) => SparkConf): SparkConf = {
     val conf = new org.apache.spark.SparkConf()
         .setAppName("PolicyTest")
@@ -55,15 +55,7 @@ class PolicyTest extends SnappyFunSuite
   }
 
   override def beforeAll(): Unit = {
-    val ms = Misc.getMemStoreBootingNoThrow
-    if (ms != null) {
-      allowCreateTableFlag = ms.tableCreationAllowed
-    }
-    if (!allowCreateTableFlag) {
-      System.setProperty("snappydata.RESTRICT_TABLE_CREATION", "false")
-    }
     this.stopAll()
-
     super.beforeAll()
     val seq = for (i <- 0 until numElements) yield {
       (s"name_$i", i)
@@ -88,11 +80,6 @@ class PolicyTest extends SnappyFunSuite
   override def afterAll(): Unit = {
     ownerContext.dropTable(colTableName, true)
     ownerContext.dropTable(rowTableName, true)
-    val ms = Misc.getMemStoreBootingNoThrow
-    if (allowCreateTableFlag != ms.tableCreationAllowed()) {
-      this.stopAll()
-      System.setProperty("snappydata.RESTRICT_TABLE_CREATION", allowCreateTableFlag.toString)
-    }
     super.afterAll()
   }
 

--- a/cluster/src/test/scala/org/apache/spark/sql/policy/PolicyTest.scala
+++ b/cluster/src/test/scala/org/apache/spark/sql/policy/PolicyTest.scala
@@ -18,7 +18,7 @@ package org.apache.spark.sql.policy
 
 import com.pivotal.gemfirexd.Attribute
 import com.pivotal.gemfirexd.internal.engine.Misc
-import io.snappydata.SnappyFunSuite
+import io.snappydata.{Constant, SnappyFunSuite}
 import org.junit.Assert.{assertEquals, assertTrue}
 import org.scalatest.{BeforeAndAfter, BeforeAndAfterAll}
 
@@ -43,13 +43,11 @@ class PolicyTest extends SnappyFunSuite
   var ownerContext: SnappyContext = _
 
   protected override def newSparkConf(addOn: (SparkConf) => SparkConf): SparkConf = {
-
-
     val conf = new org.apache.spark.SparkConf()
         .setAppName("PolicyTest")
         .setMaster("local[4]")
         .set("spark.sql.crossJoin.enabled", "true")
-
+    System.setProperty("snappydata.RESTRICT_TABLE_CREATION", "false")
     if (addOn != null) {
       addOn(conf)
     } else {
@@ -58,6 +56,8 @@ class PolicyTest extends SnappyFunSuite
   }
 
   override def beforeAll(): Unit = {
+    this.stopAll()
+
     super.beforeAll()
     val seq = for (i <- 0 until numElements) yield {
       (s"name_$i", i)
@@ -83,6 +83,7 @@ class PolicyTest extends SnappyFunSuite
     ownerContext.dropTable(colTableName, true)
     ownerContext.dropTable(rowTableName, true)
     super.afterAll()
+    System.clearProperty("snappydata.RESTRICT_TABLE_CREATION")
   }
 
   test("Policy creation on a column table using snappy context") {

--- a/cluster/src/test/scala/org/apache/spark/sql/policy/RestrictTableCreationPolicyTest.scala
+++ b/cluster/src/test/scala/org/apache/spark/sql/policy/RestrictTableCreationPolicyTest.scala
@@ -54,20 +54,12 @@ class RestrictTableCreationPolicyTest extends SnappyFunSuite
   var ownerContext: SnappyContext = _
 
   private val sysUser = "gemfire10"
-  var allowCreateTableFlag: Boolean = _
   var serverHostPort: String = _
 
 
   override def beforeAll(): Unit = {
-    val ms = Misc.getMemStoreBootingNoThrow
-    if (ms != null) {
-      allowCreateTableFlag = ms.tableCreationAllowed
-    }
-    if (allowCreateTableFlag) {
-      System.setProperty("snappydata.RESTRICT_TABLE_CREATION", "true")
-    }
+    System.setProperty("snappydata.RESTRICT_TABLE_CREATION", "true")
     this.stopAll()
-
     super.beforeAll()
     val seq = for (i <- 0 until numElements) yield {
       (s"name_$i", i)
@@ -129,10 +121,6 @@ class RestrictTableCreationPolicyTest extends SnappyFunSuite
   override def afterAll(): Unit = {
     ownerContext.dropTable(colTableName, true)
     ownerContext.dropTable(rowTableName, true)
-    val ms = Misc.getMemStoreBootingNoThrow
-    if (allowCreateTableFlag != ms.tableCreationAllowed()) {
-      System.setProperty("snappydata.RESTRICT_TABLE_CREATION", allowCreateTableFlag.toString)
-    }
     this.stopAll()
     super.afterAll()
     val ldapServer = LdapTestServer.getInstance()
@@ -148,7 +136,7 @@ class RestrictTableCreationPolicyTest extends SnappyFunSuite
     System.clearProperty(Constant.STORE_PROPERTY_PREFIX + Attribute.USERNAME_ATTR)
     System.clearProperty(Constant.STORE_PROPERTY_PREFIX + Attribute.PASSWORD_ATTR)
     System.setProperty("gemfirexd.authentication.required", "false")
-
+    System.clearProperty("snappydata.RESTRICT_TABLE_CREATION")
   }
 
 

--- a/cluster/src/test/scala/org/apache/spark/sql/policy/SecurityEnabledJdbcClientPolicyTest.scala
+++ b/cluster/src/test/scala/org/apache/spark/sql/policy/SecurityEnabledJdbcClientPolicyTest.scala
@@ -54,6 +54,7 @@ class SecurityEnabledJdbcClientPolicyTest extends SnappyFunSuite
 
   override def beforeAll(): Unit = {
     this.stopAll()
+
     super.beforeAll()
     val seq = for (i <- 0 until numElements) yield {
       (s"name_$i", i)
@@ -83,6 +84,7 @@ class SecurityEnabledJdbcClientPolicyTest extends SnappyFunSuite
     for (k <- List(Attribute.AUTH_PROVIDER, AUTH_LDAP_SERVER, AUTH_LDAP_SEARCH_BASE)) {
       System.setProperty(k, ldapProperties.getProperty(k))
     }
+    System.setProperty("snappydata.RESTRICT_TABLE_CREATION", "false")
     System.setProperty(Constant.STORE_PROPERTY_PREFIX + Attribute.USERNAME_ATTR, sysUser)
     System.setProperty(Constant.STORE_PROPERTY_PREFIX + Attribute.PASSWORD_ATTR, sysUser)
     val conf = new org.apache.spark.SparkConf()
@@ -117,6 +119,7 @@ class SecurityEnabledJdbcClientPolicyTest extends SnappyFunSuite
     System.clearProperty(Constant.STORE_PROPERTY_PREFIX + Attribute.USERNAME_ATTR)
     System.clearProperty(Constant.STORE_PROPERTY_PREFIX + Attribute.PASSWORD_ATTR)
     System.setProperty("gemfirexd.authentication.required", "false")
+     System.clearProperty("snappydata.RESTRICT_TABLE_CREATION")
   }
 
 

--- a/cluster/src/test/scala/org/apache/spark/sql/policy/SecurityEnabledJdbcClientPolicyTest.scala
+++ b/cluster/src/test/scala/org/apache/spark/sql/policy/SecurityEnabledJdbcClientPolicyTest.scala
@@ -49,20 +49,10 @@ class SecurityEnabledJdbcClientPolicyTest extends SnappyFunSuite
   var ownerContext: SnappyContext = _
 
   private val sysUser = "gemfire10"
-  var allowCreateTableFlag: Boolean = _
   var serverHostPort: String = _
 
 
   override def beforeAll(): Unit = {
-    val ms = Misc.getMemStoreBootingNoThrow
-    if (ms != null) {
-      allowCreateTableFlag = ms.tableCreationAllowed
-    }
-    if (!allowCreateTableFlag) {
-      System.setProperty("snappydata.RESTRICT_TABLE_CREATION", "false")
-    }
-    this.stopAll()
-
     super.beforeAll()
     val seq = for (i <- 0 until numElements) yield {
       (s"name_$i", i)
@@ -111,12 +101,9 @@ class SecurityEnabledJdbcClientPolicyTest extends SnappyFunSuite
   override def afterAll(): Unit = {
     ownerContext.dropTable(colTableName, true)
     ownerContext.dropTable(rowTableName, true)
-    val ms = Misc.getMemStoreBootingNoThrow
-    if (allowCreateTableFlag != ms.tableCreationAllowed()) {
-      System.setProperty("snappydata.RESTRICT_TABLE_CREATION", allowCreateTableFlag.toString)
-    }
     this.stopAll()
     super.afterAll()
+
     val ldapServer = LdapTestServer.getInstance()
     if (ldapServer.isServerStarted) {
       ldapServer.stopService()

--- a/cluster/src/test/scala/org/apache/spark/sql/policy/SecurityEnabledJdbcClientPolicyTest.scala
+++ b/cluster/src/test/scala/org/apache/spark/sql/policy/SecurityEnabledJdbcClientPolicyTest.scala
@@ -130,7 +130,6 @@ class SecurityEnabledJdbcClientPolicyTest extends SnappyFunSuite
     System.clearProperty(Constant.STORE_PROPERTY_PREFIX + Attribute.USERNAME_ATTR)
     System.clearProperty(Constant.STORE_PROPERTY_PREFIX + Attribute.PASSWORD_ATTR)
     System.setProperty("gemfirexd.authentication.required", "false")
-     System.clearProperty("snappydata.RESTRICT_TABLE_CREATION")
   }
 
 

--- a/cluster/src/test/scala/org/apache/spark/sql/policy/SecurityEnabledPolicyTest.scala
+++ b/cluster/src/test/scala/org/apache/spark/sql/policy/SecurityEnabledPolicyTest.scala
@@ -54,6 +54,7 @@ class SecurityEnabledPolicyTest extends SnappyFunSuite
 
   override def beforeAll(): Unit = {
     this.stopAll()
+
     super.beforeAll()
     val seq = for (i <- 0 until numElements) yield {
       (s"name_$i", i)
@@ -80,6 +81,7 @@ class SecurityEnabledPolicyTest extends SnappyFunSuite
     for (k <- List(Attribute.AUTH_PROVIDER, AUTH_LDAP_SERVER, AUTH_LDAP_SEARCH_BASE)) {
       System.setProperty(k, ldapProperties.getProperty(k))
     }
+    System.setProperty("snappydata.RESTRICT_TABLE_CREATION", "false")
     System.setProperty(Constant.STORE_PROPERTY_PREFIX + Attribute.USERNAME_ATTR, sysUser)
     System.setProperty(Constant.STORE_PROPERTY_PREFIX + Attribute.PASSWORD_ATTR, sysUser)
     val conf = new org.apache.spark.SparkConf()
@@ -114,6 +116,7 @@ class SecurityEnabledPolicyTest extends SnappyFunSuite
     System.clearProperty(Constant.STORE_PROPERTY_PREFIX + Attribute.USERNAME_ATTR)
     System.clearProperty(Constant.STORE_PROPERTY_PREFIX + Attribute.PASSWORD_ATTR)
     System.setProperty("gemfirexd.authentication.required", "false")
+    System.clearProperty("snappydata.RESTRICT_TABLE_CREATION")
   }
 
 

--- a/cluster/src/test/scala/org/apache/spark/sql/policy/SecurityEnabledPolicyTest.scala
+++ b/cluster/src/test/scala/org/apache/spark/sql/policy/SecurityEnabledPolicyTest.scala
@@ -51,20 +51,10 @@ class SecurityEnabledPolicyTest extends SnappyFunSuite
   val colTableName: String = s"$tableOwner.ColumnTable"
   val rowTableName: String = s"${tableOwner}.RowTable"
   var ownerContext: SnappyContext = _
-  var allowCreateTableFlag: Boolean = _
 
   private val sysUser = "gemfire10"
 
   override def beforeAll(): Unit = {
-    val ms = Misc.getMemStoreBootingNoThrow
-    if (ms != null) {
-      allowCreateTableFlag = ms.tableCreationAllowed
-    }
-    if (!allowCreateTableFlag) {
-      System.setProperty("snappydata.RESTRICT_TABLE_CREATION", "false")
-    }
-    this.stopAll()
-
     super.beforeAll()
     val seq = for (i <- 0 until numElements) yield {
       (s"name_$i", i)
@@ -110,10 +100,6 @@ class SecurityEnabledPolicyTest extends SnappyFunSuite
   override def afterAll(): Unit = {
     ownerContext.dropTable(colTableName, true)
     ownerContext.dropTable(rowTableName, true)
-    val ms = Misc.getMemStoreBootingNoThrow
-    if (allowCreateTableFlag != ms.tableCreationAllowed()) {
-      System.setProperty("snappydata.RESTRICT_TABLE_CREATION", allowCreateTableFlag.toString)
-    }
     this.stopAll()
     super.afterAll()
     val ldapServer = LdapTestServer.getInstance()

--- a/core/src/main/scala/io/snappydata/ToolsCallback.scala
+++ b/core/src/main/scala/io/snappydata/ToolsCallback.scala
@@ -66,5 +66,11 @@ trait ToolsCallback {
 
   def getLeadClassLoader(): URLClassLoader
 
-  def checkSchemaPermission(schema: String, currentOwner: String): Unit
+  /**
+   *
+   * @param schema
+   * @param currentOwner
+   * @return the schema owner, can be ldap group
+   */
+  def checkSchemaPermission(schema: String, currentOwner: String): String
 }

--- a/core/src/main/scala/org/apache/spark/sql/SnappyDDLParser.scala
+++ b/core/src/main/scala/org/apache/spark/sql/SnappyDDLParser.scala
@@ -28,6 +28,7 @@ import com.gemstone.gemfire.SystemFailure
 import com.pivotal.gemfirexd.internal.engine.Misc
 import com.pivotal.gemfirexd.internal.iapi.util.IdUtil
 import io.snappydata.Constant
+
 import org.apache.spark.deploy.SparkSubmitUtils
 import org.apache.spark.sql.catalyst.analysis.UnresolvedRelation
 import org.apache.spark.sql.catalyst.catalog.{FunctionResource, FunctionResourceType}
@@ -49,10 +50,11 @@ import org.apache.spark.sql.{SnappyParserConsts => Consts}
 import org.apache.spark.streaming._
 import org.parboiled2._
 import shapeless.{::, HNil}
-
 import scala.collection.mutable.ArrayBuffer
 import scala.util.Try
 import scala.util.control.NonFatal
+
+import com.pivotal.gemfirexd.internal.iapi.sql.dictionary.SchemaDescriptor
 
 abstract class SnappyDDLParser(session: SparkSession)
     extends SnappyBaseParser(session) {
@@ -596,10 +598,10 @@ abstract class SnappyDDLParser(session: SparkSession)
     (GRANT | REVOKE | (CREATE | DROP) ~ DISK_STORE | ("{".? ~ CALL)) ~ ANY.* ~>
         /* dummy table because we will pass sql to gemfire layer so we only need to have sql */
         (() => DMLExternalTable(TableIdentifier(SnappyStoreHiveCatalog.dummyTableName,
-          Some(SnappyStoreHiveCatalog.dummyTableSchema)),
+          Some(SchemaDescriptor.IBM_SYSTEM_SCHEMA_NAME)),
           LogicalRelation(new execution.row.DefaultSource().createRelation(session.sqlContext,
             SaveMode.Ignore, Map(JdbcExtendedUtils.DBTABLE_PROPERTY ->
-                s"${SnappyStoreHiveCatalog.dummyTableSchema}.${SnappyStoreHiveCatalog.dummyTableName}"),
+                s"${SchemaDescriptor.IBM_SYSTEM_SCHEMA_NAME }.${SnappyStoreHiveCatalog.dummyTableName}"),
             "", None)), input.sliceString(0, input.length)))
   }
 

--- a/core/src/main/scala/org/apache/spark/sql/SnappyDDLParser.scala
+++ b/core/src/main/scala/org/apache/spark/sql/SnappyDDLParser.scala
@@ -595,9 +595,11 @@ abstract class SnappyDDLParser(session: SparkSession)
   protected def grantRevoke: Rule1[LogicalPlan] = rule {
     (GRANT | REVOKE | (CREATE | DROP) ~ DISK_STORE | ("{".? ~ CALL)) ~ ANY.* ~>
         /* dummy table because we will pass sql to gemfire layer so we only need to have sql */
-        (() => DMLExternalTable(TableIdentifier("SYSDUMMY1", Some("SYSIBM")),
+        (() => DMLExternalTable(TableIdentifier(SnappyStoreHiveCatalog.dummyTableName,
+          Some(SnappyStoreHiveCatalog.dummyTableSchema)),
           LogicalRelation(new execution.row.DefaultSource().createRelation(session.sqlContext,
-            SaveMode.Ignore, Map(JdbcExtendedUtils.DBTABLE_PROPERTY -> "SYSIBM.SYSDUMMY1"),
+            SaveMode.Ignore, Map(JdbcExtendedUtils.DBTABLE_PROPERTY ->
+                s"${SnappyStoreHiveCatalog.dummyTableSchema}.${SnappyStoreHiveCatalog.dummyTableName}"),
             "", None)), input.sliceString(0, input.length)))
   }
 

--- a/core/src/main/scala/org/apache/spark/sql/execution/SecurityUtils.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/SecurityUtils.scala
@@ -83,23 +83,4 @@ object SecurityUtils {
       }
     }
   }
-  /*
-  def allowPolicyOp(currentUser: String, table: QualifiedTableName,
-      session: SnappySession): Boolean = {
-    if (Misc.isSecurityEnabled) {
-      val connProps = ExternalStoreUtils.validateAndGetAllProps(Some(session), mutable.Map.empty)
-      val pooledConn = ExternalStoreUtils.getConnection("policyConn", connProps, false)
-      try {
-        val stmt = pooledConn.createStatement()
-        stmt.executeQuery(s"select 1 from sys.systables s, sys.sysschemas c where " +
-            s"s.tablename = '${table.table}' and s.tableschemaname = '${table.schemaName}' and " +
-            s"s.schemaid = c.schemaid and c.authorizationid = '$currentUser'").next()
-      } finally {
-        pooledConn.close()
-      }
-    } else {
-      true
-    }
-  }
-  */
 }

--- a/core/src/main/scala/org/apache/spark/sql/execution/SecurityUtils.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/SecurityUtils.scala
@@ -83,7 +83,7 @@ object SecurityUtils {
       }
     }
   }
-
+  /*
   def allowPolicyOp(currentUser: String, table: QualifiedTableName,
       session: SnappySession): Boolean = {
     if (Misc.isSecurityEnabled) {
@@ -101,4 +101,5 @@ object SecurityUtils {
       true
     }
   }
+  */
 }

--- a/core/src/main/scala/org/apache/spark/sql/hive/SnappyStoreHiveCatalog.scala
+++ b/core/src/main/scala/org/apache/spark/sql/hive/SnappyStoreHiveCatalog.scala
@@ -781,7 +781,8 @@ class SnappyStoreHiveCatalog(externalCatalog: SnappyExternalCatalog,
           // TODO: the authorizationID should be correctly set in SparkSQLExecuteImpl
           // using LCC.getAuthorizationId() itself rather than getUserName()
           val user = snappySession.conf.get(Attribute.USERNAME_ATTR, "")
-          if (user.nonEmpty) {
+          if (user.nonEmpty && !(tableIdent.schemaName == SnappyStoreHiveCatalog.dummyTableSchema
+              && tableIdent.table == SnappyStoreHiveCatalog.dummyTableName)) {
             val currentUser = IdUtil.getUserAuthorizationId(user)
             callbacks.checkSchemaPermission(tableIdent.schemaName, currentUser)
           }
@@ -1457,7 +1458,8 @@ class SnappyStoreHiveCatalog(externalCatalog: SnappyExternalCatalog,
 }
 
 object SnappyStoreHiveCatalog {
-
+  val dummyTableSchema = "SYSIBM"
+  val dummyTableName = "SYSDUMMY1"
   val HIVE_PROVIDER = "spark.sql.sources.provider"
   val HIVE_SCHEMA_PROP = "spark.sql.sources.schema"
   val HIVE_METASTORE = SystemProperties.SNAPPY_HIVE_METASTORE


### PR DESCRIPTION
…lag. The table name SYSIBM.SYSDUMMY1 is to skip permission check. Will be adding new tests with restrictTableCreation flag enabled in due course

skipping the permission check for SYSIBM.SYSDUMMY1 table when doing grant/revoke


(Fill in the details about how this patch was tested)

## ReleaseNotes.txt changes

(Does this change require an entry in ReleaseNotes.txt? If yes, has it been added to it?)

## Other PRs 

(Does this change require changes in other projects- store, spark, spark-jobserver, aqp? Add the links of PR of the other subprojects that are related to this change)
