### PR TITLE
Automated hydra test to calculate load time for tables in different ways

### DIFF
--- a/dtests/src/test/java/io/snappydata/hydra/ao/loadDataPerformance.bt
+++ b/dtests/src/test/java/io/snappydata/hydra/ao/loadDataPerformance.bt
@@ -1,0 +1,24 @@
+io/snappydata/hydra/ao/loadDataUsingDataFrameFromCSV.conf
+  A=snappyStore snappyStoreHosts=1 snappyStoreVMsPerHost=1 snappyStoreThreadsPerVM=1
+  B=lead leadHosts=1 leadVMsPerHost=1 leadThreadsPerVM=2
+  C=locator locatorHosts=1 locatorVMsPerHost=1 locatorThreadsPerVM=1
+  dataLocation="/export/shared/QA_DATA/ao_data" tableName="MeterReadings"
+
+io/snappydata/hydra/ao/loadDataUsingDataFrameFromParquet.conf
+  A=snappyStore snappyStoreHosts=1 snappyStoreVMsPerHost=1 snappyStoreThreadsPerVM=1
+  B=lead leadHosts=1 leadVMsPerHost=1 leadThreadsPerVM=2
+  C=locator locatorHosts=1 locatorVMsPerHost=1 locatorThreadsPerVM=1
+  dataLocation="/export/shared/QA_DATA/ao_data" tableName="MeterReadings"
+
+io/snappydata/hydra/ao/loadDataUsingExternalTableFromCSV.conf
+  A=snappyStore snappyStoreHosts=1 snappyStoreVMsPerHost=1 snappyStoreThreadsPerVM=1
+  B=lead leadHosts=1 leadVMsPerHost=1 leadThreadsPerVM=2
+  C=locator locatorHosts=1 locatorVMsPerHost=1 locatorThreadsPerVM=1
+  dataLocation="/export/shared/QA_DATA/ao_data" tableName="MeterReadings"
+
+io/snappydata/hydra/ao/loadDataUsingExternalTableFromParquet.conf
+  A=snappyStore snappyStoreHosts=1 snappyStoreVMsPerHost=1 snappyStoreThreadsPerVM=1
+  B=lead leadHosts=1 leadVMsPerHost=1 leadThreadsPerVM=2
+  C=locator locatorHosts=1 locatorVMsPerHost=1 locatorThreadsPerVM=1
+  dataLocation="/export/shared/QA_DATA/ao_data" tableName="MeterReadings"
+

--- a/dtests/src/test/java/io/snappydata/hydra/ao/loadDataUsingDataFrameFromCSV.conf
+++ b/dtests/src/test/java/io/snappydata/hydra/ao/loadDataUsingDataFrameFromCSV.conf
@@ -1,0 +1,21 @@
+hydra.Prms-testRequirement = "Test to calculate the load time for user specified schema";
+hydra.Prms-testDescription = "This test starts the snappy cluster. Test then runs the snappy job
+ for creating and loading data in column table and calculates the load time.
+ Test loads data from csv to dataFrame and inserts data into the table using dataFrame.insertInto
+ The test can also replicate the data from the csv file provided to increase the data volume.";
+
+INCLUDE $JTESTS/io/snappydata/hydra/northwind/startEmbeddedModeCluster.conf;
+
+INITTASK    taskClass = io.snappydata.hydra.cluster.SnappyTest taskMethod = HydraTask_executeSQLScripts
+            io.snappydata.hydra.cluster.SnappyPrms-sqlScriptNames = /export/shared/QA_DATA/ao_data/create_ao_tables.sql
+            threadGroups = snappyThreads
+            ;
+
+INITTASK    taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod = HydraTask_executeSnappyJob
+            io.snappydata.hydra.cluster.SnappyPrms-jobClassNames = io.snappydata.hydra.ao.LoadData
+            io.snappydata.hydra.cluster.SnappyPrms-appPropsForJobServer = "tableName=${tableName},dataLocation=${dataLocation},iterations=50,insertUsing=dataFrame,insertFrom=csv,genDupData=false"
+            io.snappydata.hydra.cluster.SnappyPrms-userAppJar = snappydata-store-scala-tests*tests.jar
+            threadGroups = snappyThreads
+            ;
+
+INCLUDE $JTESTS/io/snappydata/hydra/northwind/stopEmbeddedModeCluster.conf;

