### PR TITLE
temporary fix for ensuring aqp bootstrap code does not copy the buffe…

### DIFF
--- a/core/src/main/scala/org/apache/spark/sql/SnappyStrategies.scala
+++ b/core/src/main/scala/org/apache/spark/sql/SnappyStrategies.scala
@@ -731,7 +731,7 @@ case class CollapseCollocatedPlans(session: SparkSession) extends Rule[SparkPlan
   override def apply(plan: SparkPlan): SparkPlan = plan.transformUp {
     // collapse aggregates including removal of exchange completely if possible
     case agg@SnappyHashAggregateExec(Some(groupingAttributes), _,
-    finalAggregateExpressions, _, resultExpressions, child, false)
+    finalAggregateExpressions, _, resultExpressions, child, false, _)
       if groupingAttributes.nonEmpty &&
           // not for child classes (like AQP extensions)
           agg.getClass == classOf[SnappyHashAggregateExec] &&


### PR DESCRIPTION
…r variable in snappyhashaggregate exec

Temporarily disabling the copy of the buffer variables ( for closed form as well as bootstrap)  if the aqp aggregate functions are present ( & bootstrap or closed form analysis is needed).

This change  will be rectified properly after understanding the reason for copying buffer variable. The bootstrap code, especially relies on the holder object ( the buffer variable) reference check to decide whether the group by key has changed or not.

## Patch testing

(Fill in the details about how this patch was tested)

## ReleaseNotes.txt changes

(Does this change require an entry in ReleaseNotes.txt? If yes, has it been added to it?)

## Other PRs 

(Does this change require changes in other projects- store, spark, spark-jobserver, aqp? Add the links of PR of the other subprojects that are related to this change)
