### PR TITLE
generating SparkR library along with snappy product

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1028,8 +1028,7 @@ task product(type: Zip) {
       into "${snappyProductDir}/benchmark"
     }
 
-    if (rootProject.hasProperty('R.enable') &&
-        rootProject.property("R.enable").toString().equalsIgnoreCase("true")) {
+    if (rootProject.hasProperty('R.enable')) {
       def targetRDir = "${snappyProductDir}/R"
       copy {
         from("${project(":snappy-spark").projectDir}/R")

--- a/build.gradle
+++ b/build.gradle
@@ -1027,6 +1027,27 @@ task product(type: Zip) {
       from("${clusterProject.projectDir}/benchmark")
       into "${snappyProductDir}/benchmark"
     }
+
+    if (rootProject.hasProperty('R.enable') &&
+        rootProject.property("R.enable").toString().equalsIgnoreCase("true")) {
+      def targetRDir = "${snappyProductDir}/R"
+      copy {
+        from("${project(":snappy-spark").projectDir}/R")
+        into targetRDir
+      }
+
+      exec {
+        environment "SPARK_HOME", snappyProductDir
+        environment "NO_TESTS", "1"
+        environment "CLEAN_INSTALL", "1"
+        workingDir targetRDir
+        commandLine "${targetRDir}/check-cran.sh"
+      }
+      
+      Arrays.stream(new File(targetRDir).list()).forEach {
+        f -> if (f != "lib") delete  "${targetRDir}/${f}"
+      }
+    }
   }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -1043,10 +1043,8 @@ task product(type: Zip) {
         workingDir targetRDir
         commandLine "${targetRDir}/check-cran.sh"
       }
-      
-      Arrays.stream(new File(targetRDir).list()).forEach {
-        f -> if (f != "lib") delete  "${targetRDir}/${f}"
-      }
+
+      fileTree(targetRDir).exclude('lib').visit { delete it.file }
     }
   }
 }


### PR DESCRIPTION
## Changes proposed in this pull request
Generating SparkR library along with snappy product.
Note that building SparkR library required R installed on the build machine.

Hence by default `./gradlew product` will not build SparkR library and it will not be included as part of
snappy's distribution.

sparkR library can be included as part of product distribution by passing `R.enable` build property.

## Patch testing

Using R version `3.5.3`
manually launched `bin/sparkR` shell and tried some CRUD SQL queries using `sql()` function of sparkR

## ReleaseNotes.txt changes

(Does this change require an entry in ReleaseNotes.txt? If yes, has it been added to it?)

## Other PRs 

https://github.com/SnappyDataInc/spark/pull/141
