### PR TITLE
A --config directory can be passed to the snappy-start-all script

### DIFF
--- a/cluster/sbin/snappy-leads.sh
+++ b/cluster/sbin/snappy-leads.sh
@@ -30,10 +30,18 @@ sbin="$(dirname "$(absPath "$0")")"
 . "$SNAPPY_HOME/bin/load-spark-env.sh"
 . "$SNAPPY_HOME/bin/load-snappy-env.sh"
 
+CONF_DIR_OPT=
+# Check if --config is passed as an argument. It is an optional parameter.
+if [ "$1" == "--config" ]
+then
+  CONF_DIR=$2
+  CONF_DIR_OPT="--config $CONF_DIR"
+  shift 2
+fi
 
 # Launch the slaves
 if echo $@ | grep -qw start; then
-  "$sbin/snappy-nodes.sh" lead cd "$SNAPPY_HOME" \; "$sbin/snappy-lead.sh" "$@" $LEAD_STARTUP_OPTIONS
+  "$sbin/snappy-nodes.sh" lead $CONF_DIR_OPT cd "$SNAPPY_HOME" \; "$sbin/snappy-lead.sh" "$@" $LEAD_STARTUP_OPTIONS
 else
-  "$sbin/snappy-nodes.sh" lead cd "$SNAPPY_HOME" \; "$sbin/snappy-lead.sh" "$@"
+  "$sbin/snappy-nodes.sh" lead $CONF_DIR_OPT cd "$SNAPPY_HOME" \; "$sbin/snappy-lead.sh" "$@"
 fi

--- a/cluster/sbin/snappy-locators.sh
+++ b/cluster/sbin/snappy-locators.sh
@@ -31,9 +31,18 @@ sbin="$(dirname "$(absPath "$0")")"
 . "$SNAPPY_HOME/bin/load-spark-env.sh"
 . "$SNAPPY_HOME/bin/load-snappy-env.sh"
 
+CONF_DIR_OPT=
+# Check if --config is passed as an argument. It is an optional parameter.
+if [ "$1" == "--config" ]
+then
+  CONF_DIR=$2
+  CONF_DIR_OPT="--config $CONF_DIR"
+  shift 2
+fi
+
 # Launch the slaves
 if echo $@ | grep -qw start; then
-  "$sbin/snappy-nodes.sh" locator cd "$SNAPPY_HOME" \; "$sbin/snappy-locator.sh" "$@" $LOCATOR_STARTUP_OPTIONS $ENCRYPT_PASSWORD_OPTIONS
+  "$sbin/snappy-nodes.sh" locator $CONF_DIR_OPT cd "$SNAPPY_HOME" \; "$sbin/snappy-locator.sh" "$@" $LOCATOR_STARTUP_OPTIONS $ENCRYPT_PASSWORD_OPTIONS
 else
-  "$sbin/snappy-nodes.sh" locator cd "$SNAPPY_HOME" \; "$sbin/snappy-locator.sh" "$@"
+  "$sbin/snappy-nodes.sh" locator $CONF_DIR_OPT cd "$SNAPPY_HOME" \; "$sbin/snappy-locator.sh" "$@"
 fi

