### PR TITLE
[SNAP-2773] improve GUI display of put into

### DIFF
--- a/cluster/src/test/scala/org/apache/spark/sql/execution/benchmark/TAQTest.scala
+++ b/cluster/src/test/scala/org/apache/spark/sql/execution/benchmark/TAQTest.scala
@@ -87,10 +87,8 @@ class TAQTest extends SnappyFunSuite {
     for (_ <- 1 to numRuns) {
       val start = System.nanoTime()
       for (_ <- 1 to numIters) {
-        // val rs = stmt.executeQuery("select * from citi_order where id=1000 " +
-        //    "--GEMFIREXD-PROPERTIES executionEngine=Spark")
-        val rs = stmt.executeQuery("select count(*) from citi_order " +
-            "--GEMFIREXD-PROPERTIES executionEngine=Spark")
+        // val rs = stmt.executeQuery("select * from citi_order where id=1000")
+        val rs = stmt.executeQuery("select count(*) from citi_order")
         var count = 0
         while (rs.next()) {
           count += 1

--- a/core/src/main/scala/org/apache/spark/sql/CachedDataFrame.scala
+++ b/core/src/main/scala/org/apache/spark/sql/CachedDataFrame.scala
@@ -619,24 +619,28 @@ object CachedDataFrame
    *
    * Custom method to allow passing in cached SparkPlanInfo and queryExecution string.
    */
-  def withNewExecutionId[T](snappySession: SnappySession,
-      queryShortForm: String, queryLongForm: String, queryExecutionStr: String,
-      queryPlanInfo: SparkPlanInfo, currentExecutionId: Long = -1L,
-      planStartTime: Long = -1L, planEndTime: Long = -1L)(body: => T): (T, Long) = {
+  def withNewExecutionId[T](snappySession: SnappySession, queryShortForm: String,
+      queryLongForm: String, queryExecutionStr: String, queryPlanInfo: SparkPlanInfo,
+      currentExecutionId: Long = -1L, planStartTime: Long = -1L, planEndTime: Long = -1L,
+      postGUIPlans: Boolean = true)(body: => T): (T, Long) = {
     val sc = snappySession.sparkContext
-    val oldExecutionId = sc.getLocalProperty(SQLExecution.EXECUTION_ID_KEY)
+    val localProperties = sc.getLocalProperties
+    val oldExecutionId = localProperties.getProperty(SQLExecution.EXECUTION_ID_KEY)
     if (oldExecutionId eq null) {
       // If the execution ID is set in the CDF that means the plan execution has already
       // been done. Use the same execution ID to link this execution to the previous one.
       val executionId = if (currentExecutionId >= 0) currentExecutionId
       else nextExecutionIdMethod.invoke(SQLExecution).asInstanceOf[Long]
-      sc.setLocalProperty(SQLExecution.EXECUTION_ID_KEY, executionId.toString)
+      val executionIdStr = java.lang.Long.toString(executionId)
+      localProperties.setProperty(SQLExecution.EXECUTION_ID_KEY, executionIdStr)
+      localProperties.setProperty(SparkContext.SPARK_JOB_DESCRIPTION, queryLongForm)
+      localProperties.setProperty(SparkContext.SPARK_JOB_GROUP_ID, executionIdStr)
+
       val startTime = System.currentTimeMillis()
       var endTime = -1L
       try {
-        snappySession.sparkContext.listenerBus.post(SparkListenerSQLExecutionStart(
-          executionId, queryShortForm, queryLongForm, queryExecutionStr,
-          queryPlanInfo, startTime))
+        if (postGUIPlans) sc.listenerBus.post(SparkListenerSQLExecutionStart(executionId,
+          queryShortForm, queryLongForm, queryExecutionStr, queryPlanInfo, startTime))
         val result = body
         endTime = System.currentTimeMillis()
         (result, endTime - startTime)
@@ -649,10 +653,11 @@ object CachedDataFrame
           endTime -= (startTime - planEndTime)
         }
         // add the time of plan execution to the end time.
-        snappySession.sparkContext.listenerBus.post(SparkListenerSQLExecutionEnd(
-          executionId, endTime))
+        if (postGUIPlans) sc.listenerBus.post(SparkListenerSQLExecutionEnd(executionId, endTime))
 
-        sc.setLocalProperty(SQLExecution.EXECUTION_ID_KEY, null)
+        localProperties.remove(SparkContext.SPARK_JOB_GROUP_ID)
+        localProperties.remove(SparkContext.SPARK_JOB_DESCRIPTION)
+        localProperties.remove(SQLExecution.EXECUTION_ID_KEY)
       }
     } else {
       // Don't support nested `withNewExecutionId`.

--- a/core/src/main/scala/org/apache/spark/sql/SnappyDDLParser.scala
+++ b/core/src/main/scala/org/apache/spark/sql/SnappyDDLParser.scala
@@ -698,7 +698,7 @@ abstract class SnappyDDLParser(session: SparkSession)
     CACHE ~ (LAZY ~ push(true)).? ~ TABLE ~ tableIdentifier ~
         (AS ~ query).? ~> ((isLazy: Any, tableIdent: TableIdentifier,
         plan: Any) => SnappyCacheTableCommand(tableIdent,
-      plan.asInstanceOf[Option[LogicalPlan]],
+      input.sliceString(0, input.length), plan.asInstanceOf[Option[LogicalPlan]],
       isLazy.asInstanceOf[Option[Boolean]].isDefined))
   }
 

--- a/core/src/main/scala/org/apache/spark/sql/SnappySession.scala
+++ b/core/src/main/scala/org/apache/spark/sql/SnappySession.scala
@@ -45,12 +45,12 @@ import org.apache.spark.jdbc.{ConnectionConf, ConnectionUtil}
 import org.apache.spark.rdd.RDD
 import org.apache.spark.scheduler.{SparkListener, SparkListenerApplicationEnd}
 import org.apache.spark.sql.SnappySession.CACHED_PUTINTO_UPDATE_PLAN
-import org.apache.spark.sql.catalyst.analysis.{EliminateSubqueryAliases, NoSuchTableException}
+import org.apache.spark.sql.catalyst.analysis.{EliminateSubqueryAliases, NoSuchTableException, UnresolvedRelation}
 import org.apache.spark.sql.catalyst.encoders._
 import org.apache.spark.sql.catalyst.expressions.aggregate.AggregateExpression
 import org.apache.spark.sql.catalyst.expressions.codegen.CodegenContext
 import org.apache.spark.sql.catalyst.expressions.{Alias, Ascending, AttributeReference, Descending, Exists, ExprId, Expression, GenericRow, ListQuery, ParamLiteral, PredicateSubquery, ScalarSubquery, SortDirection, TokenLiteral}
-import org.apache.spark.sql.catalyst.plans.logical.{Filter, LogicalPlan, Union}
+import org.apache.spark.sql.catalyst.plans.logical.{Filter, LogicalPlan, OverwriteOptions, Union}
 import org.apache.spark.sql.catalyst.{DefinedByConstructorParams, InternalRow, ScalaReflection, TableIdentifier}
 import org.apache.spark.sql.collection.{ToolsCallbackInit, Utils, WrappedInternalRow}
 import org.apache.spark.sql.execution._
@@ -2165,7 +2165,12 @@ object SnappySession extends Logging {
     // Right now the CachedDataFrame is not getting used across SnappySessions
     val executionId = CachedDataFrame.nextExecutionIdMethod.
       invoke(SQLExecution).asInstanceOf[Long]
-    session.sparkContext.setLocalProperty(SQLExecution.EXECUTION_ID_KEY, executionId.toString)
+    val executionIdStr = java.lang.Long.toString(executionId)
+    val context = session.sparkContext
+    val localProperties = context.getLocalProperties
+    localProperties.setProperty(SQLExecution.EXECUTION_ID_KEY, executionIdStr)
+    localProperties.setProperty(SparkContext.SPARK_JOB_DESCRIPTION, sqlText)
+    localProperties.setProperty(SparkContext.SPARK_JOB_GROUP_ID, executionIdStr)
     val start = System.currentTimeMillis()
     try {
       // get below two with original "ParamLiteral(" tokens that will be replaced
@@ -2176,14 +2181,16 @@ object SnappySession extends Logging {
       val postQueryExecutionStr = replaceParamLiterals(queryExecutionStr, paramLiterals, paramsId)
       val postQueryPlanInfo = PartitionedPhysicalScan.updatePlanInfo(queryPlanInfo,
         paramLiterals, paramsId)
-      session.sparkContext.listenerBus.post(SparkListenerSQLPlanExecutionStart(
+      context.listenerBus.post(SparkListenerSQLPlanExecutionStart(
         executionId, CachedDataFrame.queryStringShortForm(sqlText),
         sqlText, postQueryExecutionStr, postQueryPlanInfo, start))
       val rdd = f
       (rdd, queryExecutionStr, queryPlanInfo, postQueryExecutionStr, postQueryPlanInfo,
           executionId, start, System.currentTimeMillis())
     } finally {
-      session.sparkContext.setLocalProperty(SQLExecution.EXECUTION_ID_KEY, null)
+      localProperties.remove(SparkContext.SPARK_JOB_GROUP_ID)
+      localProperties.remove(SparkContext.SPARK_JOB_DESCRIPTION)
+      localProperties.remove(SQLExecution.EXECUTION_ID_KEY)
     }
   }
 
@@ -2192,8 +2199,8 @@ object SnappySession extends Logging {
     val (executedPlan, withFallback) = getExecutedPlan(qe.executedPlan)
     var planCaching = session.planCaching
 
-    val (cachedRDD, execution, origExecutionString, origPlanInfo, executionString, planInfo,
-    rddId, noSideEffects, executionId, planStartTime, planEndTime) = executedPlan match {
+    val (cachedRDD, execution, origExecutionString, origPlanInfo, executionString, planInfo, rddId,
+    noSideEffects, executionId, planStartTime: Long, planEndTime: Long) = executedPlan match {
       case _: ExecutedCommandExec | _: ExecutePlan =>
         // TODO add caching for point updates/deletes; a bit of complication
         // because getPlan will have to do execution with all waits/cleanups
@@ -2213,8 +2220,16 @@ object SnappySession extends Logging {
         // different Command types will post their own plans in toRdd evaluation
         val isCommand = executedPlan.isInstanceOf[ExecutedCommandExec]
         var rdd = if (isCommand) qe.toRdd else null
+        // don't post separate plan for CTAS since it already has posted one for the insert
+        val postGUIPlans = if (isCommand) executedPlan.asInstanceOf[ExecutedCommandExec].cmd match {
+          case c: CreateMetastoreTableUsingSelect if c.provider == SnappyParserConsts.ROW_SOURCE ||
+              c.provider == SnappyParserConsts.COLUMN_SOURCE => false
+          case _: SnappyCacheTableCommand => false
+          case _ => true
+        } else true
         // post final execution immediately (collect for these plans will post nothing)
-        CachedDataFrame.withNewExecutionId(session, sqlText, sqlText, executionStr, planInfo) {
+        CachedDataFrame.withNewExecutionId(session, sqlText, sqlText, executionStr, planInfo,
+          postGUIPlans = postGUIPlans) {
           // create new LogicalRDD plan so that plan does not get re-executed
           // (e.g. just toRdd is not enough since further operators like show will pass
           //   around the LogicalPlan and not the executedPlan; it works for plans using
@@ -2299,7 +2314,6 @@ object SnappySession extends Logging {
   def getPlanCache: Cache[CachedKey, CachedDataFrame] = planCache
 
   def sqlPlan(session: SnappySession, sqlText: String): CachedDataFrame = {
-    session.sparkContext.setJobDescription(sqlText)
     val parser = session.sessionState.sqlParser
     val plan = parser.parsePlan(sqlText, clearExecutionData = true)
     val planCaching = session.planCaching

--- a/core/src/main/scala/org/apache/spark/sql/execution/ddl.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/ddl.scala
@@ -41,7 +41,7 @@ import org.apache.spark.sql.execution.command.{CreateViewCommand, DescribeTableC
 import org.apache.spark.sql.hive.{QualifiedTableName, SnappyStoreHiveCatalog}
 import org.apache.spark.sql.internal.BypassRowLevelSecurity
 import org.apache.spark.sql.sources.JdbcExtendedUtils
-import org.apache.spark.sql.types.{BooleanType, MetadataBuilder, StringType, StructField, StructType}
+import org.apache.spark.sql.types.{BooleanType, LongType, MetadataBuilder, StringType, StructField, StructType}
 import org.apache.spark.storage.StorageLevel
 import org.apache.spark.streaming.{Duration, SnappyStreamingContext}
 
@@ -353,11 +353,14 @@ case class CreateSnappyViewCommand(name: TableIdentifier,
  * Alternative to Spark's CacheTableCommand that shows the plan being cached
  * in the GUI rather than count() plan for InMemoryRelation.
  */
-case class SnappyCacheTableCommand(tableIdent: TableIdentifier,
+case class SnappyCacheTableCommand(tableIdent: TableIdentifier, queryString: String,
     plan: Option[LogicalPlan], isLazy: Boolean) extends RunnableCommand {
 
   require(plan.isEmpty || tableIdent.database.isEmpty,
     "Schema name is not allowed in CACHE TABLE AS SELECT")
+
+  override def output: Seq[Attribute] = AttributeReference(
+    "batchCount", LongType)() :: Nil
 
   override protected def innerChildren: Seq[QueryPlan[_]] = plan match {
     case None => Nil
@@ -366,54 +369,60 @@ case class SnappyCacheTableCommand(tableIdent: TableIdentifier,
 
   override def run(sparkSession: SparkSession): Seq[Row] = {
     val session = sparkSession.asInstanceOf[SnappySession]
-    plan match {
-      case None => session.catalog.cacheTable(tableIdent.quotedString)
+    val df = plan match {
+      case None => session.table(tableIdent)
       case Some(lp) =>
         val df = Dataset.ofRows(session, lp)
-        val isOffHeap = SnappyContext.getClusterMode(sparkSession.sparkContext) match {
+        df.createTempView(tableIdent.quotedString)
+        df
+    }
+    val isOffHeap = {
+      { // avoids indentation change
+        SnappyContext.getClusterMode(sparkSession.sparkContext) match {
           case _: ThinClientConnectorMode =>
             SparkEnv.get.memoryManager.tungstenMemoryMode == MemoryMode.OFF_HEAP
           case _ =>
             try {
               SnappyTableStatsProviderService.getService.getMembersStatsFromService.
-                  values.forall(member => (!member.isDataServer ||
-                  (member.getOffHeapMemorySize > 0)))
+                  values.forall(member => !member.isDataServer ||
+                  (member.getOffHeapMemorySize > 0))
             }
             catch {
               case _: Throwable => false
             }
         }
-
-        if (isLazy) {
-          df.createTempView(tableIdent.quotedString)
-          if (isOffHeap) df.persist(StorageLevel.OFF_HEAP) else df.persist()
-        } else {
-          session.sessionState.enableExecutionCache = true
-          // Get the actual QueryExecution used by InMemoryRelation so that
-          // "withNewExecutionId" runs on the same and shows proper metrics in GUI.
-          val cachedExecution = try {
-            df.createTempView(tableIdent.quotedString)
-            if (isOffHeap) df.persist(StorageLevel.OFF_HEAP) else df.persist()
-            session.sessionState.getExecution(df.logicalPlan)
-          } finally {
-            session.sessionState.enableExecutionCache = false
-            session.sessionState.clearExecutionCache()
-          }
-          val memoryPlan = df.queryExecution.executedPlan.collectFirst {
-            case plan: InMemoryTableScanExec => plan.relation
-          }.get
-          val cached = new Dataset[Row](session, cachedExecution, df.exprEnc)
-          CachedDataFrame.withCallback(sparkSession, cached, "cache")(_.withNewExecutionId {
-            val start = System.nanoTime()
-            // Dummy op to materialize the cache. This does the minimal job of count on
-            // the actual cached data (RDD[CachedBatch]) to force materialization of cache
-            // while avoiding creation of any new SparkPlan.
-            memoryPlan.cachedColumnBuffers.count()
-            (Unit, System.nanoTime() - start)
-          })
-        }
+      }
     }
-    Nil
+
+    if (isLazy) {
+      if (isOffHeap) df.persist(StorageLevel.OFF_HEAP) else df.persist()
+      Nil
+    } else {
+      session.sessionState.enableExecutionCache = true
+      // Get the actual QueryExecution used by InMemoryRelation so that
+      // "withNewExecutionId" runs on the same and shows proper metrics in GUI.
+      val cachedExecution = try {
+        if (isOffHeap) df.persist(StorageLevel.OFF_HEAP) else df.persist()
+        session.sessionState.getExecution(df.logicalPlan)
+      } finally {
+        session.sessionState.enableExecutionCache = false
+        session.sessionState.clearExecutionCache()
+      }
+      val memoryPlan = df.queryExecution.executedPlan.collectFirst {
+        case plan: InMemoryTableScanExec => plan.relation
+      }.get
+      val planInfo = PartitionedPhysicalScan.getSparkPlanInfo(cachedExecution.executedPlan)
+      Row(CachedDataFrame.withCallback(session, df = null, cachedExecution, "cache")(_ =>
+        CachedDataFrame.withNewExecutionId(session, queryString, queryString,
+          cachedExecution.toString(), planInfo)({
+          val start = System.nanoTime()
+          // Dummy op to materialize the cache. This does the minimal job of count on
+          // the actual cached data (RDD[CachedBatch]) to force materialization of cache
+          // while avoiding creation of any new SparkPlan.
+          memoryPlan.cachedColumnBuffers.count()
+          (Unit, System.nanoTime() - start)
+        }))._2) :: Nil
+    }
   }
 }
 


### PR DESCRIPTION
## Changes proposed in this pull request

- pass the query string along to SnappyCacheTableCommand to display in GUI
- removed the extra DS.count() and instead pass back the count of cached batches from cache query
- put into will pass "CACHE FOR (sql)" string if SQL is available else use "PUT INTO <plan>"
  when using putInto API
- also changed CACHE TABLE <table> without query to use off-heap route if enabled,
  and display the full plan in GUI as done for the query case
- set SQL text as Spark job description to show in the jobs/stages tabs in the UI

## Patch testing

precheckin

## ReleaseNotes.txt changes

NA

## Other PRs 

NA