### PR TITLE
[SNAP-2869] handling conflation when _eventType column is not available in input

### DIFF
--- a/core/src/test/scala/org/apache/spark/sql/streaming/SnappyStoreSinkProviderSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/streaming/SnappyStoreSinkProviderSuite.scala
@@ -19,15 +19,16 @@ package org.apache.spark.sql.streaming
 
 import java.util.concurrent.atomic.AtomicInteger
 
+import scala.reflect.io.Path
+
 import io.snappydata.{SnappyFunSuite, StreamingConstants}
 import org.apache.log4j.LogManager
+import org.scalatest.{BeforeAndAfter, BeforeAndAfterAll}
 
-import org.apache.spark.sql.{AnalysisException, Row}
+import org.apache.spark.sql.Row
 import org.apache.spark.sql.catalyst.encoders.RowEncoder
 import org.apache.spark.sql.kafka010.KafkaTestUtils
 import org.apache.spark.sql.types._
-import org.scalatest.{BeforeAndAfter, BeforeAndAfterAll}
-import scala.reflect.io.Path
 
 class SnappyStoreSinkProviderSuite extends SnappyFunSuite
     with BeforeAndAfter with BeforeAndAfterAll {


### PR DESCRIPTION

## Changes proposed in this pull request
- skipping _eventType column handling from conflation logic when input dataframe doesn't contain _eventType column
- throwing AnalysisException when target table doesn't contain
key columns or primay key

## Patch testing

added tests in SnappyStoreSinkProviderSuite
