### PR TITLE
Code changes for SNAP-2989: Snappy UI rebranding to Tibco ComputeDB iff it's Enterprise Edition 

### DIFF
--- a/cluster/src/main/scala/io/snappydata/gemxd/SnappyDataVersion.scala
+++ b/cluster/src/main/scala/io/snappydata/gemxd/SnappyDataVersion.scala
@@ -133,8 +133,7 @@ object SnappyDataVersion {
   }
 
   def getSnappyDataProductVersion: mutable.HashMap[String, String] = {
-    GemFireVersion.getInstance(classOf[GemFireXDVersion], SharedUtils.GFXD_VERSION_PROPERTIES)
-    val productEditionType = if (GemFireVersion.isEnterpriseEdition) "Enterprise" else "Community"
+    GemFireVersion.getInstance(classOf[GemFireXDVersion], SNAPPYDATA_VERSION_PROPERTIES)
 
     val versionDetails = mutable.HashMap.empty[String, String]
     versionDetails.put("productName", GemFireVersion.getProductName)
@@ -144,6 +143,10 @@ object SnappyDataVersion {
     versionDetails.put("buildPlatform", GemFireVersion.getBuildPlatform)
     versionDetails.put("nativeCodeVersion", GemFireVersion.getNativeCodeVersion)
     versionDetails.put("sourceRevision", GemFireVersion.getSourceRevision)
+
+    GemFireVersion.getInstance(classOf[GemFireXDVersion], SharedUtils.GFXD_VERSION_PROPERTIES)
+    val productEditionType = if (GemFireVersion.isEnterpriseEdition) "Enterprise" else "Community"
+
     versionDetails.put("editionType", productEditionType)
 
     versionDetails

--- a/cluster/src/main/scala/io/snappydata/gemxd/SnappyDataVersion.scala
+++ b/cluster/src/main/scala/io/snappydata/gemxd/SnappyDataVersion.scala
@@ -133,7 +133,7 @@ object SnappyDataVersion {
   }
 
   def getSnappyDataProductVersion: mutable.HashMap[String, String] = {
-    GemFireVersion.getInstance(classOf[SnappyDataVersion], SNAPPYDATA_VERSION_PROPERTIES)
+    GemFireVersion.getInstance(classOf[GemFireXDVersion], SharedUtils.GFXD_VERSION_PROPERTIES)
     val productEditionType = if (GemFireVersion.isEnterpriseEdition) "Enterprise" else "Community"
 
     val versionDetails = mutable.HashMap.empty[String, String]

--- a/cluster/src/main/scala/io/snappydata/impl/LeadImpl.scala
+++ b/cluster/src/main/scala/io/snappydata/impl/LeadImpl.scala
@@ -32,21 +32,17 @@ import com.gemstone.gemfire.CancelException
 import com.gemstone.gemfire.cache.CacheClosedException
 import com.gemstone.gemfire.distributed.internal.InternalDistributedSystem
 import com.gemstone.gemfire.distributed.internal.locks.{DLockService, DistributedMemberLock}
-import com.gemstone.gemfire.internal.GemFireVersion
-import com.gemstone.gemfire.internal.cache.{CacheServerLauncher, GemFireCacheImpl, Status}
+import com.gemstone.gemfire.internal.cache.{CacheServerLauncher, Status}
 import com.gemstone.gemfire.internal.shared.ClientSharedUtils
 import com.pivotal.gemfirexd.FabricService.State
-import com.pivotal.gemfirexd.internal.GemFireXDVersion
 import com.pivotal.gemfirexd.internal.engine.Misc
 import com.pivotal.gemfirexd.internal.engine.distributed.utils.GemFireXDUtils
 import com.pivotal.gemfirexd.internal.engine.store.ServerGroupUtils
-import com.pivotal.gemfirexd.internal.shared.common.SharedUtils
 import com.pivotal.gemfirexd.internal.shared.common.reference.SQLState
 import com.pivotal.gemfirexd.{Attribute, Constants, FabricService, NetworkInterface}
 import com.typesafe.config.{Config, ConfigFactory}
 import io.snappydata.Constant.{SPARK_PREFIX, SPARK_SNAPPY_PREFIX, JOBSERVER_PROPERTY_PREFIX => JOBSERVER_PREFIX, PROPERTY_PREFIX => SNAPPY_PREFIX, STORE_PROPERTY_PREFIX => STORE_PREFIX}
 import io.snappydata.cluster.ExecutorInitiator
-import io.snappydata.gemxd.SnappyDataVersion
 import io.snappydata.util.ServiceUtils
 import io.snappydata.{Constant, Lead, LocalizedMessages, Property, ProtocolOverrides, ServiceManager, SnappyTableStatsProviderService}
 import org.apache.thrift.transport.TTransportException
@@ -164,12 +160,7 @@ class LeadImpl extends ServerImpl with Lead
         .iterator().asScala.map(k => k -> bootProperties.getProperty(k)).toSeq)
 
     val productName = {
-      GemFireCacheImpl.setGFXDSystem(true)
-      GemFireVersion.getInstance(classOf[SnappyDataVersion],
-        "io/snappydata/SnappyDataVersion.properties")
-      GemFireVersion.createVersionFile()
-      GemFireVersion.getInstance(classOf[GemFireXDVersion], SharedUtils.GFXD_VERSION_PROPERTIES)
-      if (GemFireVersion.isEnterpriseEdition) {
+      if (SnappySession.isEnterpriseEdition) {
         "TIBCO ComputeDB"
       } else {
         "SnappyData"


### PR DESCRIPTION


## Changes proposed in this pull request

1. Setting product name to SnappyData if it is community edition else TIBCO ComputeDB.
2. Loading GFXD version properties to identify correct product type

## Patch testing

 - Tested Manually

## ReleaseNotes.txt changes

 Yes

## Other PRs 

 **Spark:** https://github.com/SnappyDataInc/spark/pull/151

(Does this change require changes in other projects- store, spark, spark-jobserver, aqp? Add the links of PR of the other subprojects that are related to this change)
