### PR TITLE
Fixes for issues seen in different putInto tests

### DIFF
--- a/cluster/build.gradle
+++ b/cluster/build.gradle
@@ -34,6 +34,31 @@ dependencies {
   compile 'org.slf4j:jcl-over-slf4j:' + slf4jVersion
   compile 'org.slf4j:jul-to-slf4j:' + slf4jVersion
 
+  compile (project(':snappy-core_' + scalaBinaryVersion)) {
+    exclude(group: 'org.apache.spark', module: 'spark-unsafe_' + scalaBinaryVersion)
+    exclude(group: 'org.apache.spark', module: 'spark-core_' + scalaBinaryVersion)
+    exclude(group: 'org.apache.spark', module: 'spark-catalyst_' + scalaBinaryVersion)
+    exclude(group: 'org.apache.spark', module: 'spark-sql_' + scalaBinaryVersion)
+    exclude(group: 'org.apache.spark', module: 'spark-hive_' + scalaBinaryVersion)
+    exclude(group: 'org.apache.spark', module: 'spark-streaming_' + scalaBinaryVersion)
+    exclude(group: 'org.apache.spark', module: 'spark-streaming-kafka-0-10_' + scalaBinaryVersion)
+    exclude(group: 'org.apache.spark', module: 'spark-sql-kafka-0-10_' + scalaBinaryVersion)
+    exclude(group: 'org.apache.spark', module: 'spark-mllib_' + scalaBinaryVersion)
+    exclude(group: 'org.eclipse.jetty', module: 'jetty-servlet')
+  }
+  testCompile (project(path: ':snappy-core_' + scalaBinaryVersion, configuration: 'testOutput')) {
+    exclude(group: 'org.apache.spark', module: 'spark-unsafe_' + scalaBinaryVersion)
+    exclude(group: 'org.apache.spark', module: 'spark-core_' + scalaBinaryVersion)
+    exclude(group: 'org.apache.spark', module: 'spark-catalyst_' + scalaBinaryVersion)
+    exclude(group: 'org.apache.spark', module: 'spark-sql_' + scalaBinaryVersion)
+    exclude(group: 'org.apache.spark', module: 'spark-hive_' + scalaBinaryVersion)
+    exclude(group: 'org.apache.spark', module: 'spark-streaming_' + scalaBinaryVersion)
+    exclude(group: 'org.apache.spark', module: 'spark-streaming-kafka-0-10_' + scalaBinaryVersion)
+    exclude(group: 'org.apache.spark', module: 'spark-sql-kafka-0-10_' + scalaBinaryVersion)
+    exclude(group: 'org.apache.spark', module: 'spark-mllib_' + scalaBinaryVersion)
+    exclude(group: 'org.eclipse.jetty', module: 'jetty-servlet')
+  }
+
   if (new File(rootDir, 'spark/build.gradle').exists()) {
     compile project(':snappy-spark:snappy-spark-core_' + scalaBinaryVersion)
     compile project(':snappy-spark:snappy-spark-catalyst_' + scalaBinaryVersion)
@@ -73,18 +98,6 @@ dependencies {
     testCompile group: 'io.snappydata', name: 'snappy-spark-sql_' + scalaBinaryVersion,
                 version: snappySparkVersion, classifier: 'tests'
   }
-  compile (project(':snappy-core_' + scalaBinaryVersion)) {
-    exclude(group: 'org.apache.spark', module: 'spark-unsafe_' + scalaBinaryVersion)
-    exclude(group: 'org.apache.spark', module: 'spark-core_' + scalaBinaryVersion)
-    exclude(group: 'org.apache.spark', module: 'spark-catalyst_' + scalaBinaryVersion)
-    exclude(group: 'org.apache.spark', module: 'spark-sql_' + scalaBinaryVersion)
-    exclude(group: 'org.apache.spark', module: 'spark-hive_' + scalaBinaryVersion)
-    exclude(group: 'org.apache.spark', module: 'spark-streaming_' + scalaBinaryVersion)
-    exclude(group: 'org.apache.spark', module: 'spark-streaming-kafka-0-10_' + scalaBinaryVersion)
-    exclude(group: 'org.apache.spark', module: 'spark-sql-kafka-0-10_' + scalaBinaryVersion)
-    exclude(group: 'org.apache.spark', module: 'spark-mllib_' + scalaBinaryVersion)
-    exclude(group: 'org.eclipse.jetty', module: 'jetty-servlet')
-  }
 
   if (new File(rootDir, 'store/build.gradle').exists()) {
     testCompile project(path: ':snappy-store:snappydata-store-tools', configuration: 'testOutput')
@@ -118,18 +131,6 @@ dependencies {
   }
 
   testCompile project(':dunit')
-  testCompile (project(path: ':snappy-core_' + scalaBinaryVersion, configuration: 'testOutput')) {
-    exclude(group: 'org.apache.spark', module: 'spark-unsafe_' + scalaBinaryVersion)
-    exclude(group: 'org.apache.spark', module: 'spark-core_' + scalaBinaryVersion)
-    exclude(group: 'org.apache.spark', module: 'spark-catalyst_' + scalaBinaryVersion)
-    exclude(group: 'org.apache.spark', module: 'spark-sql_' + scalaBinaryVersion)
-    exclude(group: 'org.apache.spark', module: 'spark-hive_' + scalaBinaryVersion)
-    exclude(group: 'org.apache.spark', module: 'spark-streaming_' + scalaBinaryVersion)
-    exclude(group: 'org.apache.spark', module: 'spark-streaming-kafka-0-10_' + scalaBinaryVersion)
-    exclude(group: 'org.apache.spark', module: 'spark-sql-kafka-0-10_' + scalaBinaryVersion)
-    exclude(group: 'org.apache.spark', module: 'spark-mllib_' + scalaBinaryVersion)
-    exclude(group: 'org.eclipse.jetty', module: 'jetty-servlet')
-  }
   testCompile 'it.unimi.dsi:fastutil:8.1.1'
   testCompile "org.scalatest:scalatest_${scalaBinaryVersion}:${scalatestVersion}"
 

--- a/cluster/conf/log4j.properties.template
+++ b/cluster/conf/log4j.properties.template
@@ -43,6 +43,15 @@ log4j.appender.file.MaxBackupIndex=10000
 log4j.appender.file.layout=io.snappydata.log4j.PatternLayout
 log4j.appender.file.layout.ConversionPattern=%d{yy/MM/dd HH:mm:ss.SSS zzz} %t %p %c{1}: %m%n
 
+# Appender for code dumps of WholeStageCodegenExec, CodeGenerator etc
+log4j.appender.code=org.apache.log4j.RollingFileAppender
+log4j.appender.code.append=true
+log4j.appender.code.file=generatedcode.log
+log4j.appender.code.MaxFileSize=1GB
+log4j.appender.code.MaxBackupIndex=10000
+log4j.appender.code.layout=io.snappydata.log4j.PatternLayout
+log4j.appender.code.layout.ConversionPattern=%d{yy/MM/dd HH:mm:ss.SSS zzz} %t %p %c{1}: %m%n
+
 # Console appender
 log4j.appender.console=org.apache.log4j.ConsoleAppender
 log4j.appender.console.target=System.out
@@ -92,8 +101,6 @@ log4j.logger.org.apache.spark.scheduler.FairSchedulableBuilder=WARN
 log4j.logger.org.apache.spark.scheduler.cluster.CoarseGrainedSchedulerBackend$DriverEndpoint=WARN
 log4j.logger.org.apache.spark.storage.BlockManagerInfo=WARN
 log4j.logger.org.apache.hadoop.hive=WARN
-# for all Spark generated code (including ad-hoc UnsafeProjection calls etc)
-log4j.logger.org.apache.spark.sql.catalyst.expressions.codegen.CodeGenerator=WARN
 log4j.logger.org.apache.spark.sql.execution.datasources=WARN
 log4j.logger.org.apache.spark.scheduler.SnappyTaskSchedulerImpl=WARN
 log4j.logger.org.apache.spark.MapOutputTrackerMasterEndpoint=WARN
@@ -118,6 +125,13 @@ log4j.logger.io.snappydata.impl.LocatorImpl=INFO
 log4j.logger.spray.can.server.HttpListener=INFO
 
 # for generated code of plans
-# log4j.logger.org.apache.spark.sql.execution.WholeStageCodegenExec=DEBUG
+log4j.logger.org.apache.spark.sql.execution.WholeStageCodegenExec=INFO, code
+log4j.additivity.org.apache.spark.sql.execution.WholeStageCodegenExec=false
+log4j.logger.org.apache.spark.sql.execution.WholeStageCodegenRDD=INFO, code
+log4j.additivity.org.apache.spark.sql.execution.WholeStageCodegenRDD=false
+# for all Spark generated code (including ad-hoc UnsafeProjection calls etc)
+log4j.logger.org.apache.spark.sql.catalyst.expressions.codegen.CodeGenerator=WARN, code
+log4j.additivity.org.apache.spark.sql.catalyst.expressions.codegen.CodeGenerator=false
 # for SnappyData generated code used on store (ComplexTypeSerializer, JDBC inserts ...)
-# log4j.logger.org.apache.spark.sql.store.CodeGeneration=DEBUG
+log4j.logger.org.apache.spark.sql.store.CodeGeneration=INFO, code
+log4j.additivity.org.apache.spark.sql.store.CodeGeneration=false

--- a/cluster/src/dunit/scala/io/snappydata/cluster/ClusterManagerTestBase.scala
+++ b/cluster/src/dunit/scala/io/snappydata/cluster/ClusterManagerTestBase.scala
@@ -67,7 +67,6 @@ abstract class ClusterManagerTestBase(s: String)
     TestUtils.defaultCores.toString)
   bootProps.setProperty("spark.memory.manager",
     "org.apache.spark.memory.SnappyUnifiedMemoryManager")
-  bootProps.setProperty("spark.memory.fraction", "0.97")
   bootProps.setProperty("critical-heap-percentage", "95")
   bootProps.setProperty("gemfirexd.max-lock-wait", "60000")
   bootProps.setProperty("member-timeout", "5000")

--- a/cluster/src/dunit/scala/io/snappydata/cluster/ClusterManagerTestBase.scala
+++ b/cluster/src/dunit/scala/io/snappydata/cluster/ClusterManagerTestBase.scala
@@ -67,6 +67,7 @@ abstract class ClusterManagerTestBase(s: String)
     TestUtils.defaultCores.toString)
   bootProps.setProperty("spark.memory.manager",
     "org.apache.spark.memory.SnappyUnifiedMemoryManager")
+  bootProps.setProperty("spark.memory.fraction", "0.97")
   bootProps.setProperty("critical-heap-percentage", "95")
   bootProps.setProperty("gemfirexd.max-lock-wait", "60000")
   bootProps.setProperty("member-timeout", "5000")

--- a/cluster/src/dunit/scala/io/snappydata/cluster/SplitSnappyClusterDUnitTest.scala
+++ b/cluster/src/dunit/scala/io/snappydata/cluster/SplitSnappyClusterDUnitTest.scala
@@ -310,6 +310,8 @@ class SplitSnappyClusterDUnitTest(s: String)
     assert(!rs.next())
     rs.close()
 
+    stmt.execute("drop schema if exists anonymous")
+
     stmt.close()
     conn.close()
   }

