### PR TITLE
fix for 'text' data type coming as column datatype from spark. parsin…

### DIFF
--- a/cluster/src/test/scala/org/apache/spark/sql/store/BugTest.scala
+++ b/cluster/src/test/scala/org/apache/spark/sql/store/BugTest.scala
@@ -25,8 +25,8 @@ import io.snappydata.SnappyFunSuite
 import org.scalatest.BeforeAndAfterAll
 import org.junit.Assert._
 
-
-import org.apache.spark.sql.{Row, SaveMode, SparkSession}
+import org.apache.spark.sql.jdbc.JdbcDialects
+import org.apache.spark.sql.{Row, SaveMode, SnappyStoreClientDialect, SparkSession}
 import org.apache.spark.sql.types.{StringType, StructField, StructType}
 
 class BugTest extends SnappyFunSuite with BeforeAndAfterAll {
@@ -574,6 +574,7 @@ class BugTest extends SnappyFunSuite with BeforeAndAfterAll {
         Row("abc"),
         Row("def")
       )
+      JdbcDialects.unregisterDialect(SnappyStoreClientDialect)
       val stmt = conn.createStatement()
       val sparkSession = SparkSession.builder.appName("test").
         sparkContext(snc.sparkContext).getOrCreate()
@@ -602,6 +603,7 @@ class BugTest extends SnappyFunSuite with BeforeAndAfterAll {
       assertEquals("C", tableType)
       stmt.execute("drop table if exists test")
     } finally {
+      JdbcDialects.registerDialect(SnappyStoreClientDialect)
       TestUtil.stopNetServer
     }
   }

--- a/core/src/main/scala/org/apache/spark/sql/SnappyBaseParser.scala
+++ b/core/src/main/scala/org/apache/spark/sql/SnappyBaseParser.scala
@@ -199,6 +199,7 @@ abstract class SnappyBaseParser(session: SparkSession) extends Parser {
   final def BYTE: Rule0 = newDataType(Consts.BYTE)
   final def CHAR: Rule0 = newDataType(Consts.CHAR)
   final def CLOB: Rule0 = newDataType(Consts.CLOB)
+  final def TEXT: Rule0 = newDataType(Consts.TEXT)
   final def DATE: Rule0 = newDataType(Consts.DATE)
   final def DECIMAL: Rule0 = newDataType(Consts.DECIMAL)
   final def DOUBLE: Rule0 = newDataType(Consts.DOUBLE)
@@ -240,6 +241,7 @@ abstract class SnappyBaseParser(session: SparkSession) extends Parser {
     FLOAT ~> (() => FloatType) |
     REAL ~> (() => FloatType) |
     BOOLEAN ~> (() => BooleanType) |
+    TEXT ~> (() => StringType) |
     CLOB ~> (() => StringType) |
     BLOB ~> (() => BinaryType) |
     BINARY ~> (() => BinaryType) |
@@ -283,7 +285,7 @@ abstract class SnappyBaseParser(session: SparkSession) extends Parser {
     VARCHAR ~ '(' ~ ws ~ digits ~ ')' ~ ws ~> ((d: String) => VarcharType(d.toInt)) |
     CHAR ~ '(' ~ ws ~ digits ~ ')' ~ ws ~> ((d: String) => CharType(d.toInt)) |
     STRING ~> (() => StringType) |
-    CLOB ~> (() => VarcharType(Int.MaxValue))
+    (CLOB | TEXT) ~> (() => VarcharType(Int.MaxValue))
   }
 
   final def columnDataType: Rule1[DataType] = rule {
@@ -596,6 +598,7 @@ object SnappyParserConsts {
   final val BYTE: Keyword = nonReservedKeyword("byte")
   final val CHAR: Keyword = nonReservedKeyword("char")
   final val CLOB: Keyword = nonReservedKeyword("clob")
+  final val TEXT: Keyword = nonReservedKeyword("text")
   final val DATE: Keyword = nonReservedKeyword("date")
   final val DECIMAL: Keyword = nonReservedKeyword("decimal")
   final val DOUBLE: Keyword = nonReservedKeyword("double")


### PR DESCRIPTION
…g 'text' data type & treating it as clob

Parsing the "text" as clob data type for fixing SNAP-2368 issue.

## Patch testing
added bug test

## ReleaseNotes.txt changes

(Does this change require an entry in ReleaseNotes.txt? If yes, has it been added to it?)

## Other PRs 
[store-parser-change](https://github.com/SnappyDataInc/snappy-store/pull/464)
