### PR TITLE
SNAP-2745 - processing all delete events prior to conflating the dataframe

### DIFF
--- a/core/src/test/scala/org/apache/spark/sql/streaming/SnappyStoreSinkProviderSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/streaming/SnappyStoreSinkProviderSuite.scala
@@ -276,6 +276,47 @@ class SnappyStoreSinkProviderSuite extends SnappyFunSuite
     assertData(Array(Row(1, "name999", 999, "lname1")))
   }
 
+  test("[SNAP-2745]-conflation: delete,insert") {
+    val testId = testIdGenerator.getAndIncrement()
+    createTable()()
+    val topic = getTopic(testId)
+    kafkaTestUtils.createTopic(topic, partitions = 1)
+
+    val batch1 = Seq(Seq(1, "name1", 30, "lname1", 0))
+    kafkaTestUtils.sendMessages(topic, batch1.map(r => r.mkString(",")).toArray)
+    val streamingQuery = createAndStartStreamingQuery(topic, testId, conflation = true)
+
+    waitTillTheBatchIsPickedForProcessing(0, testId)
+    val batch2 = Seq(Seq(1, "name1", 30, "lname1", 2), Seq(1, "name1", 30, "lname1", 0))
+    kafkaTestUtils.sendMessages(topic, batch2.map(r => r.mkString(",")).toArray)
+
+    streamingQuery.processAllAvailable()
+
+    assertData(Array(Row(1, "name1", 30, "lname1")))
+  }
+
+  test("[SNAP-2745]-conflation: delete,update") {
+    val testId = testIdGenerator.getAndIncrement()
+    createTable()()
+    val topic = getTopic(testId)
+    kafkaTestUtils.createTopic(topic, partitions = 1)
+
+    val batch1 = Seq(Seq(1, "name1", 30, "lname1", 0))
+    kafkaTestUtils.sendMessages(topic, batch1.map(r => r.mkString(",")).toArray)
+    val streamingQuery = createAndStartStreamingQuery(topic, testId, conflation = true)
+
+    waitTillTheBatchIsPickedForProcessing(0, testId)
+    val batch2 = Seq(Seq(1, "name1", 30, "lname1", 0))
+    kafkaTestUtils.sendMessages(topic, batch2.map(r => r.mkString(",")).toArray)
+
+    waitTillTheBatchIsPickedForProcessing(0, testId)
+    val batch3 = Seq(Seq(1, "name1", 30, "lname1", 2), Seq(1, "name1", 30, "lname1", 1))
+    kafkaTestUtils.sendMessages(topic, batch3.map(r => r.mkString(",")).toArray)
+
+    streamingQuery.processAllAvailable()
+
+    assertData(Array(Row(1, "name1", 30, "lname1")))
+  }
 
   test("test conflation disabled") {
     val testId = testIdGenerator.getAndIncrement()


### PR DESCRIPTION
## Changes proposed in this pull request

processing all delete events prior to conflating the dataframe as skipping processing delete events might lead to extraneous records in the column table and will cause application failure in case of row tables due to the primary key constraint violation.

For example, if the target table contains some record with key k1 and the next incoming batch contains following a delete event followed by an insert event then due to conflation the delete event will be skipped and only insert will be processed. Since the existing record didn't get deleted, this will result into an extra record in case of column table or will cause failure due to unique constraint violation for row table.

## Patch testing

- existing tests in SnappyStoreSinkProviderSuite are passing and also added new tests in the same suite
