### PR TITLE
Snap 2487

### DIFF
--- a/cluster/src/main/scala/org/apache/spark/sql/streaming/SnappyStreamingContextFactory.scala
+++ b/cluster/src/main/scala/org/apache/spark/sql/streaming/SnappyStreamingContextFactory.scala
@@ -71,8 +71,9 @@ class SnappyStreamingContextFactory extends SparkContextFactory {
 
       override def stop(): Unit = {
         try {
-          val stopGracefully = config.getBoolean("streaming.stopGracefully")
-          stop(stopSparkContext = false, stopGracefully = stopGracefully)
+          val  stopGracefully = config.getBoolean("streaming.stopGracefully")
+          SnappyStreamingContext.getActive
+              .foreach( c => c.stop(stopSparkContext = false, stopGracefully = stopGracefully))
         } catch {
           case _: ConfigException.Missing => stop(stopSparkContext = false, stopGracefully = true)
         } finally {

--- a/cluster/src/main/scala/org/apache/spark/sql/streaming/SnappyStreamingContextFactory.scala
+++ b/cluster/src/main/scala/org/apache/spark/sql/streaming/SnappyStreamingContextFactory.scala
@@ -52,7 +52,7 @@ abstract class SnappyStreamingJob extends SparkJobBase {
 
   def isValidJob(sc: SnappyStreamingContext, config: Config): SnappyJobValidation
 
-  def runSnappyJob(sc: SnappyStreamingContext, jobConfig: Config): Any;
+  def runSnappyJob(sc: SnappyStreamingContext, jobConfig: Config): Any
 
 }
 
@@ -71,11 +71,12 @@ class SnappyStreamingContextFactory extends SparkContextFactory {
 
       override def stop(): Unit = {
         try {
-          val  stopGracefully = config.getBoolean("streaming.stopGracefully")
+          val stopGracefully = config.getBoolean("streaming.stopGracefully")
           SnappyStreamingContext.getActive
-              .foreach( c => c.stop(stopSparkContext = false, stopGracefully = stopGracefully))
+              .foreach(c => c.stop(stopSparkContext = false, stopGracefully = stopGracefully))
         } catch {
-          case _: ConfigException.Missing => stop(stopSparkContext = false, stopGracefully = true)
+          case _: ConfigException.Missing => SnappyStreamingContext.getActive
+              .foreach(c => c.stop(stopSparkContext = false, stopGracefully = true))
         } finally {
           SnappyUtils.clearSessionDependencies(sparkContext)
         }


### PR DESCRIPTION
## Changes proposed in this pull request

Closing the active streaming context correctly when `streaming.stopGracefully` property is not provided as part of the configuration
