### PR TITLE
Fix for SNAP-2982

### DIFF
--- a/core/src/main/java/org/apache/spark/sql/internal/SnappySharedState.java
+++ b/core/src/main/java/org/apache/spark/sql/internal/SnappySharedState.java
@@ -16,6 +16,7 @@
  */
 package org.apache.spark.sql.internal;
 
+import com.pivotal.gemfirexd.internal.engine.Misc;
 import io.snappydata.sql.catalog.SnappyExternalCatalog;
 import io.snappydata.sql.catalog.impl.SmartConnectorExternalCatalog;
 import org.apache.spark.SparkContext;
@@ -139,6 +140,8 @@ public final class SnappySharedState extends SharedState {
     if (clusterMode instanceof ThinClientConnectorMode) {
       this.embedCatalog = null;
     } else {
+      // ensure store catalog is initialized
+      Misc.getMemStoreBooting().getExistingExternalCatalog();
       this.embedCatalog = HiveClientUtil$.MODULE$.getOrCreateExternalCatalog(
           sparkContext, sparkContext.conf());
     }


### PR DESCRIPTION
## Changes proposed in this pull request

Fix for SNAP-2982 from Sumedh

Lead node and server both made a version entry in the metastore to initialise the HiveClient. However only one version entry is expected in the
metastore. It breaks while instantiating SessionHiveMetaStoreClient and hence leader does not come up.

The Hive client initialization in StoreHiveCatalog.CatalogQuery#call takes a distributed lock to prevent concurrent initialization of Hive client
by different servers and prevents such scenarios. However on lead node, SnappySharedState constructor also initializes a Hive client which is not
guarded by this lock. The fix just ensures that StoreHiveCatalog is initialized before trying to get Hive client in SnappySharedState.

Will be merging the fix as discussed in team meetings

## Patch testing
The fix has been manually verified by Paresh
Pecheckin run by Pradeep

## ReleaseNotes.txt changes
NA

## Other PRs 
NA