--- a/cluster/src/main/scala/org/apache/spark/memory/SnappyMemoryUtils.scala
+++ b/cluster/src/main/scala/org/apache/spark/memory/SnappyMemoryUtils.scala
@@ -25,8 +25,12 @@ object SnappyMemoryUtils {
     *
     * @return
     */
-  def isCriticalUp(): Boolean =
-    Option(GemFireStore.getBootingInstance).exists(_.thresholdListener.isCritical)
+  def isCriticalUp(): Boolean = {
+    GemFireStore.getBootingInstance match {
+      case null => false
+      case store => store.thresholdListener().isCritical
+    }
+  }
 
 
   /**
@@ -34,7 +38,10 @@ object SnappyMemoryUtils {
     *
     * @return
     */
-  def isEvictionUp: Boolean =
-    Option(GemFireStore.getBootingInstance).exists(_.thresholdListener.isEviction)
-
+  def isEvictionUp: Boolean = {
+    GemFireStore.getBootingInstance match {
+      case null => false
+      case store => store.thresholdListener().isEviction
+    }
+  }
 }

--- a/cluster/src/main/scala/org/apache/spark/memory/SnappyUnifiedMemoryManager.scala
+++ b/cluster/src/main/scala/org/apache/spark/memory/SnappyUnifiedMemoryManager.scala
@@ -809,6 +809,8 @@ object SnappyUnifiedMemoryManager extends Logging {
       math.max(getMaxHeapMemory / 20, 100L * 1024L * 1024L))
   }
 
+  private val DEFAULT_MEMORY_FRACTION = 0.85
+
   private val DEFAULT_EVICTION_FRACTION = 0.8
 
   private val DEFAULT_STORAGE_FRACTION = 0.5
@@ -961,8 +963,9 @@ object SnappyUnifiedMemoryManager extends Logging {
     }
 
     val usableMemory = systemMemory - reservedMemory
-    // add a cushion for GC before CRITICAL_UP is reached
-    val memoryFraction = conf.getDouble("spark.memory.fraction", 0.85)
+    // add a cushion for GC before CRITICAL_UP is reached and for temporary buffers
+    // used by various components
+    val memoryFraction = conf.getDouble("spark.memory.fraction", DEFAULT_MEMORY_FRACTION)
     (usableMemory * memoryFraction).toLong
   }
 }

--- a/cluster/src/main/scala/org/apache/spark/memory/SnappyUnifiedMemoryManager.scala
+++ b/cluster/src/main/scala/org/apache/spark/memory/SnappyUnifiedMemoryManager.scala
@@ -962,7 +962,7 @@ object SnappyUnifiedMemoryManager extends Logging {
 
     val usableMemory = systemMemory - reservedMemory
     // add a cushion for GC before CRITICAL_UP is reached
-    val memoryFraction = conf.getDouble("spark.memory.fraction", 0.97)
+    val memoryFraction = conf.getDouble("spark.memory.fraction", 0.85)
     (usableMemory * memoryFraction).toLong
   }
 }

--- a/cluster/src/test/scala/org/apache/spark/sql/execution/benchmark/TAQTest.scala
+++ b/cluster/src/test/scala/org/apache/spark/sql/execution/benchmark/TAQTest.scala
@@ -282,7 +282,6 @@ object TAQTest extends Logging with Assertions {
       conf.set("snappydata.store.memory-size", "1200m")
     }
     conf.set("spark.memory.manager", classOf[SnappyUnifiedMemoryManager].getName)
