### PR TITLE
disallow row-level security only if "enable-rls" is set

### DIFF
--- a/cluster/sbin/snappy-encrypt-password.sh
+++ b/cluster/sbin/snappy-encrypt-password.sh
@@ -30,6 +30,7 @@ for user in "$@"; do
     echo
     if [ "${passwd1}" != "${passwd2}" ]; then
       echo Passwords for $user do not match
+      echo
     else
       break
     fi

--- a/cluster/src/main/scala/io/snappydata/gemxd/SparkSQLPrepareImpl.scala
+++ b/cluster/src/main/scala/io/snappydata/gemxd/SparkSQLPrepareImpl.scala
@@ -35,7 +35,7 @@ import org.apache.spark.Logging
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.catalyst.expressions
 import org.apache.spark.sql.catalyst.expressions.{BinaryComparison, CaseWhen, Cast, Exists, Expression, Like, ListQuery, ParamLiteral, PredicateSubquery, ScalarSubquery, SubqueryExpression}
-import org.apache.spark.sql.catalyst.plans.logical.{Aggregate, Distinct, Expand, LogicalPlan, Project, Window}
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.apache.spark.sql.types._
 import org.apache.spark.util.SnappyUtils
 

--- a/cluster/src/test/scala/org/apache/spark/sql/policy/AlterTableRowLevelSecurityEnableTest.scala
+++ b/cluster/src/test/scala/org/apache/spark/sql/policy/AlterTableRowLevelSecurityEnableTest.scala
@@ -18,26 +18,12 @@ package org.apache.spark.sql.policy
 
 import java.sql.{Connection, DriverManager}
 
-import com.pivotal.gemfirexd.internal.engine.Misc
-import com.pivotal.gemfirexd.internal.engine.store.GemFireStore
 import com.pivotal.gemfirexd.{Attribute, TestUtil}
-import io.snappydata.SnappyFunSuite
-import io.snappydata.core.Data
 import org.junit.Assert._
-import org.scalatest.{BeforeAndAfter, BeforeAndAfterAll}
 
-import org.apache.spark.Logging
-import org.apache.spark.sql.{SaveMode, SnappyContext}
-import org.apache.spark.sql.catalyst.expressions.{EqualTo, Literal}
-import org.apache.spark.sql.catalyst.plans.logical.Filter
-import org.apache.spark.sql.types.StringType
-import org.apache.spark.unsafe.types.UTF8String
+import org.apache.spark.sql.SnappyContext
 
-class AlterTableRowLevelSecurityEnableTest extends SnappyFunSuite
-    with Logging
-    with BeforeAndAfter
-    with BeforeAndAfterAll {
-
+class AlterTableRowLevelSecurityEnableTest extends PolicyTestBase {
 
   var serverHostPort: String = _
 
@@ -47,7 +33,7 @@ class AlterTableRowLevelSecurityEnableTest extends SnappyFunSuite
   val rowTable = "RowTable"
   val numElements = 100
   val colTableName: String = s"$tableOwner.$colTable"
-  val rowTableName: String = s"${tableOwner}.$rowTable"
+  val rowTableName: String = s"$tableOwner.$rowTable"
 
   var ownerContext: SnappyContext = _
 
@@ -76,8 +62,8 @@ class AlterTableRowLevelSecurityEnableTest extends SnappyFunSuite
   }
 
   override def afterAll(): Unit = {
-    ownerContext.dropTable(colTableName, true)
-    ownerContext.dropTable(rowTableName, true)
+    ownerContext.dropTable(colTableName, ifExists = true)
+    ownerContext.dropTable(rowTableName, ifExists = true)
     super.afterAll()
   }
 
@@ -206,5 +192,3 @@ class AlterTableRowLevelSecurityEnableTest extends SnappyFunSuite
   }
 
 }
-
-

