### PR TITLE
SNAP-2807 - skipping putinto and deletefrom operations in the sink if not required

### DIFF
--- a/core/src/main/scala/org/apache/spark/sql/streaming/SnappySinkCallback.scala
+++ b/core/src/main/scala/org/apache/spark/sql/streaming/SnappySinkCallback.scala
@@ -21,9 +21,9 @@ import java.sql.SQLException
 import java.util.NoSuchElementException
 
 import io.snappydata.Property._
+import io.snappydata.StreamingConstants.EventType._
 import io.snappydata.StreamingConstants._
 import org.apache.log4j.Logger
-
 import org.apache.spark.sql.execution.streaming.Sink
 import org.apache.spark.sql.sources.{DataSourceRegister, StreamSinkProvider}
 import org.apache.spark.sql.streaming.DefaultSnappySinkCallback.{TEST_FAILBATCH_OPTION, log}
@@ -162,27 +162,11 @@ class DefaultSnappySinkCallback extends SnappySinkCallback {
         s", eventTypeColumnAvailable:$eventTypeColumnAvailable,possible duplicate: $posDup")
 
     if (keyColumns.nonEmpty) {
-      df.cache().count()
       val dataFrame: DataFrame = if (conflationEnabled) getConflatedDf else df
       if (eventTypeColumnAvailable) {
-        val deleteDf = dataFrame.filter(dataFrame(EVENT_TYPE_COLUMN) === EventType.DELETE)
-            .drop(EVENT_TYPE_COLUMN)
-        deleteDf.write.deleteFrom(tableName)
-        if (posDup) {
-          val upsertEventTypes = List(EventType.INSERT, EventType.UPDATE)
-          val upsertDf = dataFrame
-              .filter(dataFrame(EVENT_TYPE_COLUMN).isin(upsertEventTypes: _*))
-              .drop(EVENT_TYPE_COLUMN)
-          upsertDf.write.putInto(tableName)
-        } else {
-          val insertDf = dataFrame.filter(dataFrame(EVENT_TYPE_COLUMN) === EventType.INSERT)
-              .drop(EVENT_TYPE_COLUMN)
-          insertDf.write.insertInto(tableName)
-          val updateDf = dataFrame.filter(dataFrame(EVENT_TYPE_COLUMN) === EventType.UPDATE)
-              .drop(EVENT_TYPE_COLUMN)
-          updateDf.write.putInto(tableName)
-        }
+        processDataWithEventType(dataFrame)
       } else {
+        dataFrame.cache().count()  // this is done as a workaround for SNAP-2824
         dataFrame.write.putInto(tableName)
       }
     }
@@ -225,14 +209,41 @@ class DefaultSnappySinkCallback extends SnappySinkCallback {
         // if event type of the last event for a key is insert and there are more than one
         // events for the same key, then convert inserts to put into
         val columns = df.columns.filter(_ != EVENT_TYPE_COLUMN).map(col) ++
-            Seq(when(col(EVENT_TYPE_COLUMN) === EventType.INSERT && col(EVENT_COUNT_COLUMN) > 1,
-              EventType.UPDATE).otherwise(col(EVENT_TYPE_COLUMN)).alias(EVENT_TYPE_COLUMN))
+            Seq(when(col(EVENT_TYPE_COLUMN) === INSERT && col(EVENT_COUNT_COLUMN) > 1,
+              UPDATE).otherwise(col(EVENT_TYPE_COLUMN)).alias(EVENT_TYPE_COLUMN))
 
         df.groupBy(keyCols.head, keyCols.tail: _*)
             .agg(exprs.head, exprs.tail: _*)
             .select(columns: _*)
       }
       conflatedDf.cache()
+    }
+
+    def processDataWithEventType(dataFrame: DataFrame) = {
+      val hasUpdateOrDeleteEvents = dataFrame.cache()
+          .filter(dataFrame(EVENT_TYPE_COLUMN).isin(List(DELETE, UPDATE): _*))
+          .count() > 0
+      if (hasUpdateOrDeleteEvents) {
+        val deleteDf = dataFrame.filter(dataFrame(EVENT_TYPE_COLUMN) === DELETE)
+            .drop(EVENT_TYPE_COLUMN)
+        deleteDf.write.deleteFrom(tableName)
+      }
+      if (posDup) {
+        val upsertEventTypes = List(INSERT, UPDATE)
+        val upsertDf = dataFrame
+            .filter(dataFrame(EVENT_TYPE_COLUMN).isin(upsertEventTypes: _*))
+            .drop(EVENT_TYPE_COLUMN)
+        upsertDf.write.putInto(tableName)
+      } else {
+        val insertDf = dataFrame.filter(dataFrame(EVENT_TYPE_COLUMN) === INSERT)
+            .drop(EVENT_TYPE_COLUMN)
+        insertDf.write.insertInto(tableName)
+        if (hasUpdateOrDeleteEvents) {
+          val updateDf = dataFrame.filter(dataFrame(EVENT_TYPE_COLUMN) === UPDATE)
+              .drop(EVENT_TYPE_COLUMN)
+          updateDf.write.putInto(tableName)
+        }
+      }
     }
   }
 }

--- a/core/src/test/scala/org/apache/spark/sql/streaming/SnappyStoreSinkProviderSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/streaming/SnappyStoreSinkProviderSuite.scala
@@ -19,16 +19,15 @@ package org.apache.spark.sql.streaming
 
 import java.util.concurrent.atomic.AtomicInteger
 
-import scala.reflect.io.Path
-
 import io.snappydata.{SnappyFunSuite, StreamingConstants}
 import org.apache.log4j.LogManager
-import org.scalatest.{BeforeAndAfter, BeforeAndAfterAll}
-
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.catalyst.encoders.RowEncoder
 import org.apache.spark.sql.kafka010.KafkaTestUtils
-import org.apache.spark.sql.types.{IntegerType, LongType, StringType, StructField, StructType}
+import org.apache.spark.sql.types._
+import org.scalatest.{BeforeAndAfter, BeforeAndAfterAll}
+
+import scala.reflect.io.Path
 
 class SnappyStoreSinkProviderSuite extends SnappyFunSuite
     with BeforeAndAfter with BeforeAndAfterAll {


### PR DESCRIPTION


## Changes proposed in this pull request

skipping putinto and deletefrom operation in the sink if incoming batch doesn't contain any update or delete events

## Patch testing

- SnappyStoreSinkProviderSuite is passing
- manual testing

## ReleaseNotes.txt changes

(Does this change require an entry in ReleaseNotes.txt? If yes, has it been added to it?)

## Other PRs 

(Does this change require changes in other projects- store, spark, spark-jobserver, aqp? Add the links of PR of the other subprojects that are related to this change)
