### PR TITLE
[SNAP-2789] implement sameResult for table scans

### DIFF
--- a/cluster/src/test/scala/io/snappydata/QueryTest.scala
+++ b/cluster/src/test/scala/io/snappydata/QueryTest.scala
@@ -17,9 +17,14 @@
 
 package io.snappydata
 
+import java.io.File
+
 import scala.collection.JavaConverters._
 
+import com.pivotal.gemfirexd.TestUtil
+
 import org.apache.spark.sql.execution.benchmark.ColumnCacheBenchmark
+import org.apache.spark.sql.execution.exchange.{BroadcastExchangeExec, ShuffleExchange}
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.{AnalysisException, Row, SnappyContext, SnappySession, SparkSession}
 
@@ -317,8 +322,72 @@ class QueryTest extends SnappyFunSuite {
     snc.sql(s"create index APP.X_TEST_COL3 on APP.TEST (col3)")
     snc.sql(s"insert into TEST values ('one', 'vone', 'cone'), ('two', 'vtwo', 'ctwo')")
     val r = snc.sql(s"select count(*) from TEST").collect()
-    assert (1 === r.length)
-    assert (2 === r.head.get(0))
+    assert(1 === r.length)
+    assert(2 === r.head.get(0))
     snc.sql(s"ALTER TABLE APP.TEST ADD COLUMN COL5 blob")
+  }
+
+  /** check exchange and broadcast plan reuse for row, column and parquet */
+  test("SNAP-2789: check broadcast/exchange reuse") {
+    val session = this.snc.snappySession
+
+    val query = "select count(t1.data), count(*) from test1 t1 join test2 t2 on (t1.id = t2.id) " +
+        "union all " +
+        "select count(*), count(t1.data) from test1 t1 join test2 t2 on (t1.id = t2.id)"
+    for (tableType <- Seq("column", "row", "parquet")) {
+      val (declaration, options) = if (tableType == "parquet") {
+        "external " -> ((table: String) => s"options (path '${table}_pq')")
+      } else "" -> ((_: String) => "options (partition_by 'data')")
+
+      def tableDeclaration(table: String, size: Int): String = {
+        s"create ${declaration}table $table using $tableType ${options(table)} as " +
+            s"select id, case when id % 100 = 0 then null else 'data' || id end as data " +
+            s"from range($size)"
+      }
+
+      session.sql(tableDeclaration("test1", 50000))
+      session.sql(tableDeclaration("test2", 20000))
+
+      // with exchange
+      session.sessionState.conf.setConf(SQLConf.AUTO_BROADCASTJOIN_THRESHOLD, -1L)
+      var df = session.sql(query)
+      var plan = df.queryExecution.executedPlan
+      // exactly one exchange of test1 and test2 is expected
+      val exchanges = plan.collect {
+        case e: ShuffleExchange if e.outputPartitioning.numPartitions > 1 => e
+      }
+      assert(exchanges.length === 2)
+      assert(exchanges.head.treeString.contains("TEST1"))
+      assert(exchanges(1).treeString.contains("TEST2"))
+
+      var result = df.collect()
+      assert(result.length === 2)
+      assert(result(0).getLong(0) === 19800)
+      assert(result(1).getLong(0) === 20000)
+
+      // with broadcast
+      session.sessionState.conf.setConf(SQLConf.AUTO_BROADCASTJOIN_THRESHOLD,
+        SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.defaultValue.get)
+      df = session.sql(query)
+      plan = df.queryExecution.executedPlan
+      // exactly one broadcast of test2 is expected
+      val broadcasts = plan.collect {
+        case e: BroadcastExchangeExec => e
+      }
+      assert(broadcasts.length === 1)
+      // both sides are small enough to be broadcast
+      val broadcastString = broadcasts.head.treeString
+      assert(broadcastString.contains("TEST2") || broadcastString.contains("TEST1"))
+      result = df.collect()
+      assert(result.length === 2)
+      assert(result(0).getLong(0) === 19800)
+      assert(result(1).getLong(0) === 20000)
+
+      session.sql("drop table test1")
+      session.sql("drop table test2")
+    }
+    // delete the directories created for parquet
+    TestUtil.deleteDir(new File("test1_pq"))
+    TestUtil.deleteDir(new File("test2_pq"))
   }
 }

--- a/cluster/src/test/scala/io/snappydata/QueryTest.scala
+++ b/cluster/src/test/scala/io/snappydata/QueryTest.scala
@@ -370,7 +370,7 @@ class QueryTest extends SnappyFunSuite {
         SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.defaultValue.get)
       df = session.sql(query)
       plan = df.queryExecution.executedPlan
-      // exactly one broadcast of test2 is expected
+      // exactly one broadcast of test1 or test2 is expected
       val broadcasts = plan.collect {
         case e: BroadcastExchangeExec => e
       }

--- a/core/src/main/java/org/apache/spark/sql/internal/SnappySharedState.java
+++ b/core/src/main/java/org/apache/spark/sql/internal/SnappySharedState.java
@@ -16,8 +16,8 @@
  */
 package org.apache.spark.sql.internal;
 
-import io.snappydata.sql.catalog.ConnectorExternalCatalog;
 import io.snappydata.sql.catalog.SnappyExternalCatalog;
+import io.snappydata.sql.catalog.impl.SmartConnectorExternalCatalog;
 import org.apache.spark.SparkContext;
 import org.apache.spark.sql.ClusterMode;
 import org.apache.spark.sql.Dataset;
@@ -187,7 +187,7 @@ public final class SnappySharedState extends SharedState {
     } else {
       // create a new connector catalog instance for connector mode
       // each instance has its own set of credentials for authentication
-      return new ConnectorExternalCatalog(session);
+      return new SmartConnectorExternalCatalog(session);
     }
   }
 

--- a/core/src/main/scala/io/snappydata/impl/SmartConnectorRDDHelper.scala
+++ b/core/src/main/scala/io/snappydata/impl/SmartConnectorRDDHelper.scala
@@ -19,27 +19,20 @@ package io.snappydata.impl
 import java.sql.{Connection, PreparedStatement, ResultSet, SQLException}
 import java.util.Collections
 
-import scala.collection.JavaConverters._
 import scala.collection.mutable.ArrayBuffer
 import scala.util.Random
 
 import com.gemstone.gemfire.internal.SocketCreator
 import com.pivotal.gemfirexd.internal.iapi.types.HarmonySerialBlob
 import com.pivotal.gemfirexd.jdbc.ClientAttribute
-import io.snappydata.Constant
-import io.snappydata.thrift.BucketOwners
+import io.snappydata.sql.catalog.SmartConnectorHelper
 import io.snappydata.thrift.internal.ClientPreparedStatement
-import org.eclipse.collections.impl.map.mutable.UnifiedMap
 
-import org.apache.spark.Partition
-import org.apache.spark.sql.SnappySession
-import org.apache.spark.sql.collection.{SmartExecutorBucketPartition, Utils}
+import org.apache.spark.sql.collection.SmartExecutorBucketPartition
 import org.apache.spark.sql.execution.ConnectionPool
 import org.apache.spark.sql.execution.columnar.ExternalStoreUtils
-import org.apache.spark.sql.execution.datasources.jdbc.DriverRegistry
 import org.apache.spark.sql.row.SnappyStoreClientDialect
 import org.apache.spark.sql.sources.ConnectionProperties
