### PR TITLE
Fix to disk store validate tool

### DIFF
--- a/cluster/src/main/scala/io/snappydata/tools/SnappyUtilLauncher.scala
+++ b/cluster/src/main/scala/io/snappydata/tools/SnappyUtilLauncher.scala
@@ -30,6 +30,7 @@ import com.pivotal.gemfirexd.tools.internal.{JarTools, MiscTools}
 import com.pivotal.gemfirexd.tools.{GfxdSystemAdmin, GfxdUtilLauncher}
 import io.snappydata.LocalizedMessages
 import io.snappydata.gemxd.{SnappyDataVersion, SnappySystemAdmin}
+import org.apache.spark.sql.execution.columnar.impl.StoreCallback
 
 /**
  * Launcher class encompassing snappy processes command lines.
@@ -102,7 +103,7 @@ class SnappyUtilLauncher extends GfxdUtilLauncher {
 }
 
 
-object SnappyUtilLauncher {
+object SnappyUtilLauncher extends StoreCallback {
 
   init()
 


### PR DESCRIPTION
SnappyData specific GfxdDataSerializable types were not getting registered

when validate tool was getting launched through SnapyUtilLauncher.
This is because the StoreCallback was not getting initialized.

## Changes proposed in this pull request

Initializing the store callback with the launcher fixed the issue.

## Patch testing

Manual

## ReleaseNotes.txt changes

No.

## Other PRs 

No.