### PR TITLE
Start hive-thriftserver by default in background

### DIFF
--- a/cluster/src/main/scala/io/snappydata/impl/LeadImpl.scala
+++ b/cluster/src/main/scala/io/snappydata/impl/LeadImpl.scala
@@ -252,8 +252,8 @@ class LeadImpl extends ServerImpl with Lead
       var jobServerConfig: Config = null
       var startupString: String = null
       if (Property.JobServerEnabled.get(conf)) {
-        jobServerWait = Property.JobServerWaitForInit.get(conf) ||
-            (!startHiveServerDefault && startHiveServer)
+        jobServerWait = (!startHiveServerDefault && startHiveServer) ||
+            Property.JobServerWaitForInit.get(conf)
         confFile = conf.getOption("jobserver.configFile") match {
           case None => Array[String]()
           case Some(c) => Array(c)

--- a/cluster/src/main/scala/io/snappydata/impl/LeadImpl.scala
+++ b/cluster/src/main/scala/io/snappydata/impl/LeadImpl.scala
@@ -242,12 +242,18 @@ class LeadImpl extends ServerImpl with Lead
       ServerGroupUtils.sendUpdateProfile()
 
       val startHiveServer = Property.HiveServerEnabled.get(conf)
+      val startHiveServerDefault = Property.HiveServerEnabled.defaultValue.get &&
+          !conf.contains(Property.HiveServerEnabled.name)
+      val useHiveSession = Property.HiveServerUseHiveSession.get(conf)
+      val hiveSessionKind = if (useHiveSession) "session=hive" else "session=snappy"
+
       var jobServerWait = false
       var confFile: Array[String] = null
       var jobServerConfig: Config = null
       var startupString: String = null
       if (Property.JobServerEnabled.get(conf)) {
-        jobServerWait = startHiveServer || Property.JobServerWaitForInit.get(conf)
+        jobServerWait = Property.JobServerWaitForInit.get(conf) ||
+            (!startHiveServerDefault && startHiveServer)
         confFile = conf.getOption("jobserver.configFile") match {
           case None => Array[String]()
           case Some(c) => Array(c)
@@ -256,6 +262,10 @@ class LeadImpl extends ServerImpl with Lead
         val bindAddress = jobServerConfig.getString("spark.jobserver.bind-address")
         val port = jobServerConfig.getInt("spark.jobserver.port")
         startupString = s"job server on: $bindAddress[$port]"
+      }
+      // add default startup message for hive-thriftserver
+      if (startHiveServerDefault) {
+        addStartupMessage(s"Starting hive thrift server ($hiveSessionKind)")
       }
       if (!jobServerWait) {
         // mark RUNNING (job server and zeppelin will continue to start in background)
@@ -284,13 +294,11 @@ class LeadImpl extends ServerImpl with Lead
       SnappyTableStatsProviderService.start(sc, url = null)
 
       if (startHiveServer) {
-        val useHiveSession = Property.HiveServerUseHiveSession.get(conf)
         val hiveService = SnappyHiveThriftServer2.start(useHiveSession)
-        val sessionKind = if (useHiveSession) "session=hive" else "session=snappy"
-        SnappyHiveThriftServer2.getHostPort(hiveService) match {
-          case None => addStartupMessage(s"Started hive thrift server ($sessionKind)")
+        if (jobServerWait) SnappyHiveThriftServer2.getHostPort(hiveService) match {
+          case None => addStartupMessage(s"Started hive thrift server ($hiveSessionKind)")
           case Some((host, port)) =>
-            addStartupMessage(s"Started hive thrift server ($sessionKind) on: $host[$port]")
+            addStartupMessage(s"Started hive thrift server ($hiveSessionKind) on: $host[$port]")
         }
       }
 

--- a/compatibilityTests/build.gradle
+++ b/compatibilityTests/build.gradle
@@ -82,6 +82,7 @@ scalaTest {
     cleanIntermediateFiles(project.path)
   }
 }
-check.dependsOn test, scalaTest
+check.dependsOn.clear()
+check.dependsOn scalaTest
 
 archivesBaseName = 'snappydata-compatibility-tests_'+ scalaBinaryVersion

--- a/core/src/dunit/scala/io/snappydata/cluster/SplitClusterDUnitTest.scala
+++ b/core/src/dunit/scala/io/snappydata/cluster/SplitClusterDUnitTest.scala
@@ -687,7 +687,7 @@ object SplitClusterDUnitTest extends SplitClusterDUnitTestObject {
 
     // perform some operation thru spark-shell
     val jars = Files.newDirectoryStream(Paths.get(s"$productDir/../distributions/"),
-      "snappydata-core*.jar")
+      "TIB_compute-core*.jar")
     var securityConf = ""
     if (props.containsKey(Attribute.USERNAME_ATTR)) {
       securityConf = s" --conf spark.snappydata.store.user=${props.getProperty(Attribute

--- a/core/src/dunit/scala/io/snappydata/cluster/SplitClusterDUnitTest.scala
+++ b/core/src/dunit/scala/io/snappydata/cluster/SplitClusterDUnitTest.scala
@@ -739,7 +739,7 @@ object SplitClusterDUnitTest extends SplitClusterDUnitTestObject {
     try {
       // perform some operations through spark-shell using JDBC pool driver API on current Spark
       val jars = Files.newDirectoryStream(Paths.get(s"$productDir/../distributions/"),
-        "TIB_compute-jdbc_*.jar")
+        "TIB_compute-jdbc*.jar")
       var securityConf = ""
       if (props.containsKey(Attribute.USERNAME_ATTR)) {
         securityConf = s" --conf spark.snappydata.user=" +

--- a/core/src/dunit/scala/io/snappydata/cluster/SplitClusterDUnitTest.scala
+++ b/core/src/dunit/scala/io/snappydata/cluster/SplitClusterDUnitTest.scala
@@ -739,7 +739,7 @@ object SplitClusterDUnitTest extends SplitClusterDUnitTestObject {
     try {
       // perform some operations through spark-shell using JDBC pool driver API on current Spark
       val jars = Files.newDirectoryStream(Paths.get(s"$productDir/../distributions/"),
-        "snappydata-jdbc_*.jar")
+        "TIB_compute-jdbc_*.jar")
       var securityConf = ""
       if (props.containsKey(Attribute.USERNAME_ATTR)) {
         securityConf = s" --conf spark.snappydata.user=" +

--- a/core/src/main/scala/io/snappydata/Literals.scala
+++ b/core/src/main/scala/io/snappydata/Literals.scala
@@ -90,8 +90,8 @@ object Property extends Enumeration {
 
   val HiveServerEnabled: SparkValue[Boolean] = Val(
     s"${Constant.PROPERTY_PREFIX}hiveServer.enabled", "If true on a lead node, then an " +
-        "embedded HiveServer2 with thrift access will be started. Default is true.",
-    Some(true), prefix = null)
+        "embedded HiveServer2 with thrift access will be started in foreground. Default is true " +
+        "but starts the service in background.", Some(true), prefix = null)
 
   val HiveCompatible: SQLValue[Boolean] = SQLVal(
     s"${Constant.PROPERTY_PREFIX}sql.hiveCompatible", "Property on SnappySession to make " +

--- a/core/src/main/scala/io/snappydata/Literals.scala
+++ b/core/src/main/scala/io/snappydata/Literals.scala
@@ -90,7 +90,8 @@ object Property extends Enumeration {
 
   val HiveServerEnabled: SparkValue[Boolean] = Val(
     s"${Constant.PROPERTY_PREFIX}hiveServer.enabled", "If true on a lead node, then an " +
-        "embedded HiveServer2 with thrift access will be started", Some(false), prefix = null)
+        "embedded HiveServer2 with thrift access will be started. Default is true.",
+    Some(true), prefix = null)
 
   val HiveCompatible: SQLValue[Boolean] = SQLVal(
     s"${Constant.PROPERTY_PREFIX}sql.hiveCompatible", "Property on SnappySession to make " +

--- a/docs/howto/concurrent_apache_zeppelin_access_to_secure_snappydata.md
+++ b/docs/howto/concurrent_apache_zeppelin_access_to_secure_snappydata.md
@@ -53,7 +53,7 @@ Log on to Zeppelin from your web browser and configure the [JDBC Interpreter](ht
     |default.password|user123|The JDBC user password|
     |default.user|user1|The JDBC username|
 
-3. **Dependency settings**</br> Since Zeppelin includes only PostgreSQL driver jar by default, you need to add the Client (JDBC) JAR file path for	 SnappyData. The SnappyData Client (JDBC) JAR file (snappydata-jdbc_2.11-1.0.2.2.jar) is available on [the release page](https://github.com/SnappyDataInc/snappydata/releases/latest). </br>
+3. **Dependency settings**</br> Since Zeppelin includes only PostgreSQL driver jar by default, you need to add the Client (JDBC) JAR file path for	 SnappyData. The SnappyData Client (JDBC) JAR file (TIB_compute-jdbc-2.11_1.1.0.jar) is available on [the release page](https://github.com/SnappyDataInc/snappydata/releases/latest). </br>
 	The SnappyData Client (JDBC) JAR file can also be placed under **<ZEPPELIN_HOME>/interpreter/jdbc** before starting Zeppelin instead of providing it in the dependency setting.
 
 4. If required, edit other properties, and then click **Save** to apply your changes. 

--- a/docs/howto/connect_jdbc_client_pool_driver.md
+++ b/docs/howto/connect_jdbc_client_pool_driver.md
@@ -36,7 +36,7 @@ Where the `<locatorHostName>` is the hostname of the node on which the locator i
 **Example: SBT dependency**
 ```pre
 // https://mvnrepository.com/artifact/io.snappydata/snappydata-store-client
-libraryDependencies += "io.snappydata" % "snappydata-jdbc_2.11" % "1.0.2.1"
+libraryDependencies += "io.snappydata" % "snappydata-jdbc_2.11" % "1.1.0"
 ```
 
 !!! Note

--- a/docs/howto/connect_using_jdbc_driver.md
+++ b/docs/howto/connect_using_jdbc_driver.md
@@ -28,7 +28,7 @@ You can use the Maven or the SBT dependencies to get the latest released version
 **Example: SBT dependency**
 ```pre
 // https://mvnrepository.com/artifact/io.snappydata/snappydata-store-client
-libraryDependencies += "io.snappydata" % "snappydata-jdbc_2.11" % "1.0.2.2"
+libraryDependencies += "io.snappydata" % "snappydata-jdbc_2.11" % "1.1.0"
 ```
 
 !!! Note

--- a/docs/howto/using_snappydata_for_any_spark_dist.md
+++ b/docs/howto/using_snappydata_for_any_spark_dist.md
@@ -1,16 +1,16 @@
 ## How to use SnappyData for any Spark Distribution
 
-The **snappydata-jdbc Spark **package adds extensions to Spark’s inbuilt JDBC data source provider to work better with SnappyData. This allows SnappyData to be treated as a regular JDBC data source with all versions of Spark which are greater or equal to 2.1, while also providing speed to direct SnappyData embedded cluster for many types of queries.
+The **TIB_compute-jdbc Spark **package adds extensions to Spark’s inbuilt JDBC data source provider to work better with SnappyData. This allows SnappyData to be treated as a regular JDBC data source with all versions of Spark which are greater or equal to 2.1, while also providing speed to direct SnappyData embedded cluster for many types of queries.
 
 Following is a sample of Spark JDBC extension setup and usage: 
 
-1. Include the **snappydata-jdbc** package in the Spark job with spark-submit or spark-shell:
+1. Include the **TIB_compute-jdbc** package in the Spark job with spark-submit or spark-shell:
 
-		$SPARK_HOME/bin/spark-shell --packages io.snappydata:snappydata-jdbc_2.11:1.0.2.2
+		$SPARK_HOME/bin/spark-shell --jars TIB_compute-jdbc-2.11_1.1.0.jar
     
 2. Set the session properties.</br>The SnappyData connection properties (to enable auto-configuration of JDBC URL) and credentials can be provided in Spark configuration itself, or set later in SparkSession to avoid passing them in all the method calls. These properties can also be provided in **spark-defaults.conf ** along with all the other Spark properties.</br> Following is a sample code of configuring the properties in **SparkConf**:
 
-		$SPARK_HOME/bin/spark-shell --packages io.snappydata:snappydata-jdbc_2.11:1.0.2.2 --conf spark.snappydata.connection=localhost:1527 --conf spark.snappydata.user=<user> --conf spark.snappydata.password=<password>
+		$SPARK_HOME/bin/spark-shell --jars TIB_compute-jdbc-2.11_1.1.0.jar --conf spark.snappydata.connection=localhost:1527 --conf spark.snappydata.user=<user> --conf spark.snappydata.password=<password>
 
 	Overloads of the above methods accepting *user+password* and *host+port* is also provided in case those properties are not set in the session or needs to be overridden. You can optionally pass additional connection properties similarly as in the **DataFrameReader.jdbc** method.
 

--- a/docs/programming_guide/spark_jdbc_connector.md
+++ b/docs/programming_guide/spark_jdbc_connector.md
@@ -36,14 +36,14 @@ The SnappyData connector internally figures out the structure of the result set 
 ### Connecting to SnappyData using the JDBC Extension Connector
 Following is a sample of Spark JDBC Extension setup and usage:
 
-1.	Include the **snappydata-jdbc** package in the Spark job with spark-submit or spark-shell: 
+1.	Include the **TIB_compute-jdbc** package in the Spark job with spark-submit or spark-shell:
 
-			$SPARK_HOME/bin/spark-shell --packages io.snappydata:snappydata-jdbc_2.11:1.0.2.2
+			$SPARK_HOME/bin/spark-shell --jars TIB_compute-jdbc-2.11_1.1.0.jar
   
 2.	Set the session properties.</br> The SnappyData connection properties (to enable auto-configuration of JDBC URL) and credentials can be provided in Spark configuration itself, or set later in SparkSession to avoid passing them in all the method calls. These properties can also be provided in **spark-defaults.conf** along with all the other Spark properties.  You can also set any of these properties in your app code. </br>Overloads of the above methods accepting **user+password** and **host+port **is also provided in case those properties are not set in the session or needs to be overridden. You can optionally pass additional connection properties similarly as in the **DataFrameReader.jdbc **method.</br> Following is a sample code of configuring the properties in **SparkConf**:
 
-        	$SPARK_HOME/bin/spark-shell --packages io.snappydata:snappydata-jdbc_2.11:1.0.2.2 --conf spark.snappydata.connection=localhost:1527 --conf spark.snappydata.user=<user> --conf spark.snappydata.password=<password> 
-  
+			$SPARK_HOME/bin/spark-shell --jars TIB_compute-jdbc-2.11_1.1.0.jar --conf spark.snappydata.connection=localhost:1527 --conf spark.snappydata.user=<user> --conf spark.snappydata.password=<password>
+
 3.	Import the required implicits in the job/shell code as follows:
 
 			import io.snappydata.sql.implicits._

--- a/encoders/build.gradle
+++ b/encoders/build.gradle
@@ -34,10 +34,10 @@ dependencies {
     exclude(group: 'org.scala-lang', module: 'scala-compiler')
   }
 
-  compile "org.apache.spark:spark-core_${scalaBinaryVersion}:${sparkVersion}"
-  compile "org.apache.spark:spark-catalyst_${scalaBinaryVersion}:${sparkVersion}"
-  compile "org.apache.spark:spark-sql_${scalaBinaryVersion}:${sparkVersion}"
-  compile "org.apache.spark:spark-hive_${scalaBinaryVersion}:${sparkVersion}"
+  compileOnly "org.apache.spark:spark-core_${scalaBinaryVersion}:${sparkVersion}"
+  compileOnly "org.apache.spark:spark-catalyst_${scalaBinaryVersion}:${sparkVersion}"
+  compileOnly "org.apache.spark:spark-sql_${scalaBinaryVersion}:${sparkVersion}"
+  compileOnly "org.apache.spark:spark-hive_${scalaBinaryVersion}:${sparkVersion}"
 
   compile project(":snappy-jdbc_${scalaBinaryVersion}")
   if (new File(rootDir, 'store/build.gradle').exists()) {

--- a/jdbc/build.gradle
+++ b/jdbc/build.gradle
@@ -42,7 +42,7 @@ dependencies {
     compileOnly("org.apache.spark:spark-core_${scalaBinaryVersion}:${sparkVersion}")
     compileOnly("org.apache.spark:spark-catalyst_${scalaBinaryVersion}:${sparkVersion}")
     compileOnly("org.apache.spark:spark-sql_${scalaBinaryVersion}:${sparkVersion}")
-    compileOnly "org.eclipse.jetty:jetty-servlet:${jettyVersion}"
+    compileOnly("org.eclipse.jetty:jetty-servlet:${jettyVersion}")
   }
 
   if (new File(rootDir, 'store/build.gradle').exists()) {

--- a/launcher/src/main/java/io/snappydata/tools/QuickLauncher.java
+++ b/launcher/src/main/java/io/snappydata/tools/QuickLauncher.java
@@ -440,7 +440,11 @@ class QuickLauncher extends LauncherBase {
   private void readStatus(boolean emptyForMissing, final Path statusFile) {
     this.status = null;
     if (Files.exists(statusFile)) {
-      this.status = Status.spinRead(baseName, statusFile);
+      // try some number of times if dsMsg is null
+      for (int i = 1; i <= 3; i++) {
+        this.status = Status.spinRead(baseName, statusFile);
+        if (this.status.dsMsg != null) break;
+      }
     }
     if (this.status == null && emptyForMissing) {
       this.status = Status.create(baseName, Status.SHUTDOWN, 0, statusFile);


### PR DESCRIPTION
## Changes proposed in this pull request

- changed default of hive-thriftserver to true
- to reduce startup time, the default behaviour is to launch the thrift server
  in background with startup message stating: Starting ... (without host/port information)
- if snappydata.hiveServer.enabled=true is explicitly provided then the hive thriftserver
  is launched in foreground with proper host/port information like before

## Patch testing

precheckin

## ReleaseNotes.txt changes

docs update to mention that hive-thriftserver is started by default in background

## Other PRs 

NA