--- a/dtests/src/test/java/io/snappydata/hydra/ao/loadDataUsingDataFrameFromParquet.conf
+++ b/dtests/src/test/java/io/snappydata/hydra/ao/loadDataUsingDataFrameFromParquet.conf
@@ -1,0 +1,21 @@
+hydra.Prms-testRequirement = "Test to calculate the load time for user specified schema";
+hydra.Prms-testDescription = "This test starts the snappy cluster. Test then runs the snappy job
+ for creating and loading data in column table and calculates the load time.
+ Test loads data from parquet to dataFrame and inserts data into the table using dataFrame.insertInto
+ The test can also replicate the data from the csv file provided to increase the data volume.";
+
+INCLUDE $JTESTS/io/snappydata/hydra/northwind/startEmbeddedModeCluster.conf;
+
+INITTASK   taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = HydraTask_executeSQLScripts
+            io.snappydata.hydra.cluster.SnappyPrms-sqlScriptNames = /export/shared/QA_DATA/ao_data/create_ao_tables.sql
+            threadGroups = snappyThreads
+            ;
+
+INITTASK    taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = HydraTask_executeSnappyJob
+            io.snappydata.hydra.cluster.SnappyPrms-jobClassNames = io.snappydata.hydra.ao.LoadData
+            io.snappydata.hydra.cluster.SnappyPrms-appPropsForJobServer = "tableName=${tableName},dataLocation=${dataLocation},iterations=50,insertUsing=dataFrame,insertFrom=parquet,genDupData=false"
+            io.snappydata.hydra.cluster.SnappyPrms-userAppJar = snappydata-store-scala-tests*tests.jar
+            threadGroups = snappyThreads
+            ;
+
+INCLUDE $JTESTS/io/snappydata/hydra/northwind/stopEmbeddedModeCluster.conf;

--- a/dtests/src/test/java/io/snappydata/hydra/ao/loadDataUsingExternalTableFromCSV.conf
+++ b/dtests/src/test/java/io/snappydata/hydra/ao/loadDataUsingExternalTableFromCSV.conf
@@ -1,0 +1,21 @@
+hydra.Prms-testRequirement = "Test to calculate the load time for user specified schema";
+hydra.Prms-testDescription = "This test starts the snappy cluster. Test then runs the snappy job
+ for creating and loading data in column table and calculates the load time.
+ Test loads data from csv to external table and inserts data into the table using external table.
+ The test can also replicate the data from the csv file provided to increase the data volume.";
+
+INCLUDE $JTESTS/io/snappydata/hydra/northwind/startEmbeddedModeCluster.conf;
+
+INITTASK   taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = HydraTask_executeSQLScripts
+            io.snappydata.hydra.cluster.SnappyPrms-sqlScriptNames = /export/shared/QA_DATA/ao_data/create_ao_tables.sql
+            threadGroups = snappyThreads
+            ;
+
+INITTASK    taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = HydraTask_executeSnappyJob
+            io.snappydata.hydra.cluster.SnappyPrms-jobClassNames = io.snappydata.hydra.ao.LoadData
+            io.snappydata.hydra.cluster.SnappyPrms-appPropsForJobServer = "tableName=${tableName},dataLocation=${dataLocation},iterations=50,insertUsing=externalTable,insertFrom=csv,genDupData=false"
+            io.snappydata.hydra.cluster.SnappyPrms-userAppJar = snappydata-store-scala-tests*tests.jar
+            threadGroups = snappyThreads
+            ;
+
+INCLUDE $JTESTS/io/snappydata/hydra/northwind/stopEmbeddedModeCluster.conf;