--- a/cluster/src/test/scala/org/apache/spark/sql/policy/PolicyTestBase.scala
+++ b/cluster/src/test/scala/org/apache/spark/sql/policy/PolicyTestBase.scala
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2018 SnappyData, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License. You
+ * may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License. See accompanying
+ * LICENSE file.
+ */
+package org.apache.spark.sql.policy
+
+import com.pivotal.gemfirexd.Attribute
+import com.pivotal.gemfirexd.Property.{AUTH_LDAP_SEARCH_BASE, AUTH_LDAP_SERVER}
+import com.pivotal.gemfirexd.internal.engine.store.GemFireStore
+import com.pivotal.gemfirexd.internal.iapi.reference.Property
+import com.pivotal.gemfirexd.security.{LdapTestServer, SecurityTestUtils}
+import io.snappydata.{Constant, SnappyFunSuite}
+import org.scalatest.{BeforeAndAfter, BeforeAndAfterAll}
+
+import org.apache.spark.{Logging, SparkConf}
+
+abstract class PolicyTestBase extends SnappyFunSuite
+    with Logging
+    with BeforeAndAfter
+    with BeforeAndAfterAll {
+
+  protected val sysUser = "gemfire10"
+
+  override def beforeAll(): Unit = {
+    super.beforeAll()
+    stopAll()
+
+    System.setProperty(Property.SNAPPY_ENABLE_RLS, "true")
+    GemFireStore.ALLOW_RLS_WITHOUT_SECURITY = true
+  }
+
+  protected def newLDAPSparkConf(addOn: (SparkConf) => SparkConf): SparkConf = {
+    val ldapProperties = SecurityTestUtils.startLdapServerAndGetBootProperties(0, 0, sysUser,
+      getClass.getResource("/auth.ldif").getPath)
+    for (k <- List(Attribute.AUTH_PROVIDER, AUTH_LDAP_SERVER, AUTH_LDAP_SEARCH_BASE)) {
+      System.setProperty(k, ldapProperties.getProperty(k))
+    }
+    System.setProperty(Constant.STORE_PROPERTY_PREFIX + Attribute.USERNAME_ATTR, sysUser)
+    System.setProperty(Constant.STORE_PROPERTY_PREFIX + Attribute.PASSWORD_ATTR, sysUser)
+    val conf = new org.apache.spark.SparkConf()
+        .setAppName("PolicyTest")
+        .setMaster("local[4]")
+        .set("spark.sql.crossJoin.enabled", "true")
+        .set(Attribute.AUTH_PROVIDER, ldapProperties.getProperty(Attribute.AUTH_PROVIDER))
+        .set(Constant.STORE_PROPERTY_PREFIX + Attribute.USERNAME_ATTR, sysUser)
+        .set(Constant.STORE_PROPERTY_PREFIX + Attribute.PASSWORD_ATTR, sysUser)
+
+    if (addOn != null) {
+      addOn(conf)
+    } else {
+      conf
+    }
+  }
+
+  override def afterAll(): Unit = {
+    try {
+      super.afterAll()
+      stopAll()
+
+      val ldapServer = LdapTestServer.getInstance()
+      if (ldapServer.isServerStarted) {
+        ldapServer.stopService()
+      }
+    } finally {
+      for (k <- List(Attribute.AUTH_PROVIDER, AUTH_LDAP_SERVER, AUTH_LDAP_SEARCH_BASE)) {
+        System.clearProperty(k)
+        System.clearProperty("gemfirexd." + k)
+        System.clearProperty(Constant.STORE_PROPERTY_PREFIX + k)
+      }
+      System.clearProperty(Constant.STORE_PROPERTY_PREFIX + Attribute.USERNAME_ATTR)
+      System.clearProperty(Constant.STORE_PROPERTY_PREFIX + Attribute.PASSWORD_ATTR)
+      System.setProperty("gemfirexd.authentication.required", "false")
+      GemFireStore.ALLOW_RLS_WITHOUT_SECURITY = false
+      System.clearProperty(Property.SNAPPY_ENABLE_RLS)
+    }
+  }
+}

