### PR TITLE
[SNAP-2555] clear non-default configs for internal hive meta-store client

### DIFF
--- a/core/src/main/java/io/snappydata/impl/SnappyHiveConf.java
+++ b/core/src/main/java/io/snappydata/impl/SnappyHiveConf.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2018 SnappyData, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License. You
+ * may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License. See accompanying
+ * LICENSE file.
+ */
+package io.snappydata.impl;
+
+import java.io.InputStream;
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hive.conf.HiveConf;
+
+/**
+ * Extension of HiveConf to access few protected variables.
+ */
+public class SnappyHiveConf extends HiveConf {
+
+  private static Field loadDefaultsField;
+  private static Field resourcesField;
+  private static Method getConfVarInputStreamMethod;
+  private static Method setupSQLStdAuthWhiteListMethod;
+  private static Method setupRestrictListMethod;
+
+  static {
+    try {
+      loadDefaultsField = Configuration.class.getDeclaredField("loadDefaults");
+      loadDefaultsField.setAccessible(true);
+      resourcesField = Configuration.class.getDeclaredField("resources");
+      resourcesField.setAccessible(true);
+      getConfVarInputStreamMethod = HiveConf.class.getDeclaredMethod(
+          "getConfVarInputStream");
+      getConfVarInputStreamMethod.setAccessible(true);
+    } catch (NoSuchFieldException | NoSuchMethodException e) {
+      // disable resources reset calls
+      loadDefaultsField = null;
+      resourcesField = null;
+      getConfVarInputStreamMethod = null;
+    }
+    try {
+      setupSQLStdAuthWhiteListMethod = HiveConf.class.getDeclaredMethod(
+          "setupSQLStdAuthWhiteList");
+      setupSQLStdAuthWhiteListMethod.setAccessible(true);
+      setupRestrictListMethod = HiveConf.class.getDeclaredMethod(
+          "setupRestrictList");
+      setupRestrictListMethod.setAccessible(true);
+    } catch (NoSuchMethodException e) {
+      // disable setter calls
+      setupSQLStdAuthWhiteListMethod = null;
+      setupRestrictListMethod = null;
+    }
+  }
+
+  public SnappyHiveConf() {
+    try {
+      // create a blank HiveConf ignoring configuration from any hive-site.xml
+      clear();
+
+      // clear unwanted resources
+      if (loadDefaultsField != null) {
+        loadDefaultsField.setBoolean(this, false);
+        ArrayList<?> resources = (ArrayList<?>)resourcesField.get(this);
+        resources.clear();
+        addResource((InputStream)getConfVarInputStreamMethod.invoke(this));
+      }
+
+      for (HiveConf.ConfVars confVar : HiveConf.ConfVars.values()) {
+        String defaultValue = confVar.getDefaultValue();
+        if (defaultValue != null) {
+          set(confVar.varname, defaultValue);
+        }
+      }
+
+      // reset hive jar configuration
+      this.hiveJar = "";
+      this.auxJars = "";
+
+      // reset restriction lists
+      if (setupSQLStdAuthWhiteListMethod != null) {
+        setupSQLStdAuthWhiteListMethod.invoke(this);
+        setupRestrictListMethod.invoke(this);
+      }
+    } catch (IllegalAccessException | InvocationTargetException e) {
+      throw new RuntimeException(e);
+    }
+  }
+}

