### PR TITLE
Property to disable all hash joins

### DIFF
--- a/cluster/src/main/scala/io/snappydata/ToolsCallbackImpl.scala
+++ b/cluster/src/main/scala/io/snappydata/ToolsCallbackImpl.scala
@@ -19,7 +19,6 @@ package io.snappydata
 import java.io.File
 import java.lang.reflect.InvocationTargetException
 import java.net.URLClassLoader
-import java.util.UUID
 
 import com.pivotal.gemfirexd.internal.engine.Misc
 import com.pivotal.gemfirexd.internal.engine.distributed.utils.GemFireXDUtils
@@ -29,14 +28,13 @@ import com.pivotal.gemfirexd.internal.impl.sql.execute.PrivilegeInfo
 import com.pivotal.gemfirexd.internal.shared.common.reference.SQLState
 import io.snappydata.cluster.ExecutorInitiator
 import io.snappydata.impl.LeadImpl
+
 import org.apache.spark.executor.SnappyExecutor
-import org.apache.spark.{Logging, SparkCallbacks, SparkContext, SparkFiles}
-import org.apache.spark.sql.catalyst.expressions.Expression
-import org.apache.spark.sql.catalyst.plans.physical.{HashPartitioning, Partitioning}
 import org.apache.spark.sql.execution.columnar.ExternalStoreUtils
 import org.apache.spark.sql.execution.ui.SQLTab
 import org.apache.spark.ui.{JettyUtils, SnappyDashboardTab}
