### PR TITLE
[SNAP-2656] check for underlying Attribute with joins on aggregate columns

### DIFF
--- a/cluster/src/dunit/scala/io/snappydata/cluster/SplitSnappyClusterDUnitTest.scala
+++ b/cluster/src/dunit/scala/io/snappydata/cluster/SplitSnappyClusterDUnitTest.scala
@@ -140,7 +140,7 @@ class SplitSnappyClusterDUnitTest(s: String)
     val rdd = sc.parallelize(
       (1 to 100000).map(i => TestData(i, i.toString)))
 
-    implicit val encoder = Encoders.product[TestData]
+    implicit val encoder: Encoder[TestData] = Encoders.product[TestData]
     val dataDF = snc.createDataset(rdd)
 
     dataDF.write.insertInto(tblBatchSizeSmall)
@@ -642,7 +642,7 @@ object SplitSnappyClusterDUnitTest
     val rdd = sc.parallelize(
       (1 to 100000).map(i => TestData(i, i.toString)))
 
-    implicit val encoder = Encoders.product[TestData]
+    implicit val encoder: Encoder[TestData] = Encoders.product[TestData]
     val dataDF = snc.createDataset(rdd)
 
     dataDF.write.insertInto(tblBatchSize200)
@@ -703,6 +703,7 @@ object SplitSnappyClusterDUnitTest
     snc.sql(s"CREATE TABLE CUSTOMER AS SELECT * FROM CUSTOMER_STAGING")
     val count = snc.sql("select * from customer").count()
     assert(count == 750, s"Expected 750 rows. Actual rows = $count")
+    snc.sql("DROP TABLE CUSTOMER")
 
     val customerWithHeadersFile: String = getClass.getResource("/customer_with_headers.csv").getPath
     val customer_csv_DF = snc.read.option("header", "true")
@@ -712,6 +713,7 @@ object SplitSnappyClusterDUnitTest
     customer_csv_DF.write.format("column").mode("append").options(props1).saveAsTable("CUSTOMER_2")
     val count2 = snc.sql("select * from customer_2").count()
     assert(count2 == 750, s"Expected 750 rows. Actual rows = $count2")
+    snc.sql("DROP TABLE CUSTOMER_2")
 
     // also test temp table
     snc.sql(s"CREATE TEMPORARY TABLE CUSTOMER_TEMP AS SELECT * FROM CUSTOMER_STAGING")

--- a/cluster/src/dunit/scala/io/snappydata/cluster/SplitSnappyClusterDUnitTest.scala
+++ b/cluster/src/dunit/scala/io/snappydata/cluster/SplitSnappyClusterDUnitTest.scala
@@ -703,7 +703,6 @@ object SplitSnappyClusterDUnitTest
     snc.sql(s"CREATE TABLE CUSTOMER AS SELECT * FROM CUSTOMER_STAGING")
     val count = snc.sql("select * from customer").count()
     assert(count == 750, s"Expected 750 rows. Actual rows = $count")
-    snc.sql("DROP TABLE CUSTOMER")
 
     val customerWithHeadersFile: String = getClass.getResource("/customer_with_headers.csv").getPath
     val customer_csv_DF = snc.read.option("header", "true")
@@ -713,7 +712,6 @@ object SplitSnappyClusterDUnitTest
     customer_csv_DF.write.format("column").mode("append").options(props1).saveAsTable("CUSTOMER_2")
     val count2 = snc.sql("select * from customer_2").count()
     assert(count2 == 750, s"Expected 750 rows. Actual rows = $count2")
-    snc.sql("DROP TABLE CUSTOMER_2")
 
     // also test temp table
     snc.sql(s"CREATE TEMPORARY TABLE CUSTOMER_TEMP AS SELECT * FROM CUSTOMER_STAGING")

--- a/compatibilityTests/src/test/scala/org/apache/spark/sql/SnappyJoinSuite.scala
+++ b/compatibilityTests/src/test/scala/org/apache/spark/sql/SnappyJoinSuite.scala
@@ -19,6 +19,5 @@ package org.apache.spark.sql
 
 import org.apache.spark.sql.test.SharedSnappySessionContext
 