--- a/dtests/src/test/java/io/snappydata/hydra/ao/loadDataUsingExternalTableFromParquet.conf
+++ b/dtests/src/test/java/io/snappydata/hydra/ao/loadDataUsingExternalTableFromParquet.conf
@@ -1,0 +1,21 @@
+hydra.Prms-testRequirement = "Test to calculate the load time for user specified schema";
+hydra.Prms-testDescription = "This test starts the snappy cluster. Test then runs the snappy job
+ for creating and loading data in column table and calculates the load time.
+ Test loads data from parquet to external table and inserts data into the table using extenal table.
+ The test can also replicate the data from the csv file provided to increase the data volume.";
+
+INCLUDE $JTESTS/io/snappydata/hydra/northwind/startEmbeddedModeCluster.conf;
+
+INITTASK   taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = HydraTask_executeSQLScripts
+            io.snappydata.hydra.cluster.SnappyPrms-sqlScriptNames = /export/shared/QA_DATA/ao_data/create_ao_tables.sql
+            threadGroups = snappyThreads
+            ;
+
+INITTASK    taskClass   = io.snappydata.hydra.cluster.SnappyTest taskMethod  = HydraTask_executeSnappyJob
+            io.snappydata.hydra.cluster.SnappyPrms-jobClassNames = io.snappydata.hydra.ao.LoadData
+            io.snappydata.hydra.cluster.SnappyPrms-appPropsForJobServer = "tableName=${tableName},dataLocation=${dataLocation},iterations=50,insertUsing=externalTable,insertFrom=parquet,genDupData=false"
+            io.snappydata.hydra.cluster.SnappyPrms-userAppJar = snappydata-store-scala-tests*tests.jar
+            threadGroups = snappyThreads
+            ;
+
+INCLUDE $JTESTS/io/snappydata/hydra/northwind/stopEmbeddedModeCluster.conf;