-import org.apache.spark.util.{SnappyUtils, Utils}
+import org.apache.spark.util.SnappyUtils
+import org.apache.spark.{Logging, SparkCallbacks, SparkContext}
 
 object ToolsCallbackImpl extends ToolsCallback with Logging {
 
@@ -80,8 +78,8 @@ object ToolsCallbackImpl extends ToolsCallback with Logging {
     sc.removeAddedJar(jarName)
 
   /**
-    * Callback to spark Utils to fetch file
-    */
+   * Callback to spark Utils to fetch file
+   */
   override def doFetchFile(
       url: String,
       targetDir: File,
@@ -95,7 +93,7 @@ object ToolsCallbackImpl extends ToolsCallback with Logging {
   }
 
   override def addURIs(alias: String, jars: Array[String],
-    deploySql: String, isPackage: Boolean = true): Unit = {
+      deploySql: String, isPackage: Boolean = true): Unit = {
     if (alias != null) {
       Misc.getMemStore.getGlobalCmdRgn.put(alias, deploySql)
     }
@@ -108,7 +106,7 @@ object ToolsCallbackImpl extends ToolsCallback with Logging {
     // Close and reopen interpreter
     if (alias != null) {
       try {
-        lead.closeAndReopenInterpreterServer();
+        lead.closeAndReopenInterpreterServer()
       } catch {
         case ite: InvocationTargetException => assert(ite.getCause.isInstanceOf[SecurityException])
       }
@@ -134,19 +132,18 @@ object ToolsCallbackImpl extends ToolsCallback with Logging {
 
   override def removePackage(alias: String): Unit = {
     GemFireXDUtils.waitForNodeInitialization()
-    val packageRegion = Misc.getMemStore.getGlobalCmdRgn()
+    val packageRegion = Misc.getMemStore.getGlobalCmdRgn
     packageRegion.destroy(alias)
   }
 
   override def setLeadClassLoader(): Unit = {
     val instance = ServiceManager.currentFabricServiceInstance
     instance match {
-      case li: LeadImpl => {
+      case li: LeadImpl =>
         val loader = li.urlclassloader
         if (loader != null) {
           Thread.currentThread().setContextClassLoader(loader)
         }
-      }
       case _ =>
     }
   }
@@ -155,12 +152,11 @@ object ToolsCallbackImpl extends ToolsCallback with Logging {
     var ret: URLClassLoader = null
     val instance = ServiceManager.currentFabricServiceInstance
     instance match {
-      case li: LeadImpl => {
+      case li: LeadImpl =>
         val loader = li.urlclassloader
         if (loader != null) {
           ret = loader
         }
-      }
       case _ =>
     }
     ret
@@ -189,7 +185,7 @@ object ToolsCallbackImpl extends ToolsCallback with Logging {
             }
           }
           PrivilegeInfo.checkOwnership(currentUser, sd, sd, dd)
-          sd.getAuthorizationId;
+          sd.getAuthorizationId
         } finally {
           if (contextSet) conn.getTR.restoreContextStack()
         }

--- a/cluster/src/main/scala/org/apache/spark/scheduler/cluster/SnappyCoarseGrainedSchedulerBackend.scala
+++ b/cluster/src/main/scala/org/apache/spark/scheduler/cluster/SnappyCoarseGrainedSchedulerBackend.scala
@@ -113,7 +113,7 @@ class BlockManagerIdListener(sc: SparkContext)
     SnappyContext.clearBlockIds()
 
   private def handleNewExecutorJoin(bid: BlockManagerId) = {
-    val uris = SnappySession.getJarURIs()
+    val uris = SnappySession.getJarURIs
     Utils.mapExecutors[Unit](sc, () => {
       ToolsCallbackInit.toolsCallback.addURIsToExecutorClassLoader(uris)
       Iterator.empty

--- a/cluster/src/test/scala/org/apache/spark/sql/policy/SecurityEnabledJdbcClientPolicyTest.scala
+++ b/cluster/src/test/scala/org/apache/spark/sql/policy/SecurityEnabledJdbcClientPolicyTest.scala
@@ -45,6 +45,7 @@ class SecurityEnabledJdbcClientPolicyTest extends SnappyFunSuite
 
 
   override def beforeAll(): Unit = {
+    stopAll()
     super.beforeAll()
     val seq = for (i <- 0 until numElements) yield {
       (s"name_$i", i)

--- a/core/src/main/scala/io/snappydata/Literals.scala
+++ b/core/src/main/scala/io/snappydata/Literals.scala
@@ -219,24 +219,25 @@ object Property extends Enumeration {
     } else None
   }
 
-  val Locators = Val[String](s"${Constant.STORE_PROPERTY_PREFIX}locators",
+  val Locators: SparkValue[String] = Val[String](s"${Constant.STORE_PROPERTY_PREFIX}locators",
     "The list of locators as comma-separated host:port values that have been " +
         "configured in the SnappyData cluster.", None, Constant.SPARK_PREFIX)
 
-  val McastPort = Val[Int](s"${Constant.STORE_PROPERTY_PREFIX}mcastPort",
+  val McastPort: SparkValue[Int] = Val[Int](s"${Constant.STORE_PROPERTY_PREFIX}mcastPort",
     "[Deprecated] The multicast port configured in the SnappyData cluster " +
         "when locators are not being used. This mode is no longer supported.",
     None, Constant.SPARK_PREFIX)
 
-  val JobServerEnabled = Val(s"${Constant.JOBSERVER_PROPERTY_PREFIX}enabled",
+  val JobServerEnabled: SparkValue[Boolean] = Val(s"${Constant.JOBSERVER_PROPERTY_PREFIX}enabled",
     "If true then REST API access via Spark jobserver will be available in " +
         "the SnappyData cluster", Some(true), prefix = null, isPublic = false)
 
-  val JobServerWaitForInit = Val(s"${Constant.JOBSERVER_PROPERTY_PREFIX}waitForInitialization",
+  val JobServerWaitForInit: SparkValue[Boolean] = Val(
+    s"${Constant.JOBSERVER_PROPERTY_PREFIX}waitForInitialization",
     "If true then cluster startup will wait for Spark jobserver to be fully initialized " +
         "before marking lead as 'RUNNING'. Default is false.", Some(false), prefix = null)
 
-  val SnappyConnection = Val[String](s"${Constant.PROPERTY_PREFIX}connection",
+  val SnappyConnection: SparkValue[String] = Val[String](s"${Constant.PROPERTY_PREFIX}connection",
      "Host and client port combination in the form [host:clientPort]. This " +
      "is used by smart connector to connect to SnappyData cluster using " +
      "JDBC driver. This will be used to form a JDBC URL of the form " +
@@ -244,10 +245,11 @@ object Property extends Enumeration {
      "It is recommended that hostname and client port of the locator " +
      "be specified for this.", None, Constant.SPARK_PREFIX)
 
-  val PlanCacheSize = Val[Int](s"${Constant.PROPERTY_PREFIX}sql.planCacheSize",
+  val PlanCacheSize: SparkValue[Int] = Val[Int](s"${Constant.PROPERTY_PREFIX}sql.planCacheSize",
     s"Number of query plans that will be cached.", Some(3000))
 
-  val ColumnBatchSize = SQLVal[String](s"${Constant.PROPERTY_PREFIX}column.batchSize",
+  val ColumnBatchSize: SQLValue[String] = SQLVal[String](
+    s"${Constant.PROPERTY_PREFIX}column.batchSize",
     "The default size of blocks to use for storage in SnappyData column " +
         "store. When inserting data into the column storage this is the unit " +
         "(in bytes or k/m/g suffixes for unit) that will be used to split the data " +
@@ -255,7 +257,8 @@ object Property extends Enumeration {
         s"table using the ${ExternalStoreUtils.COLUMN_BATCH_SIZE} option in " +
         "create table DDL. Maximum allowed size is 2GB.", Some("24m"))
 
-  val ColumnMaxDeltaRows = SQLVal[Int](s"${Constant.PROPERTY_PREFIX}column.maxDeltaRows",
+  val ColumnMaxDeltaRows: SQLValue[Int] = SQLVal[Int](
+    s"${Constant.PROPERTY_PREFIX}column.maxDeltaRows",
     "The maximum number of rows that can be in the delta buffer of a column table. " +
         s"The size of delta buffer is already limited by $ColumnBatchSize but " +
         "this allows a lower limit on number of rows for better scan performance. " +
@@ -264,12 +267,21 @@ object Property extends Enumeration {
         s"each table using the ${ExternalStoreUtils.COLUMN_MAX_DELTA_ROWS} option in " +
         s"create table DDL else this setting is used for the create table.", Some(10000))
 
-  val HashJoinSize = SQLVal[String](s"${Constant.PROPERTY_PREFIX}sql.hashJoinSize",
+  val DisableHashJoin: SQLValue[Boolean] = SQLVal[Boolean](
+    s"${Constant.PROPERTY_PREFIX}sql.disableHashJoin",
+    "Disable hash joins completely including those for replicated row tables. Default is false.",
+    Some(false))
+
+  val HashJoinSize: SQLValue[String] = SQLVal[String](
+    s"${Constant.PROPERTY_PREFIX}sql.hashJoinSize",
     "The join would be converted into a hash join if the table is of size less " +
         "than hashJoinSize. The limit specifies an estimate on the input data size " +
-        "(in bytes or k/m/g/t suffixes for unit). Default value is 100MB.", Some("100m"))
+        "(in bytes or k/m/g/t suffixes for unit). Note that replicated row tables always use " +
+        s"local hash joins regardless of this property. Use ${DisableHashJoin.name} to disable " +
+        s"all hash joins. Default value is 100MB.", Some("100m"))
 
-  val HashAggregateSize = SQLVal[String](s"${Constant.PROPERTY_PREFIX}sql.hashAggregateSize",
+  val HashAggregateSize: SQLValue[String] = SQLVal[String](
+    s"${Constant.PROPERTY_PREFIX}sql.hashAggregateSize",
     "Aggregation will use optimized hash aggregation plan but one that does not " +
         "overflow to disk and can cause OOME if the result of aggregation is large. " +
         "The limit specifies the input data size (in bytes or k/m/g/t suffixes for unit) " +
@@ -311,64 +323,72 @@ object Property extends Enumeration {
     s"${Constant.PROPERTY_PREFIX}sql.parser.traceError",
     "Property to enable detailed rule tracing for parse errors", Some(false))
 
-  val EnableExperimentalFeatures = SQLVal[Boolean](
+  val EnableExperimentalFeatures: SQLValue[Boolean] = SQLVal[Boolean](
     s"${Constant.PROPERTY_PREFIX}enable-experimental-features",
     "SQLConf property that enables snappydata experimental features like distributed index " +
         "optimizer choice during query planning. Default is turned off.",
     Some(false), Constant.SPARK_PREFIX)
 
-  val SchedulerPool = SQLVal[String](
+  val SchedulerPool: SQLValue[String] = SQLVal[String](
     s"${Constant.PROPERTY_PREFIX}scheduler.pool",
     "Property to set the scheduler pool for the current session. This property can " +
       "be used to assign queries to different pools for improving " +
       "throughput of specific queries.", Some("default"))
 
-  val FlushReservoirThreshold = SQLVal[Int](s"${Constant.PROPERTY_PREFIX}flushReservoirThreshold",
+  val FlushReservoirThreshold: SQLValue[Int] = SQLVal[Int](
+    s"${Constant.PROPERTY_PREFIX}flushReservoirThreshold",
     "Reservoirs of sample table will be flushed and stored in columnar format if sampling is done" +
         " on baset table of size more than flushReservoirThreshold." +
         " Default value is 10,000.", Some(10000))
 
-  val NumBootStrapTrials = SQLVal[Int](s"${Constant.SPARK_PREFIX}sql.aqp.numBootStrapTrials",
+  val NumBootStrapTrials: SQLValue[Int] = SQLVal[Int](
+    s"${Constant.SPARK_PREFIX}sql.aqp.numBootStrapTrials",
     "Number of bootstrap trials to do for calculating error bounds. Default value is 100.",
     Some(100))
 
   // TODO: check with suyog  Why are we having two different error defaults one as 1 & other as .2?
 
-  val MaxErrorAllowed = SQLVal[Double](s"${Constant.SPARK_PREFIX}sql.aqp.maxErrorAllowed",
+  val MaxErrorAllowed: SQLValue[Double] = SQLVal[Double](
+    s"${Constant.SPARK_PREFIX}sql.aqp.maxErrorAllowed",
     "Maximum relative error tolerable in the approximate value calculation. It should be a " +
-      "fractional value not exceeding 1. Default value is 1.0", Some(1.0d), null, false)
+      "fractional value not exceeding 1. Default value is 1.0",
+    Some(1.0d), prefix = null, isPublic = false)
 
-  val Error = SQLVal[Double](s"${Constant.SPARK_PREFIX}sql.aqp.error",
+  val Error: SQLValue[Double] = SQLVal[Double](s"${Constant.SPARK_PREFIX}sql.aqp.error",
     "Maximum relative error tolerable in the approximate value calculation. It should be a " +
       s"fractional value not exceeding 1. Default value is ${Constant.DEFAULT_ERROR}",
     Some(Constant.DEFAULT_ERROR))
 
-  val Confidence = SQLVal[Double](s"${Constant.SPARK_PREFIX}sql.aqp.confidence",
+  val Confidence: SQLValue[Double] = SQLVal[Double](s"${Constant.SPARK_PREFIX}sql.aqp.confidence",
     "Confidence with which the error bounds are calculated for the approximate value. It should " +
     s"be a fractional value not exceeding 1. Default value is ${Constant.DEFAULT_CONFIDENCE}",
     None)
 
-  val Behavior = SQLVal[String](s"${Constant.SPARK_PREFIX}sql.aqp.behavior",
+  val Behavior: SQLValue[String] = SQLVal[String](s"${Constant.SPARK_PREFIX}sql.aqp.behavior",
     s" The action to be taken if the error computed goes oustide the error tolerance limit. " +
       s"Default value is ${Constant.BEHAVIOR_DO_NOTHING}", None)
 
-  val AqpDebug = SQLVal[Boolean](s"${Constant.SPARK_PREFIX}sql.aqp.debug",
+  val AqpDebug: SQLValue[Boolean] = SQLVal[Boolean](s"${Constant.SPARK_PREFIX}sql.aqp.debug",
     s" Boolean if true tells engine to do  bootstrap analysis in debug mode returning an array of" +
-      s" values for the iterations. Default is false", Some(false), null, false)
+      s" values for the iterations. Default is false", Some(false), prefix = null, isPublic = false)
 
-  val AqpDebugFixedSeed = SQLVal[Boolean](s"${Constant.SPARK_PREFIX}sql.aqp.debug.fixedSeed",
+  val AqpDebugFixedSeed: SQLValue[Boolean] = SQLVal[Boolean](
+    s"${Constant.SPARK_PREFIX}sql.aqp.debug.fixedSeed",
     s" Boolean if true tells engine to initialize the seed for poisson value calculation with a " +
-      s"fixed  number 123456789L. Default is false.", Some(false), null, false)
+      s"fixed  number 123456789L. Default is false.", Some(false), prefix = null, isPublic = false)
 
-  val AQPDebugPoissonType = SQLVal[String](s"${Constant.SPARK_PREFIX}sql.aqp.debug.poissonType",
+  val AQPDebugPoissonType: SQLValue[String] = SQLVal[String](
+    s"${Constant.SPARK_PREFIX}sql.aqp.debug.poissonType",
     s" If aqp debugging is enbaled, this property can be used to set different types of algorithm" +
-      s" to generate bootstrap multiplicity numbers. Default is Real", None, null, false)
+      s" to generate bootstrap multiplicity numbers. Default is Real",
+    None, prefix = null, isPublic = false)
 
-  val ClosedFormEstimates = SQLVal[Boolean](s"${Constant.SPARK_PREFIX}sql.aqp.closedFormEstimates",
+  val ClosedFormEstimates: SQLValue[Boolean] = SQLVal[Boolean](
+    s"${Constant.SPARK_PREFIX}sql.aqp.closedFormEstimates",
     s"Boolean if false tells engine to use bootstrap analysis for error calculation for all cases" +
-      s". Default is true.", Some(true), null, false)
+      s". Default is true.", Some(true), null, isPublic = false)
 
-  val PutIntoInnerJoinCacheSize =
+  val PutIntoInnerJoinCacheSize: SQLValue[String] =
     SQLVal[String](s"${Constant.PROPERTY_PREFIX}cache.putIntoInnerJoinResultSize",
       "The putInto inner join would be cached if the result of " +
           "join with incoming Dataset is of size less " +

--- a/core/src/main/scala/org/apache/spark/sql/SnappyDDLParser.scala
+++ b/core/src/main/scala/org/apache/spark/sql/SnappyDDLParser.scala
@@ -601,7 +601,8 @@ abstract class SnappyDDLParser(session: SparkSession)
           Some(SchemaDescriptor.IBM_SYSTEM_SCHEMA_NAME)),
           LogicalRelation(new execution.row.DefaultSource().createRelation(session.sqlContext,
             SaveMode.Ignore, Map(JdbcExtendedUtils.DBTABLE_PROPERTY ->
-                s"${SchemaDescriptor.IBM_SYSTEM_SCHEMA_NAME }.${SnappyStoreHiveCatalog.dummyTableName}"),
+                (SchemaDescriptor.IBM_SYSTEM_SCHEMA_NAME + "." +
+                    SnappyStoreHiveCatalog.dummyTableName)),
             "", None)), input.sliceString(0, input.length)))
   }
 
@@ -914,7 +915,7 @@ case class DeployCommand(
         Misc.checkIfCacheClosing(ex)
         if (restart) {
           logWarning(s"Following mvn coordinate" +
-              s" could not be resolved during restart: ${coordinates}", ex)
+              s" could not be resolved during restart: $coordinates", ex)
           if (lang.Boolean.parseBoolean(System.getProperty("FAIL_ON_JAR_UNAVAILABILITY", "true"))) {
             throw ex
           }

--- a/core/src/main/scala/org/apache/spark/sql/SnappyStrategies.scala
+++ b/core/src/main/scala/org/apache/spark/sql/SnappyStrategies.scala
@@ -16,7 +16,6 @@
  */
 package org.apache.spark.sql
 
-import scala.annotation.tailrec
 import scala.util.control.NonFatal
 
 import io.snappydata.Property
@@ -57,7 +56,7 @@ private[sql] trait SnappyStrategies {
   }
 
   def isDisabled: Boolean = {
-    snappySession.sessionState.disableStoreOptimizations
+    session.sessionState.disableStoreOptimizations
   }
 
   /** Stream related strategies to map stream specific logical plan to physical plan */
@@ -76,7 +75,7 @@ private[sql] trait SnappyStrategies {
   }
 
   object HashJoinStrategies extends Strategy with JoinQueryPlanning {
-    def apply(plan: LogicalPlan): Seq[SparkPlan] = if (isDisabled) {
+    def apply(plan: LogicalPlan): Seq[SparkPlan] = if (isDisabled || session.disableHashJoin) {
       Nil
     } else {
       plan match {

--- a/core/src/main/scala/org/apache/spark/sql/execution/ddl.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/ddl.scala
@@ -19,9 +19,8 @@ package org.apache.spark.sql.execution
 
 import org.apache.spark.sql._
 import org.apache.spark.sql.catalyst.TableIdentifier
-import org.apache.spark.sql.catalyst.analysis.UnresolvedRelation
-import org.apache.spark.sql.catalyst.expressions.{Expression, SortDirection}
-import org.apache.spark.sql.catalyst.plans.logical.{Filter, LogicalPlan}
+import org.apache.spark.sql.catalyst.expressions.SortDirection
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.apache.spark.sql.collection.Utils
 import org.apache.spark.sql.execution.command.RunnableCommand
 import org.apache.spark.sql.hive.QualifiedTableName
@@ -190,7 +189,6 @@ private[sql] case class CreatePolicyCommand(policyIdent: QualifiedTableName,
   override def run(session: SparkSession): Seq[Row] = {
     // TODO: Only allow the owner of the target table to create a policy on it
     val snc = session.asInstanceOf[SnappySession]
-    val catalog = snc.sessionState.catalog
     SparkSession.setActiveSession(snc)
     snc.createPolicy(policyIdent, tableIdent, policyFor, applyTo, expandedPolicyApplyTo,
       currentUser, filterStr, filter)

--- a/core/src/main/scala/org/apache/spark/sql/hive/SnappyStoreHiveCatalog.scala
+++ b/core/src/main/scala/org/apache/spark/sql/hive/SnappyStoreHiveCatalog.scala
@@ -784,8 +784,8 @@ class SnappyStoreHiveCatalog(externalCatalog: SnappyExternalCatalog,
           // using LCC.getAuthorizationId() itself rather than getUserName()
           val user = snappySession.conf.get(Attribute.USERNAME_ATTR, "")
           if (user.nonEmpty && !(
-              tableIdent.schemaName.equalsIgnoreCase(SchemaDescriptor.IBM_SYSTEM_SCHEMA_NAME )
-              && tableIdent.table.equalsIgnoreCase(SnappyStoreHiveCatalog.dummyTableName))) {
+              tableIdent.schemaName.equalsIgnoreCase(SchemaDescriptor.IBM_SYSTEM_SCHEMA_NAME)
+                  && tableIdent.table.equalsIgnoreCase(SnappyStoreHiveCatalog.dummyTableName))) {
             val currentUser = IdUtil.getUserAuthorizationId(user)
             callbacks.checkSchemaPermission(tableIdent.schemaName, currentUser)
           }

--- a/core/src/main/scala/org/apache/spark/sql/internal/SnappySessionState.scala
+++ b/core/src/main/scala/org/apache/spark/sql/internal/SnappySessionState.scala
@@ -768,7 +768,6 @@ class SnappyConf(@transient val session: SnappySession)
   private def keyUpdateActions(key: String, value: Option[Any], doSet: Boolean): Unit = key match {
     // clear plan cache when some size related key that effects plans changes
     case SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key |
-         Property.DisableHashJoin.name |
          Property.HashJoinSize.name |
          Property.HashAggregateSize.name |
          Property.ForceLinkPartitionsToBuckets.name => session.clearPlanCache()
@@ -819,10 +818,12 @@ class SnappyConf(@transient val session: SnappySession)
       }
       session.clearPlanCache()
 
-    case Property.DisableHashJoin.name => value match {
-      case Some(boolVal) => session.disableHashJoin = boolVal.toString.toBoolean
-      case None => session.disableHashJoin = Property.DisableHashJoin.defaultValue.get
-    }
+    case Property.DisableHashJoin.name =>
+      value match {
+        case Some(boolVal) => session.disableHashJoin = boolVal.toString.toBoolean
+        case None => session.disableHashJoin = Property.DisableHashJoin.defaultValue.get
+      }
+      session.clearPlanCache()
 
     case SQLConf.WHOLESTAGE_CODEGEN_ENABLED.key => session.clearPlanCache()
 

--- a/core/src/main/scala/org/apache/spark/sql/internal/SnappySessionState.scala
+++ b/core/src/main/scala/org/apache/spark/sql/internal/SnappySessionState.scala
@@ -22,8 +22,10 @@ import java.util.concurrent.ConcurrentHashMap
 
 import scala.collection.mutable.ArrayBuffer
 import scala.reflect.{ClassTag, classTag}
+
 import com.gemstone.gemfire.internal.cache.{CacheDistributionAdvisee, ColocationHelper, PartitionedRegion}
 import io.snappydata.Property
+
 import org.apache.spark.internal.config.{ConfigBuilder, ConfigEntry, TypedConfigBuilder}
 import org.apache.spark.sql._
 import org.apache.spark.sql.aqp.SnappyContextFunctions
@@ -36,12 +38,10 @@ import org.apache.spark.sql.catalyst.expressions.{And, EqualTo, In, ScalarSubque
 import org.apache.spark.sql.catalyst.optimizer.{Optimizer, ReorderJoin}
 import org.apache.spark.sql.catalyst.planning.ExtractEquiJoinKeys
 import org.apache.spark.sql.catalyst.plans.JoinType
-import org.apache.spark.sql.catalyst.plans.logical.{Filter => LogicalFilter}
-import org.apache.spark.sql.catalyst.plans.logical.{Aggregate, InsertIntoTable, Join, LogicalPlan, Project, Sort, _}
+import org.apache.spark.sql.catalyst.plans.logical.{Filter => LogicalFilter, _}
 import org.apache.spark.sql.catalyst.rules.{Rule, RuleExecutor}
 import org.apache.spark.sql.collection.Utils
 import org.apache.spark.sql.execution._
-import org.apache.spark.sql.execution.columnar.JDBCAppendableRelation
 import org.apache.spark.sql.execution.columnar.impl.IndexColumnFormatRelation
 import org.apache.spark.sql.execution.command.RunnableCommand
 import org.apache.spark.sql.execution.datasources._
@@ -50,7 +50,6 @@ import org.apache.spark.sql.execution.sources.{PhysicalScan, StoreDataSourceStra
 import org.apache.spark.sql.hive.{SnappyConnectorCatalog, SnappySharedState, SnappyStoreHiveCatalog}
 import org.apache.spark.sql.internal.SQLConf.SQLConfigBuilder
 import org.apache.spark.sql.policy.PolicyProperties
-import org.apache.spark.sql.row.JDBCMutableRelation
 import org.apache.spark.sql.sources._
 import org.apache.spark.sql.store.StoreUtils
 import org.apache.spark.sql.streaming.{LogicalDStreamPlan, WindowLogicalPlan}
@@ -89,7 +88,7 @@ class SnappySessionState(snappySession: SnappySession)
     override lazy val batches: Seq[Batch] = analyzer.batches.map {
       case batch if batch.name.equalsIgnoreCase("Resolution") =>
         Batch(batch.name, getStrategy(batch.strategy), batch.rules.filter(_ match {
-          case PromoteStrings => if (sqlParser.sqlParser.questionMarkCounter > 0 ) {
+          case PromoteStrings => if (sqlParser.sqlParser.questionMarkCounter > 0) {
             false
           } else {
             true
@@ -412,7 +411,7 @@ class SnappySessionState(snappySession: SnappySession)
       (f: (Expression => Boolean)) =>
         (exp: Expression) => exp.eq(PolicyProperties.rlsAppliedCondition) ||
             (exp match {
-              case And(left, right) => f(left)
+              case And(left, _) => f(left)
               case EqualTo(l: Literal, r: Literal) =>
                 l.value == r.value && l.value == PolicyProperties.rlsConditionStringUtf8
               case _ => false
@@ -430,27 +429,26 @@ class SnappySessionState(snappySession: SnappySession)
         // is happening via this command we need to handle it
         case _: RunnableCommand => plan
         case _ if !alreadyPolicyApplied(plan) => plan.transformUp {
-          case lr@LogicalRelation(rlsRelation: RowLevelSecurityRelation, _, _) => {
+          case lr@LogicalRelation(rlsRelation: RowLevelSecurityRelation, _, _) =>
             val policyFilter = snappySession.sessionState.catalog.
                 getCombinedPolicyFilterForNativeTable(rlsRelation, Some(lr))
             policyFilter match {
               case Some(filter) => filter.copy(child = lr)
               case None => lr
             }
-          }
 
-          case SubqueryAlias(name, Filter(condition, child), ti) => Filter(condition,
+          case SubqueryAlias(name, LogicalFilter(condition, child), ti) => LogicalFilter(condition,
             SubqueryAlias(name, child, ti))
 
-          case filter1@Filter(condition1, filter2@Filter(condition2, child)) =>
+          case LogicalFilter(condition1, LogicalFilter(condition2, child)) =>
             if (rlsConditionChecker(conditionEvaluator)(condition1)) {
               if (rlsConditionChecker(conditionEvaluator)(condition2)) {
-                Filter(condition1, child)
+                LogicalFilter(condition1, child)
               } else {
-                Filter(And(condition1, condition2), child)
+                LogicalFilter(And(condition1, condition2), child)
               }
             } else {
-              Filter(And(condition2, condition1), child)
+              LogicalFilter(And(condition2, condition1), child)
             }
         }
         case _ => plan
@@ -770,6 +768,7 @@ class SnappyConf(@transient val session: SnappySession)
   private def keyUpdateActions(key: String, value: Option[Any], doSet: Boolean): Unit = key match {
     // clear plan cache when some size related key that effects plans changes
     case SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key |
+         Property.DisableHashJoin.name |
          Property.HashJoinSize.name |
          Property.HashAggregateSize.name |
          Property.ForceLinkPartitionsToBuckets.name => session.clearPlanCache()
@@ -819,6 +818,11 @@ class SnappyConf(@transient val session: SnappySession)
         case None => SnappySession.tokenize = Property.Tokenize.defaultValue.get
       }
       session.clearPlanCache()
+
+    case Property.DisableHashJoin.name => value match {
+      case Some(boolVal) => session.disableHashJoin = boolVal.toString.toBoolean
+      case None => session.disableHashJoin = Property.DisableHashJoin.defaultValue.get
+    }
 
     case SQLConf.WHOLESTAGE_CODEGEN_ENABLED.key => session.clearPlanCache()
 
@@ -1079,9 +1083,9 @@ trait SQLAltName[T] extends AltName[T] {
   }
 }
 
-class DefaultPlanner(val snappySession: SnappySession, conf: SQLConf,
+class DefaultPlanner(val session: SnappySession, conf: SQLConf,
     extraStrategies: Seq[Strategy])
-    extends SparkPlanner(snappySession.sparkContext, conf, extraStrategies)
+    extends SparkPlanner(session.sparkContext, conf, extraStrategies)
         with SnappyStrategies {
 
   val sampleSnappyCase: PartialFunction[LogicalPlan, Seq[SparkPlan]] = {


### PR DESCRIPTION
## Changes proposed in this pull request

- added snappydata.sql.disableHashJoin to disable all hash joins including
  for replicated tables; the entire HashJoinStrategies is skipped with this as true
- use a boolean "disableHashJoin" in session to speed up lookup
- clear existing plan cache in case this flag is set
- clean up to remove scalastyle warnings in a bunch of classes

## Patch testing

manual

## ReleaseNotes.txt changes

Document the new property.

## Other PRs 

https://github.com/SnappyDataInc/snappy-store/pull/422