### PR TITLE
initial changes to support Null Data Type for column tables . Not sur…

### DIFF
--- a/core/src/main/java/org/apache/hadoop/hive/metastore/HiveMetaStoreInit.java
+++ b/core/src/main/java/org/apache/hadoop/hive/metastore/HiveMetaStoreInit.java
@@ -1,0 +1,7 @@
+package org.apache.hadoop.hive.metastore;
+
+public class HiveMetaStoreInit {
+  public static void initNullType() {
+    MetaStoreUtils.hiveThriftTypeMap.add("null");
+  }
+}

--- a/core/src/main/java/org/apache/spark/sql/hive/SnappyHiveCatalogBase.java
+++ b/core/src/main/java/org/apache/spark/sql/hive/SnappyHiveCatalogBase.java
@@ -19,6 +19,7 @@ package org.apache.spark.sql.hive;
 import javax.annotation.concurrent.GuardedBy;
 
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hive.metastore.HiveMetaStoreInit;
 import org.apache.spark.SparkConf;
 import org.apache.spark.sql.hive.client.HiveClient;
 
@@ -37,6 +38,7 @@ public abstract class SnappyHiveCatalogBase extends HiveExternalCatalog {
     // initialize with super's hive client but allow this to be recreated
     // in case of transient disconnect exceptions
     this.hiveClient = super.client();
+    HiveMetaStoreInit.initNullType();
   }
 
   @Override

--- a/core/src/main/scala/org/apache/spark/sql/SnappyBaseParser.scala
+++ b/core/src/main/scala/org/apache/spark/sql/SnappyBaseParser.scala
@@ -218,7 +218,7 @@ abstract class SnappyBaseParser(session: SparkSession) extends Parser {
   final def TINYINT: Rule0 = newDataType(Consts.TINYINT)
   final def VARBINARY: Rule0 = newDataType(Consts.VARBINARY)
   final def VARCHAR: Rule0 = newDataType(Consts.VARCHAR)
-
+  def NULL: Rule0
   protected final def fixedDecimalType: Rule1[DataType] = rule {
     (DECIMAL | NUMERIC) ~ '(' ~ ws ~ digits ~ commaSep ~ digits ~ ')' ~ ws ~>
         ((precision: String, scale: String) =>
@@ -247,7 +247,9 @@ abstract class SnappyBaseParser(session: SparkSession) extends Parser {
     SMALLINT ~> (() => ShortType) |
     SHORT ~> (() => ShortType) |
     TINYINT ~> (() => ByteType) |
-    BYTE ~> (() => ByteType)
+    BYTE ~> (() => ByteType) |
+    NULL ~> (() => NullType)
+
   }
 
   protected final def charType: Rule1[DataType] = rule {


### PR DESCRIPTION
The view sql which previously contained null virtual columns ( mapping to spark's NullType, I suppose ) are no longer working in current master.
The change I have done today is a very quick fix type of thing . It may or may not be correct. I will spend some more time on it on monday or as soon as I get bandwidth. Pls modify or fix the code as per best approach. 
The BugTest is checked in.
(Fill in the changes here)

## Patch testing

(Fill in the details about how this patch was tested)

## ReleaseNotes.txt changes

(Does this change require an entry in ReleaseNotes.txt? If yes, has it been added to it?)

## Other PRs 
[spark pr](https://github.com/SnappyDataInc/spark/pull/133)
