### PR TITLE
Snap 2761- using off-heap storage for caching data inside snappy sink

### DIFF
--- a/core/src/main/scala/org/apache/spark/sql/streaming/SnappySinkCallback.scala
+++ b/core/src/main/scala/org/apache/spark/sql/streaming/SnappySinkCallback.scala
@@ -171,7 +171,7 @@ class DefaultSnappySinkCallback extends SnappySinkCallback {
       if (eventTypeColumnAvailable) {
         processDataWithEventType(dataFrame)
       } else {
-        dataFrame.persist(storageLevel).count()  // this is done as a workaround for SNAP-2824
+        persist(dataFrame).count()  // this is done as a workaround for SNAP-2824
         dataFrame.write.putInto(tableName)
       }
     }
@@ -224,12 +224,12 @@ class DefaultSnappySinkCallback extends SnappySinkCallback {
       conflatedDf.cache()
     }
 
-    lazy val storageLevel = if (ServiceUtils.isOffHeapStorageAvailable(snappySession)) {
-      StorageLevel.OFF_HEAP
-    } else StorageLevel.MEMORY_AND_DISK
+    def persist(df: DataFrame) = if (ServiceUtils.isOffHeapStorageAvailable(snappySession)){
+      df.persist(StorageLevel.OFF_HEAP)
+    } else df.persist()
 
     def processDataWithEventType(dataFrame: DataFrame) = {
-      val hasUpdateOrDeleteEvents = dataFrame.persist(storageLevel)
+      val hasUpdateOrDeleteEvents = persist(dataFrame)
           .filter(dataFrame(EVENT_TYPE_COLUMN).isin(List(DELETE, UPDATE): _*))
           .count() > 0
       if (hasUpdateOrDeleteEvents) {

--- a/core/src/main/scala/org/apache/spark/sql/streaming/SnappySinkCallback.scala
+++ b/core/src/main/scala/org/apache/spark/sql/streaming/SnappySinkCallback.scala
@@ -224,12 +224,9 @@ class DefaultSnappySinkCallback extends SnappySinkCallback {
       conflatedDf.cache()
     }
 
-    lazy val storageLevel = {
-      if (ServiceUtils.isOffHeapStorageAvailable(snappySession)) {
-        StorageLevel.OFF_HEAP
-      } else StorageLevel.MEMORY_AND_DISK
-    }
-
+    lazy val storageLevel = if (ServiceUtils.isOffHeapStorageAvailable(snappySession)) {
+      StorageLevel.OFF_HEAP
+    } else StorageLevel.MEMORY_AND_DISK
 
     def processDataWithEventType(dataFrame: DataFrame) = {
       val hasUpdateOrDeleteEvents = dataFrame.cache()

--- a/core/src/main/scala/org/apache/spark/sql/streaming/SnappySinkCallback.scala
+++ b/core/src/main/scala/org/apache/spark/sql/streaming/SnappySinkCallback.scala
@@ -229,7 +229,7 @@ class DefaultSnappySinkCallback extends SnappySinkCallback {
     } else StorageLevel.MEMORY_AND_DISK
 
     def processDataWithEventType(dataFrame: DataFrame) = {
-      val hasUpdateOrDeleteEvents = dataFrame.cache()
+      val hasUpdateOrDeleteEvents = dataFrame.persist(storageLevel)
           .filter(dataFrame(EVENT_TYPE_COLUMN).isin(List(DELETE, UPDATE): _*))
           .count() > 0
       if (hasUpdateOrDeleteEvents) {

--- a/core/src/main/scala/org/apache/spark/sql/streaming/SnappySinkCallback.scala
+++ b/core/src/main/scala/org/apache/spark/sql/streaming/SnappySinkCallback.scala
@@ -21,15 +21,20 @@ import java.sql.SQLException
 import java.util.NoSuchElementException
 
 import io.snappydata.Property._
-import io.snappydata.StreamingConstants.EventType._
 import io.snappydata.StreamingConstants._
+import io.snappydata.util.ServiceUtils
 import org.apache.log4j.Logger
+
 import org.apache.spark.sql.execution.streaming.Sink
 import org.apache.spark.sql.sources.{DataSourceRegister, StreamSinkProvider}
 import org.apache.spark.sql.streaming.DefaultSnappySinkCallback.{TEST_FAILBATCH_OPTION, log}
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.sql.{DataFrame, Dataset, Row, SnappySession, _}
+import org.apache.spark.storage.StorageLevel
 import org.apache.spark.util.Utils
+import io.snappydata.StreamingConstants.EventType._
+import io.snappydata.util.ServiceUtils
+import org.apache.spark.storage.StorageLevel
 
 /**
  * Should be implemented by clients who wants to override default behavior provided by
@@ -166,7 +171,7 @@ class DefaultSnappySinkCallback extends SnappySinkCallback {
       if (eventTypeColumnAvailable) {
         processDataWithEventType(dataFrame)
       } else {
-        dataFrame.cache().count()  // this is done as a workaround for SNAP-2824
+        dataFrame.persist(storageLevel).count()  // this is done as a workaround for SNAP-2824
         dataFrame.write.putInto(tableName)
       }
     }
@@ -218,6 +223,13 @@ class DefaultSnappySinkCallback extends SnappySinkCallback {
       }
       conflatedDf.cache()
     }
+
+    lazy val storageLevel = {
+      if (ServiceUtils.isOffHeapStorageAvailable(snappySession)) {
+        StorageLevel.OFF_HEAP
+      } else StorageLevel.MEMORY_AND_DISK
+    }
+
 
     def processDataWithEventType(dataFrame: DataFrame) = {
       val hasUpdateOrDeleteEvents = dataFrame.cache()


### PR DESCRIPTION
## Changes proposed in this pull request

using off-heap storage for caching data inside snappy sink

Changes for limiting cache size (by some configurable property) is tracked separately by https://jira.snappydata.io/browse/SNAP-2829

## Patch testing

- precheckin 
- manual testing