### PR TITLE
SNAP-2723 : streaming compatibility tests

### DIFF
--- a/compatibilityTests/build.gradle
+++ b/compatibilityTests/build.gradle
@@ -47,6 +47,8 @@ dependencies {
 
   testCompile project(path: ':snappy-spark:snappy-spark-sql_' + scalaBinaryVersion,
       configuration: 'testOutput')
+  testCompile project(path: ':snappy-spark:snappy-spark-sql-kafka-0.10_' + scalaBinaryVersion,
+      configuration: 'testOutput')
   testCompile project(':dunit')
 
   compile (project(':snappy-core_' + scalaBinaryVersion)) {

--- a/compatibilityTests/src/test/scala/org/apache/spark/sql/SnappyFileStreamSinkSuite.scala
+++ b/compatibilityTests/src/test/scala/org/apache/spark/sql/SnappyFileStreamSinkSuite.scala
@@ -20,5 +20,9 @@ import org.apache.spark.sql.streaming.FileStreamSinkSuite
 import org.apache.spark.sql.test.{SharedSnappySessionContext, SnappySparkTestUtil}
 
 class SnappyFileStreamSinkSuite extends FileStreamSinkSuite
-    with SharedSnappySessionContext with SnappySparkTestUtil{
+    with SharedSnappySessionContext with SnappySparkTestUtil {
+
+  override def ignored: Seq[String] = Seq(
+    "parquet"
+  )
 }

--- a/compatibilityTests/src/test/scala/org/apache/spark/sql/SnappyFileStreamSinkSuite.scala
+++ b/compatibilityTests/src/test/scala/org/apache/spark/sql/SnappyFileStreamSinkSuite.scala
@@ -21,8 +21,4 @@ import org.apache.spark.sql.test.{SharedSnappySessionContext, SnappySparkTestUti
 
 class SnappyFileStreamSinkSuite extends FileStreamSinkSuite
     with SharedSnappySessionContext with SnappySparkTestUtil{
-
-  override def ignored: Seq[String] = Seq(
-    "parquet"
-  )
 }

--- a/compatibilityTests/src/test/scala/org/apache/spark/sql/SnappyFileStreamSourceSuite.scala
+++ b/compatibilityTests/src/test/scala/org/apache/spark/sql/SnappyFileStreamSourceSuite.scala
@@ -23,6 +23,9 @@ class SnappyFileStreamSourceSuite extends FileStreamSourceSuite
     with SharedSnappySessionContext with SnappySparkTestUtil {
 
   override def ignored: Seq[String] = Seq(
+    "FileStreamSource schema: no path",
+    "FileStreamSource schema: path doesn't exist (without schema) should throw exception",
+    "FileStreamSource schema: path doesn't exist (with schema) should throw exception",
     "SPARK-17372 - write file names to WAL as Array[String]",
     "FileStreamSource offset - read Spark 2.1.0 offset json format",
     "FileStreamSource offset - read Spark 2.1.0 offset long format",

--- a/compatibilityTests/src/test/scala/org/apache/spark/sql/execution/streaming/SnappyForeachSinkSuite.scala
+++ b/compatibilityTests/src/test/scala/org/apache/spark/sql/execution/streaming/SnappyForeachSinkSuite.scala
@@ -14,23 +14,10 @@
  * permissions and limitations under the License. See accompanying
  * LICENSE file.
  */
-package org.apache.spark.sql
+package org.apache.spark.sql.execution.streaming
 
-import org.apache.spark.sql.streaming.{FileStreamSourceStressTestSuite, FileStreamSourceSuite}
 import org.apache.spark.sql.test.{SharedSnappySessionContext, SnappySparkTestUtil}
 
-class SnappyFileStreamSourceSuite extends FileStreamSourceSuite
+class SnappyForeachSinkSuite extends ForeachSinkSuite
     with SharedSnappySessionContext with SnappySparkTestUtil {
-
-  override def ignored: Seq[String] = Seq(
-    "SPARK-17372 - write file names to WAL as Array[String]",
-    "FileStreamSource offset - read Spark 2.1.0 offset json format",
-    "FileStreamSource offset - read Spark 2.1.0 offset long format",
-    "FileStreamSourceLog - read Spark 2.1.0 log format"
-  )
-}
-
-class SnappyFileStreamSourceStressTestSuite extends FileStreamSourceStressTestSuite
-with SharedSnappySessionContext with SnappySparkTestUtil{
-
 }

--- a/compatibilityTests/src/test/scala/org/apache/spark/sql/execution/streaming/SnappyStreamMetadataSuite.scala
+++ b/compatibilityTests/src/test/scala/org/apache/spark/sql/execution/streaming/SnappyStreamMetadataSuite.scala
@@ -14,23 +14,12 @@
  * permissions and limitations under the License. See accompanying
  * LICENSE file.
  */
-package org.apache.spark.sql
+package org.apache.spark.sql.execution.streaming
 
-import org.apache.spark.sql.streaming.{FileStreamSourceStressTestSuite, FileStreamSourceSuite}
 import org.apache.spark.sql.test.{SharedSnappySessionContext, SnappySparkTestUtil}
 
-class SnappyFileStreamSourceSuite extends FileStreamSourceSuite
-    with SharedSnappySessionContext with SnappySparkTestUtil {
+class SnappyStreamMetadataSuite extends StreamMetadataSuite
+    with SharedSnappySessionContext with SnappySparkTestUtil{
 
-  override def ignored: Seq[String] = Seq(
-    "SPARK-17372 - write file names to WAL as Array[String]",
-    "FileStreamSource offset - read Spark 2.1.0 offset json format",
-    "FileStreamSource offset - read Spark 2.1.0 offset long format",
-    "FileStreamSourceLog - read Spark 2.1.0 log format"
-  )
-}
-
-class SnappyFileStreamSourceStressTestSuite extends FileStreamSourceStressTestSuite
-with SharedSnappySessionContext with SnappySparkTestUtil{
-
+  override def ignored: Seq[String] = Seq("read Spark 2.1.0 format")
 }

--- a/compatibilityTests/src/test/scala/org/apache/spark/sql/execution/streaming/SnappyTextSocketStreamSuite.scala
+++ b/compatibilityTests/src/test/scala/org/apache/spark/sql/execution/streaming/SnappyTextSocketStreamSuite.scala
@@ -14,23 +14,11 @@
  * permissions and limitations under the License. See accompanying
  * LICENSE file.
  */
-package org.apache.spark.sql
+package org.apache.spark.sql.execution.streaming
 
-import org.apache.spark.sql.streaming.{FileStreamSourceStressTestSuite, FileStreamSourceSuite}
 import org.apache.spark.sql.test.{SharedSnappySessionContext, SnappySparkTestUtil}
 
-class SnappyFileStreamSourceSuite extends FileStreamSourceSuite
-    with SharedSnappySessionContext with SnappySparkTestUtil {
-
-  override def ignored: Seq[String] = Seq(
-    "SPARK-17372 - write file names to WAL as Array[String]",
-    "FileStreamSource offset - read Spark 2.1.0 offset json format",
-    "FileStreamSource offset - read Spark 2.1.0 offset long format",
-    "FileStreamSourceLog - read Spark 2.1.0 log format"
-  )
-}
-
-class SnappyFileStreamSourceStressTestSuite extends FileStreamSourceStressTestSuite
-with SharedSnappySessionContext with SnappySparkTestUtil{
+class SnappyTextSocketStreamSuite extends TextSocketStreamSuite
+    with SharedSnappySessionContext with SnappySparkTestUtil{
 
 }

--- a/compatibilityTests/src/test/scala/org/apache/spark/sql/kafka010/SnappyKafkaSinkSuite.scala
+++ b/compatibilityTests/src/test/scala/org/apache/spark/sql/kafka010/SnappyKafkaSinkSuite.scala
@@ -14,23 +14,17 @@
  * permissions and limitations under the License. See accompanying
  * LICENSE file.
  */
-package org.apache.spark.sql
+package org.apache.spark.sql.kafka010
 
-import org.apache.spark.sql.streaming.{FileStreamSourceStressTestSuite, FileStreamSourceSuite}
 import org.apache.spark.sql.test.{SharedSnappySessionContext, SnappySparkTestUtil}
 
-class SnappyFileStreamSourceSuite extends FileStreamSourceSuite
+class SnappyKafkaSinkSuite extends KafkaSinkSuite
     with SharedSnappySessionContext with SnappySparkTestUtil {
 
   override def ignored: Seq[String] = Seq(
-    "SPARK-17372 - write file names to WAL as Array[String]",
-    "FileStreamSource offset - read Spark 2.1.0 offset json format",
-    "FileStreamSource offset - read Spark 2.1.0 offset long format",
-    "FileStreamSourceLog - read Spark 2.1.0 log format"
-  )
-}
-
-class SnappyFileStreamSourceStressTestSuite extends FileStreamSourceStressTestSuite
-with SharedSnappySessionContext with SnappySparkTestUtil{
-
+    "streaming - write to kafka with topic field",
+    "streaming - write aggregation w/o topic field, with topic option",
+    "streaming - aggregation with topic field and topic option",
+    "streaming - write data with bad schema",
+    "streaming - write data with valid schema but wrong types")
 }

--- a/compatibilityTests/src/test/scala/org/apache/spark/sql/kafka010/SnappyKafkaSinkSuite.scala
+++ b/compatibilityTests/src/test/scala/org/apache/spark/sql/kafka010/SnappyKafkaSinkSuite.scala
@@ -16,15 +16,18 @@
  */
 package org.apache.spark.sql.kafka010
 
-import org.apache.spark.sql.test.{SharedSnappySessionContext, SnappySparkTestUtil}
+import org.apache.spark.DebugFilesystem
+import org.apache.spark.sql.SnappySession
+import org.apache.spark.sql.test.{SharedSnappySessionContext, SnappySparkTestUtil, TestSnappySession}
 
 class SnappyKafkaSinkSuite extends KafkaSinkSuite
-    with SharedSnappySessionContext with SnappySparkTestUtil {
+with SharedSnappySessionContext with SnappySparkTestUtil {
+    override def createSparkSession: SnappySession = {
+        sparkConf.set("spark.hadoop.fs.file.impl", classOf[DebugFilesystem].getName)
 
-  override def ignored: Seq[String] = Seq(
-    "streaming - write to kafka with topic field",
-    "streaming - write aggregation w/o topic field, with topic option",
-    "streaming - aggregation with topic field and topic option",
-    "streaming - write data with bad schema",
-    "streaming - write data with valid schema but wrong types")
+        // setting case sensitivity to true to pass some failing tests.
+        // See https://jira.snappydata.io/browse/SNAP-2732
+        sparkConf.set("spark.sql.caseSensitive", "true")
+        new TestSnappySession(sparkConf)
+    }
 }

--- a/compatibilityTests/src/test/scala/org/apache/spark/sql/kafka010/SnappyKafkaSourceSuite.scala
+++ b/compatibilityTests/src/test/scala/org/apache/spark/sql/kafka010/SnappyKafkaSourceSuite.scala
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2018 SnappyData, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License. You
+ * may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License. See accompanying
+ * LICENSE file.
+ */
+package org.apache.spark.sql.kafka010
+
+import org.apache.spark.SparkContext
+import org.apache.spark.sql.SnappySession
+import org.apache.spark.sql.test.{SharedSnappySessionContext, SnappySparkTestUtil, TestSnappySession}
+
+class SnappyKafkaSourceSuite extends KafkaSourceSuite
+    with SharedSnappySessionContext with SnappySparkTestUtil {
+
+  override def ignored: Seq[String] =
+    Seq("deserialization of initial offset written by Spark 2.1.0")
+}
+
+class SnappyKafkaSourceStressSuite extends KafkaSourceStressSuite
+    with SharedSnappySessionContext with SnappySparkTestUtil {
+
+}
+
+class SnappyKafkaSourceStressForDontFailOnDataLossSuite
+    extends KafkaSourceStressForDontFailOnDataLossSuite
+        with SharedSnappySessionContext with SnappySparkTestUtil {
+
+  override def createSparkSession(): SnappySession = {
+    // Set maxRetries to 3 to handle NPE from `poll` when deleting a topic
+    new TestSnappySession(
+      new SparkContext("local[2,3]", "test-sql-context", sparkConf))
+  }
+}

--- a/compatibilityTests/src/test/scala/org/apache/spark/sql/streaming/SnappyMemorySinkSuite.scala
+++ b/compatibilityTests/src/test/scala/org/apache/spark/sql/streaming/SnappyMemorySinkSuite.scala
@@ -14,23 +14,11 @@
  * permissions and limitations under the License. See accompanying
  * LICENSE file.
  */
-package org.apache.spark.sql
+package org.apache.spark.sql.streaming
 
-import org.apache.spark.sql.streaming.{FileStreamSourceStressTestSuite, FileStreamSourceSuite}
+import org.apache.spark.sql.execution.streaming.MemorySinkSuite
 import org.apache.spark.sql.test.{SharedSnappySessionContext, SnappySparkTestUtil}
 
-class SnappyFileStreamSourceSuite extends FileStreamSourceSuite
-    with SharedSnappySessionContext with SnappySparkTestUtil {
-
-  override def ignored: Seq[String] = Seq(
-    "SPARK-17372 - write file names to WAL as Array[String]",
-    "FileStreamSource offset - read Spark 2.1.0 offset json format",
-    "FileStreamSource offset - read Spark 2.1.0 offset long format",
-    "FileStreamSourceLog - read Spark 2.1.0 log format"
-  )
-}
-
-class SnappyFileStreamSourceStressTestSuite extends FileStreamSourceStressTestSuite
-with SharedSnappySessionContext with SnappySparkTestUtil{
-
+class SnappyMemorySinkSuite extends MemorySinkSuite
+    with SharedSnappySessionContext with SnappySparkTestUtil{
 }

--- a/compatibilityTests/src/test/scala/org/apache/spark/sql/streaming/test/SnappyDataStreamReaderWriterSuite.scala
+++ b/compatibilityTests/src/test/scala/org/apache/spark/sql/streaming/test/SnappyDataStreamReaderWriterSuite.scala
@@ -14,23 +14,11 @@
  * permissions and limitations under the License. See accompanying
  * LICENSE file.
  */
-package org.apache.spark.sql
+package org.apache.spark.sql.streaming.test
 
-import org.apache.spark.sql.streaming.{FileStreamSourceStressTestSuite, FileStreamSourceSuite}
 import org.apache.spark.sql.test.{SharedSnappySessionContext, SnappySparkTestUtil}
 
-class SnappyFileStreamSourceSuite extends FileStreamSourceSuite
-    with SharedSnappySessionContext with SnappySparkTestUtil {
-
-  override def ignored: Seq[String] = Seq(
-    "SPARK-17372 - write file names to WAL as Array[String]",
-    "FileStreamSource offset - read Spark 2.1.0 offset json format",
-    "FileStreamSource offset - read Spark 2.1.0 offset long format",
-    "FileStreamSourceLog - read Spark 2.1.0 log format"
-  )
-}
-
-class SnappyFileStreamSourceStressTestSuite extends FileStreamSourceStressTestSuite
-with SharedSnappySessionContext with SnappySparkTestUtil{
+class SnappyDataStreamReaderWriterSuite extends DataStreamReaderWriterSuite
+    with SharedSnappySessionContext with SnappySparkTestUtil{
 
 }


### PR DESCRIPTION
## Changes proposed in this pull request

- Adding some more compatibility tests for structured streaming
- Enabling few passing tests which were ignored earlier

## Patch testing

have run the `:snappy-compatibility-tests_2.11:scalaTest` task. there are no code changes involved in this changes.