-class SnappyJoinSuite extends JoinSuite with SharedSnappySessionContext{
-
+class SnappyJoinSuite extends JoinSuite with SharedSnappySessionContext {
 }

--- a/core/src/main/scala/org/apache/spark/sql/SnappyStrategies.scala
+++ b/core/src/main/scala/org/apache/spark/sql/SnappyStrategies.scala
@@ -82,15 +82,35 @@ private[sql] trait SnappyStrategies {
     private def applyJoinHint(joinHint: String, joinType: JoinType, leftKeys: Seq[Expression],
         rightKeys: Seq[Expression], condition: Option[Expression],
         left: LogicalPlan, right: LogicalPlan, buildSide: joins.BuildSide,
-        canBuild: JoinType => Boolean): Seq[SparkPlan] = joinHint match {
+        buildPlan: LogicalPlan, canBuild: JoinType => Boolean): Seq[SparkPlan] = joinHint match {
       case Constant.JOIN_TYPE_HASH =>
         if (canBuild(joinType)) {
+          // don't hash join beyond 10GB estimated size because that is likely a mistake
+          val buildSize = buildPlan.statistics.sizeInBytes
+          if (buildSize > math.max(JoinStrategy.getMaxHashJoinSize(conf),
+            10L * 1024L * 1024L * 1024L)) {
+            session.addWarning(new SQLWarning(s"Plan hint ${QueryHint.JoinType}=" +
+                s"$joinHint for ${right.simpleString} skipped for ${joinType.sql} " +
+                s"JOIN on columns=$rightKeys due to large estimated buildSize=$buildSize. " +
+                s"Increase session property ${Property.HashJoinSize.name} to force.",
+              SQLState.LANG_INVALID_JOIN_STRATEGY))
+            return Nil
+          }
           makeLocalHashJoin(leftKeys, rightKeys, left, right, condition, joinType,
-            buildSide, replicatedTableJoin = allowsReplicatedJoin(
-              if (buildSide eq joins.BuildLeft) left else right))
+            buildSide, replicatedTableJoin = allowsReplicatedJoin(buildPlan))
         } else Nil
       case Constant.JOIN_TYPE_BROADCAST =>
         if (canBuild(joinType)) {
+          // don't broadcast beyond 1GB estimated size because that is likely a mistake
+          val buildSize = buildPlan.statistics.sizeInBytes
+          if (buildSize > math.max(conf.autoBroadcastJoinThreshold, 1L * 1024L * 1024L * 1024L)) {
+            session.addWarning(new SQLWarning(s"Plan hint ${QueryHint.JoinType}=" +
+                s"$joinHint for ${right.simpleString} skipped for ${joinType.sql} " +
+                s"JOIN on columns=$rightKeys due to large estimated buildSize=$buildSize. " +
+                s"Increase session property ${SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key} to force.",
+              SQLState.LANG_INVALID_JOIN_STRATEGY))
+            return Nil
+          }
           joins.BroadcastHashJoinExec(leftKeys, rightKeys, joinType,
             buildSide, condition, planLater(left), planLater(right)) :: Nil
         } else Nil
@@ -115,7 +135,7 @@ private[sql] trait SnappyStrategies {
             case None =>
             case Some(joinHint) =>
               applyJoinHint(joinHint, joinType, leftKeys, rightKeys, condition,
-                left, right, joins.BuildRight, canBuildRight) match {
+                left, right, joins.BuildRight, right, canBuildRight) match {
                 case Nil => session.addWarning(new SQLWarning(s"Plan hint ${QueryHint.JoinType}=" +
                     s"$joinHint for ${right.simpleString} cannot be applied for ${joinType.sql} " +
                     s"JOIN on columns=$rightKeys. Will try on the other side of join: " +
@@ -127,7 +147,7 @@ private[sql] trait SnappyStrategies {
             case None =>
             case Some(joinHint) =>
               applyJoinHint(joinHint, joinType, leftKeys, rightKeys, condition,
-                left, right, joins.BuildLeft, canBuildLeft) match {
+                left, right, joins.BuildLeft, left, canBuildLeft) match {
                 case Nil => session.addWarning(new SQLWarning(s"Plan hint ${QueryHint.JoinType}=" +
                     s"$joinHint for ${left.simpleString} cannot be applied for ${joinType.sql} " +
                     s"JOIN on columns=$leftKeys", SQLState.LANG_INVALID_JOIN_STRATEGY))
@@ -347,12 +367,16 @@ private[sql] object JoinStrategy {
         plan.statistics.sizeInBytes <= conf.autoBroadcastJoinThreshold
   }
 
+  def getMaxHashJoinSize(conf: SQLConf): Long = {
+    ExternalStoreUtils.sizeAsBytes(Property.HashJoinSize.get(conf),
+      Property.HashJoinSize.name, -1, Long.MaxValue)
+  }
+
   /**
    * Matches a plan whose size is small enough to build a hash table.
    */
   def canBuildLocalHashMap(plan: LogicalPlan, conf: SQLConf): Boolean = {
-    plan.statistics.sizeInBytes <= ExternalStoreUtils.sizeAsBytes(
-      Property.HashJoinSize.get(conf), Property.HashJoinSize.name, -1, Long.MaxValue)
+    plan.statistics.sizeInBytes <= getMaxHashJoinSize(conf)
   }
 
   def isReplicatedJoin(plan: LogicalPlan): Boolean = plan match {

--- a/core/src/main/scala/org/apache/spark/sql/collection/Utils.scala
+++ b/core/src/main/scala/org/apache/spark/sql/collection/Utils.scala
@@ -21,6 +21,7 @@ import java.nio.ByteBuffer
 import java.sql.DriverManager
 import java.util.TimeZone
 
+import scala.annotation.tailrec
 import scala.collection.{mutable, Map => SMap}
 import scala.language.existentials
 import scala.reflect.ClassTag
@@ -45,7 +46,7 @@ import org.apache.spark.scheduler.TaskLocation
 import org.apache.spark.scheduler.local.LocalSchedulerBackend
 import org.apache.spark.sql._
 import org.apache.spark.sql.catalyst.expressions.codegen.CodegenContext
-import org.apache.spark.sql.catalyst.expressions.{Attribute, Expression, GenericRow, UnsafeRow}
+import org.apache.spark.sql.catalyst.expressions.{Alias, Attribute, Expression, GenericRow, UnsafeRow}
 import org.apache.spark.sql.catalyst.json.{JSONOptions, JacksonGenerator, JacksonUtils}
 import org.apache.spark.sql.catalyst.plans.logical.{LocalRelation, LogicalPlan}
 import org.apache.spark.sql.catalyst.plans.physical.{Partitioning, PartitioningCollection}
@@ -347,6 +348,12 @@ object Utils {
       case None => throw new GemFireXDRuntimeException(
         s"SparkSQLExecuteImpl: getPartitionData() block $blockId not found")
     }
+  }
+
+  @tailrec
+  def unAlias(e: Expression, childClass: Class[_] = null): Expression = e match {
+    case a: Alias if (childClass eq null) || childClass.isInstance(a.child) => unAlias(a.child)
+    case _ => e
   }
 
   def getInternalType(dataType: DataType): Class[_] = {
@@ -918,7 +925,7 @@ final class MultiBucketExecutorPartition(private[this] var _index: Int,
       case _ => false
     }
 
-    override def iterator() = new java.util.Iterator[Integer] {
+    override def iterator(): java.util.Iterator[Integer] = new java.util.Iterator[Integer] {
       private[this] var bucket = bucketSet.nextSetBit(0)
 
       override def hasNext: Boolean = bucket >= 0

--- a/core/src/main/scala/org/apache/spark/sql/execution/joins/SnappyJoinLike.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/joins/SnappyJoinLike.scala
@@ -65,7 +65,7 @@ trait SnappyJoinLike extends SparkPlan {
           leftSubsets.find(p => rightSubsets.find(_._2 == p._2) match {
             case None => false
             case x => rightSubset = x; true
-          })
+          }).orElse(leftSubsets.headOption)
         }
       leftSubset match {
         case Some((l, li)) => rightSubset match {

--- a/core/src/main/scala/org/apache/spark/sql/execution/joins/SnappyJoinLike.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/joins/SnappyJoinLike.scala
@@ -16,11 +16,12 @@
  */
 package org.apache.spark.sql.execution.joins
 
-import org.apache.spark.sql.catalyst.expressions.Expression
+import org.apache.spark.sql.catalyst.expressions.{Attribute, Expression, NamedExpression}
 import org.apache.spark.sql.catalyst.plans.JoinType
 import org.apache.spark.sql.catalyst.plans.physical.{BroadcastDistribution, ClusteredDistribution, Distribution, Partitioning, UnknownPartitioning}
 import org.apache.spark.sql.collection.Utils
-import org.apache.spark.sql.execution.SparkPlan
+import org.apache.spark.sql.execution.aggregate.{HashAggregateExec, SnappyHashAggregateExec, SortAggregateExec}
+import org.apache.spark.sql.execution.{SparkPlan, UnaryExecNode}
 
 /**
  * Base trait for joins used in SnappyData. Currently this allows
@@ -53,8 +54,8 @@ trait SnappyJoinLike extends SparkPlan {
       leftClustered :: rightClustered :: Nil
     } else {
       // try subsets of the keys on each side
-      val leftSubset = getSubsetAndIndices(leftPartitioning, leftKeys)
-      val rightSubset = getSubsetAndIndices(rightPartitioning, rightKeys)
+      val leftSubset = getSubsetAndIndices(leftPartitioning, leftKeys, left)
+      val rightSubset = getSubsetAndIndices(rightPartitioning, rightKeys, right)
       leftSubset match {
         case Some((l, li)) => rightSubset match {
           case Some((r, ri)) =>
@@ -62,7 +63,7 @@ trait SnappyJoinLike extends SparkPlan {
             if (li == ri) {
               ClusteredDistribution(l) :: ClusteredDistribution(r) :: Nil
             } else {
-              // choose the bigger plan
+              // choose the bigger plan to match distribution and avoid shuffle
               if (leftSizeInBytes > rightSizeInBytes) {
                 ClusteredDistribution(l) ::
                     ClusteredDistribution(li.map(rightKeys.apply)) :: Nil
@@ -85,15 +86,74 @@ trait SnappyJoinLike extends SparkPlan {
 
   /**
    * Optionally return result if partitioning is a subset of given join keys,
-   * and if so then return the subset as well as the indices of subset keys
-   * in the join keys (in order).
+   * and if so then return the subset as well as the indices of subset keys in the
+   * join keys (in order). Also unwraps aliases in the keys for matching against
+   * partitioning and returns a boolean indicating whether alias was unwrapped or not.
    */
   protected def getSubsetAndIndices(partitioning: Partitioning,
-      keys: Seq[Expression]): Option[(Seq[Expression], Seq[Int])] = {
+      keys: Seq[Expression], child: SparkPlan): Option[(Seq[Expression], Seq[Int])] = {
     val numColumns = Utils.getNumColumns(partitioning)
-    if (keys.length > numColumns) {
-      keys.indices.combinations(numColumns).map(s => s.map(keys.apply) -> s)
-          .find(p => partitioning.satisfies(ClusteredDistribution(p._1)))
+    if (keys.length >= numColumns) {
+      var combination: Seq[Expression] = null
+      keys.indices.combinations(numColumns).collectFirst {
+        case s if partitioning.satisfies(ClusteredDistribution {
+          combination = s.map(keys.apply)
+          combination
+        }) => (combination, s)
+        case s if partitioning.satisfies(ClusteredDistribution {
+          combination = unAlias(s.map(keys.apply), child)
+          combination
+        }) => (combination, s)
+      }
     } else None
+  }
+
+  /**
+   * Remove the extra Aliases added by aggregates (e.g. k1 projection in
+   * "select k1, max(k2) from t1 group by k1") so partitioning can match against the base
+   * Attribute for such cases rather than the aliased one which will never match
+   * introducing an unnecessary shuffle.
+   *
+   * Since the aggregate plans generate a new Attribute for the projected grouping keys,
+   * hence this method has to go down to the resultExpressions of an aggregate and remove
+   * aliases at that level to get hold of the base Attribute.
+   */
+  private def unAlias(exprs: Seq[Expression], child: SparkPlan): Seq[Expression] = {
+    // all aggregate implementation will have output as outputExpressions.map(_.toAttribute)
+    // so search for matching attribute in output, go to the corresponding outputExpression
+    // and remove aliases from that to get the base Attribute
+    def matchAggregate(output: Seq[Attribute], outputExpressions: Seq[NamedExpression],
+        result: Array[Expression]): Unit = {
+      for (i <- output.indices) {
+        val pos = result.indexOf(output(i))
+        if (pos != -1) {
+          // only unwrap Attributes inside Aliases
+          val substitute = Utils.unAlias(outputExpressions(i), classOf[Attribute])
+          if (substitute ne outputExpressions(i)) {
+            result(pos) = substitute
+          }
+          return
+        }
+      }
+    }
+
+    def searchAggregate(plan: SparkPlan, result: Array[Expression]): Unit = plan match {
+      // resolve if possible in this aggregate and keep searching the tree afterwards
+      case a: SnappyHashAggregateExec => matchAggregate(a.output, a.resultExpressions, result)
+        searchAggregate(a.child, result)
+      case a: HashAggregateExec => matchAggregate(a.output, a.resultExpressions, result)
+        searchAggregate(a.child, result)
+      case a: SortAggregateExec => matchAggregate(a.output, a.resultExpressions, result)
+        searchAggregate(a.child, result)
+      case u: UnaryExecNode if u.outputPartitioning == u.child.outputPartitioning =>
+        searchAggregate(u.child, result)
+      case p if p.children.exists(_.outputPartitioning == p.outputPartitioning) =>
+        searchAggregate(p.children.find(_.outputPartitioning == p.outputPartitioning).get, result)
+      case _ =>
+    }
+
+    val result = exprs.toArray
+    searchAggregate(child, result)
+    result
   }
 }

--- a/core/src/main/scala/org/apache/spark/sql/execution/joins/SnappySortMergeJoinExec.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/joins/SnappySortMergeJoinExec.scala
@@ -24,10 +24,10 @@ import org.apache.spark.sql.execution.SparkPlan
  * Extension to Spark's SortMergeJoinExec to avoid exchange for cases when join keys are
  * a subset of child plan partitioning.
  */
-class SnappySortMergeJoinExec(leftKeys: Seq[Expression], rightKeys: Seq[Expression],
-    joinType: JoinType, condition: Option[Expression], left: SparkPlan, right: SparkPlan,
+class SnappySortMergeJoinExec(_leftKeys: Seq[Expression], _rightKeys: Seq[Expression],
+    _joinType: JoinType, _condition: Option[Expression], _left: SparkPlan, _right: SparkPlan,
     override val leftSizeInBytes: BigInt, override val rightSizeInBytes: BigInt)
-    extends SortMergeJoinExec(leftKeys, rightKeys, joinType, condition, left, right)
+    extends SortMergeJoinExec(_leftKeys, _rightKeys, _joinType, _condition, _left, _right)
         with SnappyJoinLike {
 
   override def productArity: Int = 8

--- a/core/src/main/scala/org/apache/spark/sql/internal/JoinQueryPlanning.scala
+++ b/core/src/main/scala/org/apache/spark/sql/internal/JoinQueryPlanning.scala
@@ -17,21 +17,15 @@
 
 package org.apache.spark.sql.internal
 
-import scala.annotation.tailrec
-
 import org.apache.spark.sql.catalyst.expressions.{Alias, Expression, NamedExpression}
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
+import org.apache.spark.sql.collection.Utils.unAlias
 
 trait JoinQueryPlanning {
 
-  @tailrec final def unAlias(e: Expression): Expression = e match {
-    case a: Alias => unAlias(a.child)
-    case _ => e
-  }
-
   def getKeyOrder(plan: LogicalPlan, joinKeys: Seq[Expression],
       partitioning: Seq[NamedExpression]): (Seq[Int], Boolean) = {
-    val part = partitioning.map(unAlias)
+    val part = partitioning.map(unAlias(_))
     lazy val planExpressions = plan.expressions
     val keyOrder = joinKeys.map { k =>
       val key = unAlias(k)
@@ -60,6 +54,6 @@ trait JoinQueryPlanning {
 
   private def joinKeySubsetOfPart(keyOrder: Seq[Int],
       partitioning: Seq[NamedExpression]): Boolean = {
-    keyOrder.filterNot(i => i == Int.MaxValue).nonEmpty
+    !keyOrder.forall(_ == Int.MaxValue)
   }
 }

--- a/core/src/test/scala/org/apache/spark/sql/store/SnappyJoinSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/store/SnappyJoinSuite.scala
@@ -754,10 +754,19 @@ class SnappyJoinSuite extends SnappyFunSuite with BeforeAndAfterAll {
   test("SNAP-2656") {
     val snc = this.snc
     val session = snc.snappySession
+    // set broadcast back to default due to changes by previous tests
+    session.sql("set spark.sql.autoBroadcastJoinThreshold=10000000")
+
     session.sql("create table t1 (c1 int, c2 int) options (partition_by 'c1')")
     session.sql("create table t2 (c1 int, c2 int) options (partition_by 'c1')")
     session.sql("insert into t1 values (2, 10), (2, 20), (3, 30)")
     session.sql("insert into t2 values (1, 10), (2, 20), (3, 30)")
+    session.sql("create table t3 (c1 int, c2 int, c3 string) using column " +
+        "options (partition_by 'c1,c2')")
+    session.sql("create table t4 (c1 int, c2 int, c3 string) using column " +
+        "options (partition_by 'c1,c2')")
+    session.sql("insert into t3 values (1, 10, 'one'), (2, 20, 'two'), (3, 30, 'three')")
+    session.sql("insert into t4 values (2, 10, 'two1'), (2, 20, 'two'), (3, 30, '3')")
 
     val q1 = "select t1.*, t2.c2 from t1 join t2 on (t1.c1 = t2.c1) " +
         "where t1.c2 = (select max(c2) from t2 where t1.c1 = t2.c1)"
@@ -768,12 +777,30 @@ class SnappyJoinSuite extends SnappyFunSuite with BeforeAndAfterAll {
     val q4 = "select t1.*, t2.c2 from t1 join t2 on (t1.c1 = t2.c1 and t1.c2 = t2.c2) " +
         "where t1.c2 = (select max(c2) from t2 where t1.c1 = t2.c1 and t1.c2 = t2.c2)"
 
-    // all four queries will result in broadcast plans due to small size
+    val q5 = "select t4.*, t3.c3 from t3 join t4 on (t3.c1 = t4.c1 and t3.c2 = t4.c2) " +
+        "where t3.c3 = (select max(c3) from t4 where t3.c1 = t4.c1 and t3.c2 = t4.c2)"
+    val res5 = Array(Row(2, 20, "two", "two"))
+    val q6 = "select t4.*, t3.c3 from t4 join t3 on (t4.c2 = t3.c2 and t4.c1 = t3.c1) " +
+        "where t3.c2 = (select max(c2) from t4 where t4.c1 = t3.c1 and t4.c2 = t3.c2)"
+    val res6 = Array(Row(2, 20, "two", "two"), Row(3, 30, "3", "three"))
+    val q7 = "select t4.*, t3.c3 from t3 join t4 on (t3.c1 = t4.c1) " +
+        "where t3.c2 = (select max(c2) from t4 where t3.c1 = t4.c1 and t3.c2 = t4.c2)"
+    val q8 = "select t4.*, t3.c3 from t4 join t3 on (t4.c1 = t3.c1 and t4.c3 = t3.c3) " +
+        "where t3.c2 = (select max(c2) from t4 where t4.c1 = t3.c1 and t4.c2 = t3.c2)"
+    val res5_8 = Array(res5, res6, Row(2, 10, "two1", "two") +: res6, res5)
+
+    // all queries will result in broadcast plans due to small size
     for (q <- Seq(q1, q2, q3, q4)) {
       val df = session.sql(q)
       checkForBroadcast(df, session, broadcastExpected = true)
       val result = df.collect()
       assert(result.sortBy(_.getInt(0)) === Array(Row(2, 20, 20), Row(3, 30, 30)))
+    }
+    for ((q, i) <- Seq(q5, q6, q7, q8).zipWithIndex) {
+      val df = session.sql(q)
+      checkForBroadcast(df, session, broadcastExpected = true)
+      val result = df.collect()
+      assert(result.sortBy(r => r.getInt(0) * 100 + r.getInt(1)) === res5_8(i))
     }
 
     // turning off broadcast should ensure it does not result in a shuffle in any of the queries
@@ -786,9 +813,25 @@ class SnappyJoinSuite extends SnappyFunSuite with BeforeAndAfterAll {
       val result = df.collect()
       assert(result.sortBy(_.getInt(0)) === Array(Row(2, 20, 20), Row(3, 30, 30)))
     }
+    for ((q, i) <- Seq(q5, q6, q7, q8).zipWithIndex) {
+      val df = session.sql(q)
+      checkForBroadcast(df, session, broadcastExpected = false)
+      // exchange is expected when join keys are a subset or partially overlap partitioning keys
+      checkForShuffle(df.logicalPlan, snc, shuffleExpected = i >= 2)
+      // exactly two shuffles for last two
+      if (i >= 2) {
+        assert(df.queryExecution.executedPlan.collect {
+          case _: Exchange => true
+        }.length === 2)
+      }
+      val result = df.collect()
+      assert(result.sortBy(r => r.getInt(0) * 100 + r.getInt(1)) === res5_8(i))
+    }
 
     session.sql("drop table t1")
     session.sql("drop table t2")
+    session.sql("drop table t3")
+    session.sql("drop table t4")
   }
 
   def partitionToPartitionJoinAssertions(snc: SnappyContext,

--- a/dunit/src/main/java/io/snappydata/test/dunit/standalone/ProcessManager.java
+++ b/dunit/src/main/java/io/snappydata/test/dunit/standalone/ProcessManager.java
@@ -176,6 +176,10 @@ public class ProcessManager {
     String classPath = System.getProperty("java.class.path");
     //String tmpDir = System.getProperty("java.io.tmpdir");
     String agent = getAgentString();
+    // limit netty buffer arenas and sizes to avoid occasional OOMEs with 1g heap
+    int pageSize = 8192;
+    int maxOrder = 10; // total size of each chunk will be "pageSize << maxOrder" i.e. 8MB
+    int numArenas = Math.min(8, Runtime.getRuntime().availableProcessors() * 2);
     return new String[] {
       cmd, "-classpath", classPath,
       "-D" + DUnitLauncher.RMI_PORT_PARAM + "=" + namingPort,
@@ -200,9 +204,10 @@ public class ProcessManager {
       "-Dsun.rmi.dgc.client.gcInterval=600000 ",
       "-Dsun.rmi.dgc.server.gcInterval=600000",
       "-Dsun.rmi.transport.tcp.handshakeTimeout=3600000",
-      // limit netty buffer arenas to avoid occasional OOMEs with 1g heap
-      "-Dio.netty.allocator.numHeapArenas=4",
-      "-Dio.netty.allocator.numDirectArenas=4",
+      "-Dio.netty.allocator.pageSize=" + pageSize,
+      "-Dio.netty.allocator.maxOrder=" + maxOrder,
+      "-Dio.netty.allocator.numHeapArenas=" + numArenas,
+      "-Dio.netty.allocator.numDirectArenas=" + numArenas,
       "-ea",
       agent,
       ChildVM.class.getName()

--- a/dunit/src/main/java/io/snappydata/test/dunit/standalone/ProcessManager.java
+++ b/dunit/src/main/java/io/snappydata/test/dunit/standalone/ProcessManager.java
@@ -176,8 +176,6 @@ public class ProcessManager {
     String classPath = System.getProperty("java.class.path");
     //String tmpDir = System.getProperty("java.io.tmpdir");
     String agent = getAgentString();
-    // limit netty buffer arenas to avoid occasional OOMEs with 1g heap
-    int numArenas = Math.min(6, Runtime.getRuntime().availableProcessors() * 2);
     return new String[] {
       cmd, "-classpath", classPath,
       "-D" + DUnitLauncher.RMI_PORT_PARAM + "=" + namingPort,
@@ -202,8 +200,9 @@ public class ProcessManager {
       "-Dsun.rmi.dgc.client.gcInterval=600000 ",
       "-Dsun.rmi.dgc.server.gcInterval=600000",
       "-Dsun.rmi.transport.tcp.handshakeTimeout=3600000",
-      "-Dio.netty.allocator.numHeapArenas=" + numArenas,
-      "-Dio.netty.allocator.numDirectArenas=" + numArenas,
+      // limit netty buffer arenas to avoid occasional OOMEs with 1g heap
+      "-Dio.netty.allocator.numHeapArenas=4",
+      "-Dio.netty.allocator.numDirectArenas=4",
       "-ea",
       agent,
       ChildVM.class.getName()


### PR DESCRIPTION
For queries like:

```sql
  select * from t1 join t2 on (t1.c1 = t2.c1)
  where t1.c2 = (select max(c2) from t2 where t1.c1 = t2.c1)
```

when t1, t2 are partitioned on c1, should not result in a shuffle. This PR adds a change to
determine underlying attributes across aggregate projection alias columns.

## Changes proposed in this pull request

- drill down into the underlying attribute beyond aggregate plans when checking for
  partitioning columns matching with join keys
- skip join hint for hash/broadcast in case estimated size is too large because
  it can result in OOME with warning that session properties need to be set explicitly

## Patch testing

precheckin

## ReleaseNotes.txt changes

NA

## Other PRs 

NA