### PR TITLE
adding commandline arg to kill on OOM

### DIFF
--- a/launcher/src/main/java/io/snappydata/tools/QuickLauncher.java
+++ b/launcher/src/main/java/io/snappydata/tools/QuickLauncher.java
@@ -124,6 +124,10 @@ class QuickLauncher extends LauncherBase {
     // add java path to command-line first
     commandLine.add(System.getProperty("java.home") + "/bin/java");
     commandLine.add("-server");
+    // https://github.com/airlift/jvmkill is added to libgemfirexd.so
+    // adding agentpath helps kill jvm in case of OOM. kill -9 is not
+    // used as it fails in certain cases
+    commandLine.add("-agentpath:" + snappyHome + "/jars/libgemfirexd.so");
     // get the startup options and command-line arguments (JVM arguments etc)
     HashMap<String, Object> options = getStartOptions(args, snappyHome, commandLine, env);
 


### PR DESCRIPTION
## Changes proposed in this pull request

Related to jira [SNAP-2503](https://jira.snappydata.io/browse/SNAP-2503). adding commandline arguments to register jvmkill agent to kill jvm on OOM.

## Patch testing

Manually tested on local machine by submitting a job which causes OOM

## Other PRs 

Has dependency on [snappy/store](https://github.com/gemxd/gemfirexd-oss/pull/14).