### PR TITLE
Disabling conflation by default in default snappy streaming callback

### DIFF
--- a/core/src/main/scala/org/apache/spark/sql/streaming/SnappySinkCallback.scala
+++ b/core/src/main/scala/org/apache/spark/sql/streaming/SnappySinkCallback.scala
@@ -154,7 +154,7 @@ class DefaultSnappySinkCallback extends SnappySinkCallback {
     val conflationEnabled = if (parameters.contains(CONFLATION)) {
       parameters(CONFLATION).toBoolean
     } else {
-      true
+      false
     }
     val keyColumns = snappySession.sessionCatalog.getKeyColumns(tableName)
     val eventTypeColumnAvailable = df.schema.map(_.name).contains(EVENT_TYPE_COLUMN)


### PR DESCRIPTION
## Changes proposed in this pull request

Disabling conflation by default in default snappy streaming callback

## Patch testing

have run following suites: SnappyStoreSinkProviderSuite, SnappyStructuredKafkaSuite, SnappySinkProviderDUnitTest

## ReleaseNotes.txt changes

N/A

## Other PRs 
N/A