--- a/cluster/src/test/scala/org/apache/spark/sql/policy/RestrictTableCreationPolicyTest.scala
+++ b/cluster/src/test/scala/org/apache/spark/sql/policy/RestrictTableCreationPolicyTest.scala
@@ -33,10 +33,8 @@ class RestrictTableCreationPolicyTest extends PolicyTestBase {
   val user2 = "gemfire2"
   val user3 = "gemfire3"
   val tableCreator: String = user1
-  val ownerLdapGroup = "gemGroup1"
-  // users gem1, gem2, gem3
-  val otherLdapGroup = "gemGroup3"
-  // users gem6, gem7, gem8
+  val ownerLdapGroup = "gemGroup1" // users gem1, gem2, gem3
+  val otherLdapGroup = "gemGroup3" // users gem6, gem7, gem8
   val otherUser = "gemfire6"
   val props = Map.empty[String, String]
   val schema = "tax"
@@ -92,6 +90,7 @@ class RestrictTableCreationPolicyTest extends PolicyTestBase {
     ownerContext.dropTable(colTableName, ifExists = true)
     ownerContext.dropTable(rowTableName, ifExists = true)
     super.afterAll()
+    System.clearProperty(Property.SNAPPY_RESTRICT_TABLE_CREATE)
   }
 
 

--- a/core/src/main/scala/org/apache/spark/sql/execution/ddl.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/ddl.scala
@@ -196,13 +196,13 @@ private[sql] case class CreatePolicyCommand(policyIdent: QualifiedTableName,
   override def run(session: SparkSession): Seq[Row] = {
     if (!Misc.isSecurityEnabled && !GemFireStore.ALLOW_RLS_WITHOUT_SECURITY) {
       throw Util.generateCsSQLException(SQLState.SECURITY_EXCEPTION_ENCOUNTERED,
-        null, new IllegalStateException("Security (" + Attribute.AUTH_PROVIDER +
-            ") not enabled in the system"))
+        null, new IllegalStateException("CREATE POLICY failed: Security (" +
+            Attribute.AUTH_PROVIDER + ") not enabled in the system"))
     }
     if (!Misc.getMemStoreBooting.isRLSEnabled) {
       throw Util.generateCsSQLException(SQLState.SECURITY_EXCEPTION_ENCOUNTERED,
-        null, new IllegalStateException("Row level security (" + Property.SNAPPY_ENABLE_RLS +
-            ") not enabled in the system"))
+        null, new IllegalStateException("CREATE POLICY failed: Row level security (" +
+            Property.SNAPPY_ENABLE_RLS + ") not enabled in the system"))
     }
     val snc = session.asInstanceOf[SnappySession]
     SparkSession.setActiveSession(snc)

--- a/core/src/main/scala/org/apache/spark/sql/execution/ddl.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/ddl.scala
@@ -17,6 +17,13 @@
 
 package org.apache.spark.sql.execution
 
+import com.pivotal.gemfirexd.Attribute
+import com.pivotal.gemfirexd.internal.engine.Misc
+import com.pivotal.gemfirexd.internal.engine.store.GemFireStore
+import com.pivotal.gemfirexd.internal.iapi.reference.Property
+import com.pivotal.gemfirexd.internal.impl.jdbc.Util
+import com.pivotal.gemfirexd.internal.shared.common.reference.SQLState
+
 import org.apache.spark.sql._
 import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.expressions.SortDirection
@@ -187,7 +194,16 @@ private[sql] case class CreatePolicyCommand(policyIdent: QualifiedTableName,
     filter: BypassRowLevelSecurity) extends RunnableCommand {
 
   override def run(session: SparkSession): Seq[Row] = {
-    // TODO: Only allow the owner of the target table to create a policy on it
+    if (!Misc.isSecurityEnabled && !GemFireStore.ALLOW_RLS_WITHOUT_SECURITY) {
+      throw Util.generateCsSQLException(SQLState.SECURITY_EXCEPTION_ENCOUNTERED,
+        null, new IllegalStateException("Security (" + Attribute.AUTH_PROVIDER +
+            ") not enabled in the system"))
+    }
+    if (!Misc.getMemStoreBooting.isRLSEnabled) {
+      throw Util.generateCsSQLException(SQLState.SECURITY_EXCEPTION_ENCOUNTERED,
+        null, new IllegalStateException("Row level security (" + Property.SNAPPY_ENABLE_RLS +
+            ") not enabled in the system"))
+    }
     val snc = session.asInstanceOf[SnappySession]
     SparkSession.setActiveSession(snc)
     snc.createPolicy(policyIdent, tableIdent, policyFor, applyTo, expandedPolicyApplyTo,

--- a/core/src/test/scala/io/snappydata/SnappyFunSuite.scala
+++ b/core/src/test/scala/io/snappydata/SnappyFunSuite.scala
@@ -177,8 +177,9 @@ abstract class SnappyFunSuite
 
   def stopAll(): Unit = {
     val sc = SnappyContext.globalSparkContext
-    logInfo("Stopping spark context = " + sc)
+    logInfo("Check stop required for spark context = " + sc)
     if (sc != null && !sc.isStopped) {
+      logInfo("Stopping spark context = " + sc)
       sc.stop()
     }
     cachedContext = null

--- a/examples/src/test/scala/io/snappydata/quickstart/ExampleTestSuite.scala
+++ b/examples/src/test/scala/io/snappydata/quickstart/ExampleTestSuite.scala
@@ -48,11 +48,11 @@ class ExampleTestSuite extends SnappyTestRunner {
     Job("io.snappydata.examples.CreateAndLoadAirlineDataJob", localLead, quickStartJar)
 
     SparkSubmit("AirlineDataApp", appClass = "io.snappydata.examples.AirlineDataSparkApp", None,
-      confs = Seq("snappydata.connection=localhost:1527", "spark.ui.port=4041"),
+      confs = Seq("snappydata.connection=localhost:1527", "spark.ui.port=4051"),
       appJar = quickStartJar)
 
     SparkSubmit("PythonAirlineDataApp", appClass = "", None,
-      confs = Seq("snappydata.connection=localhost:1527", "spark.ui.port=4041"),
+      confs = Seq("snappydata.connection=localhost:1527", "spark.ui.port=4051"),
       appJar = s"$snappyHome/quickstart/python/AirlineDataPythonApp.py")
 
   }


### PR DESCRIPTION
## Changes proposed in this pull request

* disallow CREATE POLICY without security and enable-rls enabled
* link to store that disables smart connector and route-query=false client
  connections with enable-rls disabled
* test changes to use a base PolicyTestBase that enables RLS and a flag
  to allow RLS tests without security enabled
* other minor changes to fix occasional failures in ExampleTestSuite

## Patch testing

precheckin in progress

## ReleaseNotes.txt changes

document that RLS is not allowed with route-query=false

## Other PRs 

https://github.com/SnappyDataInc/snappy-store/pull/424