### PR TITLE
Worakaround fix for SNAP-2440.

### DIFF
--- a/cluster/src/test/scala/org/apache/spark/sql/MiscTest.scala
+++ b/cluster/src/test/scala/org/apache/spark/sql/MiscTest.scala
@@ -88,4 +88,31 @@ class MiscTest extends SnappyFunSuite with Logging {
       snc.sql(s"set schema app")
     }
   }
+
+  test("SNAP-2440") {
+    snc.sql(s"create table test(col1 int not null, col2 int not null) using column options()")
+    snc.sql(s"insert into test values (1, 2), (4, 5), (6, 7)")
+    val sz = snc.sql(s"select * from app.test").collect().size
+    val sqlstrs = Seq(s"select app.test.* from app.test",
+      s"select app.test.col1, app.test.col2 from app.test",
+      s"select col1, col2 from app.test",
+      s"select * from app.test",
+      s"select test.* from test")
+    sqlstrs.foreach(sqlstr => {
+      val res = snc.sql(sqlstr).collect()
+      assert(res.size === 3)
+      assert(res(0).get(0) != res(0).get(1))
+    })
+
+    val badsqls = Seq(s"select apppp.test.* from app.test",
+      s"select app.test.col99, app.test.col2 from app.test",
+      s"select testt.* from app.test")
+    badsqls.foreach(sqlstr =>
+      try {
+        snc.sql(sqlstr)
+        fail(s"expected analysis exception for $sqlstr")
+      } catch {
+        case ae: AnalysisException => // expected ... ignore
+      })
+  }
 }

