### PR TITLE
Store the temporary join result in offheap

### DIFF
--- a/core/src/main/scala/org/apache/spark/sql/execution/ddl.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/ddl.scala
@@ -24,8 +24,10 @@ import com.pivotal.gemfirexd.internal.engine.store.GemFireStore
 import com.pivotal.gemfirexd.internal.iapi.reference.{Property => GemXDProperty}
 import com.pivotal.gemfirexd.internal.impl.jdbc.Util
 import com.pivotal.gemfirexd.internal.shared.common.reference.SQLState
-import io.snappydata.{Constant, Property}
+import io.snappydata.{Constant, Property, SnappyTableStatsProviderService}
 
+import org.apache.spark.SparkEnv
+import org.apache.spark.memory.MemoryMode
 import org.apache.spark.sql._
 import org.apache.spark.sql.catalyst.catalog.CatalogTableType
 import org.apache.spark.sql.catalyst.catalog.CatalogTypes.TablePartitionSpec
@@ -40,6 +42,7 @@ import org.apache.spark.sql.hive.{QualifiedTableName, SnappyStoreHiveCatalog}
 import org.apache.spark.sql.internal.BypassRowLevelSecurity
 import org.apache.spark.sql.sources.JdbcExtendedUtils
 import org.apache.spark.sql.types.{BooleanType, MetadataBuilder, StringType, StructField, StructType}
+import org.apache.spark.storage.StorageLevel
 import org.apache.spark.streaming.{Duration, SnappyStreamingContext}
 
 
@@ -367,16 +370,31 @@ case class SnappyCacheTableCommand(tableIdent: TableIdentifier,
       case None => session.catalog.cacheTable(tableIdent.quotedString)
       case Some(lp) =>
         val df = Dataset.ofRows(session, lp)
+        val isOffHeap = SnappyContext.getClusterMode(sparkSession.sparkContext)
+        match {
+          case _: ThinClientConnectorMode =>
+            SparkEnv.get.memoryManager.tungstenMemoryMode == MemoryMode.OFF_HEAP
+          case _ =>
+            try {
+              SnappyTableStatsProviderService.getService.getMembersStatsOnDemand.
+                  values.exists(member => (member.isDataServer
+                  && (member.getOffHeapMemorySize > 0)))
+            }
+            catch {
+              case _: Throwable => false
+            }
+        }
+
         if (isLazy) {
           df.createTempView(tableIdent.quotedString)
-          df.persist()
+          if (isOffHeap) df.persist(StorageLevel.OFF_HEAP) else df.persist()
         } else {
           session.sessionState.enableExecutionCache = true
           // Get the actual QueryExecution used by InMemoryRelation so that
           // "withNewExecutionId" runs on the same and shows proper metrics in GUI.
           val cachedExecution = try {
             df.createTempView(tableIdent.quotedString)
-            df.persist()
+            if (isOffHeap) df.persist(StorageLevel.OFF_HEAP) else df.persist()
             session.sessionState.getExecution(df.logicalPlan)
           } finally {
             session.sessionState.enableExecutionCache = false

--- a/core/src/main/scala/org/apache/spark/sql/execution/ddl.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/ddl.scala
@@ -370,14 +370,13 @@ case class SnappyCacheTableCommand(tableIdent: TableIdentifier,
       case None => session.catalog.cacheTable(tableIdent.quotedString)
       case Some(lp) =>
         val df = Dataset.ofRows(session, lp)
-        val isOffHeap = SnappyContext.getClusterMode(sparkSession.sparkContext)
-        match {
+        val isOffHeap = SnappyContext.getClusterMode(sparkSession.sparkContext) match {
           case _: ThinClientConnectorMode =>
             SparkEnv.get.memoryManager.tungstenMemoryMode == MemoryMode.OFF_HEAP
           case _ =>
             try {
               SnappyTableStatsProviderService.getService.getMembersStatsFromService.
-                  values.exists(member => (member.isDataServer
+                  values.forall(member => (member.isDataServer
                   && (member.getOffHeapMemorySize > 0)))
             }
             catch {

--- a/core/src/main/scala/org/apache/spark/sql/execution/ddl.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/ddl.scala
@@ -376,7 +376,7 @@ case class SnappyCacheTableCommand(tableIdent: TableIdentifier,
             SparkEnv.get.memoryManager.tungstenMemoryMode == MemoryMode.OFF_HEAP
           case _ =>
             try {
-              SnappyTableStatsProviderService.getService.getMembersStatsOnDemand.
+              SnappyTableStatsProviderService.getService.getMembersStatsFromService.
                   values.exists(member => (member.isDataServer
                   && (member.getOffHeapMemorySize > 0)))
             }

--- a/core/src/main/scala/org/apache/spark/sql/execution/ddl.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/ddl.scala
@@ -376,8 +376,8 @@ case class SnappyCacheTableCommand(tableIdent: TableIdentifier,
           case _ =>
             try {
               SnappyTableStatsProviderService.getService.getMembersStatsFromService.
-                  values.forall(member => (member.isDataServer
-                  && (member.getOffHeapMemorySize > 0)))
+                  values.forall(member => (!member.isDataServer ||
+                  (member.getOffHeapMemorySize > 0)))
             }
             catch {
               case _: Throwable => false


### PR DESCRIPTION
## Changes proposed in this pull request

Check if there are servers with offheap setting and if so store them in offheap.
## Patch testing

(Fill in the details about how this patch was tested)

## ReleaseNotes.txt changes

(Does this change require an entry in ReleaseNotes.txt? If yes, has it been added to it?)

## Other PRs 

(Does this change require changes in other projects- store, spark, spark-jobserver, aqp? Add the links of PR of the other subprojects that are related to this change)
