### PR TITLE
Fix to SNAP-2577

### DIFF
--- a/core/src/main/scala/org/apache/spark/sql/execution/columnar/impl/JDBCSourceAsColumnarStore.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/columnar/impl/JDBCSourceAsColumnarStore.scala
@@ -468,7 +468,7 @@ class JDBCSourceAsColumnarStore(private var _connProperties: ConnectionPropertie
 
   override def getConnection(id: String, onExecutor: Boolean): Connection = {
     connectionType match {
-      case ConnectionType.Embedded =>
+      case ConnectionType.Embedded if onExecutor =>
         val currentCM = ContextService.getFactory.getCurrentContextManager
         if (currentCM ne null) {
           val conn = EmbedConnectionContext.getEmbedConnection(currentCM)


### PR DESCRIPTION
## Changes proposed in this pull request
This is specific to single vm tests where the same vm gets booted as db, then doubles up as lead and executor.
Column buffer table creation gets fired on an embedded connection which gets created as part of booting up of db and on that routing again happens for table creation which should not happen. Embedded connetion should be picked up only on Executor/Servers. Added that check.

## Patch testing
This test was added which fails without the change.
ignore("Column table creation test - SNAP-2577")
Activated this test.

## ReleaseNotes.txt changes

None.

## Other PRs 

(Does this change require changes in other projects- store, spark, spark-jobserver, aqp? Add the links of PR of the other subprojects that are related to this change)
