### PR TITLE
Removing duplicate key events while processing streaming batch in default sink callback 

### DIFF
--- a/core/src/main/scala/io/snappydata/Literals.scala
+++ b/core/src/main/scala/io/snappydata/Literals.scala
@@ -188,6 +188,7 @@ object StreamingConstants {
   val TABLE_NAME = "tablename"
   val STREAM_QUERY_ID = "streamqueryid"
   val SINK_CALLBACK = "sinkcallback"
+  val CONFLATION = "conflation"
 
   object EventType {
     val INSERT = 0

--- a/core/src/main/scala/org/apache/spark/sql/streaming/SnappySinkCallback.scala
+++ b/core/src/main/scala/org/apache/spark/sql/streaming/SnappySinkCallback.scala
@@ -29,6 +29,7 @@ import org.apache.spark.sql.streaming.DefaultSnappySinkCallback.{TEST_FAILBATCH_
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.sql.{DataFrame, Dataset, Row, SnappySession, _}
 import org.apache.spark.util.Utils
+
 /**
  * Should be implemented by clients who wants to override default behavior provided by
  * [[DefaultSnappySinkCallback]].
@@ -184,7 +185,13 @@ class DefaultSnappySinkCallback extends SnappySinkCallback {
 
     log.debug(s"Processing batchId $batchId with parameters $parameters ... Done.")
 
-    // group by key columns and get the last record
+
+    // We are grouping by key columns and getting the last record.
+    // Note that this approach will work as far as the incoming dataframe is partitioned
+    // by key columns and events are available in the correct order in the respective partition.
+    // If above conditions are not met in that case we will need separate ordering column(s) to
+    // order the events. A new optional parameter needs to be exposed as part of the snappysink
+    // API to accept the ordering column(s).
     def getConflatedDf = {
       import org.apache.spark.sql.functions._
       val keyColumnNames = keyColumns.map(_.name)

--- a/core/src/main/scala/org/apache/spark/sql/streaming/SnappySinkCallback.scala
+++ b/core/src/main/scala/org/apache/spark/sql/streaming/SnappySinkCallback.scala
@@ -20,7 +20,7 @@ package org.apache.spark.sql.streaming
 import java.sql.SQLException
 import java.util.NoSuchElementException
 
-import io.snappydata.Property
+import io.snappydata.Property._
 import io.snappydata.StreamingConstants._
 import org.apache.log4j.Logger
 
@@ -108,16 +108,16 @@ case class SnappyStoreSink(snappySession: SnappySession,
       }
     }
 
-    val hashAggregateSize = Property.HashAggregateSize.get(snappySession.sessionState.conf)
-    val hashAggregateSizeSetToDefault = hashAggregateSize.equals("0")
-    if (hashAggregateSizeSetToDefault) {
-      Property.HashAggregateSize.set(snappySession.sessionState.conf, "10m")
+    val hashAggregateSizeChanged = HashAggregateSize.get(snappySession.sessionState.conf)
+        .equals(HashAggregateSize.defaultValue.get)
+    if (hashAggregateSizeChanged) {
+      HashAggregateSize.set(snappySession.sessionState.conf, "10m")
     }
     try {
       sinkCallback.process(snappySession, parameters, batchId, convert(data), posDup)
     } finally {
-      if (hashAggregateSizeSetToDefault) {
-        Property.HashAggregateSize.set(snappySession.sessionState.conf, "0")
+      if (hashAggregateSizeChanged) {
+        HashAggregateSize.set(snappySession.sessionState.conf, HashAggregateSize.defaultValue.get)
       }
     }
   }

--- a/core/src/test/scala/org/apache/spark/sql/streaming/SnappyStoreSinkProviderSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/streaming/SnappyStoreSinkProviderSuite.scala
@@ -69,20 +69,20 @@ class SnappyStoreSinkProviderSuite extends SnappyFunSuite
     val topic = getTopic(testId)
     kafkaTestUtils.createTopic(topic, partitions = 3)
 
-    val dataBatch1 = Seq(Seq(1, "name1", 30), Seq(2, "name2", 10),
-      Seq(3, "name3", 30))
+    val dataBatch1 = Seq(Seq(1, "name1", 30, "lname1"), Seq(2, "name2", 10, "lname2"),
+      Seq(3, "name3", 30, "lname3"))
     kafkaTestUtils.sendMessages(topic, dataBatch1.map(r => r.mkString(",")).toArray)
 
     val streamingQuery = createAndStartStreamingQuery(topic, testId, withEventTypeColumn = false)
     waitTillTheBatchIsPickedForProcessing(0, testId)
 
-    val dataBatch2 = Seq(Seq(1, "name11", 40), Seq(4, "name4", 50))
+    val dataBatch2 = Seq(Seq(1, "name11", 40, "lname1"), Seq(4, "name4", 50, "lname4"))
     kafkaTestUtils.sendMessages(topic, dataBatch2.map(r => r.mkString(",")).toArray)
 
     streamingQuery.processAllAvailable()
 
-    val rows = Array(Row(1, "name11", 40), Row(2, "name2", 10),
-      Row(3, "name3", 30), Row(4, "name4", 50))
+    val rows = Array(Row(1, "name11", 40, "lname1"), Row(2, "name2", 10, "lname2"),
+      Row(3, "name3", 30, "lname3"), Row(4, "name4", 50, "lname4"))
     assertData(rows)
   }
 
@@ -94,14 +94,14 @@ class SnappyStoreSinkProviderSuite extends SnappyFunSuite
 
     val streamingQuery = createAndStartStreamingQuery(topic, testId, withEventTypeColumn = false)
 
-    val dataBatch = Seq(Seq(1, "name1", 30), Seq(2, "name2", 10),
-      Seq(3, "name3", 30), Seq(1, "name1", 30))
+    val dataBatch = Seq(Seq(1, "name1", 30, "lname1"), Seq(2, "name2", 10, "lname2"),
+      Seq(3, "name3", 30, "lname3"), Seq(1, "name1", 30, "lname1"))
     kafkaTestUtils.sendMessages(topic, dataBatch.map(r => r.mkString(",")).toArray)
 
     streamingQuery.processAllAvailable()
 
-    val rows = Array(Row(1, "name1", 30), Row(1, "name1", 30), Row(2, "name2", 10),
-      Row(3, "name3", 30))
+    val rows = Array(Row(1, "name1", 30, "lname1"), Row(1, "name1", 30, "lname1"),
+      Row(2, "name2", 10, "lname2"), Row(3, "name3", 30, "lname3"))
     assertData(rows)
   }
 
@@ -111,18 +111,18 @@ class SnappyStoreSinkProviderSuite extends SnappyFunSuite
     val topic = getTopic(testId)
     kafkaTestUtils.createTopic(topic, partitions = 3)
 
-    val dataBatch1 = Seq(Seq(1, "name1", 20, 0), Seq(2, "name2", 10, 0))
+    val dataBatch1 = Seq(Seq(1, "name1", 20, "lname1", 0), Seq(2, "name2", 10, "lname2", 0))
     kafkaTestUtils.sendMessages(topic, dataBatch1.map(r => r.mkString(",")).toArray)
 
     val streamingQuery: StreamingQuery = createAndStartStreamingQuery(topic, testId)
     waitTillTheBatchIsPickedForProcessing(0, testId)
 
-    val dataBatch2 = Seq(Seq(1, "name11", 30, 1), Seq(2, "name2", 10, 2),
-      Seq(3, "name3", 30, 0), Seq(4, "name4", 10, 2))
+    val dataBatch2 = Seq(Seq(1, "name11", 30, "lname1", 1), Seq(2, "name2", 10, "lname2", 2),
+      Seq(3, "name3", 30, "lname3", 0), Seq(4, "name4", 10, "lname4", 2))
     kafkaTestUtils.sendMessages(topic, dataBatch2.map(r => r.mkString(",")).toArray)
     streamingQuery.processAllAvailable()
 
-    assertData(Array(Row(1, "name11", 30), Row(3, "name3", 30)))
+    assertData(Array(Row(1, "name11", 30, "lname1"), Row(3, "name3", 30, "lname3")))
   }
 
   test("_eventType column: present, key columns: undefined, table type: column") {
@@ -131,7 +131,7 @@ class SnappyStoreSinkProviderSuite extends SnappyFunSuite
     val topic = getTopic(testId)
     kafkaTestUtils.createTopic(topic, partitions = 3)
 
-    val dataBatch = Seq(Seq(1, "name1", 20, 0), Seq(2, "name2", 10, 0))
+    val dataBatch = Seq(Seq(1, "name1", 20, "lname1", 0), Seq(2, "name2", 10, "lname2", 0))
     kafkaTestUtils.sendMessages(topic, dataBatch.map(r => r.mkString(",")).toArray)
 
     val thrown = intercept[StreamingQueryException] {
@@ -149,20 +149,20 @@ class SnappyStoreSinkProviderSuite extends SnappyFunSuite
     val topic = getTopic(testId)
     kafkaTestUtils.createTopic(topic, partitions = 3)
 
-    val dataBatch1 = Seq(Seq(1, "name1", 30), Seq(2, "name2", 10),
-      Seq(3, "name3", 30))
+    val dataBatch1 = Seq(Seq(1, "name1", 30, "lname1"), Seq(2, "name2", 10, "lname2"),
+      Seq(3, "name3", 30, "lname3"))
     kafkaTestUtils.sendMessages(topic, dataBatch1.map(r => r.mkString(",")).toArray)
 
     val streamingQuery = createAndStartStreamingQuery(topic, testId, withEventTypeColumn = false)
     waitTillTheBatchIsPickedForProcessing(0, testId)
 
-    val dataBatch2 = Seq(Seq(1, "name11", 40), Seq(4, "name4", 50))
+    val dataBatch2 = Seq(Seq(1, "name11", 40, "lname1"), Seq(4, "name4", 50, "lname4"))
     kafkaTestUtils.sendMessages(topic, dataBatch2.map(r => r.mkString(",")).toArray)
 
     streamingQuery.processAllAvailable()
 
-    val rows = Array(Row(1, "name11", 40), Row(2, "name2", 10),
-      Row(3, "name3", 30), Row(4, "name4", 50))
+    val rows = Array(Row(1, "name11", 40, "lname1"), Row(2, "name2", 10, "lname2"),
+      Row(3, "name3", 30, "lname3"), Row(4, "name4", 50, "lname4"))
     assertData(rows)
   }
 
@@ -174,14 +174,14 @@ class SnappyStoreSinkProviderSuite extends SnappyFunSuite
 
     val streamingQuery = createAndStartStreamingQuery(topic, testId, withEventTypeColumn = false)
 
-    val dataBatch = Seq(Seq(1, "name1", 30), Seq(2, "name2", 10),
-      Seq(3, "name3", 30), Seq(1, "name1", 30))
+    val dataBatch = Seq(Seq(1, "name1", 30, "lname1"), Seq(2, "name2", 10, "lname2"),
+      Seq(3, "name3", 30, "lname3"), Seq(1, "name1", 30, "lname1"))
     kafkaTestUtils.sendMessages(topic, dataBatch.map(r => r.mkString(",")).toArray)
 
     streamingQuery.processAllAvailable()
 
-    val rows = Array(Row(1, "name1", 30), Row(1, "name1", 30), Row(2, "name2", 10),
-      Row(3, "name3", 30))
+    val rows = Array(Row(1, "name1", 30, "lname1"), Row(1, "name1", 30, "lname1"),
+      Row(2, "name2", 10, "lname2"), Row(3, "name3", 30, "lname3"))
     assertData(rows)
   }
 
@@ -191,18 +191,18 @@ class SnappyStoreSinkProviderSuite extends SnappyFunSuite
     val topic = getTopic(testId)
     kafkaTestUtils.createTopic(topic, partitions = 3)
 
-    val dataBatch1 = Seq(Seq(1, "name1", 20, 0), Seq(2, "name2", 10, 0))
+    val dataBatch1 = Seq(Seq(1, "name1", 20, "lname1", 0), Seq(2, "name2", 10, "lname2", 0))
     kafkaTestUtils.sendMessages(topic, dataBatch1.map(r => r.mkString(",")).toArray)
 
     val streamingQuery: StreamingQuery = createAndStartStreamingQuery(topic, testId)
     waitTillTheBatchIsPickedForProcessing(0, testId)
 
-    val dataBatch2 = Seq(Seq(1, "name11", 30, 1), Seq(2, "name2", 10, 2),
-      Seq(3, "name3", 30, 0), Seq(4, "name4", 10, 2))
+    val dataBatch2 = Seq(Seq(1, "name11", 30, "lname1", 1), Seq(2, "name2", 10, "lname2", 2),
+      Seq(3, "name3", 30, "lname3", 0), Seq(4, "name4", 10, "lname4", 2))
     kafkaTestUtils.sendMessages(topic, dataBatch2.map(r => r.mkString(",")).toArray)
     streamingQuery.processAllAvailable()
 
-    assertData(Array(Row(1, "name11", 30), Row(3, "name3", 30)))
+    assertData(Array(Row(1, "name11", 30, "lname1"), Row(3, "name3", 30, "lname3")))
   }
 
   test("_eventType column: present, key columns: undefined, table type: row") {
@@ -211,7 +211,7 @@ class SnappyStoreSinkProviderSuite extends SnappyFunSuite
     val topic = getTopic(testId)
     kafkaTestUtils.createTopic(topic, partitions = 3)
 
-    val dataBatch = Seq(Seq(1, "name1", 20, 0), Seq(2, "name2", 10, 0))
+    val dataBatch = Seq(Seq(1, "name1", 20, "lname1", 0), Seq(2, "name2", 10, "lname2", 0))
     kafkaTestUtils.sendMessages(topic, dataBatch.map(r => r.mkString(",")).toArray)
 
     val thrown = intercept[StreamingQueryException] {
@@ -229,14 +229,14 @@ class SnappyStoreSinkProviderSuite extends SnappyFunSuite
     val topic = getTopic(testId)
     kafkaTestUtils.createTopic(topic, partitions = 3)
 
-    kafkaTestUtils.sendMessages(topic, (0 to 10).map(i => s"$i,name$i,$i,0").toArray)
+    kafkaTestUtils.sendMessages(topic, (0 to 10).map(i => s"$i,name$i,$i,lname$i,0").toArray)
 
     val streamingQuery: StreamingQuery = createAndStartStreamingQuery(topic, testId)
     waitTillTheBatchIsPickedForProcessing(0, testId)
     streamingQuery.stop()
 
     val streamingQuery1: StreamingQuery = createAndStartStreamingQuery(topic, testId, true, true)
-    kafkaTestUtils.sendMessages(topic, (11 to 20).map(i => s"$i,name$i,$i,0").toArray)
+    kafkaTestUtils.sendMessages(topic, (11 to 20).map(i => s"$i,name$i,$i,lname$i,0").toArray)
     try {
       streamingQuery1.processAllAvailable()
     } catch {
@@ -246,11 +246,11 @@ class SnappyStoreSinkProviderSuite extends SnappyFunSuite
 
     val streamingQuery2: StreamingQuery = createAndStartStreamingQuery(topic, testId)
 
-    kafkaTestUtils.sendMessages(topic, (21 to 30).map(i => s"$i,name$i,$i,0").toArray)
+    kafkaTestUtils.sendMessages(topic, (21 to 30).map(i => s"$i,name$i,$i,lname$i,0").toArray)
     waitTillTheBatchIsPickedForProcessing(1, testId)
     streamingQuery2.processAllAvailable()
 
-    assertData((0 to 30).map(i => Row(i, s"name$i", i)).toArray)
+    assertData((0 to 30).map(i => Row(i, s"name$i", i, s"lname$i")).toArray)
   }
 
   test("test conflation") {
@@ -260,7 +260,8 @@ class SnappyStoreSinkProviderSuite extends SnappyFunSuite
     kafkaTestUtils.createTopic(topic, partitions = 3)
 
     // producing all records with same key `1` on partition 0.
-    kafkaTestUtils.sendMessages(topic, (0 to 999).map(i => s"1,name$i,$i,${i%3}").toArray, Some(0))
+    kafkaTestUtils.sendMessages(topic, (0 to 999)
+        .map(i => s"1,name$i,$i,lname1,${i % 3}").toArray, Some(0))
 
     // producing records with keh `1` on multiple partitions. This may not lead to expected result
     // kafkaTestUtils.sendMessages(topic, (0 to 999).map(i => s"1,name$i,$i,${i%3}").toArray)
@@ -269,7 +270,7 @@ class SnappyStoreSinkProviderSuite extends SnappyFunSuite
 
     streamingQuery.processAllAvailable()
 
-    assertData(Array(Row(1, "name999", 999)))
+    assertData(Array(Row(1, "name999", 999, "lname1")))
   }
 
   private def waitTillTheBatchIsPickedForProcessing(batchId: Int, testId: Int,
@@ -288,7 +289,7 @@ class SnappyStoreSinkProviderSuite extends SnappyFunSuite
   }
 
   private def assertData(expectedData: Array[Row]) = {
-    val actualData = session.sql("select * from " + tableName + " order by id").collect()
+    val actualData = session.sql("select * from " + tableName + " order by id, last_name").collect()
     assertResult(expectedData)(actualData)
   }
 
@@ -296,13 +297,10 @@ class SnappyStoreSinkProviderSuite extends SnappyFunSuite
     snc.sql("drop table if exists users")
 
     def provider = if (isRowTable) "row" else "column"
-
-    def options = if (!isRowTable && withKeyColumn) "options(key_columns 'id')" else ""
-
-    def primaryKey = if (isRowTable && withKeyColumn) "primary key" else ""
-
-    val s = s"create table users (id long $primaryKey, name varchar(40), age int) " +
-        s"using $provider $options"
+    def options = if (!isRowTable && withKeyColumn) "options(key_columns 'id,last_name')" else ""
+    def primaryKey = if (isRowTable && withKeyColumn) ", primary key (id, last_name)" else ""
+    val s = s"create table users (id long , first_name varchar(40), age int, " +
+        s"last_name varchar(40) $primaryKey) using $provider $options "
     LogManager.getRootLogger.error(s)
     snc.sql(s)
   }
@@ -319,8 +317,9 @@ class SnappyStoreSinkProviderSuite extends SnappyFunSuite
 
     def structFields() = {
       StructField("id", LongType, nullable = false) ::
-          StructField("name", StringType, nullable = true) ::
+          StructField("first_name", StringType, nullable = true) ::
           StructField("age", IntegerType, nullable = true) ::
+          StructField("last_name", StringType, nullable = true) ::
           (if (withEventTypeColumn) {
             StructField("_eventType", IntegerType, nullable = false) :: Nil
           }
@@ -337,10 +336,10 @@ class SnappyStoreSinkProviderSuite extends SnappyFunSuite
         .as[String]
         .map(_.split(","))
         .map(r => {
-          if (r.length == 4) {
-            Row(r(0).toLong, r(1), r(2).toInt, r(3).toInt)
+          if (r.length == 5) {
+            Row(r(0).toLong, r(1), r(2).toInt, r(3), r(4).toInt)
           } else {
-            Row(r(0).toLong, r(1), r(2).toInt)
+            Row(r(0).toLong, r(1), r(2).toInt, r(3))
           }
         })
         .writeStream


### PR DESCRIPTION
## Changes proposed in this pull request

- Removing multiple records with the same key columns from the incoming batch by grouping record by key columns and picking the last record. This approach may work only when data in the in-coming dataframe batch is partitioned by key columns and the record order is maintained on each partition.
 
- An optional parameter with key `conflation` is exposed for `snappysink` default callback implementation. This parameter controls the conflation behavior.  The valid values for this parameter is `true` or `false`. By default conflation is enabled, it can be disabled by explicitly setting this parameter to `false`.

- If `HashAggregateSize` property of `SnappySession` is set to default then it is set to `10m` (10 MB) before processing the batch and resetting it back to default `0` after processing the batch. This is done to fallback to Spark's aggregation when input data size is > 10 MB and hence spark aggregator will use sort aggregation instead of hash aggregation if output data size is actually large at runtime. This is needed as hash aggreation can be expensive in terms of GC hit if the incoming data batch is large. 

## Patch testing

Manual testing, Scalatest, Hydra test with actual CDC like flow is under progress