--- a/dtests/src/test/scala/io/snappydata/hydra/ao/LoadData.scala
+++ b/dtests/src/test/scala/io/snappydata/hydra/ao/LoadData.scala
@@ -1,0 +1,149 @@
+/*
+ * Copyright (c) 2016 SnappyData, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License. You
+ * may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License. See accompanying
+ * LICENSE file.
+ */
+
+package io.snappydata.hydra.ao
+
+import java.io.{File, PrintWriter}
+import java.sql.Timestamp
+
+import scala.util.{Failure, Success, Try}
+
+import com.typesafe.config.Config
+
+import org.apache.spark.sql._
+
+
+object LoadData extends SnappySQLJob {
+
+  val currDir: String = new java.io.File(".").getCanonicalPath
+  val fileSep: String = File.separator
+  override def runSnappyJob(snSession: SnappySession, jobConfig: Config): Any = {
+    val outputFileName = s"LoadTimeTest_${System.currentTimeMillis()}.out"
+    val pw = new PrintWriter(outputFileName)
+    Try {
+      // scalastyle:off println
+      val snc = snSession.sqlContext
+      val tableName = jobConfig.getString("tableName")
+      val dataLocation = jobConfig.getString("dataLocation")
+      val genDupData: Boolean = jobConfig.getBoolean("genDupData")
+      val numIter: Int = jobConfig.getInt("iterations")
+      val insertType: String = jobConfig.getString("insertUsing") // external table for dataframe
+      val insertFrom: String = jobConfig.getString("insertFrom") // csv or parquet
+
+      val parquetFileLoc = dataLocation + fileSep + numIter + "_iters" + fileSep + "parquetFiles"
+      val csvFileLoc = dataLocation + fileSep + numIter + "_iters" + fileSep + "csvFiles"
+
+      if (genDupData) {
+        generateDupData(tableName, pw, numIter, snc, dataLocation, csvFileLoc, parquetFileLoc)
+      }
+
+      var fileLocation: String = ""
+      if(insertFrom.equals("csv")) {
+        fileLocation = csvFileLoc
+      } else {
+        fileLocation = parquetFileLoc
+      }
+      insertData(tableName, pw, snc, insertType, insertFrom, fileLocation)
+
+    } match {
+      case Success(v) => pw.close()
+        s"See ${currDir}/$outputFileName"
+      case Failure(e) => pw.close();
+        throw e;
+    }
+  }
+
+  def insertData(tableName: String, pw: PrintWriter, snc: SQLContext, insertType: String,
+      insertFrom: String, fileLocation: String): Any = {
+    pw.println(s"Loading using $insertType from $insertFrom...")
+
+    snc.sql(s"drop table if exists STAGING_$tableName")
+
+    var externalTableDDL: String = s"CREATE EXTERNAL TABLE STAGING_$tableName USING "
+    if(insertFrom.equals("csv")){
+      externalTableDDL = externalTableDDL + s" com.databricks.spark.csv OPTIONS(path " +
+          s"'$fileLocation/$tableName', header 'false', inferSchema 'false', " +
+          s"nullValue 'NULL', maxCharsPerColumn '4096')"
+    } else { // parquet
+      externalTableDDL = externalTableDDL + s" parquet OPTIONS(path " +
+          s"'$fileLocation/$tableName')"
+    }
+
+    // loading data
+    val startTime = System.currentTimeMillis()
+    pw.println(s"[${new Timestamp(startTime)}] Start loading data...")
+    if(insertType.equals("externalTable")){
+      snc.sql(externalTableDDL)
+      snc.sql(s"insert into ${tableName} select * from STAGING_$tableName" )
+    } else { // dataframe.insertinto
+      var meterReadings_DF: DataFrame = null
+      if (insertFrom.equals("csv")) {
+        meterReadings_DF =
+            snc.read.format("com.databricks.spark.csv")
+                .option("header", "false")
+                .option("inferSchema", "false")
+                .option("maxCharsPerColumn", "4096")
+                .option("nullValue", "")
+                .csv(s"${fileLocation}/$tableName")
+      } else { // parquet
+        meterReadings_DF =
+            snc.read.load(s"${fileLocation}/$tableName")
+      }
+      meterReadings_DF.write.insertInto(s"${tableName}")
+    }
+    val endTime = System.currentTimeMillis()
+    val totalTime = (endTime - startTime)/1000
+    pw.println(s"[${new Timestamp(endTime)}] Loading data using $insertType from $insertFrom took" +
+        s" $totalTime secs")
+    pw.flush()
+  }
+
+  def generateDupData(tableName: String, pw: PrintWriter, numIter: Int, snc: SQLContext,
+  dataLocation: String, csvFileLocation: String, parquetFileLocation: String): Any
+  = {
+    def temp_DF: DataFrame =
+      snc.read.format("com.databricks.spark.csv")
+          .option("header", "false")
+          .option("inferSchema", "false")
+          .option("maxCharsPerColumn", "4096")
+          .option("nullValue", "")
+          .csv(s"${dataLocation}/${tableName}.csv")
+
+    // generating 10 million records from 2 lac records
+    pw.println("Duplicating data to temp table...")
+    for (i <- 0 until numIter) {
+      temp_DF.write.format("column").mode(SaveMode.Append).saveAsTable(s"tempTable")
+    }
+
+    // writing dat to parquet and csv
+    pw.println("creating df with duplicate records and writing it to csv and parquet..")
+    val df = snc.sql("select * from meterReadingstemp")
+    df.write.parquet(s"${parquetFileLocation}/${tableName}")
+    df.write.csv(s"${csvFileLocation}/$tableName")
+
+    pw.println("Dropping temp table")
+    snc.sql(s"drop table if exists ${tableName}Temp")
+    pw.flush()
+  }
+
+  /**
+    * Validate if the data files are available, else throw SparkJobInvalid
+    *
+    */
+  override def isValidJob(sc: SnappySession, config: Config): SnappyJobValidation = SnappyJobValid()
+
+}


### PR DESCRIPTION

## Changes proposed in this pull request
1. Using DataFrame from csv
2. Using DataFrame from parquet
3. Using externalTable from csv.
4. Using externalTable from parquet.

## Patch testing
Ran the new created tests.

## ReleaseNotes.txt changes
N/A

## Other PRs 
N/A