### PR TITLE
SNAP-2602 : On snappy UI, add column named "Overflown Size"/ "Disk Size" in Tables.

### DIFF
--- a/cluster/src/dunit/scala/io/snappydata/cluster/SnappyTableStatsProviderDUnitTest.scala
+++ b/cluster/src/dunit/scala/io/snappydata/cluster/SnappyTableStatsProviderDUnitTest.scala
@@ -214,6 +214,7 @@ object SnappyTableStatsProviderDUnitTest {
     entryOverhead *= entryCount
     stats.setSizeInMemory(stats.getSizeInMemory + memSize + entryOverhead)
     stats.setTotalSize(stats.getTotalSize + totalSize + entryOverhead)
+    stats.setSizeOnDisk(stats.getTotalSize - stats.getSizeInMemory)
     stats
   }
 
@@ -249,6 +250,7 @@ object SnappyTableStatsProviderDUnitTest {
     totalSize += overhead * result.getRowCount
     result.setSizeInMemory(totalSize)
     result.setTotalSize(totalSize)
+    result.setSizeOnDisk(0)
     result
   }
 

--- a/cluster/src/main/scala/org/apache/spark/status/api/v1/TableDetails.scala
+++ b/cluster/src/main/scala/org/apache/spark/status/api/v1/TableDetails.scala
@@ -45,7 +45,7 @@ object TableDetails {
 
       new TableSummary(table.getTableName, storageModel, distributionType,
         table.isColumnTable, table.isReplicatedTable, table.getRowCount, table.getSizeInMemory,
-        table.getTotalSize, table.getBucketCount)
+        table.getSizeOnDisk, table.getTotalSize, table.getBucketCount)
     }).values.toList
 
   }

--- a/cluster/src/main/scala/org/apache/spark/status/api/v1/snappyapi.scala
+++ b/cluster/src/main/scala/org/apache/spark/status/api/v1/snappyapi.scala
@@ -88,6 +88,7 @@ class TableSummary private[spark](
     val isReplicatedTable: Boolean,
     val rowCount: Long,
     val sizeInMemory: Long,
+    val sizeOnDisk: Long,
     val totalSize: Long,
     val bucketCount: Int
 )

--- a/cluster/src/main/scala/org/apache/spark/ui/SnappyDashboardPage.scala
+++ b/cluster/src/main/scala/org/apache/spark/ui/SnappyDashboardPage.scala
@@ -243,7 +243,7 @@ private[ui] class SnappyDashboardPage (parent: SnappyDashboardTab)
                 {SnappyDashboardPage.tableStatsColumn("distributionType")}
               </span>
             </th>
-            <th class="table-th-col-heading" style="width: 200px;">
+            <th class="table-th-col-heading" style="width: 150px;">
               <span data-toggle="tooltip" title=""
                     data-original-title={
                       SnappyDashboardPage.tableStatsColumn("rowCountTooltip")
@@ -251,7 +251,7 @@ private[ui] class SnappyDashboardPage (parent: SnappyDashboardTab)
                 {SnappyDashboardPage.tableStatsColumn("rowCount")}
               </span>
             </th>
-            <th class="table-th-col-heading" style="width: 200px;">
+            <th class="table-th-col-heading" style="width: 150px;">
               <span data-toggle="tooltip" title=""
                     data-original-title={
                       SnappyDashboardPage.tableStatsColumn("sizeInMemoryTooltip")
@@ -259,15 +259,23 @@ private[ui] class SnappyDashboardPage (parent: SnappyDashboardTab)
                 {SnappyDashboardPage.tableStatsColumn("sizeInMemory")}
               </span>
             </th>
-            <th class="table-th-col-heading" style="width: 200px;">
+            <th class="table-th-col-heading" style="width: 150px;">
               <span data-toggle="tooltip" title=""
                     data-original-title={
-                      SnappyDashboardPage.tableStatsColumn("totalSizeTooltip")
+                      SnappyDashboardPage.tableStatsColumn("sizeOnDiskTooltip")
+                    }>
+                {SnappyDashboardPage.tableStatsColumn("sizeOnDisk")}
+              </span>
+            </th>
+            <th class="table-th-col-heading" style="width: 150px;">
+              <span data-toggle="tooltip" title=""
+                    data-original-title={
+                    SnappyDashboardPage.tableStatsColumn("totalSizeTooltip")
                     }>
                 {SnappyDashboardPage.tableStatsColumn("totalSize")}
               </span>
             </th>
-            <th class="table-th-col-heading" style="width: 200px;">
+            <th class="table-th-col-heading" style="width: 100px;">
               <span data-toggle="tooltip" title=""
                     data-original-title={
                       SnappyDashboardPage.tableStatsColumn("bucketCountTooltip")
@@ -416,9 +424,11 @@ object SnappyDashboardPage {
   tableStatsColumn += ("rowCountTooltip" -> "Total Rows in Table")
   tableStatsColumn += ("sizeInMemory" -> "Memory Size")
   tableStatsColumn += ("sizeInMemoryTooltip" -> "Tables Size in Memory")
+  tableStatsColumn += ("sizeOnDisk" -> "Disk Size")
+  tableStatsColumn += ("sizeOnDiskTooltip" -> "Tables Size on Disk")
   tableStatsColumn += ("totalSize" -> "Total Size")
   tableStatsColumn += ("totalSizeTooltip" ->
-      "Tables Total Size (In Memory size + Disk Overflow Size)")
+      "Tables Total Size (In Memory size + Overflown To Disk Size)")
   tableStatsColumn += ("bucketCount" -> "Buckets")
   tableStatsColumn += ("bucketCountTooltip" -> "Number of Buckets in Table")
 


### PR DESCRIPTION
## Changes proposed in this pull request

Feature Request:
 - On snappy UI, add column named "Overflown Size / Disk Size" in Tables, to show how much data is overflown to disk.

Changes:
 - HTML and CSS changes for displaying tables overflown size to disk on UI.
 - TableSummary is updated to hold tables size on disk.
 - SnappyTableStatsProviderDUnitTest is updated accordingly.

(Fill in the changes here)

## Patch testing

 - Tested Manually.

## ReleaseNotes.txt changes

 - YES

## Other PRs 

 - Spark: https://github.com/SnappyDataInc/spark/pull/127
 - Store: https://github.com/SnappyDataInc/snappy-store/pull/440