--- a/cluster/src/test/scala/org/apache/spark/sql/MiscTest.scala
+++ b/cluster/src/test/scala/org/apache/spark/sql/MiscTest.scala
@@ -90,23 +90,33 @@ class MiscTest extends SnappyFunSuite with Logging {
   }
 
   test("SNAP-2440") {
-    snc.sql(s"create table test(col1 int not null, col2 int not null) using column options()")
-    snc.sql(s"insert into test values (1, 2), (4, 5), (6, 7)")
-    val sz = snc.sql(s"select * from app.test").collect().size
-    val sqlstrs = Seq(s"select app.test.* from app.test",
-      s"select app.test.col1, app.test.col2 from app.test",
-      s"select col1, col2 from app.test",
-      s"select * from app.test",
-      s"select test.* from test")
+    snc.sql("create table test(col1 int not null, col2 int not null) using column")
+    snc.sql("create table emp.test1(col1 int not null, col2 int not null) using column")
+    snc.sql("insert into test values (1, 2), (4, 5), (6, 7)")
+    snc.sql("insert into emp.test1 values (1, 2), (4, 5), (6, 7)")
+    val sz = snc.sql(s"select * from app.test").collect().length
+    val sqlstrs = Seq("select app.test.* from app.test",
+      "select app.test.col1, app.test.col2 from app.test",
+      "select col1, col2 from app.test",
+      "select * from app.test",
+      "select test.* from test",
+      "select emp.test1.* from emp.test1",
+      "select emp.test1.col1, emp.test1.col2 from emp.test1",
+      "select col1, col2 from emp.test1",
+      "select * from emp.test1",
+      "select test1.* from emp.test1")
     sqlstrs.foreach(sqlstr => {
       val res = snc.sql(sqlstr).collect()
-      assert(res.size === 3)
+      assert(res.length === 3)
       assert(res(0).get(0) != res(0).get(1))
     })
 
-    val badsqls = Seq(s"select apppp.test.* from app.test",
-      s"select app.test.col99, app.test.col2 from app.test",
-      s"select testt.* from app.test")
+    val badsqls = Seq("select apppp.test.* from app.test",
+      "select app.test.col99, app.test.col2 from app.test",
+      "select testt.* from app.test",
+      "select apppp.test.* from emp.test1",
+      "select emp.test1.col99, emp.test1.col2 from emp.test1",
+      "select testt.* from emp.test1")
     badsqls.foreach(sqlstr =>
       try {
         snc.sql(sqlstr)

--- a/core/src/main/scala/org/apache/spark/sql/SnappySession.scala
+++ b/core/src/main/scala/org/apache/spark/sql/SnappySession.scala
@@ -27,7 +27,6 @@ import scala.concurrent.Future
 import scala.language.implicitConversions
 import scala.reflect.runtime.universe.{TypeTag, typeOf}
 import scala.util.control.NonFatal
-
 import com.gemstone.gemfire.internal.GemFireVersion
 import com.gemstone.gemfire.internal.cache.{GemFireCacheImpl, PartitionedRegion}
 import com.gemstone.gemfire.internal.shared.{ClientResolverUtils, FinalizeHolder, FinalizeObject}
@@ -39,12 +38,11 @@ import com.pivotal.gemfirexd.internal.shared.common.{SharedUtils, StoredFormatId
 import io.snappydata.sql.catalog.{CatalogObjectType, SnappyExternalCatalog}
 import io.snappydata.{Constant, Property, SnappyDataFunctions, SnappyTableStatsProviderService}
 import org.eclipse.collections.impl.map.mutable.UnifiedMap
-
 import org.apache.spark.annotation.{DeveloperApi, Experimental}
 import org.apache.spark.jdbc.{ConnectionConf, ConnectionUtil}
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.SnappySession.CACHED_PUTINTO_UPDATE_PLAN
-import org.apache.spark.sql.catalyst.analysis.{NoSuchTableException, UnresolvedRelation}
+import org.apache.spark.sql.catalyst.analysis.{NoSuchTableException, UnresolvedAttribute, UnresolvedRelation, UnresolvedStar}
 import org.apache.spark.sql.catalyst.catalog.{CatalogTable, CatalogTableType}
 import org.apache.spark.sql.catalyst.encoders._
 import org.apache.spark.sql.catalyst.expressions.aggregate.AggregateExpression
@@ -209,13 +207,21 @@ class SnappySession(_sc: SparkContext) extends SparkSession(_sc) {
     sessionState.analyzerPrepare.execute(logical)
   }
 
-  private[sql] final def executePlan(plan: LogicalPlan): QueryExecution = {
+  private[sql] final def executePlan(plan: LogicalPlan, retryCnt: Int = 0): QueryExecution = {
     try {
       val execution = sessionState.executePlan(plan)
       execution.assertAnalyzed()
       execution
     } catch {
       case e: AnalysisException =>
+        val unresolvedNodes = plan.expressions.filter(
+          x => x.isInstanceOf[UnresolvedStar] | x.isInstanceOf[UnresolvedAttribute])
+        if (e.getMessage().contains("cannot resolve") && unresolvedNodes.size > 0) {
+          reAnalyzeForUnresolvedAttribute(plan, e, retryCnt) match {
+            case Some(p) => return executePlan(p, retryCnt + 1)
+            case None => //
+          }
+        }
         // in case of connector mode, exception can be thrown if
         // table form is changed (altered) and we have old table
         // object in SnappyExternalCatalog cache
@@ -237,6 +243,51 @@ class SnappySession(_sc: SparkContext) extends SparkSession(_sc) {
             throw e
         }
     }
+  }
+
+  // Hack to fix SNAP-2440 ( TODO: Will return after 1.1.0 for a better fix )
+  private def reAnalyzeForUnresolvedAttribute(
+    originalPlan: LogicalPlan, e: AnalysisException,
+    retryCount: Int): Option[LogicalPlan] = {
+
+    if (!e.getMessage().contains("cannot resolve")) return None
+    val unresolvedNodes = originalPlan.expressions.filter(
+      x => x.isInstanceOf[UnresolvedStar] | x.isInstanceOf[UnresolvedAttribute])
+    if (retryCount > unresolvedNodes.size) return None
+
+    val errMsg = e.getMessage().split('\n').map(_.trim.filter(_ >= ' ')).mkString
+    val newPlan = originalPlan transformExpressions {
+      case us@UnresolvedStar(option) if (option.isDefined) =>
+        val targetString = option.get.mkString(".")
+        var matched = false
+        errMsg match {
+          case SnappySession.unresolvedStarRegex(first, schema, table, last) =>
+            if (sessionCatalog.tableExists(tableIdentifier(s"$schema.$table"))) {
+              val qname = s"$schema.$table"
+              if (qname.equalsIgnoreCase(targetString)) {
+                matched = true
+              }
+            }
+          case _ => matched = false
+        }
+        if (matched) UnresolvedStar(None) else us
+
+      case ua@UnresolvedAttribute(nameparts) =>
+        val targetString = nameparts.mkString(".")
+        var uqc = ""
+        var matched = false
+        errMsg match {
+          case SnappySession.unresolvedColRegex(first, schema, table, col, last) =>
+            if (sessionCatalog.tableExists(tableIdentifier(s"$schema.$table"))) {
+              val qname = s"$schema.$table.$col"
+              if (qname.equalsIgnoreCase(targetString)) matched = true
+              uqc = col
+            }
+          case _ => matched = false
+        }
+        if (matched) UnresolvedAttribute(uqc) else ua
+    }
+    if (!newPlan.equals(originalPlan)) Some(newPlan) else None
   }
 
   @transient
@@ -1797,6 +1848,9 @@ object SnappySession extends Logging {
   private[this] val ID = new AtomicInteger(0)
   private[sql] val ExecutionKey = "EXECUTION"
   private[sql] val CACHED_PUTINTO_UPDATE_PLAN = "cached_putinto_logical_plan"
+
+  val unresolvedStarRegex = """(cannot resolve ')(\w+).(\w+).*(' given input columns.*)""".r
+  val unresolvedColRegex = """(cannot resolve '`)(\w+).(\w+).(\w+)(.*given input columns.*)""".r
 
   lazy val isEnterpriseEdition: Boolean = {
     GemFireCacheImpl.setGFXDSystem(true)

--- a/core/src/main/scala/org/apache/spark/sql/internal/SnappySessionCatalog.scala
+++ b/core/src/main/scala/org/apache/spark/sql/internal/SnappySessionCatalog.scala
@@ -339,6 +339,15 @@ class SnappySessionCatalog(val externalCatalog: SnappyExternalCatalog,
     super.createDatabase(schemaDefinition, ignoreIfExists)
   }
 
+  def requireSchemaExists(schemaName: String,
+      ignoreIfNotExists: Boolean = false): Boolean = {
+    if (!databaseExists(schemaName)) {
+      if (ignoreIfNotExists) return false
+      else throw new AnalysisException(s"Schema $schemaName not found")
+    }
+    true
+  }
+
   /**
    * Drop all the objects in a schema. The provided schema must already be formatted
    * with a call to [[formatDatabaseName]].
@@ -349,10 +358,7 @@ class SnappySessionCatalog(val externalCatalog: SnappyExternalCatalog,
       throw new AnalysisException(s"$schemaName is a system reserved schema")
     }
 
-    if (!externalCatalog.databaseExists(schemaName)) {
-      if (ignoreIfNotExists) return
-      else throw new AnalysisException(s"Schema $schemaName not found")
-    }
+    if (!requireSchemaExists(schemaName, ignoreIfNotExists)) return
     checkSchemaPermission(schemaName, table = "", defaultUser = null, ignoreIfNotExists)
 
     if (cascade) {


### PR DESCRIPTION
For single table this workaround will work. But for tables with same name
but in different schema it will have issues. Will be revisited as part of
SNAP-2442

## Changes proposed in this pull request

Catching Analysis exception and checking if it is a resolution issue and if UnresolvedStar or UnresolvedAttribute kind of node is present in the execution plan. If yes then replace them by just star or minimally qualified column name.

## Patch testing

Unit test added. Precheckin underway.

## ReleaseNotes.txt changes

(Does this change require an entry in ReleaseNotes.txt? If yes, has it been added to it?)

## Other PRs 

None.
