### PR TITLE
Changes for SNAP-2974: Snappy UI re-branding to TIBCO ComputeDB

### DIFF
--- a/cluster/src/main/scala/io/snappydata/gemxd/SnappyDataVersion.scala
+++ b/cluster/src/main/scala/io/snappydata/gemxd/SnappyDataVersion.scala
@@ -134,6 +134,8 @@ object SnappyDataVersion {
 
   def getSnappyDataProductVersion: mutable.HashMap[String, String] = {
     GemFireVersion.getInstance(classOf[SnappyDataVersion], SNAPPYDATA_VERSION_PROPERTIES)
+    val productEditionType = if (GemFireVersion.isEnterpriseEdition) "Enterprise" else "Community"
+
     val versionDetails = mutable.HashMap.empty[String, String]
     versionDetails.put("productName", GemFireVersion.getProductName)
     versionDetails.put("productVersion", GemFireVersion.getProductVersion)
@@ -142,6 +144,7 @@ object SnappyDataVersion {
     versionDetails.put("buildPlatform", GemFireVersion.getBuildPlatform)
     versionDetails.put("nativeCodeVersion", GemFireVersion.getNativeCodeVersion)
     versionDetails.put("sourceRevision", GemFireVersion.getSourceRevision)
+    versionDetails.put("editionType", productEditionType)
 
     versionDetails
   }

--- a/cluster/src/main/scala/io/snappydata/impl/LeadImpl.scala
+++ b/cluster/src/main/scala/io/snappydata/impl/LeadImpl.scala
@@ -166,7 +166,7 @@ class LeadImpl extends ServerImpl with Lead
       val locator = bootProperties.getProperty(Property.Locators.name)
       val conf = new SparkConf(false) // system properties already in bootProperties
       conf.setMaster(s"${Constant.SNAPPY_URL_PREFIX}$locator").
-          setAppName("SnappyData").
+          setAppName("TIBCO ComputeDB").
           set(Property.JobServerEnabled.name, "true").
           set("spark.scheduler.mode", "FAIR").
           setIfMissing("spark.memory.manager",

--- a/cluster/src/main/scala/org/apache/spark/ui/SnappyDashboardPage.scala
+++ b/cluster/src/main/scala/org/apache/spark/ui/SnappyDashboardPage.scala
@@ -119,7 +119,7 @@ private[ui] class SnappyDashboardPage (parent: SnappyDashboardTab)
         </h3>
       </div>
     </div>
-    <div id="CPUCoresContainer" style="position: absolute; width: 100%;">
+    <div id="CPUCoresContainer">
       <div id="CPUCoresDetails">
         <div id="TotalCoresHolder">
           <span style="padding-left: 5px;"> Total CPU Cores: </span>
@@ -351,7 +351,7 @@ private[ui] class SnappyDashboardPage (parent: SnappyDashboardTab)
 }
 
 object SnappyDashboardPage {
-  val pageHeaderText = "SnappyData Dashboard"
+  val pageHeaderText = "Dashboard"
 
   object Status {
     val normal = "Normal"
@@ -363,7 +363,7 @@ object SnappyDashboardPage {
   val ValueNotApplicable = "N/A"
 
   val clusterStatsTitle = "Cluster"
-  val clusterStatsTitleTooltip = "SnappyData Clusters Summary"
+  val clusterStatsTitleTooltip = "Clusters Summary"
   val clusterStats = scala.collection.mutable.HashMap.empty[String, Any]
   clusterStats += ("status" -> "Cluster Status")
   clusterStats += ("members" -> "Members")
@@ -384,7 +384,7 @@ object SnappyDashboardPage {
   clusterStats += ("jvmHeapUsageTooltip" -> "Clusters Total JVM Heap Usage")
 
   val membersStatsTitle = "Members"
-  val membersStatsTitleTooltip = "SnappyData Members Summary"
+  val membersStatsTitleTooltip = "Members Summary"
   val memberStatsColumn = scala.collection.mutable.HashMap.empty[String, String]
   memberStatsColumn += ("expandCollapseTooltip" -> "Expand/Collapse All Rows")
   memberStatsColumn += ("status" -> "Status")
@@ -433,7 +433,7 @@ object SnappyDashboardPage {
   memberStatsColumn += ("jvmHeapMemoryTooltip" -> "Members used and total JVM Heap")
 
   val tablesStatsTitle = "Tables"
-  val tablesStatsTitleTooltip = "SnappyData Tables Summary"
+  val tablesStatsTitleTooltip = "Tables Summary"
   val tableStatsColumn = scala.collection.mutable.HashMap.empty[String, String]
   tableStatsColumn += ("id" -> "Id")
   tableStatsColumn += ("idTooltip" -> "Tables unique Identifier")
@@ -457,7 +457,7 @@ object SnappyDashboardPage {
   tableStatsColumn += ("bucketCountTooltip" -> "Number of Buckets in Table")
 
   val extTablesStatsTitle = "External Tables"
-  val extTablesStatsTitleTooltip = "SnappyData ExternalTables Summary"
+  val extTablesStatsTitleTooltip = "External Tables Summary"
   val extTableStatsColumn = scala.collection.mutable.HashMap.empty[String, String]
   extTableStatsColumn += ("id" -> "Id")
   extTableStatsColumn += ("idTooltip" -> "External Tables unique Identifier")

--- a/cluster/src/main/scala/org/apache/spark/ui/SnappyMemberDetailsPage.scala
+++ b/cluster/src/main/scala/org/apache/spark/ui/SnappyMemberDetailsPage.scala
@@ -452,7 +452,7 @@ private[ui] class SnappyMemberDetailsPage(parent: SnappyDashboardTab)
 }
 
 object SnappyMemberDetailsPage {
-  val pageHeaderText = "SnappyData Member Details"
+  val pageHeaderText = "Member Details"
 
   object Status {
     val stopped = "Stopped"


### PR DESCRIPTION
## Changes proposed in this pull request

  1. Adding product Edition type in version information
  2. Changing App Name from SnappyData to TIBCO ComputeDB
  3. Renaming pages to just Dashboard, Member Details and Jobs
  4. Removing or Changing user visible SnappyData references on UI to TIBCO ComputeDB.

## Patch testing

 - Tested manually

## ReleaseNotes.txt changes

 - Yes

## Other PRs 

 Spark: https://github.com/SnappyDataInc/spark/pull/150