--- a/core/src/main/scala/io/snappydata/util/ServiceUtils.scala
+++ b/core/src/main/scala/io/snappydata/util/ServiceUtils.scala
@@ -92,12 +92,20 @@ object ServiceUtils {
 
   def invokeStartFabricServer(sc: SparkContext,
       hostData: Boolean): Unit = {
-    val properties = getStoreProperties(sc.getConf.getAll)
+    val properties = getStoreProperties(Utils.getInternalSparkConf(sc).getAll)
     // overriding the host-data property based on the provided flag
     if (!hostData) {
       properties.setProperty("host-data", "false")
       // no DataDictionary persistence for non-embedded mode
       properties.setProperty("persist-dd", "false")
+    }
+    // set the log-level from initialized SparkContext's level
+    if (!properties.containsKey("log-level")) {
+      val level = org.apache.log4j.Logger.getRootLogger.getLevel
+      if (level ne null) {
+        properties.setProperty("log-level",
+          ClientSharedUtils.convertToJavaLogLevel(level).getName.toLowerCase)
+      }
     }
     ServerManager.getServerInstance.start(properties)
 

--- a/core/src/main/scala/org/apache/spark/sql/collection/Utils.scala
+++ b/core/src/main/scala/org/apache/spark/sql/collection/Utils.scala
@@ -670,6 +670,8 @@ object Utils {
   def newChunkedByteBuffer(chunks: Array[ByteBuffer]): ChunkedByteBuffer =
     new ChunkedByteBuffer(chunks)
 
+  def getInternalSparkConf(sc: SparkContext): SparkConf = sc.conf
+
   def setDefaultConfProperty(conf: SparkConf, name: String,
       default: String): Unit = {
     conf.getOption(name) match {

--- a/core/src/main/scala/org/apache/spark/sql/hive/HiveClientUtil.scala
+++ b/core/src/main/scala/org/apache/spark/sql/hive/HiveClientUtil.scala
@@ -21,15 +21,17 @@ import java.net.{URL, URLClassLoader}
 import java.util.Properties
 
 import scala.collection.JavaConverters._
+
 import com.gemstone.gemfire.internal.shared.{ClientSharedUtils, SystemProperties}
 import com.pivotal.gemfirexd.Attribute.{PASSWORD_ATTR, USERNAME_ATTR}
 import com.pivotal.gemfirexd.internal.engine.Misc
 import io.snappydata.Constant
 import io.snappydata.Constant.{SPARK_STORE_PREFIX, STORE_PROPERTY_PREFIX}
-import io.snappydata.impl.SnappyHiveCatalog
-import org.apache.hadoop.hive.conf.HiveConf
+import io.snappydata.impl.{SnappyHiveCatalog, SnappyHiveConf}
+import org.apache.hadoop.hive.conf.HiveConf.ConfVars
 import org.apache.hadoop.util.VersionInfo
 import org.apache.log4j.LogManager
+
 import org.apache.spark.sql._
 import org.apache.spark.sql.collection.ToolsCallbackInit
 import org.apache.spark.sql.execution.SparkPlan
@@ -133,7 +135,7 @@ private class HiveClientUtil(sparkContext: SparkContext) extends Logging {
         val props = new Properties()
         props.setProperty("log4j.logger.DataNucleus.Datastore", "ERROR")
         props.setProperty("log4j.logger.DataNucleus.Query", "ERROR")
-        ClientSharedUtils.initLog4J(null, props, currentLevel)
+        ClientSharedUtils.initLog4j(null, props, currentLevel)
       })
       // wait for store hive client to initialize first
       val store = Misc.getMemStoreBootingNoThrow
@@ -150,7 +152,7 @@ private class HiveClientUtil(sparkContext: SparkContext) extends Logging {
       hc
     } finally { // reset log config
       ifSmartConn(() => {
-        ClientSharedUtils.initLog4J(null, currentLevel)
+        ClientSharedUtils.initLog4j(null, currentLevel)
       })
     }
   }
@@ -165,12 +167,10 @@ private class HiveClientUtil(sparkContext: SparkContext) extends Logging {
   private def newClient(): HiveClient = SnappyHiveCatalog.hiveClientSync.synchronized {
 
     val metaVersion = IsolatedClientLoader.hiveVersion(hiveMetastoreVersion)
-    // We instantiate a HiveConf here to read in the hive-site.xml file and
-    // then pass the options into the isolated client loader
-    val metadataConf = new HiveConf()
+    val metadataConf = new SnappyHiveConf
     SnappyContext.getClusterMode(sparkContext) match {
       case _: ThinClientConnectorMode =>
-        metadataConf.setBoolVar(HiveConf.ConfVars.METASTORE_AUTO_CREATE_SCHEMA, false)
+        metadataConf.setBoolVar(ConfVars.METASTORE_AUTO_CREATE_SCHEMA, false)
         metadataConf.set("datanucleus.generateSchema.database.mode", "none")
       case _ =>
     }
@@ -188,13 +188,13 @@ private class HiveClientUtil(sparkContext: SparkContext) extends Logging {
           ";user=" + user.get
       logURL + ";password=" + password.get + ";"
     } else {
-      metadataConf.setVar(HiveConf.ConfVars.METASTORE_CONNECTION_USER_NAME,
+      metadataConf.setVar(ConfVars.METASTORE_CONNECTION_USER_NAME,
         SystemProperties.SNAPPY_HIVE_METASTORE)
       dbURL
     }
     logInfo(s"Using dbURL = $logURL for Hive metastore initialization")
-    metadataConf.setVar(HiveConf.ConfVars.METASTORECONNECTURLKEY, secureDbURL)
-    metadataConf.setVar(HiveConf.ConfVars.METASTORE_CONNECTION_DRIVER, dbDriver)
+    metadataConf.setVar(ConfVars.METASTORECONNECTURLKEY, secureDbURL)
+    metadataConf.setVar(ConfVars.METASTORE_CONNECTION_DRIVER, dbDriver)
 
     val warehouse = SnappyHiveCatalog.initCommonHiveMetaStoreProperties(metadataConf)
     logInfo("Default warehouse location is " + warehouse)
@@ -304,7 +304,7 @@ object HiveClientUtil {
     // replay global sql commands
     if (ToolsCallbackInit.toolsCallback != null) {
       SnappyContext.getClusterMode(sparkContext) match {
-        case _: SnappyEmbeddedMode => {
+        case _: SnappyEmbeddedMode =>
           val deployCmds = ToolsCallbackInit.toolsCallback.getAllGlobalCmnds()
           // logInfo(s"deploycmnds size = ${deployCmds.size}")
           // deployCmds.foreach(s => logDebug(s"s"))
@@ -315,14 +315,13 @@ object HiveClientUtil {
               val repos = if (cmdFields(1).isEmpty) None else Some(cmdFields(1))
               val cache = if (cmdFields(2).isEmpty) None else Some(cmdFields(2))
               val session = SparkSession.builder().getOrCreate()
-              DeployCommand(coordinate, null, repos, cache, true).run(session)
+              DeployCommand(coordinate, null, repos, cache, restart = true).run(session)
             }
             else {
               // Jars we have
-              DeployJarCommand(null, cmdFields(0), true)
+              DeployJarCommand(null, cmdFields(0), restart = true)
             }
           })
-        }
         case _ => // Nothing
       }
     }


### PR DESCRIPTION
These changes are to avoid interference in internal hive meta-store used by SnappyData from any
external hive meta-store configuration.

## Changes proposed in this pull request

- adding a new "SnappyHiveConf" that extends HiveConf to clear all non-default configuration
  (via reflection for few items) from the internal hive meta-store client
- preserve log-level from initialized SparkContext when booting store in local mode
  if not set explicitly at store level (using "snappydata.store.log-level" property)
- correct scalastyle warnings/errors in some files

## Patch testing

precheckin; manual testing with external hive meta-store using SparkSession

## ReleaseNotes.txt changes

NA

## Other PRs 

NA