### PR TITLE
Fix for SNAP-2645:

### DIFF
--- a/core/src/main/scala/org/apache/spark/sql/streaming/DirectKafkaStreamSource.scala
+++ b/core/src/main/scala/org/apache/spark/sql/streaming/DirectKafkaStreamSource.scala
@@ -67,14 +67,10 @@ final class DirectKafkaStreamRelation(
   private val preferredHosts = LocationStrategies.PreferConsistent
   private val startingOffsets = getStartingOffsets
 
-  private def getStartingOffsets = {
-
-    if (options.contains(STARTING_OFFSETS_PROP)) {
-      partitionOffsetMethod.invoke(null, options(STARTING_OFFSETS_PROP))
-          .asInstanceOf[Map[TopicPartition, Long]]
-    } else {
-      Map.empty[TopicPartition, Long]
-    }
+  private def getStartingOffsets = options.get(STARTING_OFFSETS_PROP) match {
+    case Some(offsets) => partitionOffsetMethod.invoke(null, offsets)
+        .asInstanceOf[Map[TopicPartition, Long]]
+    case None => Map.empty[TopicPartition, Long]
   }
 
   override protected def createRowStream(): DStream[InternalRow] = {

--- a/core/src/test/scala/org/apache/spark/sql/kafka010/SnappyStreamingKafkaSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/kafka010/SnappyStreamingKafkaSuite.scala
@@ -23,20 +23,21 @@ import java.util.concurrent.ConcurrentLinkedQueue
 import java.util.concurrent.atomic.AtomicInteger
 
 import scala.collection.JavaConverters._
+import scala.concurrent.duration._
+import scala.language.postfixOps
+import scala.util.Random
+
 import io.snappydata.SnappyFunSuite
 import org.apache.kafka.common.TopicPartition
 import org.apache.kafka.common.serialization._
+import org.scalatest.concurrent.Eventually
+import org.scalatest.{BeforeAndAfter, BeforeAndAfterAll}
 
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.streaming.StreamToRowsConverter
 import org.apache.spark.sql.types.{IntegerType, LongType, StringType, StructField, StructType}
-import org.apache.spark.streaming.{Duration, Milliseconds, SnappyStreamingContext}
 import org.apache.spark.streaming.kafka010.{ConsumerStrategies, KafkaUtils, LocationStrategies}
-import org.scalatest.{BeforeAndAfter, BeforeAndAfterAll}
-import org.scalatest.concurrent.Eventually
-import scala.util.Random
-import scala.concurrent.duration._
-import scala.language.postfixOps
+import org.apache.spark.streaming.{Duration, Milliseconds, SnappyStreamingContext}
 
 class SnappyStreamingKafkaSuite extends SnappyFunSuite with Eventually
     with BeforeAndAfter with BeforeAndAfterAll {
@@ -90,7 +91,6 @@ class SnappyStreamingKafkaSuite extends SnappyFunSuite with Eventually
 
 
   test("basic kafka streaming pipeline") {
-    import session.implicits._
     val topics = List("pat1", "pat2", "pat3", "advanced3")
     // Should match 3 out of 4 topics
     val pat =
@@ -132,7 +132,6 @@ class SnappyStreamingKafkaSuite extends SnappyFunSuite with Eventually
   }
 
   test("Snappy kafka streaming") {
-    import session.implicits._
     val topic = newTopic()
     kafkaTestUtils.createTopic(topic, partitions = 3)
 
@@ -178,7 +177,6 @@ class SnappyStreamingKafkaSuite extends SnappyFunSuite with Eventually
 
 
   test("Snappy kafka streaming with custom deserializer") {
-    import session.implicits._
 
     val topic = newTopic()
     kafkaTestUtils.createTopic(topic, partitions = 3)
@@ -192,7 +190,6 @@ class SnappyStreamingKafkaSuite extends SnappyFunSuite with Eventually
       new TopicPartition(topic, 2) -> 0L
     )
 
-    val startingOffsets = JsonUtils.partitionOffsets(partitions)
     kafkaTestUtils.sendMessages(topic,
       (100 to 200).map(i => s"$i,name$i,$i").toArray)
     ssnc.sql("create stream table kafkaStream (" +
@@ -203,7 +200,6 @@ class SnappyStreamingKafkaSuite extends SnappyFunSuite with Eventually
         "key.deserializer->org.apache.kafka.common.serialization.StringDeserializer;" +
         "value.deserializer->org.apache.spark.sql.kafka010.UserDeserializer;" +
         s"group.id->$groupId;auto.offset.reset->earliest'," +
-        s"startingOffsets '$startingOffsets', " +
         s" subscribe '$topic')")
 
     snc.dropTable("snappyTable", ifExists = true)


### PR DESCRIPTION

## Changes proposed in this pull request

Making startingOffsets property optional as spark's streaming API takes care of that by using committed offset or kafka param "auto.offset.reset" if no explicit value is set for startingOffsets

## Patch testing

Updated SnappyStreamingKafkaSuite test scenario to test streaming without passing "startingOffsets" param

