### PR TITLE
Fix buffer reference count for couple of cases

### DIFF
--- a/core/src/main/scala/org/apache/spark/sql/execution/columnar/ColumnBatchIterator.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/columnar/ColumnBatchIterator.scala
@@ -69,7 +69,7 @@ final class ColumnBatchIterator(region: LocalRegion, val batch: ColumnBatch,
   private var currentKeyPartitionId: Int = _
   private var currentKeyUUID: Long = _
   private var batchProcessed = false
-  private var currentColumns = new ArrayBuffer[ColumnFormatValue]()
+  private var currentColumns: ArrayBuffer[ColumnFormatValue] = _
 
   override protected def createIterator(container: GemFireContainer, region: LocalRegion,
       tx: TXStateInterface): PRIterator = if (region ne null) {

--- a/encoders/src/main/scala/org/apache/spark/sql/execution/columnar/encoding/ColumnDeltaEncoder.scala
+++ b/encoders/src/main/scala/org/apache/spark/sql/execution/columnar/encoding/ColumnDeltaEncoder.scala
@@ -273,12 +273,13 @@ final class ColumnDeltaEncoder(val hierarchyDepth: Int) extends ColumnEncoder {
 
   override private[sql] def close(releaseData: Boolean): Unit = {
     realEncoder.close(releaseData)
-    /*
+  }
+
+  private def clearPositions(): Unit = {
     if (positionsArray ne null) {
       BufferAllocator.releaseBuffer(positionsArray)
       positionsArray = null
     }
-    */
   }
 
   private def consumeDecoder(decoder: ColumnDecoder, decoderNullPosition: Int,
@@ -413,7 +414,7 @@ final class ColumnDeltaEncoder(val hierarchyDepth: Int) extends ColumnEncoder {
     } else {
       positionIndex = 0
       maxSize = 0
-      positionsArray = null
+      clearPositions()
     }
 
     var position1 = ColumnEncoding.readInt(columnBytes1, positionCursor1)
@@ -546,8 +547,9 @@ final class ColumnDeltaEncoder(val hierarchyDepth: Int) extends ColumnEncoder {
     // finally copy the entire encoded data
     Platform.copyMemory(encodedBytes, deltaStart, columnBytes, cursor, deltaSize)
 
-    // release the intermediate buffer
+    // release the intermediate buffers
     allocator.release(encodedData)
+    clearPositions()
     close(releaseData = false)
 
     buffer
@@ -599,8 +601,9 @@ final class ColumnDeltaEncoder(val hierarchyDepth: Int) extends ColumnEncoder {
     }
     Platform.copyMemory(dataBuffer, dataBeginPosition, columnBytes, cursor, dataSize)
 
-    // release the old buffer
+    // release the old buffers
     dataAllocator.release(dataColumnBytes)
+    clearPositions()
     // clear the encoder
     close(releaseData = false)
     buffer

--- a/encoders/src/main/scala/org/apache/spark/sql/execution/columnar/impl/ColumnFormatEntry.scala
+++ b/encoders/src/main/scala/org/apache/spark/sql/execution/columnar/impl/ColumnFormatEntry.scala
@@ -643,7 +643,7 @@ class ColumnFormatValue extends SerializedDiskBuffer
       synchronized {
         // check if another thread already compressed and changed the underlying buffer
         if (this.decompressionState <= 0) {
-          BufferAllocator.releaseBuffer(compressed)
+          allocator.release(compressed)
           return this
         }
 
@@ -651,7 +651,8 @@ class ColumnFormatValue extends SerializedDiskBuffer
         state = this.decompressionState
         val bufferLen = buffer.remaining()
         val startCompression = perfStats.startCompression()
-        compressed = CompressionUtils.codecCompress(codecId, buffer, bufferLen, compressed)
+        compressed = CompressionUtils.codecCompress(codecId, buffer, bufferLen,
+          compressed, allocator)
         // update compression stats
         perfStats.endCompression(startCompression, bufferLen, compressed.limit())
         if (compressed ne buffer) {

--- a/encoders/src/main/scala/org/apache/spark/sql/store/CompressionUtils.scala
+++ b/encoders/src/main/scala/org/apache/spark/sql/store/CompressionUtils.scala
@@ -77,7 +77,7 @@ object CompressionUtils {
   }
 
   def codecCompress(codecId: Int, input: ByteBuffer, len: Int,
-      result: ByteBuffer): ByteBuffer = {
+      result: ByteBuffer, allocator: BufferAllocator): ByteBuffer = {
     val position = input.position()
     val resultLen = try codecId match {
       case CompressionCodecId.LZ4_ID =>
@@ -104,6 +104,7 @@ object CompressionUtils {
       result.limit(resultLen + COMPRESSION_HEADER_SIZE)
       result
     } else {
+      allocator.release(result)
       input
     }
   }


### PR DESCRIPTION
## Changes proposed in this pull request

- release compression buffer if compression has been determined to be ineffective
- release positions array buffer created by ColumnDeltaEncoder

## Patch testing

precheckin -Pstore

## ReleaseNotes.txt changes

NA

## Other PRs 

https://github.com/SnappyDataInc/snappy-store/pull/474