### PR TITLE
[SNAP-2582] allow for NONE as a valid policy for server-auth-provider

### DIFF
--- a/cluster/src/dunit/scala/io/snappydata/cluster/ClusterManagerLDAPTestBase.scala
+++ b/cluster/src/dunit/scala/io/snappydata/cluster/ClusterManagerLDAPTestBase.scala
@@ -20,13 +20,15 @@ import java.util.Properties
 
 import scala.language.postfixOps
 
+import com.gemstone.org.jgroups.protocols.AUTH
 import com.pivotal.gemfirexd.Attribute
 import com.pivotal.gemfirexd.security.{LdapTestServer, SecurityTestUtils}
+import io.snappydata.test.dunit.SerializableRunnable
 
 /**
  * Base class for start and stop of LDAP Server
  */
-object ClusterManagerLDAPTestBase{
+object ClusterManagerLDAPTestBase {
   val securityProperties: Properties = new Properties()
 }
 
@@ -35,10 +37,24 @@ abstract class ClusterManagerLDAPTestBase(s: String, val adminUser: String = "ge
 
   override def beforeClass(): Unit = {
     val ldapProperties = SecurityTestUtils.startLdapServerAndGetBootProperties(0, 0, adminUser,
-      getClass.getResource("/auth.ldif").getPath)
+      getClass.getResource("/auth.ldif").getPath, true)
     setSecurityProps(ldapProperties)
     super.beforeClass()
     SplitClusterDUnitSecurityTest.bootExistingAuthModule(ldapProperties)
+
+    // check that server-auth-provider has disabled the GFE JGroups authenticator
+    val serverAuth = ldapProperties.getProperty(Attribute.SERVER_AUTH_PROVIDER)
+    assert(serverAuth == "NONE")
+
+    val checkServerAuth = new SerializableRunnable() {
+      override def run(): Unit = {
+        val authInit = AUTH.getAuthInit
+        val authenticator = AUTH.getAuthenticator
+        assert((authInit eq null) || authInit.isEmpty)
+        assert((authenticator eq null) || authenticator.isEmpty)
+      }
+    }
+    Seq(vm0, vm1, vm2).foreach(_.invoke(checkServerAuth))
   }
 
   override def afterClass(): Unit = {
@@ -60,17 +76,22 @@ abstract class ClusterManagerLDAPTestBase(s: String, val adminUser: String = "ge
   }
 
   def setSecurityProps(ldapProperties: Properties): Unit = {
-    import com.pivotal.gemfirexd.Property.{AUTH_LDAP_SERVER, AUTH_LDAP_SEARCH_BASE}
+    import com.pivotal.gemfirexd.Property.{AUTH_LDAP_SEARCH_BASE, AUTH_LDAP_SERVER}
     for (k <- List(Attribute.AUTH_PROVIDER, AUTH_LDAP_SERVER, AUTH_LDAP_SEARCH_BASE)) {
       System.setProperty(k, ldapProperties.getProperty(k))
     }
-    for (k <- List(Attribute.AUTH_PROVIDER, AUTH_LDAP_SERVER, AUTH_LDAP_SEARCH_BASE,
-      Attribute.USERNAME_ATTR, Attribute.PASSWORD_ATTR)) {
-      locatorNetProps.setProperty(k, ldapProperties.getProperty(k))
-      bootProps.setProperty(k, ldapProperties.getProperty(k))
-      ClusterManagerLDAPTestBase.securityProperties.setProperty(k, ldapProperties.getProperty(k))
+    for (k <- List(Attribute.AUTH_PROVIDER, Attribute.SERVER_AUTH_PROVIDER, AUTH_LDAP_SERVER,
+      AUTH_LDAP_SEARCH_BASE, Attribute.USERNAME_ATTR, Attribute.PASSWORD_ATTR)) {
+      val propValue = ldapProperties.getProperty(k)
+      if (propValue ne null) {
+        locatorNetProps.setProperty(k, propValue)
+        bootProps.setProperty(k, propValue)
+        ClusterManagerLDAPTestBase.securityProperties.setProperty(k, propValue)
+      } else {
+        locatorNetProps.remove(k)
+        bootProps.remove(k)
+        ClusterManagerLDAPTestBase.securityProperties.remove(k)
+      }
     }
   }
 }
-
-

--- a/cluster/src/main/scala/org/apache/spark/scheduler/cluster/SnappyCoarseGrainedSchedulerBackend.scala
+++ b/cluster/src/main/scala/org/apache/spark/scheduler/cluster/SnappyCoarseGrainedSchedulerBackend.scala
@@ -17,7 +17,8 @@
 package org.apache.spark.scheduler.cluster
 
 import com.pivotal.gemfirexd.internal.engine.Misc
-import org.apache.spark.{Logging, SparkContext}
+
+import org.apache.spark.SparkContext
 import org.apache.spark.rpc.{RpcEndpointAddress, RpcEnv}
 import org.apache.spark.scheduler.{SparkListener, SparkListenerApplicationEnd, SparkListenerBlockManagerAdded, SparkListenerBlockManagerRemoved, SparkListenerExecutorAdded, SparkListenerExecutorRemoved, TaskSchedulerImpl}
 import org.apache.spark.sql.collection.{ToolsCallbackInit, Utils}

--- a/cluster/src/main/scala/org/apache/spark/scheduler/cluster/SnappyEmbeddedModeClusterManager.scala
+++ b/cluster/src/main/scala/org/apache/spark/scheduler/cluster/SnappyEmbeddedModeClusterManager.scala
@@ -97,7 +97,7 @@ class SnappyEmbeddedModeClusterManager extends ExternalClusterManager {
   }
 
   def stopLead(): Unit = {
-    LeadImpl.invokeLeadStop(null)
+    LeadImpl.invokeLeadStop()
   }
 
 }

--- a/cluster/src/main/scala/org/apache/spark/ui/SnappyBasicAuthenticator.scala
+++ b/cluster/src/main/scala/org/apache/spark/ui/SnappyBasicAuthenticator.scala
@@ -25,7 +25,6 @@ import javax.servlet.http.HttpServletRequest
 import scala.collection.JavaConverters._
 
 import com.pivotal.gemfirexd.Attribute
-import com.pivotal.gemfirexd.internal.engine.db.FabricDatabase
 import com.pivotal.gemfirexd.internal.engine.distributed.utils.GemFireXDUtils
 import com.pivotal.gemfirexd.internal.engine.{GfxdConstants, Misc}
 import com.pivotal.gemfirexd.internal.shared.common.sanity.SanityManager
@@ -44,8 +43,9 @@ class SnappyBasicAuthenticator extends BasicAuthenticator with Logging {
     props.setProperty(Attribute.USERNAME_ATTR, username)
     props.setProperty(Attribute.PASSWORD_ATTR, password.toString)
 
-    val result = FabricDatabase.getAuthenticationServiceBase.authenticate(Misc
-        .getMemStoreBooting.getDatabaseName, props)
+    val memStore = Misc.getMemStoreBooting
+    val result = memStore.getDatabase.getAuthenticationService.authenticate(
+      memStore.getDatabaseName, props)
 
     if (result != null) {
       val msg = s"ACCESS DENIED, user [$username]. $result"

--- a/core/src/dunit/scala/io/snappydata/cluster/SplitClusterDUnitSecurityTest.scala
+++ b/core/src/dunit/scala/io/snappydata/cluster/SplitClusterDUnitSecurityTest.scala
@@ -27,7 +27,7 @@ import scala.sys.process._
 import com.pivotal.gemfirexd.Attribute
 import com.pivotal.gemfirexd.Property.{AUTH_LDAP_SEARCH_BASE, AUTH_LDAP_SERVER}
 import com.pivotal.gemfirexd.internal.engine.Misc
-import com.pivotal.gemfirexd.internal.engine.db.FabricDatabase
+import com.pivotal.gemfirexd.internal.iapi.services.monitor.ModuleControl
 import com.pivotal.gemfirexd.security.{LdapTestServer, SecurityTestUtils}
 import io.snappydata.Constant
 import io.snappydata.test.dunit.DistributedTestBase.WaitCriterion
@@ -937,14 +937,14 @@ object SplitClusterDUnitSecurityTest extends SplitClusterDUnitTestObject {
       override def run(): Unit = {
         val store = Misc.getMemStoreBootingNoThrow
         if (store ne null) {
-          val authModule = FabricDatabase.getAuthenticationServiceBase
+          val authModule = store.getDatabase.getAuthenticationService
           if (authModule ne null) {
             val propNamesIter = props.stringPropertyNames().iterator()
             while (propNamesIter.hasNext) {
               val propName = propNamesIter.next()
               store.setBootProperty(propName, props.getProperty(propName))
             }
-            authModule.boot(false, props)
+            authModule.asInstanceOf[ModuleControl].boot(false, props)
           }
         }
       }

--- a/core/src/dunit/scala/io/snappydata/cluster/SplitClusterDUnitSecurityTest.scala
+++ b/core/src/dunit/scala/io/snappydata/cluster/SplitClusterDUnitSecurityTest.scala
@@ -27,7 +27,6 @@ import scala.sys.process._
 import com.pivotal.gemfirexd.Attribute
 import com.pivotal.gemfirexd.Property.{AUTH_LDAP_SEARCH_BASE, AUTH_LDAP_SERVER}
 import com.pivotal.gemfirexd.internal.engine.Misc
-import com.pivotal.gemfirexd.internal.iapi.services.monitor.ModuleControl
 import com.pivotal.gemfirexd.security.{LdapTestServer, SecurityTestUtils}
 import io.snappydata.Constant
 import io.snappydata.test.dunit.DistributedTestBase.WaitCriterion
@@ -944,7 +943,7 @@ object SplitClusterDUnitSecurityTest extends SplitClusterDUnitTestObject {
               val propName = propNamesIter.next()
               store.setBootProperty(propName, props.getProperty(propName))
             }
-            authModule.asInstanceOf[ModuleControl].boot(false, props)
+            authModule.boot(false, props)
           }
         }
       }

--- a/core/src/main/java/io/snappydata/impl/SnappyHiveCatalog.java
+++ b/core/src/main/java/io/snappydata/impl/SnappyHiveCatalog.java
@@ -633,6 +633,8 @@ public class SnappyHiveCatalog implements ExternalCatalog {
           Constant.JDBC_EMBEDDED_DRIVER());
       initCommonHiveMetaStoreProperties(metadataConf);
 
+      // wait for stats sampler initialization
+      Misc.waitForSamplerInitialization();
       final short numRetries = 40;
       short count = 0;
       while (true) {


### PR DESCRIPTION
These set of changes (along with those in store-side PR) allow one to specify server-auth-provider=NONE so that gemfire-level p2p authentication is disabled while the auth-provider will set the connection-level authentication (both for client connections and internal connections).

## Changes proposed in this pull request

- allow for NONE as a valid security policy in Lead boot
- fixed and cleaned up lead property handling to set the properties correctly for start and stop
- updated calls from snappy layer to use the authentication service from the Database module
  rather than the static version (which has not been removed on the store side)
- wait for sampler to fully initialiaze before proceeding with hive catalog initialization
- changed tests extending ClusterManagerLDAPTestBase to use server-auth-provider=NONE
  and test that authentication has been disabled at jgroups AUTH layer

## Patch testing

precheckin with the new tests; manual testing

## ReleaseNotes.txt changes

Document the possibility of setting "-server-auth-provider=NONE" to disable peer-to-peer authentication

## Other PRs 

https://github.com/SnappyDataInc/snappy-store/pull/429
