### PR TITLE
Fix to enforce unique alias names to packages - deploy package command

### DIFF
--- a/cluster/src/main/scala/io/snappydata/ToolsCallbackImpl.scala
+++ b/cluster/src/main/scala/io/snappydata/ToolsCallbackImpl.scala
@@ -20,6 +20,7 @@ import java.io.File
 import java.lang.reflect.InvocationTargetException
 import java.net.URLClassLoader
 
+import com.gemstone.gemfire.cache.EntryExistsException
 import com.pivotal.gemfirexd.internal.engine.Misc
 import com.pivotal.gemfirexd.internal.engine.distributed.utils.GemFireXDUtils
 import com.pivotal.gemfirexd.internal.iapi.error.StandardException
@@ -96,7 +97,12 @@ object ToolsCallbackImpl extends ToolsCallback with Logging {
   override def addURIs(alias: String, jars: Array[String],
       deploySql: String, isPackage: Boolean = true): Unit = {
     if (alias != null) {
-      Misc.getMemStore.getGlobalCmdRgn.put(alias, deploySql)
+      try {
+        Misc.getMemStore.getGlobalCmdRgn.create(alias, deploySql)
+      } catch {
+        case eee: EntryExistsException => throw StandardException.newException(
+          SQLState.LANG_DB2_DUPLICATE_NAMES, alias , "of deploying jars/packages")
+      }
     }
     val lead = ServiceManager.getLeadInstance.asInstanceOf[LeadImpl]
     val loader = lead.urlclassloader


### PR DESCRIPTION
Using "create" , which does not allow duplicates - solves unique alias name issue.

## Changes proposed in this pull request
* Use "create" instead of "put" 
* Catching EntryExistsException explicitly; otherwise it categorises it as severity 0 and closes the connection

## Patch testing

Ran precheckin

## ReleaseNotes.txt changes

(Does this change require an entry in ReleaseNotes.txt? If yes, has it been added to it?)

## Other PRs 

(Does this change require changes in other projects- store, spark, spark-jobserver, aqp? Add the links of PR of the other subprojects that are related to this change)
