### PR TITLE
Branch 1.0.2.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -71,7 +71,7 @@ allprojects {
   apply plugin: 'nebula.ospackage-base'
 
   group = 'io.snappydata'
-  version = '1.0.2.1'
+  version = '1.0.2.2'
 
   // apply compiler options
   tasks.withType(JavaCompile) {

--- a/jdbc/build.gradle
+++ b/jdbc/build.gradle
@@ -91,7 +91,6 @@ shadowJar {
 
   // avoid conflict with the 0.9.2 version in stock Spark
   relocate 'org.apache.thrift', 'io.snappydata.org.apache.thrift'
-  // relocate 'org.apache.spark.unsafe', 'io.snappydata.org.apache.spark.unsafe'
 
   mergeServiceFiles()
   exclude 'log4j.properties'

--- a/jdbc/build.gradle
+++ b/jdbc/build.gradle
@@ -35,7 +35,6 @@ dependencies {
     exclude(group: 'org.slf4j', module: 'slf4j-api')
   }
 
-
   // always use stock spark so that snappy extensions don't get accidently
   // included here in snappy-jdbc code.
   if (System.properties.containsKey('ideaBuild') && new File(rootDir, 'spark/build.gradle').exists()) {
@@ -43,7 +42,6 @@ dependencies {
     compile project(':snappy-spark:snappy-spark-catalyst_' + scalaBinaryVersion)
     compile project(':snappy-spark:snappy-spark-sql_' + scalaBinaryVersion)
     compileOnly "org.eclipse.jetty:jetty-servlet:${jettyVersion}"
-
   } else {
     compileOnly("org.apache.spark:spark-core_${scalaBinaryVersion}:${sparkVersion}")
     compileOnly("org.apache.spark:spark-catalyst_${scalaBinaryVersion}:${sparkVersion}")
@@ -61,7 +59,6 @@ dependencies {
     }
   }
 }
-
 
 task packageScalaDocs(type: Jar, dependsOn: scaladoc) {
   classifier = 'javadoc'

--- a/jdbc/build.gradle
+++ b/jdbc/build.gradle
@@ -50,13 +50,9 @@ dependencies {
   }
 
   if (new File(rootDir, 'store/build.gradle').exists()) {
-    compile (project(':snappy-store:snappydata-store-client')) {
-      exclude(group: 'org.apache.spark', module: 'spark-unsafe_' + scalaBinaryVersion)
-    }
+	compile project(':snappy-store:snappydata-store-client')
   } else {
-    compile(group: 'io.snappydata', name: 'snappydata-store-client', version: snappyStoreVersion) {
-      exclude(group: 'org.apache.spark', module: 'spark-unsafe_' + scalaBinaryVersion)
-    }
+	compile group: 'io.snappydata', name: 'snappydata-store-client', version: snappyStoreVersion
   }
 }
 
@@ -88,6 +84,7 @@ shadowJar {
 
   // avoid conflict with the 0.9.2 version in stock Spark
   relocate 'org.apache.thrift', 'io.snappydata.org.apache.thrift'
+  relocate 'org.apache.spark.unsafe', 'io.snappydata.org.apache.spark.unsafe'
 
   mergeServiceFiles()
   exclude 'log4j.properties'

--- a/jdbc/build.gradle
+++ b/jdbc/build.gradle
@@ -35,6 +35,7 @@ dependencies {
     exclude(group: 'org.slf4j', module: 'slf4j-api')
   }
 
+
   // always use stock spark so that snappy extensions don't get accidently
   // included here in snappy-jdbc code.
   if (System.properties.containsKey('ideaBuild') && new File(rootDir, 'spark/build.gradle').exists()) {
@@ -42,6 +43,7 @@ dependencies {
     compile project(':snappy-spark:snappy-spark-catalyst_' + scalaBinaryVersion)
     compile project(':snappy-spark:snappy-spark-sql_' + scalaBinaryVersion)
     compileOnly "org.eclipse.jetty:jetty-servlet:${jettyVersion}"
+
   } else {
     compileOnly("org.apache.spark:spark-core_${scalaBinaryVersion}:${sparkVersion}")
     compileOnly("org.apache.spark:spark-catalyst_${scalaBinaryVersion}:${sparkVersion}")
@@ -50,11 +52,16 @@ dependencies {
   }
 
   if (new File(rootDir, 'store/build.gradle').exists()) {
-    compile project(':snappy-store:snappydata-store-client')
+    compile (project(':snappy-store:snappydata-store-client')) {
+      exclude(group: 'org.apache.spark', module: 'spark-unsafe_' + scalaBinaryVersion)
+    }
   } else {
-    compile group: 'io.snappydata', name: 'snappydata-store-client', version: snappyStoreVersion
+    compile(group: 'io.snappydata', name: 'snappydata-store-client', version: snappyStoreVersion) {
+      exclude(group: 'org.apache.spark', module: 'spark-unsafe_' + scalaBinaryVersion)
+    }
   }
 }
+
 
 task packageScalaDocs(type: Jar, dependsOn: scaladoc) {
   classifier = 'javadoc'
@@ -84,6 +91,7 @@ shadowJar {
 
   // avoid conflict with the 0.9.2 version in stock Spark
   relocate 'org.apache.thrift', 'io.snappydata.org.apache.thrift'
+  // relocate 'org.apache.spark.unsafe', 'io.snappydata.org.apache.spark.unsafe'
 
   mergeServiceFiles()
   exclude 'log4j.properties'


### PR DESCRIPTION
## Changes proposed in this pull request

Removed the spark classes from the snappy-jdbc.jar It was containing the spark classes of the org.apache.spark.unsafe package, snappy-jdbc.jar was causing an issue while using it in the spark 2.3.1 version.

## Patch testing

Yes

## ReleaseNotes.txt changes
No

## Other PRs 
No
