### PR TITLE
Snap 2576

### DIFF
--- a/cluster/src/test/scala/org/apache/spark/sql/policy/PolicyJdbcClientTest.scala
+++ b/cluster/src/test/scala/org/apache/spark/sql/policy/PolicyJdbcClientTest.scala
@@ -203,7 +203,7 @@ class PolicyJdbcClientTest extends PolicyTestBase {
     val stmt = conn.createStatement()
     val conn1 = getConnection(Some("UserX"))
     val stmt1 = conn1.createStatement()
-    stmt.execute(s"CREATE TABLE temp (username String, id Int) " +
+    ownerContext.sql(s"CREATE TABLE temp (username String, id Int) " +
         s" USING $tableType ")
     val seq = Seq("USERX" -> 4, "USERX" -> 5, "USERX" -> 6, "USERY" -> 7,
       "USERY" -> 8, "USERY" -> 9)

--- a/cluster/src/test/scala/org/apache/spark/sql/policy/PolicyJdbcClientTest.scala
+++ b/cluster/src/test/scala/org/apache/spark/sql/policy/PolicyJdbcClientTest.scala
@@ -22,6 +22,8 @@ import java.util.Properties
 import com.pivotal.gemfirexd.internal.engine.Misc
 import com.pivotal.gemfirexd.{Attribute, TestUtil}
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Assert.assertFalse
 
 import org.apache.spark.sql.SnappyContext
 
@@ -186,6 +188,61 @@ class PolicyJdbcClientTest extends PolicyTestBase {
       conn.close()
       conn1.close()
     }
+  }
+
+  test("test policy not applied for update | delete on row table") {
+    this.updateOrDeleteOntableWithPolicy("row")
+  }
+
+  test("test policy not applied for update | delete on column table") {
+    this.updateOrDeleteOntableWithPolicy("column")
+  }
+
+  private def updateOrDeleteOntableWithPolicy(tableType: String): Unit = {
+    val conn = getConnection(Some(tableOwner))
+    val stmt = conn.createStatement()
+    val conn1 = getConnection(Some("UserX"))
+    val stmt1 = conn1.createStatement()
+    stmt.execute(s"CREATE TABLE temp (username String, id Int) " +
+        s" USING $tableType ")
+    val seq = Seq("USERX" -> 4, "USERX" -> 5, "USERX" -> 6, "USERY" -> 7,
+      "USERY" -> 8, "USERY" -> 9)
+    val rdd = sc.parallelize(seq)
+
+    val dataDF = ownerContext.createDataFrame(rdd)
+
+    dataDF.write.insertInto("temp")
+
+    stmt.execute(s"create policy testPolicy1 on  " +
+        s" temp for select to current_user using " +
+        s" id < 0")
+
+    stmt.execute("alter table temp enable row level security")
+
+
+    val q1 = s"select * from $tableOwner.temp"
+    var rs = stmt1.executeQuery(q1)
+    assertFalse(rs.next())
+
+    var n = stmt1.executeUpdate(s"update $tableOwner.temp set " +
+        s"username = 'USERZ' where username = 'USERX'")
+
+    assertEquals(3, n)
+
+    rs = stmt.executeQuery(s"select * from temp where username = 'USERZ'")
+    n = 0
+    while(rs.next()) {
+      n += 1
+    }
+    assertEquals(3, n)
+
+    n = stmt1.executeUpdate(s"delete from $tableOwner.temp  where username = 'USERZ'")
+    assertEquals(3, n)
+    rs = stmt.executeQuery(s"select * from temp where username = 'USERZ'")
+    assertFalse(rs.next())
+
+    ownerContext.sql("drop policy testPolicy1")
+    ownerContext.sql(s"drop table temp")
   }
 
   test("test multiple policies application using snappy context on column table") {

--- a/cluster/src/test/scala/org/apache/spark/sql/policy/PolicyTest.scala
+++ b/cluster/src/test/scala/org/apache/spark/sql/policy/PolicyTest.scala
@@ -283,6 +283,52 @@ class PolicyTest extends PolicyTestBase {
     this.tableWithPolicyJoinedToItself(colTableName)
   }
 
+  test("test policy not applied for update | delete on row table") {
+    this.updateOrDeleteOntableWithPolicy("row")
+  }
+
+  test("test policy not applied for update | delete on column table") {
+    this.updateOrDeleteOntableWithPolicy("column")
+  }
+
+  private def updateOrDeleteOntableWithPolicy(tableType: String): Unit = {
+
+    ownerContext.sql(s"CREATE TABLE temp (username String, id Int) " +
+        s" USING $tableType ")
+    val seq = Seq("USERX" -> 4, "USERX" -> 5, "USERX" -> 6, "USERY" -> 7,
+      "USERY" -> 8, "USERY" -> 9)
+    val rdd = sc.parallelize(seq)
+
+    val dataDF = ownerContext.createDataFrame(rdd)
+
+    dataDF.write.insertInto("temp")
+
+    ownerContext.sql(s"create policy testPolicy1 on  " +
+        s" temp for select to current_user using " +
+        s" id < 0")
+
+    ownerContext.sql("alter table temp enable row level security")
+
+    val snc2 = snc.newSession()
+    snc2.snappySession.conf.set(Attribute.USERNAME_ATTR, "UserX")
+    val q1 = s"select * from $tableOwner.temp"
+    var rs = snc2.sql(q1).collect()
+    assertEquals(0, rs.length)
+
+    snc2.sql(s"update $tableOwner.temp set username = 'USERZ' where username = 'USERX'")
+
+    rs = ownerContext.sql(s"select * from temp where username = 'USERZ'").collect()
+    assertEquals(3, rs.length)
+
+    snc2.sql(s"delete from $tableOwner.temp  where username = 'USERZ'")
+
+    rs = ownerContext.sql(s"select * from temp where username = 'USERZ'").collect()
+    assertEquals(0, rs.length)
+
+    ownerContext.sql("drop policy testPolicy1")
+    ownerContext.sql(s"drop table temp")
+  }
+
   private def tableWithPolicyJoinedToItself(tableName: String): Unit = {
     val mappingTable = "mapping"
     ownerContext.sql(s"CREATE TABLE $mappingTable (username String, hisid Int) " +

--- a/core/src/main/scala/org/apache/spark/sql/internal/SnappySessionState.scala
+++ b/core/src/main/scala/org/apache/spark/sql/internal/SnappySessionState.scala
@@ -423,7 +423,8 @@ class SnappySessionState(snappySession: SnappySession)
 
     def apply(plan: LogicalPlan): LogicalPlan = {
       plan match {
-        case _: BypassRowLevelSecurity => plan
+        case  (_: BypassRowLevelSecurity | _: Update | _: Delete | _: DeleteFromTable) => plan
+
         // TODO: Asif: Bypass row level security filter apply if the command
         // is of type RunnableCommad. Later if it turns out any data operation
         // is happening via this command we need to handle it


### PR DESCRIPTION
The query plan if it of type Update | Delete | Delete From Table , the policy filter application to plan is to be skipped.
Fixes SNAP-2576

Added bug test


## ReleaseNotes.txt changes

No change in release notes.
## Other PRs 

(Does this change require changes in other projects- store, spark, spark-jobserver, aqp? Add the links of PR of the other subprojects that are related to this change)
