### PR TITLE
Set default value for spark.sql.files.maxPartitionBytes to 32mb

### DIFF
--- a/cluster/src/main/scala/io/snappydata/impl/LeadImpl.scala
+++ b/cluster/src/main/scala/io/snappydata/impl/LeadImpl.scala
@@ -91,6 +91,8 @@ class LeadImpl extends ServerImpl with Lead
     bootProperties.remove("isTest")
     val authSpecified = Misc.checkLDAPAuthProvider(bootProperties)
 
+    ServiceUtils.setCommonBootDefaults(bootProperties, false)
+
     // prefix all store properties with "snappydata.store" for SparkConf
 
     // first the passed in bootProperties
@@ -142,10 +144,6 @@ class LeadImpl extends ServerImpl with Lead
     bootProperties.setProperty(serverGroupsProp, groups)
     bootProperties.setProperty(STORE_PREFIX + Attribute.GFXD_HOST_DATA, "false")
     bootProperties.setProperty(STORE_PREFIX + Attribute.GFXD_PERSIST_DD, "false")
-    // default value for spark.sql.files.maxPartitionBytes in snappy is 32mb
-    if (bootProperties.getProperty("spark.sql.files.maxPartitionBytes") == null) {
-      bootProperties.setProperty("spark.sql.files.maxPartitionBytes", "33554432")
-    }
 
     // copy store related properties into a separate properties bag
     // to be used by store boot while original will be used by SparkConf

--- a/cluster/src/main/scala/io/snappydata/impl/LeadImpl.scala
+++ b/cluster/src/main/scala/io/snappydata/impl/LeadImpl.scala
@@ -142,6 +142,10 @@ class LeadImpl extends ServerImpl with Lead
     bootProperties.setProperty(serverGroupsProp, groups)
     bootProperties.setProperty(STORE_PREFIX + Attribute.GFXD_HOST_DATA, "false")
     bootProperties.setProperty(STORE_PREFIX + Attribute.GFXD_PERSIST_DD, "false")
+    // default value for spark.sql.files.maxPartitionBytes in snappy is 32mb
+    if (bootProperties.getProperty("spark.sql.files.maxPartitionBytes") == null) {
+      bootProperties.setProperty("spark.sql.files.maxPartitionBytes", "33554432")
+    }
 
     // copy store related properties into a separate properties bag
     // to be used by store boot while original will be used by SparkConf

--- a/core/src/main/scala/io/snappydata/util/ServiceUtils.scala
+++ b/core/src/main/scala/io/snappydata/util/ServiceUtils.scala
@@ -80,6 +80,11 @@ object ServiceUtils {
       if (storeProps.getProperty("spark.locality.wait") == null) {
         storeProps.setProperty("spark.locality.wait", "10s")
       }
+      // default value for spark.sql.files.maxPartitionBytes in snappy is 32mb
+      if (storeProps.getProperty("spark.sql.files.maxPartitionBytes") == null) {
+        storeProps.setProperty("spark.sql.files.maxPartitionBytes", "33554432")
+      }
+
     }
     // set default member-timeout higher for GC pauses (SNAP-1777)
     if (storeProps.getProperty(DistributionConfig.MEMBER_TIMEOUT_NAME) == null) {


### PR DESCRIPTION
## Changes proposed in this pull request
Set default value for spark.sql.files.maxPartitionBytes in snappy to 32mb. User can change the value if required. 

## Patch testing
Verified the patch manually
The setting of 32mb has been verfied by Swati/Sonal using parquet, csv and ORC formats

## ReleaseNotes.txt changes

## Other PRs 