-    conf.set("spark.memory.fraction", "0.97")
     conf.set("spark.serializer", "org.apache.spark.serializer.PooledKryoSerializer")
     conf.set("spark.closure.serializer", "org.apache.spark.serializer.PooledKryoSerializer")
     if (addOn != null) {

--- a/cluster/src/test/scala/org/apache/spark/sql/execution/benchmark/TAQTest.scala
+++ b/cluster/src/test/scala/org/apache/spark/sql/execution/benchmark/TAQTest.scala
@@ -282,6 +282,7 @@ object TAQTest extends Logging with Assertions {
       conf.set("snappydata.store.memory-size", "1200m")
     }
     conf.set("spark.memory.manager", classOf[SnappyUnifiedMemoryManager].getName)
+    conf.set("spark.memory.fraction", "0.97")
     conf.set("spark.serializer", "org.apache.spark.serializer.PooledKryoSerializer")
     conf.set("spark.closure.serializer", "org.apache.spark.serializer.PooledKryoSerializer")
     if (addOn != null) {

--- a/cluster/src/test/scala/org/apache/spark/sql/kafka010/SnappyStructuredKafkaSuite.scala
+++ b/cluster/src/test/scala/org/apache/spark/sql/kafka010/SnappyStructuredKafkaSuite.scala
@@ -21,10 +21,14 @@ import java.util.concurrent.atomic.AtomicInteger
 
 import io.snappydata.SnappyFunSuite
 import org.apache.kafka.common.TopicPartition
+
 import org.apache.spark.sql.functions.{count, window}
 import org.apache.spark.sql.streaming.ProcessingTime
 import org.scalatest.concurrent.Eventually
 import org.scalatest.{BeforeAndAfter, BeforeAndAfterAll}
+
+import org.apache.spark.sql.Row
+import org.apache.spark.sql.catalyst.encoders.RowEncoder
 
 case class Account(accountName: String)
 
@@ -59,13 +63,15 @@ class SnappyStructuredKafkaSuite extends SnappyFunSuite with Eventually
     import session.implicits._
 
     snc.sql("drop table if exists users")
-    snc.sql("create table users (id int) using column options(key_columns 'id')")
+    snc.sql("create table users (id int, name string) using column options(key_columns 'id')")
 
     val topic = newTopic()
     kafkaTestUtils.createTopic(topic, partitions = 3)
-    kafkaTestUtils.sendMessages(topic, (100 to 200).map(_.toString).toArray, Some(0))
-    kafkaTestUtils.sendMessages(topic, (10 to 20).map(_.toString).toArray, Some(1))
-    kafkaTestUtils.sendMessages(topic, Array("1"), Some(2))
+    kafkaTestUtils.sendMessages(topic,
+      (100 to 200).map(i => i.toString + ",name_" + i).toArray, Some(0))
+    kafkaTestUtils.sendMessages(topic,
+      (10 to 20).map(i => i.toString + ",name_" + i).toArray, Some(1))
+    kafkaTestUtils.sendMessages(topic, Array("1,name_1"), Some(2))
 
     val streamingDF = session
       .readStream
@@ -75,10 +81,15 @@ class SnappyStructuredKafkaSuite extends SnappyFunSuite with Eventually
       .option("startingOffsets", "earliest")
       .load
 
+    implicit val encoder = RowEncoder(snc.table("users").schema)
+
     val streamingQuery = streamingDF
-      .selectExpr("CAST(key AS STRING)", "CAST(value AS STRING)")
-      .as[(String, String)]
-      .map(kv => kv._2.toInt)
+        .selectExpr("CAST(value AS STRING)")
+        .as[String]
+        .map(_.split(","))
+        .map(r => {
+          Row(r(0).toInt, r(1))
+        })
       .writeStream
       .format("snappysink")
       .queryName("simple")

--- a/cluster/src/test/scala/org/apache/spark/sql/store/ColumnUpdateDeleteTest.scala
+++ b/cluster/src/test/scala/org/apache/spark/sql/store/ColumnUpdateDeleteTest.scala
@@ -23,7 +23,7 @@ import io.snappydata.cluster.PreparedQueryRoutingSingleNodeSuite
 
 import org.apache.spark.SparkConf
 import org.apache.spark.memory.SnappyUnifiedMemoryManager
-import org.apache.spark.sql.{Row, SnappySession}
+import org.apache.spark.sql.SnappySession
 
 /**
  * Tests for updates/deletes on column table.
@@ -40,7 +40,7 @@ class ColumnUpdateDeleteTest extends ColumnTablesTestBase {
     stopAll()
   }
 
-  override protected def newSparkConf(addOn: (SparkConf) => SparkConf): SparkConf = {
+  override protected def newSparkConf(addOn: SparkConf => SparkConf): SparkConf = {
     val conf = new SparkConf()
     conf.setIfMissing("spark.master", "local[*]")
         .setAppName(getClass.getName)

--- a/core/src/main/scala/io/snappydata/collection/ByteBufferHashMap.scala
+++ b/core/src/main/scala/io/snappydata/collection/ByteBufferHashMap.scala
@@ -73,7 +73,7 @@ class ByteBufferHashMap(initialCapacity: Int, val loadFactor: Double,
   if (keyData eq null) {
     val buffer = allocator.allocate(_capacity * fixedKeySize, "HASHMAP")
     // clear the key data
-    allocator.clearPostAllocate(buffer)
+    allocator.clearPostAllocate(buffer, 0)
     keyData = new ByteBufferData(buffer, allocator)
   }
   if (valueData eq null) {
@@ -203,7 +203,7 @@ class ByteBufferHashMap(initialCapacity: Int, val loadFactor: Double,
     val newCapacity = OpenHashSet.checkCapacity(_capacity << 1)
     val newKeyBuffer = allocator.allocate(newCapacity * fixedKeySize, "HASHMAP")
     // clear the key data
-    allocator.clearPostAllocate(newKeyBuffer)
+    allocator.clearPostAllocate(newKeyBuffer, 0)
     val newKeyData = new ByteBufferData(newKeyBuffer, allocator)
     val newKeyObject = newKeyData.baseObject
     val newKeyBaseOffset = newKeyData.baseOffset

--- a/core/src/main/scala/org/apache/spark/sql/SnappySession.scala
+++ b/core/src/main/scala/org/apache/spark/sql/SnappySession.scala
@@ -57,7 +57,7 @@ import org.apache.spark.sql.execution._
 import org.apache.spark.sql.execution.aggregate.CollectAggregateExec
 import org.apache.spark.sql.execution.columnar.impl.ColumnFormatRelation
 import org.apache.spark.sql.execution.columnar.{ExternalStoreUtils, InMemoryTableScanExec}
-import org.apache.spark.sql.execution.command.ExecutedCommandExec
+import org.apache.spark.sql.execution.command.{ExecutedCommandExec, UncacheTableCommand}
 import org.apache.spark.sql.execution.datasources.jdbc.{JDBCOptions, JdbcUtils}
 import org.apache.spark.sql.execution.datasources.{DataSource, LogicalRelation}
 import org.apache.spark.sql.execution.exchange.BroadcastExchangeExec
@@ -90,6 +90,8 @@ class SnappySession(_sc: SparkContext) extends SparkSession(_sc) {
    * ----------------------- */
 
   private[spark] val id = SnappySession.newId()
+
+  private[this] val putIntoIndex = new AtomicInteger(0)
 
   new FinalizeSession(this)
 
@@ -414,7 +416,8 @@ class SnappySession(_sc: SparkContext) extends SparkSession(_sc) {
   private[sql] def getHashVar(ctx: CodegenContext,
       keyVars: Seq[String]): Option[String] = getContextObject(ctx, "H", keyVars)
 
-  private[sql] def cachePutInto(plan: Option[LogicalPlan], table: String): Boolean = {
+  private[sql] def cachePutInto(doCache: Boolean, updateSubQuery: LogicalPlan,
+      table: String): Option[LogicalPlan] = {
     // first acquire the global lock for putInto
     val lock = SnappyContext.getClusterMode(sparkContext) match {
       case _: ThinClientConnectorMode => null
@@ -422,43 +425,46 @@ class SnappySession(_sc: SparkContext) extends SparkSession(_sc) {
         PartitionedRegion.getRegionLock("PUTINTO_" + table, GemFireCacheImpl.getExisting)
     }
     if (lock ne null) lock.lock()
-    var hasUpdates = false
+    var newUpdateSubQuery: Option[LogicalPlan] = None
     try {
-      val cachedPlan = plan match {
-        case Some(updateSubQuery) =>
-          val joinDS = new Dataset(this, updateSubQuery, RowEncoder(updateSubQuery.schema))
-          joinDS.persist()
-          if (joinDS.count() > 0) {
-            hasUpdates = true
-            plan
-          } else {
-            joinDS.unpersist(blocking = true)
-            None
-          }
-        case None =>
-          // assume that there are updates
-          hasUpdates = true
+      val cachedTable = if (doCache) {
+        val tableName = s"snappyDataInternalTempPutIntoCache${putIntoIndex.incrementAndGet()}"
+        val tableIdent = new TableIdentifier(tableName)
+        // use cache table command to display full plan
+        SnappyCacheTableCommand(tableIdent, Some(updateSubQuery), isLazy = false).run(this)
+        val joinDS = this.table(tableIdent)
+        if (joinDS.count() > 0) {
+          newUpdateSubQuery = Some(joinDS.logicalPlan)
+          Some(tableIdent)
+        } else {
+          joinDS.unpersist(blocking = true)
           None
+        }
+      } else {
+        // assume that there are updates
+        newUpdateSubQuery = Some(updateSubQuery)
+        None
       }
-      if (hasUpdates) {
+      if (newUpdateSubQuery.isDefined) {
         // Adding to context after the count operation, as count will clear the context object.
-        addContextObject[(Option[LogicalPlan], PartitionedRegion.RegionLock)](
-          CACHED_PUTINTO_UPDATE_PLAN, cachedPlan -> lock)
+        addContextObject[(Option[TableIdentifier], PartitionedRegion.RegionLock)](
+          CACHED_PUTINTO_UPDATE_PLAN, cachedTable -> lock)
       }
-      hasUpdates
+      newUpdateSubQuery
     } finally {
       // release lock immediately if no updates are to be done
-      if (!hasUpdates && (lock ne null)) lock.unlock()
+      if (newUpdateSubQuery.isEmpty && (lock ne null)) lock.unlock()
     }
   }
 
   private[sql] def clearPutInto(): Unit = {
     contextObjects.remove(CACHED_PUTINTO_UPDATE_PLAN) match {
       case null =>
-      case (cachedPlan: Option[LogicalPlan], lock) =>
+      case (cachedTable: Option[TableIdentifier], lock) =>
         if (lock != null) lock.asInstanceOf[PartitionedRegion.RegionLock].unlock()
-        if (cachedPlan.isDefined) {
-          sharedState.cacheManager.uncacheQuery(this, cachedPlan.get, blocking = true)
+        if (cachedTable.isDefined) {
+          UncacheTableCommand(cachedTable.get, ifExists = false).run(this)
+          dropTable(sessionCatalog.newQualifiedTableName(cachedTable.get), ifExists = false)
         }
     }
   }

--- a/core/src/main/scala/org/apache/spark/sql/SnappySession.scala
+++ b/core/src/main/scala/org/apache/spark/sql/SnappySession.scala
@@ -91,7 +91,7 @@ class SnappySession(_sc: SparkContext) extends SparkSession(_sc) {
 
   private[spark] val id = SnappySession.newId()
 
-  private[this] val putIntoIndex = new AtomicInteger(0)
+  private[this] val tempCacheIndex = new AtomicInteger(0)
 
   new FinalizeSession(this)
 
@@ -428,7 +428,7 @@ class SnappySession(_sc: SparkContext) extends SparkSession(_sc) {
     var newUpdateSubQuery: Option[LogicalPlan] = None
     try {
       val cachedTable = if (doCache) {
-        val tableName = s"snappyDataInternalTempPutIntoCache${putIntoIndex.incrementAndGet()}"
+        val tableName = s"snappyDataInternalTempPutIntoCache${tempCacheIndex.incrementAndGet()}"
         val tableIdent = new TableIdentifier(tableName)
         // use cache table command to display full plan
         SnappyCacheTableCommand(tableIdent, Some(updateSubQuery), isLazy = false).run(this)

--- a/core/src/main/scala/org/apache/spark/sql/execution/columnar/ColumnDeleteExec.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/columnar/ColumnDeleteExec.scala
@@ -18,7 +18,7 @@
 package org.apache.spark.sql.execution.columnar
 
 import org.apache.spark.sql.catalyst.expressions.codegen.{CodegenContext, ExprCode, ExpressionCanonicalizer}
-import org.apache.spark.sql.catalyst.expressions.{Attribute, BindReferences, Expression, SortOrder}
+import org.apache.spark.sql.catalyst.expressions.{Attribute, BindReferences, Expression}
 import org.apache.spark.sql.execution.SparkPlan
 import org.apache.spark.sql.execution.columnar.encoding.ColumnDeleteEncoder
 import org.apache.spark.sql.execution.columnar.impl.ColumnDelta
@@ -48,14 +48,6 @@ case class ColumnDeleteExec(child: SparkPlan, columnTable: String,
   override protected def opType: String = "Delete"
 
   override def nodeName: String = "ColumnDelete"
-
-  // Require per-partition sort on batchId+ordinal because deltas are accumulated for
-  // consecutive batchIds+ordinals else it will  be very inefficient for bulk deletes.
-  // BatchId attribute is always third last in the keyColumns while ordinal
-  // (index of row in the batch) is the one before that.
-  override def requiredChildOrdering: Seq[Seq[SortOrder]] =
-  Seq(Seq(StoreUtils.getColumnUpdateDeleteOrdering(keyColumns(keyColumns.length - 3)),
-    StoreUtils.getColumnUpdateDeleteOrdering(keyColumns(keyColumns.length - 4))))
 
   override lazy val metrics: Map[String, SQLMetric] = {
     if (onExecutor) Map.empty

--- a/core/src/main/scala/org/apache/spark/sql/execution/columnar/ColumnExec.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/columnar/ColumnExec.scala
@@ -20,9 +20,12 @@ package org.apache.spark.sql.execution.columnar
 import java.sql.Connection
 
 import org.apache.spark.sql.catalyst.expressions.codegen.CodegenContext
+import org.apache.spark.sql.catalyst.expressions.{Attribute, SortOrder}
+import org.apache.spark.sql.catalyst.plans.physical.{ClusteredDistribution, Distribution}
 import org.apache.spark.sql.collection.Utils
 import org.apache.spark.sql.execution.columnar.impl.{JDBCSourceAsColumnarStore, SnapshotConnectionListener}
 import org.apache.spark.sql.execution.row.RowExec
+import org.apache.spark.sql.store.StoreUtils
 
 /**
  * Base class for bulk column table insert, update, put, delete operations.
@@ -36,6 +39,26 @@ trait ColumnExec extends RowExec {
   override def resolvedName: String = externalStore.tableName
 
   protected def delayRollover: Boolean = false
+
+  def keyColumns: Seq[Attribute]
+
+  override def requiredChildDistribution: Seq[Distribution] = {
+    if (partitioned) super.requiredChildDistribution
+    else {
+      // for tables with no partitioning, require partitioning on batchId so that all rows of
+      // a batch are together else it results in very large number of changes for each batch
+      // strewn across all partitions
+      ClusteredDistribution(keyColumns(keyColumns.length - 3) :: Nil) :: Nil
+    }
+  }
+
+  // Require per-partition sort on batchId+ordinal because deltas/deletes are accumulated for
+  // consecutive batchIds+ordinals else it will  be very inefficient for bulk updates/deletes.
+  // BatchId attribute is always third last in the keyColumns while ordinal
+  // (index of row in the batch) is the one before that.
+  override def requiredChildOrdering: Seq[Seq[SortOrder]] =
+    Seq(Seq(StoreUtils.getColumnUpdateDeleteOrdering(keyColumns(keyColumns.length - 3)),
+      StoreUtils.getColumnUpdateDeleteOrdering(keyColumns(keyColumns.length - 4))))
 
   override protected def connectionCodes(ctx: CodegenContext): (String, String, String) = {
     val connectionClass = classOf[Connection].getName

--- a/core/src/main/scala/org/apache/spark/sql/execution/columnar/ColumnUpdateExec.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/columnar/ColumnUpdateExec.scala
@@ -20,7 +20,7 @@ package org.apache.spark.sql.execution.columnar
 import io.snappydata.collection.IntObjectHashMap
 
 import org.apache.spark.sql.catalyst.expressions.codegen.{CodegenContext, ExprCode, ExpressionCanonicalizer}
-import org.apache.spark.sql.catalyst.expressions.{Attribute, BindReferences, Expression, SortOrder}
+import org.apache.spark.sql.catalyst.expressions.{Attribute, BindReferences, Expression}
 import org.apache.spark.sql.collection.Utils
 import org.apache.spark.sql.execution.SparkPlan
 import org.apache.spark.sql.execution.columnar.encoding.{ColumnDeltaEncoder, ColumnEncoder, ColumnStatsSchema}
@@ -83,14 +83,6 @@ case class ColumnUpdateExec(child: SparkPlan, columnTable: String,
   override protected def opType: String = "Update"
 
   override def nodeName: String = "ColumnUpdate"
-
-  // Require per-partition sort on batchId+ordinal because deltas are accumulated for
-  // consecutive batchIds+ordinals else it will  be very inefficient for bulk updates
-  // (e.g. for putInto). BatchId attribute is always third last in the keyColumns
-  // while ordinal (index of row in the batch) is the one before that.
-  override def requiredChildOrdering: Seq[Seq[SortOrder]] =
-  Seq(Seq(StoreUtils.getColumnUpdateDeleteOrdering(keyColumns(keyColumns.length - 3)),
-    StoreUtils.getColumnUpdateDeleteOrdering(keyColumns(keyColumns.length - 4))))
 
   override lazy val metrics: Map[String, SQLMetric] = {
     if (onExecutor) Map.empty

--- a/core/src/main/scala/org/apache/spark/sql/execution/columnar/ExternalStoreUtils.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/columnar/ExternalStoreUtils.scala
@@ -93,6 +93,11 @@ object ExternalStoreUtils {
   final val RELATION_FOR_SAMPLE = "RELATION_FOR_SAMPLE"
   // internal properties stored as hive table parameters
   final val USER_SPECIFIED_SCHEMA = "USER_SCHEMA"
+
+  // inbuilt basic table properties
+  final val PARTITION_BY = "PARTITION_BY"
+  final val REPLICATE = "REPLICATE"
+  final val BUCKETS = "BUCKETS"
   final val KEY_COLUMNS = "KEY_COLUMNS"
 
   val ddlOptions: Seq[String] = Seq(INDEX_NAME, COLUMN_BATCH_SIZE,
@@ -554,10 +559,6 @@ object ExternalStoreUtils {
       col += 1
     }
   }
-
-  final val PARTITION_BY = "PARTITION_BY"
-  final val REPLICATE = "REPLICATE"
-  final val BUCKETS = "BUCKETS"
 
   def getAndSetTotalPartitions(sparkContext: Option[SparkContext],
       parameters: mutable.Map[String, String],

--- a/core/src/main/scala/org/apache/spark/sql/execution/columnar/encoding/ColumnDeltaDecoder.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/columnar/encoding/ColumnDeltaDecoder.scala
@@ -134,4 +134,6 @@ final class ColumnDeltaDecoder(buffer: ByteBuffer, field: StructField) {
 
   @inline def readStruct(numFields: Int): InternalRow =
     realDecoder.readStruct(deltaBytes, numFields, nonNullPosition)
+
+  @inline def close(): Unit = realDecoder.close()
 }

--- a/core/src/main/scala/org/apache/spark/sql/execution/columnar/encoding/ColumnDeltaEncoder.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/columnar/encoding/ColumnDeltaEncoder.scala
@@ -17,7 +17,7 @@
 
 package org.apache.spark.sql.execution.columnar.encoding
 
-import java.nio.ByteBuffer
+import java.nio.{ByteBuffer, ByteOrder}
 
 import com.gemstone.gemfire.internal.cache.GemFireCacheImpl
 import com.gemstone.gemfire.internal.shared.BufferAllocator
@@ -117,7 +117,12 @@ final class ColumnDeltaEncoder(val hierarchyDepth: Int) extends ColumnEncoder {
      SparkRadixSort            0 /    0         82.3          12.2      15.6X
      RadixSort                 1 /    1         16.6          60.1       3.2X
    */
-  private[this] var positionsArray: Array[Int] = _
+  /**
+   * The position array is maintained as a raw ByteBuffer with native ByteOrder so
+   * that ByteBuffer.get/put and Unsafe access via Platform class are equivalent.
+   */
+  private[this] var positionsArray: ByteBuffer = _
+
   /**
    * Relative index of the current delta i.e. 1st delta is 0, 2nd delta is 1 and so on.
    * so on. Initialized to -1 so that pre-increment in write initializes to 0 and the
@@ -127,6 +132,8 @@ final class ColumnDeltaEncoder(val hierarchyDepth: Int) extends ColumnEncoder {
   private[this] var realEncoder: ColumnEncoder = _
   private[this] var dataOffset: Long = _
   private[this] var maxSize: Int = _
+
+  private[this] def bufferOwner: String = "DELTA_ENCODER"
 
   override def typeId: Int = realEncoder.typeId
 
@@ -141,6 +148,11 @@ final class ColumnDeltaEncoder(val hierarchyDepth: Int) extends ColumnEncoder {
   override protected[sql] def writeNulls(columnBytes: AnyRef, cursor: Long,
       numWords: Int): Long = realEncoder.writeNulls(columnBytes, cursor, numWords)
 
+  private[this] def allocatePositions(size: Int): Unit = {
+    positionsArray = allocator.allocate(size, bufferOwner).order(ByteOrder.nativeOrder())
+    allocator.clearPostAllocate(positionsArray, 0)
+  }
+
   override def initialize(dataType: DataType, nullable: Boolean, initSize: Int,
       withHeader: Boolean, allocator: BufferAllocator, minBufferSize: Int = -1): Long = {
     if (initSize < 4 || (initSize < ColumnDelta.INIT_SIZE && hierarchyDepth > 0)) {
@@ -150,7 +162,7 @@ final class ColumnDeltaEncoder(val hierarchyDepth: Int) extends ColumnEncoder {
     this.dataType = dataType
     this.allocator = allocator
     this.maxSize = initSize
-    positionsArray = new Array[Int](initSize)
+    allocatePositions(initSize << 2)
     realEncoder = ColumnEncoding.getColumnEncoder(dataType, nullable)
     val cursor = realEncoder.initialize(dataType, nullable,
       initSize, withHeader, allocator, minBufferSize)
@@ -185,16 +197,24 @@ final class ColumnDeltaEncoder(val hierarchyDepth: Int) extends ColumnEncoder {
   override protected[sql] def initializeNulls(initSize: Int): Int =
     realEncoder.initializeNulls(initSize)
 
+  private[this] def baseSetPosition(index: Int, value: Int): Unit = {
+    positionsArray.putInt(index << 2, value)
+  }
+
   def setUpdatePosition(position: Int): Unit = {
     // sorted on LSB so position goes in LSB
     positionIndex += 1
-    if (positionIndex == maxSize) {
-      val newPositionsArray = new Array[Int](maxSize << 1)
-      System.arraycopy(positionsArray, 0, newPositionsArray, 0, maxSize)
-      maxSize <<= 1
-      positionsArray = newPositionsArray
+    if (positionIndex >= maxSize) {
+      // expand by currentSize / 2
+      val expandBy = maxSize >> 1
+      val limit = positionsArray.limit()
+      // expand will ensure ByteOrder to be same
+      positionsArray = allocator.expand(positionsArray, expandBy << 2, bufferOwner)
+      assert(positionsArray.order() == ByteOrder.nativeOrder())
+      allocator.clearPostAllocate(positionsArray, limit)
+      maxSize += expandBy
     }
-    positionsArray(positionIndex) = position
+    baseSetPosition(positionIndex, position)
   }
 
   def getRealEncoder: ColumnEncoder = realEncoder
@@ -255,6 +275,16 @@ final class ColumnDeltaEncoder(val hierarchyDepth: Int) extends ColumnEncoder {
 
   override def flushWithoutFinish(cursor: Long): Long = realEncoder.flushWithoutFinish(cursor)
 
+  override private[sql] def close(releaseData: Boolean): Unit = {
+    realEncoder.close(releaseData)
+    /*
+    if (positionsArray ne null) {
+      BufferAllocator.releaseBuffer(positionsArray)
+      positionsArray = null
+    }
+    */
+  }
+
   private def consumeDecoder(decoder: ColumnDecoder, decoderNullPosition: Int,
       decoderBytes: AnyRef, writer: DeltaWriter, encoderCursor: Long,
       encoderPosition: Int, doWrite: Boolean = true): Long = {
@@ -271,7 +301,7 @@ final class ColumnDeltaEncoder(val hierarchyDepth: Int) extends ColumnEncoder {
   }
 
   private def writeHeader(columnBytes: AnyRef, cursor: Long, numNullWords: Int,
-      numBaseRows: Int, positions: Array[Int], numDeltas: Int): Long = {
+      numBaseRows: Int, positions: ByteBuffer, numDeltas: Int): Long = {
     var deltaCursor = cursor
     // typeId
     ColumnEncoding.writeInt(columnBytes, deltaCursor, typeId)
@@ -290,11 +320,14 @@ final class ColumnDeltaEncoder(val hierarchyDepth: Int) extends ColumnEncoder {
     // write the positions next
     ColumnEncoding.writeInt(columnBytes, deltaCursor, numDeltas)
     deltaCursor += 4
-    var i = 0
-    while (i < numDeltas) {
-      ColumnEncoding.writeInt(columnBytes, deltaCursor, positions(i))
+    positions.rewind()
+    val positionsObj = allocator.baseObject(positions)
+    var posCursor = allocator.baseOffset(positions)
+    val posCursorEnd = posCursor + (numDeltas << 2)
+    while (posCursor < posCursorEnd) {
+      ColumnEncoding.writeInt(columnBytes, deltaCursor, Platform.getInt(positionsObj, posCursor))
       deltaCursor += 4
-      i += 1
+      posCursor += 4
     }
     // pad to nearest word boundary before writing encoded data
     ((deltaCursor + 7) >> 3) << 3
@@ -380,7 +413,7 @@ final class ColumnDeltaEncoder(val hierarchyDepth: Int) extends ColumnEncoder {
       numPositions2 = tmpNumPositions
       positionCursor2 = tmpPositionCursor
       maxSize = numPositions1 + numPositions2
-      positionsArray = new Array[Int](maxSize)
+      allocatePositions(maxSize << 2)
     } else {
       positionIndex = 0
       maxSize = 0
@@ -405,7 +438,7 @@ final class ColumnDeltaEncoder(val hierarchyDepth: Int) extends ColumnEncoder {
       val isGreater = position1 > position2
       if (isGreater || areEqual) {
         // set next update position to be from second
-        if (existingIsDelta && !areEqual) positionsArray(encoderPosition) = position2
+        if (existingIsDelta && !areEqual) baseSetPosition(encoderPosition, position2)
         // consume data at position2 and move it if position2 is smaller
         // else if they are equal then newValue gets precedence
         cursor = consumeDecoder(decoder2, if (nullable2) relativePosition2 else -1,
@@ -426,7 +459,7 @@ final class ColumnDeltaEncoder(val hierarchyDepth: Int) extends ColumnEncoder {
       // write for the second was skipped in the first block above
       if (!isGreater) {
         // set next update position to be from first
-        if (existingIsDelta) positionsArray(encoderPosition) = position1
+        if (existingIsDelta) baseSetPosition(encoderPosition, position1)
         // consume data at position1 and move it
         cursor = consumeDecoder(decoder1, if (nullable1) relativePosition1 else -1,
           columnBytes1, writer, cursor, encoderPosition)
@@ -446,7 +479,7 @@ final class ColumnDeltaEncoder(val hierarchyDepth: Int) extends ColumnEncoder {
       encoderPosition += 1
       // set next update position to be from first
       if (existingIsDelta) {
-        positionsArray(encoderPosition) = ColumnEncoding.readInt(columnBytes1, positionCursor1)
+        baseSetPosition(encoderPosition, ColumnEncoding.readInt(columnBytes1, positionCursor1))
         positionCursor1 += 4
       }
       cursor = consumeDecoder(decoder1, if (nullable1) relativePosition1 else -1,
@@ -458,7 +491,7 @@ final class ColumnDeltaEncoder(val hierarchyDepth: Int) extends ColumnEncoder {
       encoderPosition += 1
       // set next update position to be from second
       if (existingIsDelta) {
-        positionsArray(encoderPosition) = ColumnEncoding.readInt(columnBytes2, positionCursor2)
+        baseSetPosition(encoderPosition, ColumnEncoding.readInt(columnBytes2, positionCursor2))
         positionCursor2 += 4
       }
       cursor = consumeDecoder(decoder2, if (nullable2) relativePosition2 else -1,
@@ -519,7 +552,7 @@ final class ColumnDeltaEncoder(val hierarchyDepth: Int) extends ColumnEncoder {
 
     // release the intermediate buffer
     allocator.release(encodedData)
-    realEncoder.clearSource(0, releaseData = false)
+    close(releaseData = false)
 
     buffer
   }
@@ -562,13 +595,18 @@ final class ColumnDeltaEncoder(val hierarchyDepth: Int) extends ColumnEncoder {
     cursor = realEncoder.columnBeginPosition + cursorOffset
 
     // copy the encoded data
-    assert(cursor + dataSize == realEncoder.columnEndPosition)
+    if (cursor + dataSize != realEncoder.columnEndPosition) {
+      throw new AssertionError("Unexpected data size mismatch." +
+          s"Begin position = ${realEncoder.columnBeginPosition}, " +
+          s"End position = ${realEncoder.columnEndPosition}, " +
+          s"Data size = $dataSize, Cursor offset = $cursorOffset")
+    }
     Platform.copyMemory(dataBuffer, dataBeginPosition, columnBytes, cursor, dataSize)
 
     // release the old buffer
     dataAllocator.release(dataColumnBytes)
     // clear the encoder
-    realEncoder.clearSource(0, releaseData = false)
+    close(releaseData = false)
     buffer
   }
 }

--- a/core/src/main/scala/org/apache/spark/sql/execution/columnar/encoding/UpdatedColumnDecoder.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/columnar/encoding/UpdatedColumnDecoder.scala
@@ -134,4 +134,9 @@ abstract class UpdatedColumnDecoderBase(decoder: ColumnDecoder, field: StructFie
   final def getStringDictionary: StringDictionary = null
 
   final def readDictionaryIndex: Int = -1
+
+  def close(): Unit = {
+    if (delta1 ne null) delta1.close()
+    if (delta2 ne null) delta2.close()
+  }
 }

--- a/core/src/main/scala/org/apache/spark/sql/execution/columnar/impl/ColumnDelta.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/columnar/impl/ColumnDelta.scala
@@ -98,12 +98,16 @@ final class ColumnDelta extends ColumnFormatValue with Delta {
           // ignore if either of the buffers is empty (old placeholder of 4 bytes
           // while UnsafeRow based data can never be less than 8 bytes)
           if (existingBuffer.limit() <= 4 || newBuffer.limit() <= 4) {
-            oldColValue
+            // returned value should be the original and not oldColValue which may be a temp copy
+            oldValue
           } else {
             val merged = mergeStats(existingBuffer, newBuffer, schema)
             if (merged ne null) {
               new ColumnFormatValue(merged, oldColValue.compressionCodecId, isCompressed = false)
-            } else oldColValue
+            } else {
+              // returned value should be the original and not oldColValue which may be a temp copy
+              oldValue
+            }
           }
         } else {
           val tableColumnIndex = ColumnDelta.tableColumnIndex(columnIndex) - 1

--- a/core/src/main/scala/org/apache/spark/sql/execution/columnar/impl/ColumnFormatRelation.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/columnar/impl/ColumnFormatRelation.scala
@@ -547,7 +547,7 @@ class ColumnFormatRelation(
     _partitioningColumns,
     _context)
   with ParentRelation with DependentRelation with BulkPutRelation {
-  val tableOptions = new CaseInsensitiveMutableHashMap(_origOptions)
+  val tableOptions = new CaseInsensitiveMutableHashMap(origOptions)
 
   override def withKeyColumns(relation: LogicalRelation,
       keyColumns: Seq[String]): LogicalRelation = {
@@ -557,6 +557,7 @@ class ColumnFormatRelation(
           s"required=${ColumnDelta.mutableKeyNames}")
     }
     val cr = relation.relation.asInstanceOf[ColumnFormatRelation]
+    if (cr.schema.exists(_.name.startsWith(ColumnDelta.mutableKeyNamePrefix))) return relation
     val schema = StructType(cr.schema ++ ColumnDelta.mutableKeyFields)
     val newRelation = new ColumnFormatRelation(cr.table, cr.provider,
       cr.mode, schema, cr.schemaExtensions, cr.ddlExtensionForShadowTable,
@@ -704,7 +705,7 @@ class ColumnFormatRelation(
   }
 
   override def getPutKeys: Option[Seq[String]] = {
-    val keys = _origOptions.get(ExternalStoreUtils.KEY_COLUMNS)
+    val keys = origOptions.get(ExternalStoreUtils.KEY_COLUMNS)
     keys match {
       case Some(x) => Some(x.split(",").map(s => s.trim).toSeq)
       case None => None
@@ -748,6 +749,7 @@ class IndexColumnFormatRelation(
   override def withKeyColumns(relation: LogicalRelation,
       keyColumns: Seq[String]): LogicalRelation = {
     val cr = relation.relation.asInstanceOf[IndexColumnFormatRelation]
+    if (cr.schema.exists(_.name.startsWith(ColumnDelta.mutableKeyNamePrefix))) return relation
     val schema = StructType(cr.schema ++ ColumnDelta.mutableKeyFields)
     val newRelation = new IndexColumnFormatRelation(cr.table, cr.provider,
       cr.mode, schema, cr.schemaExtensions, cr.ddlExtensionForShadowTable, cr.origOptions,

--- a/core/src/main/scala/org/apache/spark/sql/execution/columnar/impl/ColumnFormatRelation.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/columnar/impl/ColumnFormatRelation.scala
@@ -448,8 +448,15 @@ abstract class BaseColumnFormatRelation(
         val sql =
           s"CREATE TABLE ${quotedName(tableName)} $schemaExtensions ENABLE CONCURRENCY CHECKS"
         val pass = connProperties.connProps.remove(com.pivotal.gemfirexd.Attribute.PASSWORD_ATTR)
-        logInfo(s"Applying DDL (url=${connProperties.url}; " +
-            s"props=${connProperties.connProps}): $sql")
+        if (isInfoEnabled) {
+          val schemaString = JdbcExtendedUtils.schemaString(schema, connProperties.dialect)
+          val optsString = if (origOptions.nonEmpty) {
+            origOptions.map(p => s"${p._1} '${p._2}'").mkString(" OPTIONS (", ", ", ")")
+          } else ""
+          logInfo(s"Executing DDL (url=${connProperties.url}; " +
+              s"props=${connProperties.connProps}): CREATE TABLE ${quotedName(tableName)} " +
+              s"$schemaString USING $provider$optsString")
+        }
         if (pass != null) {
           connProperties.connProps.setProperty(com.pivotal.gemfirexd.Attribute.PASSWORD_ATTR,
             pass.asInstanceOf[String])

--- a/core/src/main/scala/org/apache/spark/sql/internal/ColumnTableBulkOps.scala
+++ b/core/src/main/scala/org/apache/spark/sql/internal/ColumnTableBulkOps.scala
@@ -46,9 +46,8 @@ object ColumnTableBulkOps {
     table.collectFirst {
       case LogicalRelation(mutable: BulkPutRelation, _, _) =>
         val putKeys = mutable.getPutKeys match {
-          case None =>
-            throw new AnalysisException(
-              s"PutInto in a column table requires key column(s) but got empty string")
+          case None => throw new AnalysisException(
+            s"PutInto in a column table requires key column(s) but got empty string")
           case Some(k) => k
         }
         val condition = prepareCondition(sparkSession, table, subQuery, putKeys)

--- a/core/src/main/scala/org/apache/spark/sql/internal/SnappySessionState.scala
+++ b/core/src/main/scala/org/apache/spark/sql/internal/SnappySessionState.scala
@@ -635,7 +635,7 @@ class SnappySessionState(val snappySession: SnappySession)
           }.unzip
           // collect all references and project on them to explicitly eliminate
           // any extra columns
-          val allReferences = newChild.references ++
+          val allReferences = newChild.references ++ AttributeSet(updateAttrs) ++
               AttributeSet(newUpdateExprs.flatMap(_.references)) ++ AttributeSet(keyAttrs)
           u.copy(child = Project(newChild.output.filter(allReferences.contains), newChild),
             keyColumns = keyAttrs.map(_.toAttribute),

--- a/core/src/main/scala/org/apache/spark/sql/internal/SnappySessionState.scala
+++ b/core/src/main/scala/org/apache/spark/sql/internal/SnappySessionState.scala
@@ -34,13 +34,12 @@ import org.apache.spark.sql.catalyst.analysis
 import org.apache.spark.sql.catalyst.analysis.TypeCoercion.PromoteStrings
 import org.apache.spark.sql.catalyst.analysis.{Analyzer, EliminateSubqueryAliases, NoSuchTableException, Star, UnresolvedRelation}
 import org.apache.spark.sql.catalyst.catalog.CatalogRelation
-import org.apache.spark.sql.catalyst.expressions.aggregate._
 import org.apache.spark.sql.catalyst.expressions.{And, EqualTo, In, ScalarSubquery, _}
 import org.apache.spark.sql.catalyst.optimizer.{Optimizer, ReorderJoin}
 import org.apache.spark.sql.catalyst.planning.ExtractEquiJoinKeys
 import org.apache.spark.sql.catalyst.plans.JoinType
 import org.apache.spark.sql.catalyst.plans.logical.{Filter => LogicalFilter, _}
-import org.apache.spark.sql.catalyst.rules.{Rule, RuleExecutor}
+import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.collection.Utils
 import org.apache.spark.sql.execution._
 import org.apache.spark.sql.execution.columnar.impl.IndexColumnFormatRelation
@@ -143,17 +142,6 @@ class SnappySessionState(val snappySession: SnappySession)
       getExtendedResolutionRules(this)
 
     override val extendedCheckRules: Seq[LogicalPlan => Unit] = getExtendedCheckRules
-  }
-
-  /**
-   * A set of basic analysis rules required to be run before plan caching to allow
-   * for proper analysis before ParamLiterals are marked as "tokenized". For example,
-   * grouping or ordering expressions used in projections will need to be resolved
-   * here so that ParamLiterals are considered as equal based of value and not position.
-   */
-  private[sql] lazy val preCacheRules: RuleExecutor[LogicalPlan] = new RuleExecutor[LogicalPlan] {
-    override val batches: Seq[Batch] = Batch("Resolution", Once,
-      ResolveAggregationExpressions :: Nil: _*) :: Nil
   }
 
   override lazy val optimizer: Optimizer = new SparkOptimizer(catalog, conf, experimentalMethods) {
@@ -1420,102 +1408,6 @@ object LikeEscapeSimplification {
   def apply(plan: LogicalPlan): LogicalPlan = plan transformAllExpressions {
     case l@Like(left, Literal(pattern, StringType)) =>
       simplifyLike(null, l, left, pattern.toString)
-  }
-}
-
-/**
- * Rule to "normalize" ParamLiterals for the case of aggregation expression being used
- * in projection. Specifically the ParamLiterals from aggregations need to be replaced
- * into projection so that latter can be resolved successfully in plan execution
- * because ParamLiterals will match expression only by position and not value at the
- * time of execution. This rule is useful only before plan caching after parsing.
- *
- * See Spark's PhysicalAggregation rule for more details.
- */
-object ResolveAggregationExpressions extends Rule[LogicalPlan] {
-
-  private val identityGet: Expression => Expression = identity
-  private val toNamedExpression: (NamedExpression, Expression) => NamedExpression =
-    (_, e) => e.asInstanceOf[NamedExpression]
-
-  private val sortOrderGet: SortOrder => Expression = order => order.child
-  private val toSortOrder: (SortOrder, Expression) => SortOrder =
-    (order, e) => if (order.child eq e) order else order.copy(child = e)
-
-  private def useValueEquality[T](exprs: Seq[T], valueEquals: Boolean,
-      getExpr: T => Expression): Unit = {
-    exprs.foreach(getExpr(_).transform {
-      case p: ParamLiteral =>
-        if (valueEquals) {
-          // mark tokenized for consistent hashCode in canonicalized for semanticEquals
-          p.tokenized = true
-          p.positionIndependent = true
-          p.valueEquals = true
-        } else p.valueEquals = false
-        p
-    })
-  }
-
-  private def copyParamLiterals[T](groupingExpressions: Seq[Expression],
-      resultExpressions: Seq[T], getExpr: T => Expression,
-      getResult: (T, Expression) => T): Seq[T] = {
-    useValueEquality(groupingExpressions, valueEquals = true, identityGet)
-    useValueEquality(resultExpressions, valueEquals = true, getExpr)
-    // Replace any ParamLiterals in the original resultExpressions with any matching ones
-    // in groupingExpressions matching on the value like a Literal rather than position.
-    val newResultExpressions = resultExpressions.map { expr =>
-      getResult(expr, {
-        getExpr(expr).transformDown {
-          case e: AggregateExpression => e
-          case expression =>
-            groupingExpressions.collectFirst {
-              case p: ParamLiteral if (p ne expression) && p.equals(expression) =>
-                // ensure newLiteral != p so that it is replaced in tree
-                expression.asInstanceOf[ParamLiteral].valueEquals = false
-                p.valueEquals = false
-                p
-              case e if e.semanticEquals(expression) =>
-                // collect ParamLiterals from grouping expressions and apply
-                // to result expressions in the same order
-                val literals = new ArrayBuffer[ParamLiteral](2)
-                e.transformDown {
-                  case p: ParamLiteral => literals += p; p
-                }
-                if (literals.nonEmpty) {
-                  val iter = literals.iterator
-                  expression.transformDown {
-                    case p: ParamLiteral =>
-                      val newLiteral = iter.next()
-                      assert(newLiteral.equals(p))
-                      assert(p.tokenized)
-                      assert(newLiteral.tokenized)
-                      // ensure newLiteral != p so that it is replaced in tree
-                      p.valueEquals = false
-                      newLiteral.valueEquals = false
-                      newLiteral
-                  }
-                } else expression
-            } match {
-              case Some(e) => e
-              case _ => expression
-            }
-        }
-      })
-    }
-    useValueEquality(groupingExpressions, valueEquals = false, identityGet)
-    useValueEquality(newResultExpressions, valueEquals = false, getExpr)
-    newResultExpressions
-  }
-
-  def apply(plan: LogicalPlan): LogicalPlan = plan resolveOperators {
-    case Aggregate(groupingExpressions, resultExpressions, child) =>
-      val newResultExpressions = copyParamLiterals(groupingExpressions, resultExpressions,
-        identityGet, toNamedExpression)
-      Aggregate(groupingExpressions, newResultExpressions, child)
-
-    case Sort(order, global, a@Aggregate(groupingExpressions, _, _)) =>
-      val newOrder = copyParamLiterals(groupingExpressions, order, sortOrderGet, toSortOrder)
-      Sort(newOrder, global, a)
   }
 }
 

--- a/core/src/test/scala/io/snappydata/core/LocalTestData.scala
+++ b/core/src/test/scala/io/snappydata/core/LocalTestData.scala
@@ -81,6 +81,7 @@ object LocalSparkConf {
     val conf = new SparkConf()
         .setIfMissing("spark.master", "local[4]")
         .setIfMissing("spark.memory.debugFill", "true")
+        .setIfMissing("spark.memory.fraction", "0.97")
         .setAppName(getClass.getName)
     if (addOn != null) {
       addOn(conf)

--- a/core/src/test/scala/io/snappydata/core/LocalTestData.scala
+++ b/core/src/test/scala/io/snappydata/core/LocalTestData.scala
@@ -81,7 +81,6 @@ object LocalSparkConf {
     val conf = new SparkConf()
         .setIfMissing("spark.master", "local[4]")
         .setIfMissing("spark.memory.debugFill", "true")
-        .setIfMissing("spark.memory.fraction", "0.97")
         .setAppName(getClass.getName)
     if (addOn != null) {
       addOn(conf)

--- a/core/src/test/scala/org/apache/spark/sql/store/MetadataTest.scala
+++ b/core/src/test/scala/org/apache/spark/sql/store/MetadataTest.scala
@@ -201,7 +201,8 @@ object MetadataTest extends Assertions {
       StructField(p._1, StringType, nullable = false, getMetadata(p._1, p._2, p._3)))))
     val expectedDefaultSchemas = List("APP", "NULLID", "SNAPPY_HIVE_METASTORE", "SQLJ",
       "SYS", "SYSCAT", "SYSCS_DIAG", "SYSCS_UTIL", "SYSFUN", "SYSIBM", "SYSPROC", "SYSSTAT")
-    assert(rs.length === expectedDefaultSchemas.length)
+    assert(rs.length === expectedDefaultSchemas.length,
+      s"Got ${rs.map(_.getString(1)).mkString(", ")}")
     assert(rs.map(_.getString(1)).sorted === expectedDefaultSchemas)
 
     ds = executeSQL("select * from sys.sysTables where tableSchemaName = 'SYS'")


### PR DESCRIPTION
## Changes proposed in this pull request

- switched all intermediate arrays in decoders/encoders to use BufferAllocator so that it can
  be accounted propertly (only in off-heap config for now)
- added proper close methods everywhere for both encoders and decoders for above and invoke
  the close in ColumnTableScan generated code
- force a repartition on the implicit BATCHID column in column update/delete when there is
  no explicit partitioning in the table so that all changes for a batch are together and get
  applied as a single delta rather than spread across all partitions
- use KEY_COLUMNS as partitioning columns if none have been specified expliciitly
- use SnappyCacheTableCommand for putInto intermediate cache to show the plan of cache properly
- moved task interrupt checks to both column and row iterators so that task execution can
  stop quickly; removed the check from ColumnTableScan generated code

## Patch testing

precheckin in progress

## ReleaseNotes.txt changes

NA

## Other PRs 

https://github.com/SnappyDataInc/snappy-store/pull/447