### PR TITLE
SNAP-2902 Mismatch in the expected and actual inserted rows

### DIFF
--- a/core/src/main/scala/org/apache/spark/sql/store/StoreUtils.scala
+++ b/core/src/main/scala/org/apache/spark/sql/store/StoreUtils.scala
@@ -23,6 +23,7 @@ import scala.collection.mutable
 
 import com.gemstone.gemfire.distributed.internal.membership.InternalDistributedMember
 import com.gemstone.gemfire.internal.cache.{CacheDistributionAdvisee, PartitionedRegion}
+import com.gemstone.gemfire.internal.shared.SystemProperties
 import com.pivotal.gemfirexd.internal.engine.{GfxdConstants, Misc}
 import io.snappydata.sql.catalog.SnappyExternalCatalog
 import org.eclipse.collections.impl.map.mutable.UnifiedMap
@@ -108,8 +109,8 @@ object StoreUtils {
     Pattern.CASE_INSENSITIVE | Pattern.DOTALL)
 
   /** for testing only (a long convoluted name chosen deliberately) */
-  var TEST_RANDOM_BUCKETID_ASSIGNMENT: Boolean = java.lang.Boolean.getBoolean(
-    "SNAPPYTEST_RANDOM_BUCKETID_TO_PARTITION_ASSIGNMENT")
+  var TEST_RANDOM_BUCKETID_ASSIGNMENT: Boolean = SystemProperties.getServerInstance.getBoolean(
+    "SNAPPYTEST_RANDOM_BUCKETID_TO_PARTITION_ASSIGNMENT", false)
 
   // private property to indicate One-to-one mapping of partitions to buckets
   // which is enabled per-query using `LinkPartitionsToBuckets` rule
@@ -181,7 +182,7 @@ object StoreUtils {
       preferPrimaries: Boolean): Array[Partition] = {
 
     val callbacks = ToolsCallbackInit.toolsCallback
-    if (!linkBucketsToPartitions && callbacks != null) {
+    if (!linkBucketsToPartitions && callbacks != null && !TEST_RANDOM_BUCKETID_ASSIGNMENT) {
       allocateBucketsToPartitions(session, region, preferPrimaries)
     } else {
       val numPartitions = region.getTotalNumberOfBuckets

--- a/encoders/src/main/scala/org/apache/spark/sql/collection/SharedUtils.scala
+++ b/encoders/src/main/scala/org/apache/spark/sql/collection/SharedUtils.scala
@@ -107,10 +107,6 @@ object SharedUtils {
         releaseStorageMemoryForObject(objectName, numBytes, mode)
   }
 
-  /** for testing only (a long convoluted name chosen deliberately) */
-  var TEST_RANDOM_BUCKETID_ASSIGNMENT: Boolean = java.lang.Boolean.getBoolean(
-    "SNAPPYTEST_RANDOM_BUCKETID_TO_PARTITION_ASSIGNMENT")
-
   /**
    * For V2 connector filters are pushed in java serialized format
    */


### PR DESCRIPTION
## Changes proposed in this pull request

- Issue is not insert specific rather is in RemoteEntriesIterator where
statsRows iterator does a fetchNextBatch in its next method (around line
130). 
- In addition to fetching the next batch this causes the current batch values to be freed. So the higher level iterator ColumnBatchIterator looks at the last value but finds it to be empty
buffer so skips it. As a result iteration over remote entries
consistently misses one ColumnBatch per 1000 (which is the size of a
batch of keys fetched in RemoteEntriesIterator).


## Patch testing
Yes. 
As discussed in the meeting patch is verified and tested manually also.

## ReleaseNotes.txt changes
No

## Other PRs 
No