--- a/cluster/sbin/snappy-nodes.sh
+++ b/cluster/sbin/snappy-nodes.sh
@@ -264,6 +264,7 @@ function execute() {
       fi
     fi
     launchcommand="${@// /\\ } ${args} ${postArgs} < /dev/null 2>&1"
+    echo "LAUNCH_COMMAND = $launchcommand"
     eval $launchcommand &
     LAST_PID="$!"
   fi

--- a/cluster/sbin/snappy-nodes.sh
+++ b/cluster/sbin/snappy-nodes.sh
@@ -264,7 +264,6 @@ function execute() {
       fi
     fi
     launchcommand="${@// /\\ } ${args} ${postArgs} < /dev/null 2>&1"
-    echo "LAUNCH_COMMAND = $launchcommand"
     eval $launchcommand &
     LAST_PID="$!"
   fi

--- a/cluster/sbin/snappy-servers.sh
+++ b/cluster/sbin/snappy-servers.sh
@@ -41,9 +41,16 @@ elif [ "$1" = "-fg" -o "$1" = "--foreground" ]; then
   shift
 fi
 
+# Check for conf dir  specification
+CONF_DIR_OPT=
+if [ "$1" = "--config" ]; then
+  CONF_DIR_OPT="--config $2"
+  shift 2
+fi
+
 # Launch the slaves
 if echo $@ | grep -qw start; then
-  "$sbin/snappy-nodes.sh" server $BACKGROUND cd "$SNAPPY_HOME" \; "$sbin/snappy-server.sh" "$@" $SERVER_STARTUP_OPTIONS
+  "$sbin/snappy-nodes.sh" server $BACKGROUND $CONF_DIR_OPT cd "$SNAPPY_HOME" \; "$sbin/snappy-server.sh" "$@" $SERVER_STARTUP_OPTIONS
 else
-  "$sbin/snappy-nodes.sh" server $BACKGROUND cd "$SNAPPY_HOME" \; "$sbin/snappy-server.sh" "$@"
+  "$sbin/snappy-nodes.sh" server $BACKGROUND $CONF_DIR_OPT cd "$SNAPPY_HOME" \; "$sbin/snappy-server.sh" "$@"
 fi

--- a/cluster/sbin/snappy-start-all.sh
+++ b/cluster/sbin/snappy-start-all.sh
@@ -51,7 +51,7 @@ while (( "$#" )); do
     -conf | --config)
       conf_dir="$2"
       if [ ! -d $conf_dir ] ; then
-        echo "Conf directory $conf_dir does not exists"
+        echo "Conf directory $conf_dir does not exist"
         exit 1
       fi
       CONF_DIR_ARG="--config $conf_dir"

--- a/cluster/sbin/snappy-start-all.sh
+++ b/cluster/sbin/snappy-start-all.sh
@@ -36,6 +36,7 @@ fi
 
 BACKGROUND=-bg
 clustermode=
+CONF_DIR_ARG=
 
 while (( "$#" )); do
   param="$1"
@@ -47,6 +48,14 @@ while (( "$#" )); do
     -fg | --foreground)
       BACKGROUND=-fg
     ;;
+    -conf | --config)
+      conf_dir="$2"
+      if [ ! -d $conf_dir ] ; then
+        echo "Conf directory $conf_dir does not exists"
+        exit 1
+      fi
+      CONF_DIR_ARG="--config $conf_dir"
+      shift ;;
     rowstore)
       clustermode="rowstore"
     ;;
@@ -58,12 +67,12 @@ done
 
 
 # Start Locators
-"$sbin"/snappy-locators.sh start $clustermode "$@"
+"$sbin"/snappy-locators.sh $CONF_DIR_ARG start $clustermode "$@"
 
 # Start Servers
-"$sbin"/snappy-servers.sh $BACKGROUND start $clustermode "$@"
+"$sbin"/snappy-servers.sh $BACKGROUND $CONF_DIR_ARG start $clustermode "$@"
 
 # Start Leads
 if [ "$clustermode" != "rowstore" ]; then
-  "$sbin"/snappy-leads.sh start
+  "$sbin"/snappy-leads.sh $CONF_DIR_ARG start
 fi

--- a/cluster/sbin/snappy-stop-all.sh
+++ b/cluster/sbin/snappy-stop-all.sh
@@ -32,6 +32,7 @@ sbin="$(dirname "$(absPath "$0")")"
 
 BACKGROUND=-fg
 clustermode=
+CONF_DIR_ARG=
 
 while (( "$#" )); do
   param="$1"
@@ -43,6 +44,14 @@ while (( "$#" )); do
     -fg | --foreground)
       BACKGROUND=-fg
     ;;
+    -conf | --config)
+      conf_dir="$2"
+      if [ ! -d $conf_dir ] ; then
+        echo "Conf directory $conf_dir does not exists"
+        exit 1
+      fi
+      CONF_DIR_ARG="--config $conf_dir"
+      shift ;;
     rowstore)
       clustermode="rowstore"
     ;;
@@ -54,11 +63,11 @@ done
 
 # Stop Leads
 if [ "$clustermode" != "rowstore" ]; then
-  "$sbin"/snappy-leads.sh stop
+  "$sbin"/snappy-leads.sh $CONF_DIR_ARG stop
 fi
 
 # Stop Servers
-"$sbin"/snappy-servers.sh $BACKGROUND stop
+"$sbin"/snappy-servers.sh $BACKGROUND $CONF_DIR_ARG stop
 
 # Stop locators
-"$sbin"/snappy-locators.sh stop
+"$sbin"/snappy-locators.sh $CONF_DIR_ARG stop


### PR DESCRIPTION
To take config files from that folder instead of default conf folder.
Please note log4j.properties file is still taken from the default conf folder.
Will fix this anomaly later.

## Changes proposed in this pull request

(Fill in the changes here)

## Patch testing

Manual. QA is also verifying as it has been done mainly for them.

## ReleaseNotes.txt changes

(Does this change require an entry in ReleaseNotes.txt? If yes, has it been added to it?)

## Other PRs 

(Does this change require changes in other projects- store, spark, spark-jobserver, aqp? Add the links of PR of the other subprojects that are related to this change)