-import org.apache.spark.sql.store.StoreUtils
 
 final class SmartConnectorRDDHelper {
 
@@ -75,7 +68,7 @@ final class SmartConnectorRDDHelper {
 
   def getConnectionAndTXId(connProperties: ConnectionProperties,
       part: SmartExecutorBucketPartition, preferHost: Boolean): (Connection, String) = {
-    SmartConnectorRDDHelper.snapshotTxIdForRead.get() match {
+    SmartConnectorHelper.snapshotTxIdForRead.get() match {
       case null | ("", _) =>
         createConnection(connProperties, part.hostList, preferHost) -> null
       case (tx, hostAndUrl) =>
@@ -121,181 +114,6 @@ final class SmartConnectorRDDHelper {
         newHostList.remove(index)
         createConnection(connProperties, hostList, preferHost)
       }
-    }
-  }
-}
-
-object SmartConnectorRDDHelper {
-
-  DriverRegistry.register(Constant.JDBC_CLIENT_DRIVER)
-
-  val snapshotTxIdForRead: ThreadLocal[(String, (String, String))] =
-    new ThreadLocal[(String, (String, String))]
-  val snapshotTxIdForWrite: ThreadLocal[String] = new ThreadLocal[String]
-
-  private[this] val urlPrefix: String = Constant.DEFAULT_THIN_CLIENT_URL
-  // no query routing or load-balancing
-  private[this] val urlSuffix: String = "/" + ClientAttribute.ROUTE_QUERY + "=false;" +
-      ClientAttribute.LOAD_BALANCE + "=false"
-
-  /**
-   * Get pair of TXId and (host, network server URL) pair.
-   */
-  def getTxIdAndHostUrl(txIdAndHost: String, preferHost: Boolean): (String, (String, String)) = {
-    val index = txIdAndHost.indexOf('@')
-    if (index < 0) {
-      throw new AssertionError(s"Unexpected TXId@HostURL string = $txIdAndHost")
-    }
-    val server = txIdAndHost.substring(index + 1)
-    val hostUrl = getNetUrl(server, preferHost, urlPrefix, urlSuffix, availableNetUrls = null)
-    txIdAndHost.substring(0, index) -> hostUrl
-  }
-
-  def getPartitions(bucketToServerList: Array[ArrayBuffer[(String, String)]]): Array[Partition] = {
-    val numPartitions = bucketToServerList.length
-    val partitions = new Array[Partition](numPartitions)
-    // choose only one server from the list so that partition routing and connection
-    // creation are attempted on the same server if possible (i.e. should not happen
-    // that routing selected some server but connection create used some other from the list)
-    val numServers = bucketToServerList(0).length
-    val chosenServerIndex = if (numServers > 1) scala.util.Random.nextInt(numServers) else 0
-    for (p <- 0 until numPartitions) {
-      if (StoreUtils.TEST_RANDOM_BUCKETID_ASSIGNMENT) {
-        partitions(p) = new SmartExecutorBucketPartition(p, p,
-          bucketToServerList(scala.util.Random.nextInt(numPartitions)))
-      } else {
-        val servers = bucketToServerList(p)
-        partitions(p) = new SmartExecutorBucketPartition(p, p,
-          if (servers.isEmpty) Nil
-          else if (servers.length >= numServers) servers(chosenServerIndex) :: Nil
-          else servers(0) :: Nil)
-      }
-    }
-    partitions
-  }
-
-  def preferHostName(session: SnappySession): Boolean = {
-    // check if Spark executors are using IP addresses or host names
-    Utils.executorsListener(session.sparkContext) match {
-      case Some(l) =>
-        val preferHost = l.activeStorageStatusList.collectFirst {
-          case status if status.blockManagerId.executorId != "driver" =>
-            val host = status.blockManagerId.host
-            host.indexOf('.') == -1 && host.indexOf("::") == -1
-        }
-        preferHost.isDefined && preferHost.get
-      case _ => false
-    }
-  }
-
-  private def getNetUrl(server: String, preferHost: Boolean, urlPrefix: String,
-      urlSuffix: String, availableNetUrls: UnifiedMap[String, String]): (String, String) = {
-    val hostAddressPort = returnHostPortFromServerString(server)
-    val hostName = hostAddressPort._1
-    val host = if (preferHost) hostName else hostAddressPort._2
-    val netUrl = urlPrefix + hostName + "[" + hostAddressPort._3 + "]" + urlSuffix
-    if ((availableNetUrls ne null) && !availableNetUrls.containsKey(host)) {
-      availableNetUrls.put(host, netUrl)
-    }
-    host -> netUrl
-  }
-
-  def setBucketToServerMappingInfo(numBuckets: Int, buckets: java.util.List[BucketOwners],
-      session: SnappySession): Array[ArrayBuffer[(String, String)]] = {
-    if (!buckets.isEmpty) {
-      // check if Spark executors are using IP addresses or host names
-      val preferHost = preferHostName(session)
-      val preferPrimaries = session.preferPrimaries
-      var orphanBuckets: ArrayBuffer[Int] = null
-      val allNetUrls = new Array[ArrayBuffer[(String, String)]](numBuckets)
-      val availableNetUrls = new UnifiedMap[String, String](4)
-      for (bucket <- buckets.asScala) {
-        val bucketId = bucket.getBucketId
-        // use primary so that DMLs are routed optimally
-        val primary = bucket.getPrimary
-        if (primary ne null) {
-          // get (host,addr,port)
-          val secondaries = if (preferPrimaries) Collections.emptyList()
-          else bucket.getSecondaries
-          val netUrls = new ArrayBuffer[(String, String)](secondaries.size() + 1)
-          netUrls += getNetUrl(primary, preferHost, urlPrefix, urlSuffix, availableNetUrls)
-          if (secondaries.size() > 0) {
-            for (secondary <- secondaries.asScala) {
-              netUrls += getNetUrl(secondary, preferHost, urlPrefix, urlSuffix, availableNetUrls)
-            }
-          }
-          allNetUrls(bucketId) = netUrls
-        } else {
-          // Save the bucket which does not have a neturl,
-          // and later assign available ones to it.
-          if (orphanBuckets eq null) {
-            orphanBuckets = new ArrayBuffer[Int](2)
-          }
-          orphanBuckets += bucketId
-        }
-      }
-      if (orphanBuckets ne null) {
-        val netUrls = new ArrayBuffer[(String, String)](availableNetUrls.size())
-        val netUrlsIter = availableNetUrls.entrySet().iterator()
-        while (netUrlsIter.hasNext) {
-          val entry = netUrlsIter.next()
-          netUrls += entry.getKey -> entry.getValue
-        }
-        for (bucket <- orphanBuckets) {
-          allNetUrls(bucket) = netUrls
-        }
-      }
-      return allNetUrls
-    }
-    Array.empty
-  }
-
-  def setReplicasToServerMappingInfo(replicaNodes: java.util.List[String],
-      session: SnappySession): Array[ArrayBuffer[(String, String)]] = {
-    // check if Spark executors are using IP addresses or host names
-    val preferHost = preferHostName(session)
-    val urlPrefix = Constant.DEFAULT_THIN_CLIENT_URL
-    // no query routing or load-balancing
-    val urlSuffix = "/" + ClientAttribute.ROUTE_QUERY + "=false;" +
-        ClientAttribute.LOAD_BALANCE + "=false"
-    val netUrls = ArrayBuffer.empty[(String, String)]
-    for (host <- replicaNodes.asScala) {
-      val hostAddressPort = returnHostPortFromServerString(host)
-      val hostName = hostAddressPort._1
-      val h = if (preferHost) hostName else hostAddressPort._2
-      netUrls += h ->
-          (urlPrefix + hostName + "[" + hostAddressPort._3 + "]" + urlSuffix)
-    }
-    Array(netUrls)
-  }
-
-  /*
-  * The pattern to extract addresses from the result of
-  * GET_ALLSERVERS_AND_PREFSERVER2 procedure; format is:
-  *
-  * host1/addr1[port1]{kind1},host2/addr2[port2]{kind2},...
-  */
-  private lazy val addrPattern =
-    java.util.regex.Pattern.compile("([^,/]*)(/[^,\\[]+)?\\[([\\d]+)\\](\\{[^}]+\\})?")
-
-  private def returnHostPortFromServerString(serverStr: String): (String, String, String) = {
-    if (serverStr == null || serverStr.length == 0) {
-      return null
-    }
-    val matcher: java.util.regex.Matcher = addrPattern.matcher(serverStr)
-    val matchFound: Boolean = matcher.find
-    if (!matchFound) {
-      (null, null, null)
-    } else {
-      val host: String = matcher.group(1)
-      var address = matcher.group(2)
-      if ((address ne null) && address.length > 0) {
-        address = address.substring(1)
-      } else {
-        address = host
-      }
-      val portStr: String = matcher.group(3)
-      (host, address, portStr)
     }
   }
 }

--- a/core/src/main/scala/io/snappydata/sql/catalog/ConnectorExternalCatalog.scala
+++ b/core/src/main/scala/io/snappydata/sql/catalog/ConnectorExternalCatalog.scala
@@ -21,43 +21,34 @@ import java.util.Collections
 import javax.annotation.concurrent.GuardedBy
 
 import scala.collection.JavaConverters._
-import scala.collection.mutable.ArrayBuffer
 
-import com.gemstone.gemfire.internal.cache.LocalRegion
 import com.google.common.cache.{Cache, CacheBuilder}
 import com.pivotal.gemfirexd.internal.shared.common.reference.SQLState
-import io.snappydata.impl.SmartConnectorRDDHelper
+import io.snappydata.Property
 import io.snappydata.thrift._
 
-import org.apache.spark.sql.catalyst.analysis.{NoSuchPartitionException, NoSuchPermanentFunctionException}
-import org.apache.spark.sql.catalyst.catalog.CatalogTypes.TablePartitionSpec
 import org.apache.spark.sql.catalyst.catalog._
-import org.apache.spark.sql.catalyst.expressions.{And, AttributeReference, BoundReference, Expression}
 import org.apache.spark.sql.catalyst.plans.logical.{ColumnStat, Statistics}
 import org.apache.spark.sql.catalyst.{FunctionIdentifier, TableIdentifier}
+import org.apache.spark.sql.collection.Utils
 import org.apache.spark.sql.collection.Utils.EMPTY_STRING_ARRAY
-import org.apache.spark.sql.collection.{SmartExecutorBucketPartition, Utils}
-import org.apache.spark.sql.execution.RefreshMetadata
 import org.apache.spark.sql.execution.columnar.ExternalStoreUtils
-import org.apache.spark.sql.{SnappySession, TableNotFoundException}
-import org.apache.spark.{Logging, Partition}
+import org.apache.spark.sql.{SparkSession, TableNotFoundException}
+import org.apache.spark.{Logging, Partition, SparkEnv}
 
 /**
- * An ExternalCatalog implementation for the smart connector mode.
- *
- * Note that unlike other ExternalCatalog implementations, this is created one for each session
- * rather than being a singleton in the SharedState because each request needs to be authenticated
- * independently using the credentials of the user that created the session. Consequently calls
- * to "sharedState.externalCatalog()" will return null in smart connector mode and should never
- * be used. For internal code paths in Spark that use it, an alternative dummy global might
- * be added later that switches the user authentication using thread-locals or similar, but as
- * of now it is used only by some hive insert paths which are not used in SnappySessionState.
+ * Base class for catalog implementations for connector modes. This is either used as basis
+ * for ExternalCatalog implementation (in smart connector) or as a helper class for catalog
+ * queries like in connector v2 implementation.
  */
-class ConnectorExternalCatalog(val session: SnappySession)
-    extends SnappyExternalCatalog with Logging {
+trait ConnectorExternalCatalog {
+
+  def session: SparkSession
+
+  def jdbcUrl: String
 
   @GuardedBy("this")
-  protected var connectorHelper: SmartConnectorHelper = new SmartConnectorHelper(session)
+  protected var connectorHelper: SmartConnectorHelper = new SmartConnectorHelper(session, jdbcUrl)
 
   protected def withExceptionHandling[T](function: => T): T = synchronized {
     try {
@@ -66,7 +57,7 @@ class ConnectorExternalCatalog(val session: SnappySession)
       case e: SQLException if isConnectionException(e) =>
         // attempt to create a new connection
         connectorHelper.close()
-        connectorHelper = new SmartConnectorHelper(session)
+        connectorHelper = new SmartConnectorHelper(session, jdbcUrl)
         function
     }
   }
@@ -77,21 +68,7 @@ class ConnectorExternalCatalog(val session: SnappySession)
         e.getSQLState.startsWith(SQLState.GFXD_NODE_SHUTDOWN_PREFIX)
   }
 
-  override def invalidateCaches(relations: Seq[(String, String)]): Unit = {
-    // invalidation of a single table can result in all cached RelationInfo being
-    // out of date due to lower schema version, so always invalidate all
-    invalidateAll()
-    // there is no version update in this call here, rather only the caches are cleared
-    RefreshMetadata.executeLocal(RefreshMetadata.UPDATE_CATALOG_SCHEMA_VERSION, args = null)
-  }
-
-  override def invalidate(name: (String, String)): Unit = {
-    // invalidation of a single table can result in all cached RelationInfo being
-    // out of date due to lower schema version, so always invalidate all
-    invalidateAll()
-  }
-
-  override def invalidateAll(): Unit = {
+  def invalidateAll(): Unit = {
     // invalidate all the RelationInfo objects inside as well as the cache itself
     val iter = ConnectorExternalCatalog.cachedCatalogTables.asMap().values().iterator()
     while (iter.hasNext) {
@@ -103,374 +80,22 @@ class ConnectorExternalCatalog(val session: SnappySession)
     ConnectorExternalCatalog.cachedCatalogTables.invalidateAll()
   }
 
-  // Using a common procedure to update catalog meta-data for create/drop/alter methods
-  // and likewise a common procedure to get catalog meta-data for get/exists/list methods
-
-  override def createDatabase(schemaDefinition: CatalogDatabase, ignoreIfExists: Boolean): Unit = {
-    val request = new CatalogMetadataDetails()
-    request.setCatalogSchema(new CatalogSchemaObject(schemaDefinition.name,
-      schemaDefinition.description, schemaDefinition.locationUri,
-      schemaDefinition.properties.asJava))
-    withExceptionHandling(connectorHelper.updateCatalogMetadata(
-      snappydataConstants.CATALOG_CREATE_SCHEMA, request))
-  }
-
-  override def dropDatabase(schema: String, ignoreIfNotExists: Boolean, cascade: Boolean): Unit = {
-    val request = new CatalogMetadataDetails()
-    request.setNames(Collections.singletonList(schema)).setExists(ignoreIfNotExists)
-        .setOtherFlags(Collections.singletonList(flag(cascade)))
-    withExceptionHandling(connectorHelper.updateCatalogMetadata(
-      snappydataConstants.CATALOG_DROP_SCHEMA, request))
-  }
-
-  override def getDatabase(schema: String): CatalogDatabase = {
-    if (schema == SnappyExternalCatalog.SYS_SCHEMA) return systemSchemaDefinition
-    val request = new CatalogMetadataRequest()
-    request.setSchemaName(schema)
-    val result = withExceptionHandling(connectorHelper.getCatalogMetadata(
-      snappydataConstants.CATALOG_GET_SCHEMA, request))
-    if (result.isSetCatalogSchema) {
-      val schemaObj = result.getCatalogSchema
-      CatalogDatabase(name = schemaObj.getName, description = schemaObj.getDescription,
-        locationUri = schemaObj.getLocationUri, properties = schemaObj.getProperties.asScala.toMap)
-    } else throw schemaNotFoundException(schema)
-  }
-
-  override def databaseExists(schema: String): Boolean = {
-    // this is invoked frequently so instead of messaging right away, check the common
-    // case if there exists a cached table in the schema
-    if (schema == SnappyExternalCatalog.SYS_SCHEMA) true
-    else {
-      val itr = ConnectorExternalCatalog.cachedCatalogTables.asMap().keySet().iterator()
-      while (itr.hasNext) {
-        val tableWithSchema = itr.next()
-        if (tableWithSchema._1 == schema) return true
-      }
-      val request = new CatalogMetadataRequest()
-      request.setSchemaName(schema)
-      withExceptionHandling(connectorHelper.getCatalogMetadata(
-        snappydataConstants.CATALOG_SCHEMA_EXISTS, request)).exists
-    }
-  }
-
-  override def listDatabases(): Seq[String] = listDatabases("*")
-
-  override def listDatabases(pattern: String): Seq[String] = {
-    val request = new CatalogMetadataRequest()
-    request.setNameOrPattern(pattern)
-    withExceptionHandling(connectorHelper.getCatalogMetadata(
-      snappydataConstants.CATALOG_LIST_SCHEMAS, request)).getNames.asScala
-  }
-
-  override def setCurrentDatabase(schema: String): Unit = {
-    connectorHelper.setCurrentSchema(schema)
-  }
-
-  override def createTable(table: CatalogTable, ignoreIfExists: Boolean): Unit = {
-    val request = new CatalogMetadataDetails()
-    request.setCatalogTable(ConnectorExternalCatalog.convertFromCatalogTable(table))
-        .setExists(ignoreIfExists)
-    withExceptionHandling(connectorHelper.updateCatalogMetadata(
-      snappydataConstants.CATALOG_CREATE_TABLE, request))
-
-    // version stored in RelationInfo will be out-of-date now for all tables so clear everything
-    invalidateCaches(Nil)
-  }
-
-  override def dropTable(schema: String, table: String, ignoreIfNotExists: Boolean,
-      purge: Boolean): Unit = {
-    val request = new CatalogMetadataDetails()
-    request.setNames((schema :: table :: Nil).asJava).setExists(ignoreIfNotExists)
-        .setOtherFlags(Collections.singletonList(flag(purge)))
-    withExceptionHandling(connectorHelper.updateCatalogMetadata(
-      snappydataConstants.CATALOG_DROP_TABLE, request))
-
-    // version stored in RelationInfo will be out-of-date now for all tables so clear everything
-    invalidateCaches(Nil)
-  }
-
-  override def alterTable(table: CatalogTable): Unit = {
-    val request = new CatalogMetadataDetails()
-    request.setCatalogTable(ConnectorExternalCatalog.convertFromCatalogTable(table))
-    withExceptionHandling(connectorHelper.updateCatalogMetadata(
-      snappydataConstants.CATALOG_ALTER_TABLE, request))
-
-    // version stored in RelationInfo will be out-of-date now for all tables so clear everything
-    invalidateCaches(Nil)
-  }
-
-  override def renameTable(schemaName: String, oldName: String, newName: String): Unit = {
-    val request = new CatalogMetadataDetails()
-    request.setNames((schemaName :: oldName :: newName :: Nil).asJava)
-    withExceptionHandling(connectorHelper.updateCatalogMetadata(
-      snappydataConstants.CATALOG_RENAME_TABLE, request))
-
-    // version stored in RelationInfo will be out-of-date now for all tables so clear everything
-    invalidateCaches(Nil)
-  }
-
-  override def createPolicy(schemaName: String, policyName: String, targetTable: String,
-      policyFor: String, policyApplyTo: Seq[String], expandedPolicyApplyTo: Seq[String],
-      owner: String, filterString: String): Unit = {
-    throw Utils.analysisException("CREATE POLICY for Row Level Security " +
-        "not supported for smart connector mode")
-  }
-
-  override protected def getCachedCatalogTable(schema: String, table: String): CatalogTable = {
-    ConnectorExternalCatalog.getCatalogTable(schema -> table, catalog = this)
-  }
-
-  override def getTableOption(schema: String, table: String): Option[CatalogTable] = {
-    try {
-      Some(getTable(schema, table))
-    } catch {
-      case _: TableNotFoundException => None
-    }
-  }
-
-  override def getRelationInfo(schema: String, table: String,
-      rowTable: Boolean): (RelationInfo, Option[LocalRegion]) = {
-    if (schema == SnappyExternalCatalog.SYS_SCHEMA) {
-      // SYS tables are treated as single partition replicated tables visible
-      // from all executors using the JDBC connection
-      RelationInfo(1, isPartitioned = false, partitions = Array(
-        new SmartExecutorBucketPartition(0, 0, ArrayBuffer.empty))) -> None
-    } else {
-      assert(schema.length > 0)
-      ConnectorExternalCatalog.getRelationInfo(schema -> table, catalog = this) match {
-        case None => throw new TableNotFoundException(schema, table, Some(new RuntimeException(
-          "RelationInfo for the table is missing. Its region may have been destroyed.")))
-        case Some(r) => r -> None
-      }
-    }
-  }
-
-  override def tableExists(schema: String, table: String): Boolean = {
-    if (ConnectorExternalCatalog.cachedCatalogTables.getIfPresent(schema -> table) ne null) true
-    else {
-      val request = new CatalogMetadataRequest()
-      request.setSchemaName(schema).setNameOrPattern(table)
-      withExceptionHandling(connectorHelper.getCatalogMetadata(
-        snappydataConstants.CATALOG_TABLE_EXISTS, request)).exists
-    }
-  }
-
-  override def listTables(schema: String): Seq[String] = listTables(schema, "*")
-
-  override def listTables(schema: String, pattern: String): Seq[String] = {
-    val request = new CatalogMetadataRequest()
-    request.setSchemaName(schema).setNameOrPattern(pattern)
-    withExceptionHandling(connectorHelper.getCatalogMetadata(
-      snappydataConstants.CATALOG_LIST_TABLES, request)).getNames.asScala
-  }
-
-  private def flag(b: Boolean): java.lang.Integer = if (b) 1 else 0
-
-  override def loadTable(schema: String, table: String, loadPath: String,
-      isOverwrite: Boolean, holdDDLTime: Boolean): Unit = {
-    val request = new CatalogMetadataDetails()
-    request.setNames((schema :: table :: loadPath :: Nil).asJava)
-        .setOtherFlags((flag(isOverwrite) :: flag(holdDDLTime) :: Nil).asJava)
-    withExceptionHandling(connectorHelper.updateCatalogMetadata(
-      snappydataConstants.CATALOG_LOAD_TABLE, request))
-
-    invalidateCaches(schema -> table :: Nil)
-  }
-
-  // --------------------------------------------------------------------------
-  // Partitions
-  // --------------------------------------------------------------------------
-
-  override def createPartitions(schema: String, table: String, parts: Seq[CatalogTablePartition],
-      ignoreIfExists: Boolean): Unit = {
-    val request = new CatalogMetadataDetails()
-    request.setNames((schema :: table :: Nil).asJava).setCatalogPartitions(parts.map(
-      ConnectorExternalCatalog.convertFromCatalogPartition).asJava).setExists(ignoreIfExists)
-    withExceptionHandling(connectorHelper.updateCatalogMetadata(
-      snappydataConstants.CATALOG_CREATE_PARTITIONS, request))
-
-    invalidateCaches(schema -> table :: Nil)
-  }
-
-  override def dropPartitions(schema: String, table: String, parts: Seq[TablePartitionSpec],
-      ignoreIfNotExists: Boolean, purge: Boolean, retainData: Boolean): Unit = {
-    val request = new CatalogMetadataDetails()
-    request.setNames((schema :: table :: Nil).asJava).setProperties(parts.map(_.asJava).asJava)
-        .setExists(ignoreIfNotExists)
-        .setOtherFlags((flag(purge) :: flag(retainData) :: Nil).asJava)
-    withExceptionHandling(connectorHelper.updateCatalogMetadata(
-      snappydataConstants.CATALOG_DROP_PARTITIONS, request))
-
-    invalidateCaches(schema -> table :: Nil)
-  }
-
-  override def alterPartitions(schema: String, table: String,
-      parts: Seq[CatalogTablePartition]): Unit = {
-    val request = new CatalogMetadataDetails()
-    request.setNames((schema :: table :: Nil).asJava).setCatalogPartitions(parts.map(
-      ConnectorExternalCatalog.convertFromCatalogPartition).asJava)
-    withExceptionHandling(connectorHelper.updateCatalogMetadata(
-      snappydataConstants.CATALOG_ALTER_PARTITIONS, request))
-
-    invalidateCaches(schema -> table :: Nil)
-  }
-
-  override def renamePartitions(schema: String, table: String, specs: Seq[TablePartitionSpec],
-      newSpecs: Seq[TablePartitionSpec]): Unit = {
-    val request = new CatalogMetadataDetails()
-    request.setNames((schema :: table :: Nil).asJava).setProperties(specs.map(_.asJava).asJava)
-        .setNewProperties(newSpecs.map(_.asJava).asJava)
-    withExceptionHandling(connectorHelper.updateCatalogMetadata(
-      snappydataConstants.CATALOG_RENAME_PARTITIONS, request))
-
-    invalidateCaches(schema -> table :: Nil)
-  }
-
-  override def loadPartition(schema: String, table: String, loadPath: String,
-      partition: TablePartitionSpec, isOverwrite: Boolean, holdDDLTime: Boolean,
-      inheritTableSpecs: Boolean): Unit = {
-    val request = new CatalogMetadataDetails()
-    request.setNames((schema :: table :: loadPath :: Nil).asJava)
-        .setProperties(Collections.singletonList(partition.asJava)).setOtherFlags(
-      (flag(isOverwrite) :: flag(holdDDLTime) :: flag(inheritTableSpecs) :: Nil).asJava)
-    withExceptionHandling(connectorHelper.updateCatalogMetadata(
-      snappydataConstants.CATALOG_LOAD_PARTITION, request))
-
-    invalidateCaches(schema -> table :: Nil)
-  }
-
-  override def loadDynamicPartitions(schema: String, table: String, loadPath: String,
-      partition: TablePartitionSpec, replace: Boolean, numDP: Int, holdDDLTime: Boolean): Unit = {
-    val request = new CatalogMetadataDetails()
-    request.setNames((schema :: table :: loadPath :: Nil).asJava)
-        .setProperties(Collections.singletonList(partition.asJava)).setOtherFlags(
-      (flag(replace) :: Int.box(numDP) :: flag(holdDDLTime) :: Nil).asJava)
-    withExceptionHandling(connectorHelper.updateCatalogMetadata(
-      snappydataConstants.CATALOG_LOAD_DYNAMIC_PARTITIONS, request))
-
-    invalidateCaches(schema -> table :: Nil)
-  }
-
-  override def getPartition(schema: String, table: String,
-      spec: TablePartitionSpec): CatalogTablePartition = {
-    getPartitionOption(schema, table, spec) match {
-      case Some(p) => p
-      case None => throw new NoSuchPartitionException(schema, table, spec)
-    }
-  }
-
-  override def getPartitionOption(schema: String, table: String,
-      spec: TablePartitionSpec): Option[CatalogTablePartition] = {
-    val request = new CatalogMetadataRequest()
-    request.setSchemaName(schema).setNameOrPattern(table).setProperties(spec.asJava)
-    val result = withExceptionHandling(connectorHelper.getCatalogMetadata(
-      snappydataConstants.CATALOG_GET_PARTITION, request))
-    if (result.getCatalogPartitionsSize == 1) {
-      Some(ConnectorExternalCatalog.convertToCatalogPartition(result.getCatalogPartitions.get(0)))
-    } else None
-  }
-
-  override def listPartitionNames(schema: String, table: String,
-      partialSpec: Option[TablePartitionSpec]): Seq[String] = {
-    val request = new CatalogMetadataRequest()
-    request.setSchemaName(schema).setNameOrPattern(table)
-    if (partialSpec.isDefined) request.setProperties(partialSpec.get.asJava)
-    val result = withExceptionHandling(connectorHelper.getCatalogMetadata(
-      snappydataConstants.CATALOG_LIST_PARTITION_NAMES, request))
-    result.getNames.asScala
-  }
-
-  override def listPartitions(schema: String, table: String,
-      partialSpec: Option[TablePartitionSpec]): Seq[CatalogTablePartition] = {
-    val request = new CatalogMetadataRequest()
-    request.setSchemaName(schema).setNameOrPattern(table)
-    if (partialSpec.isDefined) request.setProperties(partialSpec.get.asJava)
-    val result = withExceptionHandling(connectorHelper.getCatalogMetadata(
-      snappydataConstants.CATALOG_LIST_PARTITIONS, request))
-    if (result.getCatalogPartitionsSize > 0) {
-      result.getCatalogPartitions.asScala.map(ConnectorExternalCatalog.convertToCatalogPartition)
-    } else Nil
-  }
-
-  override def listPartitionsByFilter(schema: String, table: String,
-      predicates: Seq[Expression]): Seq[CatalogTablePartition] = {
-    // taken from HiveExternalCatalog.listPartitionsByFilter
-    val catalogTable = getTable(schema, table)
-    val partitionColumnNames = catalogTable.partitionColumnNames.toSet
-    val nonPartitionPruningPredicates = predicates.filterNot {
-      _.references.map(_.name).toSet.subsetOf(partitionColumnNames)
-    }
-    if (nonPartitionPruningPredicates.nonEmpty) {
-      throw new IllegalArgumentException("Expected only partition pruning predicates: " +
-          predicates.reduceLeft(And))
-    }
-
-    val partitionSchema = catalogTable.partitionSchema
-    val partitions = listPartitions(schema, table, None)
-    if (predicates.nonEmpty) {
-      val boundPredicate = predicates.reduce(And).transform {
-        case attr: AttributeReference =>
-          val index = partitionSchema.indexWhere(_.name == attr.name)
-          BoundReference(index, partitionSchema(index).dataType, nullable = true)
-      }
-      partitions.filter(p => boundPredicate.eval(p.toRow(partitionSchema)).asInstanceOf[Boolean])
-    } else partitions
-  }
-
-  override def createFunction(schema: String, function: CatalogFunction): Unit = {
-    val request = new CatalogMetadataDetails()
-    request.setCatalogFunction(ConnectorExternalCatalog.convertFromCatalogFunction(function))
-        .setNames(Collections.singletonList(schema))
-    withExceptionHandling(connectorHelper.updateCatalogMetadata(
-      snappydataConstants.CATALOG_CREATE_FUNCTION, request))
-  }
-
-  override def dropFunction(schema: String, funcName: String): Unit = {
-    val request = new CatalogMetadataDetails().setNames((schema :: funcName :: Nil).asJava)
-    withExceptionHandling(connectorHelper.updateCatalogMetadata(
-      snappydataConstants.CATALOG_DROP_FUNCTION, request))
-  }
-
-  override def renameFunction(schema: String, oldName: String, newName: String): Unit = {
-    val request = new CatalogMetadataDetails()
-        .setNames((schema :: oldName :: newName :: Nil).asJava)
-    withExceptionHandling(connectorHelper.updateCatalogMetadata(
-      snappydataConstants.CATALOG_RENAME_FUNCTION, request))
-  }
-
-  override def getFunction(schema: String, funcName: String): CatalogFunction = {
-    val request = new CatalogMetadataRequest()
-    request.setSchemaName(schema).setNameOrPattern(funcName)
-    val result = withExceptionHandling(connectorHelper.getCatalogMetadata(
-      snappydataConstants.CATALOG_GET_FUNCTION, request))
-    if (result.isSetCatalogFunction) {
-      ConnectorExternalCatalog.convertToCatalogFunction(result.getCatalogFunction)
-    } else throw new NoSuchPermanentFunctionException(schema, funcName)
-  }
-
-  override def functionExists(schema: String, funcName: String): Boolean = {
-    val request = new CatalogMetadataRequest()
-    request.setSchemaName(schema).setNameOrPattern(funcName)
-    withExceptionHandling(connectorHelper.getCatalogMetadata(
-      snappydataConstants.CATALOG_FUNCTION_EXISTS, request)).exists
-  }
-
-  override def listFunctions(schema: String, pattern: String): Seq[String] = {
-    val request = new CatalogMetadataRequest()
-    request.setSchemaName(schema).setNameOrPattern(pattern)
-    withExceptionHandling(connectorHelper.getCatalogMetadata(
-      snappydataConstants.CATALOG_LIST_FUNCTIONS, request)).getNames.asScala
-  }
-
-  override def close(): Unit = connectorHelper.close()
+  def close(): Unit = connectorHelper.close()
 }
 
 object ConnectorExternalCatalog extends Logging {
 
+  def cacheSize: Int = {
+    SparkEnv.get match {
+      case null => Property.CatalogCacheSize.defaultValue.get
+      case env => Property.CatalogCacheSize.get(env.conf)
+    }
+  }
+
   /** A cache of Spark SQL data source tables that have been accessed. */
-  private lazy val cachedCatalogTables: Cache[(String, String),
+  private[catalog] lazy val cachedCatalogTables: Cache[(String, String),
       (CatalogTable, Option[RelationInfo])] = {
-    CacheBuilder.newBuilder().maximumSize(SnappyExternalCatalog.cacheSize).build()
+    CacheBuilder.newBuilder().maximumSize(cacheSize).build()
   }
 
   private def toArray(columns: java.util.List[String]): Array[String] =
@@ -483,7 +108,7 @@ object ConnectorExternalCatalog extends Logging {
   }
 
   private[snappydata] def convertToCatalogTable(request: CatalogMetadataDetails,
-      session: SnappySession): (CatalogTable, Option[RelationInfo]) = {
+      session: SparkSession): (CatalogTable, Option[RelationInfo]) = {
     val tableObj = request.getCatalogTable
     val identifier = TableIdentifier(tableObj.getTableName, Option(tableObj.getSchemaName))
     val tableType = tableObj.getTableType match {
@@ -548,15 +173,15 @@ object ConnectorExternalCatalog extends Logging {
       val indexCols = toArray(tableObj.getIndexColumns)
       val pkCols = toArray(tableObj.getPrimaryKeyColumns)
       if (bucketCount > 0) {
-        val allNetUrls = SmartConnectorRDDHelper.setBucketToServerMappingInfo(
+        val allNetUrls = SmartConnectorHelper.setBucketToServerMappingInfo(
           bucketCount, bucketOwners, session)
-        val partitions = SmartConnectorRDDHelper.getPartitions(allNetUrls)
+        val partitions = SmartConnectorHelper.getPartitions(allNetUrls)
         table -> Some(RelationInfo(bucketCount, isPartitioned = true, partitionCols,
           indexCols, pkCols, partitions, catalogSchemaVersion))
       } else {
-        val allNetUrls = SmartConnectorRDDHelper.setReplicasToServerMappingInfo(
+        val allNetUrls = SmartConnectorHelper.setReplicasToServerMappingInfo(
           tableObj.getBucketOwners.get(0).getSecondaries, session)
-        val partitions = SmartConnectorRDDHelper.getPartitions(allNetUrls)
+        val partitions = SmartConnectorHelper.getPartitions(allNetUrls)
         table -> Some(RelationInfo(1, isPartitioned = false, EMPTY_STRING_ARRAY, indexCols,
           pkCols, partitions, catalogSchemaVersion))
       }

--- a/core/src/main/scala/io/snappydata/sql/catalog/ConnectorExternalCatalog.scala
+++ b/core/src/main/scala/io/snappydata/sql/catalog/ConnectorExternalCatalog.scala
@@ -80,7 +80,7 @@ trait ConnectorExternalCatalog {
     ConnectorExternalCatalog.cachedCatalogTables.invalidateAll()
   }
 
-  def close(): Unit = connectorHelper.close()
+  def close(): Unit = synchronized(connectorHelper.close())
 }
 
 object ConnectorExternalCatalog extends Logging {

--- a/core/src/main/scala/io/snappydata/sql/catalog/SmartConnectorHelper.scala
+++ b/core/src/main/scala/io/snappydata/sql/catalog/SmartConnectorHelper.scala
@@ -47,8 +47,6 @@ class SmartConnectorHelper(session: SparkSession, jdbcUrl: String) extends Loggi
     JdbcUtils.createConnectionFactory(jdbcOptions)()
   }
 
-  private val getJarsStmtString = "call sys.GET_DEPLOYED_JARS(?)"
-
   private lazy val getCatalogMetaDataStmt: CallableStatement =
     conn.prepareCall("call sys.GET_CATALOG_METADATA(?, ?, ?)")
 
@@ -56,7 +54,7 @@ class SmartConnectorHelper(session: SparkSession, jdbcUrl: String) extends Loggi
     conn.prepareCall("call sys.UPDATE_CATALOG_METADATA(?, ?)")
 
   {
-    val stmt = conn.prepareCall(getJarsStmtString)
+    val stmt = conn.prepareCall("call sys.GET_DEPLOYED_JARS(?)")
     val sc = session.sparkContext
     if ((sc ne null) && System.getProperty("pull-deployed-jars", "true").toBoolean) {
       try {

--- a/core/src/main/scala/io/snappydata/sql/catalog/SmartConnectorHelper.scala
+++ b/core/src/main/scala/io/snappydata/sql/catalog/SmartConnectorHelper.scala
@@ -19,26 +19,30 @@ package io.snappydata.sql.catalog
 import java.net.URL
 import java.nio.file.{Files, Paths}
 import java.sql.{CallableStatement, Connection, SQLException}
+import java.util.Collections
 
+import scala.collection.JavaConverters._
 import scala.collection.mutable
+import scala.collection.mutable.ArrayBuffer
 
 import com.pivotal.gemfirexd.Attribute
 import com.pivotal.gemfirexd.internal.engine.distributed.utils.GemFireXDUtils
 import com.pivotal.gemfirexd.internal.iapi.types.HarmonySerialBlob
-import io.snappydata.Constant
-import io.snappydata.thrift.{CatalogMetadataDetails, CatalogMetadataRequest}
+import com.pivotal.gemfirexd.jdbc.ClientAttribute
+import io.snappydata.thrift.{BucketOwners, CatalogMetadataDetails, CatalogMetadataRequest}
+import io.snappydata.{Constant, Property}
+import org.eclipse.collections.impl.map.mutable.UnifiedMap
 
-import org.apache.spark.sql.collection.Utils
-import org.apache.spark.sql.execution.datasources.jdbc.{JDBCOptions, JdbcUtils}
-import org.apache.spark.sql.{SnappyContext, SnappySession, ThinClientConnectorMode}
-import org.apache.spark.{Logging, SparkContext}
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.collection.{SmartExecutorBucketPartition, Utils}
+import org.apache.spark.sql.execution.datasources.jdbc.{DriverRegistry, JDBCOptions, JdbcUtils}
+import org.apache.spark.sql.store.StoreUtils
+import org.apache.spark.{Logging, Partition, SparkContext}
 
-class SmartConnectorHelper(snappySession: SnappySession) extends Logging {
+class SmartConnectorHelper(session: SparkSession, jdbcUrl: String) extends Logging {
 
   private val conn: Connection = {
-    val url = SnappyContext.getClusterMode(snappySession.sparkContext)
-        .asInstanceOf[ThinClientConnectorMode].url
-    val jdbcOptions = new JDBCOptions(url + getSecurePart + ";route-query=false;", "",
+    val jdbcOptions = new JDBCOptions(jdbcUrl + getSecurePart + ";route-query=false;", "",
       Map("driver" -> Constant.JDBC_CLIENT_DRIVER))
     JdbcUtils.createConnectionFactory(jdbcOptions)()
   }
@@ -53,26 +57,26 @@ class SmartConnectorHelper(snappySession: SnappySession) extends Logging {
 
   {
     val stmt = conn.prepareCall(getJarsStmtString)
-    val sc = snappySession.sparkContext
+    val sc = session.sparkContext
     if ((sc ne null) && System.getProperty("pull-deployed-jars", "true").toBoolean) {
       try {
         executeGetJarsStmt(sc, stmt)
       } catch {
         case sqle: SQLException => logWarning(s"could not get jar and" +
-            s" package information from snappy cluster", sqle)
+            s" package information from SnappyData cluster", sqle)
       }
     }
   }
 
   private def getSecurePart: String = {
     var securePart = ""
-    val user = snappySession.conf.get(Constant.SPARK_STORE_PREFIX + Attribute
+    val user = session.conf.get(Constant.SPARK_STORE_PREFIX + Attribute
         .USERNAME_ATTR, "")
     if (!user.isEmpty) {
-      val pass = snappySession.conf.get(Constant.SPARK_STORE_PREFIX + Attribute
+      val pass = session.conf.get(Constant.SPARK_STORE_PREFIX + Attribute
           .PASSWORD_ATTR, "")
       securePart = s";user=$user;password=$pass"
-      logInfo(s"Using $user credentials to securely connect to snappydata cluster")
+      logInfo(s"Using $user credentials to securely connect to SnappyData cluster")
     }
     securePart
   }
@@ -141,6 +145,184 @@ class SmartConnectorHelper(snappySession: SnappySession) extends Logging {
       conn.close()
     } catch {
       case _: SQLException => // ignore
+    }
+  }
+}
+
+object SmartConnectorHelper {
+
+  DriverRegistry.register(Constant.JDBC_CLIENT_DRIVER)
+
+  val snapshotTxIdForRead: ThreadLocal[(String, (String, String))] =
+    new ThreadLocal[(String, (String, String))]
+  val snapshotTxIdForWrite: ThreadLocal[String] = new ThreadLocal[String]
+
+  private[this] val urlPrefix: String = Constant.DEFAULT_THIN_CLIENT_URL
+  // no query routing or load-balancing
+  private[this] val urlSuffix: String = "/" + ClientAttribute.ROUTE_QUERY + "=false;" +
+      ClientAttribute.LOAD_BALANCE + "=false"
+
+  /**
+   * Get pair of TXId and (host, network server URL) pair.
+   */
+  def getTxIdAndHostUrl(txIdAndHost: String, preferHost: Boolean): (String, (String, String)) = {
+    val index = txIdAndHost.indexOf('@')
+    if (index < 0) {
+      throw new AssertionError(s"Unexpected TXId@HostURL string = $txIdAndHost")
+    }
+    val server = txIdAndHost.substring(index + 1)
+    val hostUrl = getNetUrl(server, preferHost, urlPrefix, urlSuffix, availableNetUrls = null)
+    txIdAndHost.substring(0, index) -> hostUrl
+  }
+
+  def getPartitions(bucketToServerList: Array[ArrayBuffer[(String, String)]]): Array[Partition] = {
+    val numPartitions = bucketToServerList.length
+    val partitions = new Array[Partition](numPartitions)
+    // choose only one server from the list so that partition routing and connection
+    // creation are attempted on the same server if possible (i.e. should not happen
+    // that routing selected some server but connection create used some other from the list)
+    val numServers = bucketToServerList(0).length
+    val chosenServerIndex = if (numServers > 1) scala.util.Random.nextInt(numServers) else 0
+    for (p <- 0 until numPartitions) {
+      if (StoreUtils.TEST_RANDOM_BUCKETID_ASSIGNMENT) {
+        partitions(p) = new SmartExecutorBucketPartition(p, p,
+          bucketToServerList(scala.util.Random.nextInt(numPartitions)))
+      } else {
+        val servers = bucketToServerList(p)
+        partitions(p) = new SmartExecutorBucketPartition(p, p,
+          if (servers.isEmpty) Nil
+          else if (servers.length >= numServers) servers(chosenServerIndex) :: Nil
+          else servers(0) :: Nil)
+      }
+    }
+    partitions
+  }
+
+  def preferHostName(session: SparkSession): Boolean = {
+    // check if Spark executors are using IP addresses or host names
+    Utils.executorsListener(session.sparkContext) match {
+      case Some(l) =>
+        val preferHost = l.activeStorageStatusList.collectFirst {
+          case status if status.blockManagerId.executorId != "driver" =>
+            val host = status.blockManagerId.host
+            host.indexOf('.') == -1 && host.indexOf("::") == -1
+        }
+        preferHost.isDefined && preferHost.get
+      case _ => false
+    }
+  }
+
+  private def getNetUrl(server: String, preferHost: Boolean, urlPrefix: String,
+      urlSuffix: String, availableNetUrls: UnifiedMap[String, String]): (String, String) = {
+    val hostAddressPort = returnHostPortFromServerString(server)
+    val hostName = hostAddressPort._1
+    val host = if (preferHost) hostName else hostAddressPort._2
+    val netUrl = urlPrefix + hostName + "[" + hostAddressPort._3 + "]" + urlSuffix
+    if ((availableNetUrls ne null) && !availableNetUrls.containsKey(host)) {
+      availableNetUrls.put(host, netUrl)
+    }
+    host -> netUrl
+  }
+
+  def setBucketToServerMappingInfo(numBuckets: Int, buckets: java.util.List[BucketOwners],
+      session: SparkSession): Array[ArrayBuffer[(String, String)]] = {
+    if (!buckets.isEmpty) {
+      // check if Spark executors are using IP addresses or host names
+      val preferHost = preferHostName(session)
+      val preferPrimaries = session.conf.getOption(Property.PreferPrimariesInQuery.name) match {
+        case None => Property.PreferPrimariesInQuery.defaultValue.get
+        case Some(p) => p.toBoolean
+      }
+      var orphanBuckets: ArrayBuffer[Int] = null
+      val allNetUrls = new Array[ArrayBuffer[(String, String)]](numBuckets)
+      val availableNetUrls = new UnifiedMap[String, String](4)
+      for (bucket <- buckets.asScala) {
+        val bucketId = bucket.getBucketId
+        // use primary so that DMLs are routed optimally
+        val primary = bucket.getPrimary
+        if (primary ne null) {
+          // get (host,addr,port)
+          val secondaries = if (preferPrimaries) Collections.emptyList()
+          else bucket.getSecondaries
+          val netUrls = new ArrayBuffer[(String, String)](secondaries.size() + 1)
+          netUrls += getNetUrl(primary, preferHost, urlPrefix, urlSuffix, availableNetUrls)
+          if (secondaries.size() > 0) {
+            for (secondary <- secondaries.asScala) {
+              netUrls += getNetUrl(secondary, preferHost, urlPrefix, urlSuffix, availableNetUrls)
+            }
+          }
+          allNetUrls(bucketId) = netUrls
+        } else {
+          // Save the bucket which does not have a neturl,
+          // and later assign available ones to it.
+          if (orphanBuckets eq null) {
+            orphanBuckets = new ArrayBuffer[Int](2)
+          }
+          orphanBuckets += bucketId
+        }
+      }
+      if (orphanBuckets ne null) {
+        val netUrls = new ArrayBuffer[(String, String)](availableNetUrls.size())
+        val netUrlsIter = availableNetUrls.entrySet().iterator()
+        while (netUrlsIter.hasNext) {
+          val entry = netUrlsIter.next()
+          netUrls += entry.getKey -> entry.getValue
+        }
+        for (bucket <- orphanBuckets) {
+          allNetUrls(bucket) = netUrls
+        }
+      }
+      return allNetUrls
+    }
+    Array.empty
+  }
+
+  def setReplicasToServerMappingInfo(replicaNodes: java.util.List[String],
+      session: SparkSession): Array[ArrayBuffer[(String, String)]] = {
+    // check if Spark executors are using IP addresses or host names
+    val preferHost = preferHostName(session)
+    val urlPrefix = Constant.DEFAULT_THIN_CLIENT_URL
+    // no query routing or load-balancing
+    val urlSuffix = "/" + ClientAttribute.ROUTE_QUERY + "=false;" +
+        ClientAttribute.LOAD_BALANCE + "=false"
+    val netUrls = ArrayBuffer.empty[(String, String)]
+    for (host <- replicaNodes.asScala) {
+      val hostAddressPort = returnHostPortFromServerString(host)
+      val hostName = hostAddressPort._1
+      val h = if (preferHost) hostName else hostAddressPort._2
+      netUrls += h ->
+          (urlPrefix + hostName + "[" + hostAddressPort._3 + "]" + urlSuffix)
+    }
+    Array(netUrls)
+  }
+
+  /*
+  * The pattern to extract addresses from the result of
+  * GET_ALLSERVERS_AND_PREFSERVER2 procedure; format is:
+  *
+  * host1/addr1[port1]{kind1},host2/addr2[port2]{kind2},...
+  */
+  private lazy val addrPattern =
+    java.util.regex.Pattern.compile("([^,/]*)(/[^,\\[]+)?\\[([\\d]+)\\](\\{[^}]+\\})?")
+
+  private def returnHostPortFromServerString(serverStr: String): (String, String, String) = {
+    if (serverStr == null || serverStr.length == 0) {
+      return null
+    }
+    val matcher: java.util.regex.Matcher = addrPattern.matcher(serverStr)
+    val matchFound: Boolean = matcher.find
+    if (!matchFound) {
+      (null, null, null)
+    } else {
+      val host: String = matcher.group(1)
+      var address = matcher.group(2)
+      if ((address ne null) && address.length > 0) {
+        address = address.substring(1)
+      } else {
+        address = host
+      }
+      val portStr: String = matcher.group(3)
+      (host, address, portStr)
     }
   }
 }

--- a/core/src/main/scala/io/snappydata/sql/catalog/SnappyExternalCatalog.scala
+++ b/core/src/main/scala/io/snappydata/sql/catalog/SnappyExternalCatalog.scala
@@ -28,10 +28,9 @@ import com.pivotal.gemfirexd.Attribute
 import com.pivotal.gemfirexd.internal.engine.diag.SysVTIs
 import com.pivotal.gemfirexd.internal.iapi.sql.dictionary.SchemaDescriptor
 import com.pivotal.gemfirexd.internal.shared.common.reference.SQLState
+import io.snappydata.Constant
 import io.snappydata.sql.catalog.SnappyExternalCatalog._
-import io.snappydata.{Constant, Property}
 
-import org.apache.spark.SparkEnv
 import org.apache.spark.jdbc.{ConnectionConf, ConnectionUtil}
 import org.apache.spark.sql.catalyst.catalog.{CatalogDatabase, CatalogStorageFormat, CatalogTable, CatalogTableType, ExternalCatalog}
 import org.apache.spark.sql.catalyst.util.CaseInsensitiveMap
@@ -230,10 +229,10 @@ trait SnappyExternalCatalog extends ExternalCatalog {
       case None =>
         val params = new CaseInsensitiveMap(tableDefinition.storage.properties)
         params.get(BASETABLE_PROPERTY) match {
-        // older released didn't have base table entry for indexes
-        case None => params.get(INDEXED_TABLE).map(Utils.toUpperCase)
-        case Some(t) => Some(Utils.toUpperCase(t))
-      }
+          // older released didn't have base table entry for indexes
+          case None => params.get(INDEXED_TABLE).map(Utils.toUpperCase)
+          case Some(t) => Some(Utils.toUpperCase(t))
+        }
       case Some(t) => Some(Utils.toUpperCase(t))
     }
   }
@@ -289,13 +288,6 @@ object SnappyExternalCatalog {
   private[sql] val PASSWORD_MATCH = "(?i)(password|passwd).*".r
 
   val currentFunctionIdentifier = new ThreadLocal[FunctionIdentifier]
-
-  def cacheSize: Int = {
-    SparkEnv.get match {
-      case null => Property.CatalogCacheSize.defaultValue.get
-      case env => Property.CatalogCacheSize.get(env.conf)
-    }
-  }
 
   def getDependents(properties: Map[String, String]): Array[String] = {
     properties.get(DEPENDENT_RELATIONS) match {

--- a/core/src/main/scala/io/snappydata/sql/catalog/SnappyExternalCatalog.scala
+++ b/core/src/main/scala/io/snappydata/sql/catalog/SnappyExternalCatalog.scala
@@ -286,6 +286,7 @@ object SnappyExternalCatalog {
   val INDEXED_TABLE = "INDEXED_TABLE"
 
   val EMPTY_SCHEMA: StructType = StructType(Nil)
+  private[sql] val PASSWORD_MATCH = "(?i)(password|passwd).*".r
 
   val currentFunctionIdentifier = new ThreadLocal[FunctionIdentifier]
 

--- a/core/src/main/scala/io/snappydata/sql/catalog/impl/SmartConnectorExternalCatalog.scala
+++ b/core/src/main/scala/io/snappydata/sql/catalog/impl/SmartConnectorExternalCatalog.scala
@@ -1,0 +1,425 @@
+/*
+ * Copyright (c) 2018 SnappyData, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License. You
+ * may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License. See accompanying
+ * LICENSE file.
+ */
+package io.snappydata.sql.catalog.impl
+
+import java.util.Collections
+
+import scala.collection.JavaConverters._
+import scala.collection.mutable.ArrayBuffer
+
+import com.gemstone.gemfire.internal.cache.LocalRegion
+import io.snappydata.sql.catalog.{ConnectorExternalCatalog, RelationInfo, SnappyExternalCatalog}
+import io.snappydata.thrift.{CatalogMetadataDetails, CatalogMetadataRequest, CatalogSchemaObject, snappydataConstants}
+
+import org.apache.spark.sql.catalyst.analysis.{NoSuchPartitionException, NoSuchPermanentFunctionException}
+import org.apache.spark.sql.catalyst.catalog.CatalogTypes.TablePartitionSpec
+import org.apache.spark.sql.catalyst.catalog.{CatalogDatabase, CatalogFunction, CatalogTable, CatalogTablePartition}
+import org.apache.spark.sql.catalyst.expressions.{And, AttributeReference, BoundReference, Expression}
+import org.apache.spark.sql.collection.{SmartExecutorBucketPartition, Utils}
+import org.apache.spark.sql.execution.RefreshMetadata
+import org.apache.spark.sql.{SnappyContext, SparkSession, TableNotFoundException, ThinClientConnectorMode}
+
+/**
+ * An ExternalCatalog implementation for the smart connector mode.
+ *
+ * Note that unlike other ExternalCatalog implementations, this is created one for each session
+ * rather than being a singleton in the SharedState because each request needs to be authenticated
+ * independently using the credentials of the user that created the session. Consequently calls
+ * to "sharedState.externalCatalog()" will return null in smart connector mode and should never
+ * be used. For internal code paths in Spark that use it, an alternative dummy global might
+ * be added later that switches the user authentication using thread-locals or similar, but as
+ * of now it is used only by some hive insert paths which are not used in SnappySessionState.
+ */
+class SmartConnectorExternalCatalog(override val session: SparkSession)
+    extends SnappyExternalCatalog with ConnectorExternalCatalog {
+
+  override val jdbcUrl: String = SnappyContext.getClusterMode(session.sparkContext)
+      .asInstanceOf[ThinClientConnectorMode].url
+
+  override def invalidate(name: (String, String)): Unit = {
+    // invalidation of a single table can result in all cached RelationInfo being
+    // out of date due to lower schema version, so always invalidate all
+    invalidateAll()
+  }
+
+  override def invalidateCaches(relations: Seq[(String, String)]): Unit = {
+    // invalidation of a single table can result in all cached RelationInfo being
+    // out of date due to lower schema version, so always invalidate all
+    invalidateAll()
+    // there is no version update in this call here, rather only the caches are cleared
+    RefreshMetadata.executeLocal(RefreshMetadata.UPDATE_CATALOG_SCHEMA_VERSION, args = null)
+  }
+
+  // Using a common procedure to update catalog meta-data for create/drop/alter methods
+  // and likewise a common procedure to get catalog meta-data for get/exists/list methods
+
+  override def createDatabase(schemaDefinition: CatalogDatabase, ignoreIfExists: Boolean): Unit = {
+    val request = new CatalogMetadataDetails()
+    request.setCatalogSchema(new CatalogSchemaObject(schemaDefinition.name,
+      schemaDefinition.description, schemaDefinition.locationUri,
+      schemaDefinition.properties.asJava))
+    withExceptionHandling(connectorHelper.updateCatalogMetadata(
+      snappydataConstants.CATALOG_CREATE_SCHEMA, request))
+  }
+
+  override def dropDatabase(schema: String, ignoreIfNotExists: Boolean, cascade: Boolean): Unit = {
+    val request = new CatalogMetadataDetails()
+    request.setNames(Collections.singletonList(schema)).setExists(ignoreIfNotExists)
+        .setOtherFlags(Collections.singletonList(flag(cascade)))
+    withExceptionHandling(connectorHelper.updateCatalogMetadata(
+      snappydataConstants.CATALOG_DROP_SCHEMA, request))
+  }
+
+  override def getDatabase(schema: String): CatalogDatabase = {
+    if (schema == SnappyExternalCatalog.SYS_SCHEMA) return systemSchemaDefinition
+    val request = new CatalogMetadataRequest()
+    request.setSchemaName(schema)
+    val result = withExceptionHandling(connectorHelper.getCatalogMetadata(
+      snappydataConstants.CATALOG_GET_SCHEMA, request))
+    if (result.isSetCatalogSchema) {
+      val schemaObj = result.getCatalogSchema
+      CatalogDatabase(name = schemaObj.getName, description = schemaObj.getDescription,
+        locationUri = schemaObj.getLocationUri, properties = schemaObj.getProperties.asScala.toMap)
+    } else throw schemaNotFoundException(schema)
+  }
+
+  override def databaseExists(schema: String): Boolean = {
+    // this is invoked frequently so instead of messaging right away, check the common
+    // case if there exists a cached table in the schema
+    if (schema == SnappyExternalCatalog.SYS_SCHEMA) true
+    else {
+      val itr = ConnectorExternalCatalog.cachedCatalogTables.asMap().keySet().iterator()
+      while (itr.hasNext) {
+        val tableWithSchema = itr.next()
+        if (tableWithSchema._1 == schema) return true
+      }
+      val request = new CatalogMetadataRequest()
+      request.setSchemaName(schema)
+      withExceptionHandling(connectorHelper.getCatalogMetadata(
+        snappydataConstants.CATALOG_SCHEMA_EXISTS, request)).exists
+    }
+  }
+
+  override def listDatabases(): Seq[String] = listDatabases("*")
+
+  override def listDatabases(pattern: String): Seq[String] = {
+    val request = new CatalogMetadataRequest()
+    request.setNameOrPattern(pattern)
+    withExceptionHandling(connectorHelper.getCatalogMetadata(
+      snappydataConstants.CATALOG_LIST_SCHEMAS, request)).getNames.asScala
+  }
+
+  override def setCurrentDatabase(schema: String): Unit = {
+    connectorHelper.setCurrentSchema(schema)
+  }
+
+  override def createTable(table: CatalogTable, ignoreIfExists: Boolean): Unit = {
+    val request = new CatalogMetadataDetails()
+    request.setCatalogTable(ConnectorExternalCatalog.convertFromCatalogTable(table))
+        .setExists(ignoreIfExists)
+    withExceptionHandling(connectorHelper.updateCatalogMetadata(
+      snappydataConstants.CATALOG_CREATE_TABLE, request))
+
+    // version stored in RelationInfo will be out-of-date now for all tables so clear everything
+    invalidateCaches(Nil)
+  }
+
+  override def dropTable(schema: String, table: String, ignoreIfNotExists: Boolean,
+      purge: Boolean): Unit = {
+    val request = new CatalogMetadataDetails()
+    request.setNames((schema :: table :: Nil).asJava).setExists(ignoreIfNotExists)
+        .setOtherFlags(Collections.singletonList(flag(purge)))
+    withExceptionHandling(connectorHelper.updateCatalogMetadata(
+      snappydataConstants.CATALOG_DROP_TABLE, request))
+
+    // version stored in RelationInfo will be out-of-date now for all tables so clear everything
+    invalidateCaches(Nil)
+  }
+
+  override def alterTable(table: CatalogTable): Unit = {
+    val request = new CatalogMetadataDetails()
+    request.setCatalogTable(ConnectorExternalCatalog.convertFromCatalogTable(table))
+    withExceptionHandling(connectorHelper.updateCatalogMetadata(
+      snappydataConstants.CATALOG_ALTER_TABLE, request))
+
+    // version stored in RelationInfo will be out-of-date now for all tables so clear everything
+    invalidateCaches(Nil)
+  }
+
+  override def renameTable(schemaName: String, oldName: String, newName: String): Unit = {
+    val request = new CatalogMetadataDetails()
+    request.setNames((schemaName :: oldName :: newName :: Nil).asJava)
+    withExceptionHandling(connectorHelper.updateCatalogMetadata(
+      snappydataConstants.CATALOG_RENAME_TABLE, request))
+
+    // version stored in RelationInfo will be out-of-date now for all tables so clear everything
+    invalidateCaches(Nil)
+  }
+
+  override def createPolicy(schemaName: String, policyName: String, targetTable: String,
+      policyFor: String, policyApplyTo: Seq[String], expandedPolicyApplyTo: Seq[String],
+      owner: String, filterString: String): Unit = {
+    throw Utils.analysisException("CREATE POLICY for Row Level Security " +
+        "not supported for smart connector mode")
+  }
+
+  override protected def getCachedCatalogTable(schema: String, table: String): CatalogTable = {
+    ConnectorExternalCatalog.getCatalogTable(schema -> table, catalog = this)
+  }
+
+  override def getTableOption(schema: String, table: String): Option[CatalogTable] = {
+    try {
+      Some(getTable(schema, table))
+    } catch {
+      case _: TableNotFoundException => None
+    }
+  }
+
+  override def getRelationInfo(schema: String, table: String,
+      rowTable: Boolean): (RelationInfo, Option[LocalRegion]) = {
+    if (schema == SnappyExternalCatalog.SYS_SCHEMA) {
+      // SYS tables are treated as single partition replicated tables visible
+      // from all executors using the JDBC connection
+      RelationInfo(1, isPartitioned = false, partitions = Array(
+        new SmartExecutorBucketPartition(0, 0, ArrayBuffer.empty))) -> None
+    } else {
+      assert(schema.length > 0)
+      ConnectorExternalCatalog.getRelationInfo(schema -> table, catalog = this) match {
+        case None => throw new TableNotFoundException(schema, table, Some(new RuntimeException(
+          "RelationInfo for the table is missing. Its region may have been destroyed.")))
+        case Some(r) => r -> None
+      }
+    }
+  }
+
+  override def tableExists(schema: String, table: String): Boolean = {
+    if (ConnectorExternalCatalog.cachedCatalogTables.getIfPresent(schema -> table) ne null) true
+    else {
+      val request = new CatalogMetadataRequest()
+      request.setSchemaName(schema).setNameOrPattern(table)
+      withExceptionHandling(connectorHelper.getCatalogMetadata(
+        snappydataConstants.CATALOG_TABLE_EXISTS, request)).exists
+    }
+  }
+
+  override def listTables(schema: String): Seq[String] = listTables(schema, "*")
+
+  override def listTables(schema: String, pattern: String): Seq[String] = {
+    val request = new CatalogMetadataRequest()
+    request.setSchemaName(schema).setNameOrPattern(pattern)
+    withExceptionHandling(connectorHelper.getCatalogMetadata(
+      snappydataConstants.CATALOG_LIST_TABLES, request)).getNames.asScala
+  }
+
+  private def flag(b: Boolean): java.lang.Integer = if (b) 1 else 0
+
+  override def loadTable(schema: String, table: String, loadPath: String,
+      isOverwrite: Boolean, holdDDLTime: Boolean): Unit = {
+    val request = new CatalogMetadataDetails()
+    request.setNames((schema :: table :: loadPath :: Nil).asJava)
+        .setOtherFlags((flag(isOverwrite) :: flag(holdDDLTime) :: Nil).asJava)
+    withExceptionHandling(connectorHelper.updateCatalogMetadata(
+      snappydataConstants.CATALOG_LOAD_TABLE, request))
+
+    invalidateCaches(schema -> table :: Nil)
+  }
+
+  // --------------------------------------------------------------------------
+  // Partitions
+  // --------------------------------------------------------------------------
+
+  override def createPartitions(schema: String, table: String, parts: Seq[CatalogTablePartition],
+      ignoreIfExists: Boolean): Unit = {
+    val request = new CatalogMetadataDetails()
+    request.setNames((schema :: table :: Nil).asJava).setCatalogPartitions(parts.map(
+      ConnectorExternalCatalog.convertFromCatalogPartition).asJava).setExists(ignoreIfExists)
+    withExceptionHandling(connectorHelper.updateCatalogMetadata(
+      snappydataConstants.CATALOG_CREATE_PARTITIONS, request))
+
+    invalidateCaches(schema -> table :: Nil)
+  }
+
+  override def dropPartitions(schema: String, table: String, parts: Seq[TablePartitionSpec],
+      ignoreIfNotExists: Boolean, purge: Boolean, retainData: Boolean): Unit = {
+    val request = new CatalogMetadataDetails()
+    request.setNames((schema :: table :: Nil).asJava).setProperties(parts.map(_.asJava).asJava)
+        .setExists(ignoreIfNotExists)
+        .setOtherFlags((flag(purge) :: flag(retainData) :: Nil).asJava)
+    withExceptionHandling(connectorHelper.updateCatalogMetadata(
+      snappydataConstants.CATALOG_DROP_PARTITIONS, request))
+
+    invalidateCaches(schema -> table :: Nil)
+  }
+
+  override def alterPartitions(schema: String, table: String,
+      parts: Seq[CatalogTablePartition]): Unit = {
+    val request = new CatalogMetadataDetails()
+    request.setNames((schema :: table :: Nil).asJava).setCatalogPartitions(parts.map(
+      ConnectorExternalCatalog.convertFromCatalogPartition).asJava)
+    withExceptionHandling(connectorHelper.updateCatalogMetadata(
+      snappydataConstants.CATALOG_ALTER_PARTITIONS, request))
+
+    invalidateCaches(schema -> table :: Nil)
+  }
+
+  override def renamePartitions(schema: String, table: String, specs: Seq[TablePartitionSpec],
+      newSpecs: Seq[TablePartitionSpec]): Unit = {
+    val request = new CatalogMetadataDetails()
+    request.setNames((schema :: table :: Nil).asJava).setProperties(specs.map(_.asJava).asJava)
+        .setNewProperties(newSpecs.map(_.asJava).asJava)
+    withExceptionHandling(connectorHelper.updateCatalogMetadata(
+      snappydataConstants.CATALOG_RENAME_PARTITIONS, request))
+
+    invalidateCaches(schema -> table :: Nil)
+  }
+
+  override def loadPartition(schema: String, table: String, loadPath: String,
+      partition: TablePartitionSpec, isOverwrite: Boolean, holdDDLTime: Boolean,
+      inheritTableSpecs: Boolean): Unit = {
+    val request = new CatalogMetadataDetails()
+    request.setNames((schema :: table :: loadPath :: Nil).asJava)
+        .setProperties(Collections.singletonList(partition.asJava)).setOtherFlags(
+      (flag(isOverwrite) :: flag(holdDDLTime) :: flag(inheritTableSpecs) :: Nil).asJava)
+    withExceptionHandling(connectorHelper.updateCatalogMetadata(
+      snappydataConstants.CATALOG_LOAD_PARTITION, request))
+
+    invalidateCaches(schema -> table :: Nil)
+  }
+
+  override def loadDynamicPartitions(schema: String, table: String, loadPath: String,
+      partition: TablePartitionSpec, replace: Boolean, numDP: Int, holdDDLTime: Boolean): Unit = {
+    val request = new CatalogMetadataDetails()
+    request.setNames((schema :: table :: loadPath :: Nil).asJava)
+        .setProperties(Collections.singletonList(partition.asJava)).setOtherFlags(
+      (flag(replace) :: Int.box(numDP) :: flag(holdDDLTime) :: Nil).asJava)
+    withExceptionHandling(connectorHelper.updateCatalogMetadata(
+      snappydataConstants.CATALOG_LOAD_DYNAMIC_PARTITIONS, request))
+
+    invalidateCaches(schema -> table :: Nil)
+  }
+
+  override def getPartition(schema: String, table: String,
+      spec: TablePartitionSpec): CatalogTablePartition = {
+    getPartitionOption(schema, table, spec) match {
+      case Some(p) => p
+      case None => throw new NoSuchPartitionException(schema, table, spec)
+    }
+  }
+
+  override def getPartitionOption(schema: String, table: String,
+      spec: TablePartitionSpec): Option[CatalogTablePartition] = {
+    val request = new CatalogMetadataRequest()
+    request.setSchemaName(schema).setNameOrPattern(table).setProperties(spec.asJava)
+    val result = withExceptionHandling(connectorHelper.getCatalogMetadata(
+      snappydataConstants.CATALOG_GET_PARTITION, request))
+    if (result.getCatalogPartitionsSize == 1) {
+      Some(ConnectorExternalCatalog.convertToCatalogPartition(result.getCatalogPartitions.get(0)))
+    } else None
+  }
+
+  override def listPartitionNames(schema: String, table: String,
+      partialSpec: Option[TablePartitionSpec]): Seq[String] = {
+    val request = new CatalogMetadataRequest()
+    request.setSchemaName(schema).setNameOrPattern(table)
+    if (partialSpec.isDefined) request.setProperties(partialSpec.get.asJava)
+    val result = withExceptionHandling(connectorHelper.getCatalogMetadata(
+      snappydataConstants.CATALOG_LIST_PARTITION_NAMES, request))
+    result.getNames.asScala
+  }
+
+  override def listPartitions(schema: String, table: String,
+      partialSpec: Option[TablePartitionSpec]): Seq[CatalogTablePartition] = {
+    val request = new CatalogMetadataRequest()
+    request.setSchemaName(schema).setNameOrPattern(table)
+    if (partialSpec.isDefined) request.setProperties(partialSpec.get.asJava)
+    val result = withExceptionHandling(connectorHelper.getCatalogMetadata(
+      snappydataConstants.CATALOG_LIST_PARTITIONS, request))
+    if (result.getCatalogPartitionsSize > 0) {
+      result.getCatalogPartitions.asScala.map(ConnectorExternalCatalog.convertToCatalogPartition)
+    } else Nil
+  }
+
+  override def listPartitionsByFilter(schema: String, table: String,
+      predicates: Seq[Expression]): Seq[CatalogTablePartition] = {
+    // taken from HiveExternalCatalog.listPartitionsByFilter
+    val catalogTable = getTable(schema, table)
+    val partitionColumnNames = catalogTable.partitionColumnNames.toSet
+    val nonPartitionPruningPredicates = predicates.filterNot {
+      _.references.map(_.name).toSet.subsetOf(partitionColumnNames)
+    }
+    if (nonPartitionPruningPredicates.nonEmpty) {
+      throw new IllegalArgumentException("Expected only partition pruning predicates: " +
+          predicates.reduceLeft(And))
+    }
+
+    val partitionSchema = catalogTable.partitionSchema
+    val partitions = listPartitions(schema, table, None)
+    if (predicates.nonEmpty) {
+      val boundPredicate = predicates.reduce(And).transform {
+        case attr: AttributeReference =>
+          val index = partitionSchema.indexWhere(_.name == attr.name)
+          BoundReference(index, partitionSchema(index).dataType, nullable = true)
+      }
+      partitions.filter(p => boundPredicate.eval(p.toRow(partitionSchema)).asInstanceOf[Boolean])
+    } else partitions
+  }
+
+  override def createFunction(schema: String, function: CatalogFunction): Unit = {
+    val request = new CatalogMetadataDetails()
+    request.setCatalogFunction(ConnectorExternalCatalog.convertFromCatalogFunction(function))
+        .setNames(Collections.singletonList(schema))
+    withExceptionHandling(connectorHelper.updateCatalogMetadata(
+      snappydataConstants.CATALOG_CREATE_FUNCTION, request))
+  }
+
+  override def dropFunction(schema: String, funcName: String): Unit = {
+    val request = new CatalogMetadataDetails().setNames((schema :: funcName :: Nil).asJava)
+    withExceptionHandling(connectorHelper.updateCatalogMetadata(
+      snappydataConstants.CATALOG_DROP_FUNCTION, request))
+  }
+
+  override def renameFunction(schema: String, oldName: String, newName: String): Unit = {
+    val request = new CatalogMetadataDetails()
+        .setNames((schema :: oldName :: newName :: Nil).asJava)
+    withExceptionHandling(connectorHelper.updateCatalogMetadata(
+      snappydataConstants.CATALOG_RENAME_FUNCTION, request))
+  }
+
+  override def getFunction(schema: String, funcName: String): CatalogFunction = {
+    val request = new CatalogMetadataRequest()
+    request.setSchemaName(schema).setNameOrPattern(funcName)
+    val result = withExceptionHandling(connectorHelper.getCatalogMetadata(
+      snappydataConstants.CATALOG_GET_FUNCTION, request))
+    if (result.isSetCatalogFunction) {
+      ConnectorExternalCatalog.convertToCatalogFunction(result.getCatalogFunction)
+    } else throw new NoSuchPermanentFunctionException(schema, funcName)
+  }
+
+  override def functionExists(schema: String, funcName: String): Boolean = {
+    val request = new CatalogMetadataRequest()
+    request.setSchemaName(schema).setNameOrPattern(funcName)
+    withExceptionHandling(connectorHelper.getCatalogMetadata(
+      snappydataConstants.CATALOG_FUNCTION_EXISTS, request)).exists
+  }
+
+  override def listFunctions(schema: String, pattern: String): Seq[String] = {
+    val request = new CatalogMetadataRequest()
+    request.setSchemaName(schema).setNameOrPattern(pattern)
+    withExceptionHandling(connectorHelper.getCatalogMetadata(
+      snappydataConstants.CATALOG_LIST_FUNCTIONS, request)).getNames.asScala
+  }
+}

--- a/core/src/main/scala/io/snappydata/sql/catalog/impl/SmartConnectorExternalCatalog.scala
+++ b/core/src/main/scala/io/snappydata/sql/catalog/impl/SmartConnectorExternalCatalog.scala
@@ -47,7 +47,7 @@ import org.apache.spark.sql.{SnappyContext, SparkSession, TableNotFoundException
 class SmartConnectorExternalCatalog(override val session: SparkSession)
     extends SnappyExternalCatalog with ConnectorExternalCatalog {
 
-  override val jdbcUrl: String = SnappyContext.getClusterMode(session.sparkContext)
+  override def jdbcUrl: String = SnappyContext.getClusterMode(session.sparkContext)
       .asInstanceOf[ThinClientConnectorMode].url
 
   override def invalidate(name: (String, String)): Unit = {
@@ -123,7 +123,7 @@ class SmartConnectorExternalCatalog(override val session: SparkSession)
       snappydataConstants.CATALOG_LIST_SCHEMAS, request)).getNames.asScala
   }
 
-  override def setCurrentDatabase(schema: String): Unit = {
+  override def setCurrentDatabase(schema: String): Unit = synchronized {
     connectorHelper.setCurrentSchema(schema)
   }
 

--- a/core/src/main/scala/io/snappydata/sql/catalog/impl/StoreHiveCatalog.scala
+++ b/core/src/main/scala/io/snappydata/sql/catalog/impl/StoreHiveCatalog.scala
@@ -14,7 +14,7 @@
  * permissions and limitations under the License. See accompanying
  * LICENSE file.
  */
-package io.snappydata.sql.catalog
+package io.snappydata.sql.catalog.impl
 
 import java.sql.SQLException
 import java.util.Collections
@@ -36,6 +36,7 @@ import com.pivotal.gemfirexd.internal.impl.sql.catalog.GfxdDataDictionary
 import com.pivotal.gemfirexd.internal.shared.common.reference.SQLState
 import io.snappydata.Constant
 import io.snappydata.sql.catalog.SnappyExternalCatalog.checkSchemaPermission
+import io.snappydata.sql.catalog.{CatalogObjectType, ConnectorExternalCatalog, SnappyExternalCatalog}
 import io.snappydata.thrift._
 import org.apache.log4j.{Level, LogManager}
 

--- a/core/src/main/scala/org/apache/spark/sql/SnappySession.scala
+++ b/core/src/main/scala/org/apache/spark/sql/SnappySession.scala
@@ -1898,6 +1898,8 @@ object SnappySession extends Logging {
         var rdd = if (isCommand) qe.toRdd else null
         // don't post separate plan for CTAS since it already has posted one for the insert
         val postGUIPlans = if (isCommand) executedPlan.asInstanceOf[ExecutedCommandExec].cmd match {
+          case c: CreateTableUsingCommand if c.query.isDefined && CatalogObjectType
+              .isTableBackedByRegion(SnappyContext.getProviderType(c.provider)) => false
           case c: CreateDataSourceTableAsSelectCommand if CatalogObjectType.isTableBackedByRegion(
             CatalogObjectType.getTableType(c.table)) => false
           case _: SnappyCacheTableCommand => false

--- a/core/src/main/scala/org/apache/spark/sql/execution/ExistingPlans.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/ExistingPlans.scala
@@ -177,7 +177,7 @@ private[sql] object PartitionedPhysicalScan {
           columnScan.sqlContext.sessionState.analyzer.resolver(left.name, right.name)
 
         val rowBufferScan = RowTableScan(output, StructType.fromAttributes(
-          output), baseTableRDD, numBuckets, Nil, Nil, table, caseSensitive)
+          output), baseTableRDD, numBuckets, Nil, Nil, table.table, table, caseSensitive)
         val otherPartKeys = partitionColumns.map(_.transform {
           case a: AttributeReference => rowBufferScan.output.find(resolveCol(_, a)).getOrElse {
             throw new AnalysisException(s"RowBuffer output column $a not found in " +
@@ -205,7 +205,7 @@ private[sql] object PartitionedPhysicalScan {
         }
       case r: RowFormatRelation =>
         RowTableScan(output, StructType.fromAttributes(output), rdd, numBuckets,
-          partitionColumns, partitionColumnAliases, relation,
+          partitionColumns, partitionColumnAliases, relation.table, relation,
           r.sqlContext.conf.caseSensitiveAnalysis)
     }
 

--- a/core/src/main/scala/org/apache/spark/sql/execution/columnar/ColumnTableScan.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/columnar/ColumnTableScan.scala
@@ -83,6 +83,12 @@ private[sql] final case class ColumnTableScan(
 
   override val nodeName: String = "ColumnTableScan"
 
+  override def sameResult(plan: SparkPlan): Boolean = plan match {
+    case r: ColumnTableScan => r.baseRelation.table == baseRelation.table &&
+        r.numBuckets == numBuckets && r.schema == schema
+    case _ => false
+  }
+
   @transient private val MAX_SCHEMA_LENGTH = 40
 
   override lazy val outputOrdering: Seq[SortOrder] = {

--- a/core/src/main/scala/org/apache/spark/sql/execution/columnar/impl/StoreCallbacksImpl.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/columnar/impl/StoreCallbacksImpl.scala
@@ -133,7 +133,7 @@ object StoreCallbacksImpl extends StoreCallbacks with Logging with Serializable 
             schema = schema.add(Utils.WEIGHTAGE_COLUMN_NAME,
               LongType, nullable = false)
           }
-          val batchCreator = new ColumnBatchCreator(pr,
+          val batchCreator = new ColumnBatchCreator(pr, tableName,
             ColumnFormatRelation.columnBatchTableName(tableName), schema,
             catalogEntry.externalStore.asInstanceOf[ExternalStore],
             catalogEntry.compressionCodec)

--- a/core/src/main/scala/org/apache/spark/sql/execution/sources/StoreDataSourceStrategy.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/sources/StoreDataSourceStrategy.scala
@@ -44,7 +44,7 @@ import org.apache.spark.sql.catalyst.plans.physical.UnknownPartitioning
 import org.apache.spark.sql.catalyst.{CatalystTypeConverters, InternalRow, analysis, expressions}
 import org.apache.spark.sql.execution.datasources.LogicalRelation
 import org.apache.spark.sql.execution.{PartitionedDataSourceScan, RowDataSourceScanExec}
-import org.apache.spark.sql.sources.{Filter, IsNotNull, PrunedUnsafeFilteredScan}
+import org.apache.spark.sql.sources.{Filter, PrunedUnsafeFilteredScan}
 import org.apache.spark.sql.{AnalysisException, SnappySession, SparkSession, Strategy, execution, sources}
 
 /**
@@ -72,7 +72,7 @@ private[sql] object StoreDataSourceStrategy extends Strategy {
           0,
           Nil,
           (a, f) => t.buildUnsafeScan(a.map(_.name).toArray, f.toArray)) :: Nil
-      case LogicalRelation(_, _, _) => {
+      case LogicalRelation(_, _, _) =>
         var foundParamLiteral = false
         val tp = plan.transformAllExpressions {
           case pl: ParamLiteral =>
@@ -86,7 +86,6 @@ private[sql] object StoreDataSourceStrategy extends Strategy {
         } else {
           Nil
         }
-      }
       case _ => Nil
     }
     case _ => Nil

--- a/core/src/main/scala/org/apache/spark/sql/hive/SnappyHiveExternalCatalog.scala
+++ b/core/src/main/scala/org/apache/spark/sql/hive/SnappyHiveExternalCatalog.scala
@@ -34,7 +34,7 @@ import com.pivotal.gemfirexd.internal.engine.diag.SysVTIs
 import com.pivotal.gemfirexd.internal.engine.distributed.utils.GemFireXDUtils
 import com.pivotal.gemfirexd.internal.impl.sql.catalog.GfxdDataDictionary
 import io.snappydata.sql.catalog.SnappyExternalCatalog._
-import io.snappydata.sql.catalog.{CatalogObjectType, RelationInfo, SnappyExternalCatalog}
+import io.snappydata.sql.catalog.{CatalogObjectType, ConnectorExternalCatalog, RelationInfo, SnappyExternalCatalog}
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.hive.ql.metadata.Hive
 import org.apache.http.annotation.GuardedBy
@@ -104,12 +104,12 @@ class SnappyHiveExternalCatalog private[hive](val conf: SparkConf,
         }
       }
     }
-    CacheBuilder.newBuilder().maximumSize(cacheSize).build(cacheLoader)
+    CacheBuilder.newBuilder().maximumSize(ConnectorExternalCatalog.cacheSize).build(cacheLoader)
   }
 
   /** A cache of SQL data source tables that are missing in catalog. */
   protected val nonExistentTables: Cache[(String, String), java.lang.Boolean] = {
-    CacheBuilder.newBuilder().maximumSize(cacheSize).build()
+    CacheBuilder.newBuilder().maximumSize(ConnectorExternalCatalog.cacheSize).build()
   }
 
   private def isDisconnectException(t: Throwable): Boolean = {

--- a/core/src/main/scala/org/apache/spark/sql/internal/SnappySessionState.scala
+++ b/core/src/main/scala/org/apache/spark/sql/internal/SnappySessionState.scala
@@ -28,10 +28,9 @@ import com.pivotal.gemfirexd.internal.engine.Misc
 import com.pivotal.gemfirexd.internal.engine.store.GemFireStore
 import com.pivotal.gemfirexd.internal.impl.jdbc.Util
 import com.pivotal.gemfirexd.internal.shared.common.reference.SQLState
-import io.snappydata.Property
 import io.snappydata.Property.HashAggregateSize
-import io.snappydata.{Constant, Property}
 import io.snappydata.sql.catalog.{CatalogObjectType, SnappyExternalCatalog}
+import io.snappydata.{Constant, Property}
 
 import org.apache.spark.internal.config.{ConfigBuilder, ConfigEntry, TypedConfigBuilder}
 import org.apache.spark.sql._


### PR DESCRIPTION
Broadcast/exchange reuse was not happening for column/row tables because the scans
had RDD and BaseRelation objects in their case classes so the equality match against
similar scan but having different objects for those two failed.

## Changes proposed in this pull request

- added overrides for sameResult to both column and table scans that depends only on the table name
  and schema of the output projection
- added a unit test for checking reuse of exchange/broadcast in QueryTest
- corrected the code to avoid two execution display in SQL tab for CTAS (was missing
    the check against CreateTableUsingCommand)
- enhanced the data path in ExternalTableMetadata to include locationUri's for file based stores,
  URL for JDBC sources masking the password portion

## Patch testing

precheckin; TPC-DS run will be manually confirmed

## ReleaseNotes.txt changes

Add a note that dashboard "Source" now shows the password-masked JDBC URL for JDBC sources

## Other PRs 

https://github.com/SnappyDataInc/snappy-store/pull/453