### PR TITLE
Make SnappyConf key name search case-insensitive

### DIFF
--- a/core/src/main/scala/org/apache/spark/sql/internal/SnappySessionState.scala
+++ b/core/src/main/scala/org/apache/spark/sql/internal/SnappySessionState.scala
@@ -806,7 +806,9 @@ class SnappyConf(@transient val session: SnappySession)
     case SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key |
          Property.HashJoinSize.name |
          Property.HashAggregateSize.name |
-         Property.ForceLinkPartitionsToBuckets.name => session.clearPlanCache(); key
+         Property.ForceLinkPartitionsToBuckets.name =>
+      session.clearPlanCache()
+      key
     case SQLConf.SHUFFLE_PARTITIONS.key =>
       // stop dynamic determination of shuffle partitions
       if (doSet) {
@@ -860,7 +862,9 @@ class SnappyConf(@transient val session: SnappySession)
       session.clearPlanCache()
       key
 
-    case SQLConf.WHOLESTAGE_CODEGEN_ENABLED.key => session.clearPlanCache(); key
+    case SQLConf.WHOLESTAGE_CODEGEN_ENABLED.key =>
+      session.clearPlanCache()
+      key
 
     case Constant.TRIGGER_AUTHENTICATION => value match {
       case Some(boolVal) if boolVal.toString.toBoolean =>

--- a/core/src/main/scala/org/apache/spark/sql/internal/SnappySessionState.scala
+++ b/core/src/main/scala/org/apache/spark/sql/internal/SnappySessionState.scala
@@ -800,12 +800,13 @@ class SnappyConf(@transient val session: SnappySession)
     else math.min(super.numShufflePartitions, session.sparkContext.defaultParallelism)
   }
 
-  private def keyUpdateActions(key: String, value: Option[Any], doSet: Boolean): Unit = key match {
+  private def keyUpdateActions(key: String, value: Option[Any],
+      doSet: Boolean, search: Boolean = true): String = key match {
     // clear plan cache when some size related key that effects plans changes
     case SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key |
          Property.HashJoinSize.name |
          Property.HashAggregateSize.name |
-         Property.ForceLinkPartitionsToBuckets.name => session.clearPlanCache()
+         Property.ForceLinkPartitionsToBuckets.name => session.clearPlanCache(); key
     case SQLConf.SHUFFLE_PARTITIONS.key =>
       // stop dynamic determination of shuffle partitions
       if (doSet) {
@@ -815,18 +816,22 @@ class SnappyConf(@transient val session: SnappySession)
         dynamicShufflePartitions = coreCountForShuffle
       }
       session.clearPlanCache()
+      key
     case Property.SchedulerPool.name =>
       schedulerPool = value match {
         case None => Property.SchedulerPool.defaultValue.get
         case Some(pool: String) if session.sparkContext.getPoolForName(pool).isDefined => pool
         case Some(pool) => throw new IllegalArgumentException(s"Invalid Pool $pool")
       }
+      key
 
-    case Property.PartitionPruning.name => value match {
-      case Some(b) => session.partitionPruning = b.toString.toBoolean
-      case None => session.partitionPruning = Property.PartitionPruning.defaultValue.get
-    }
+    case Property.PartitionPruning.name =>
+      value match {
+        case Some(b) => session.partitionPruning = b.toString.toBoolean
+        case None => session.partitionPruning = Property.PartitionPruning.defaultValue.get
+      }
       session.clearPlanCache()
+      key
 
     case Property.PlanCaching.name =>
       value match {
@@ -837,6 +842,7 @@ class SnappyConf(@transient val session: SnappySession)
           session.planCaching = boolVal.toString.toBoolean
         case None => session.planCaching = Property.PlanCaching.defaultValue.get
       }
+      key
 
     case Property.Tokenize.name =>
       value match {
@@ -844,6 +850,7 @@ class SnappyConf(@transient val session: SnappySession)
         case None => session.tokenize = Property.Tokenize.defaultValue.get
       }
       session.clearPlanCache()
+      key
 
     case Property.DisableHashJoin.name =>
       value match {
@@ -851,8 +858,9 @@ class SnappyConf(@transient val session: SnappySession)
         case None => session.disableHashJoin = Property.DisableHashJoin.defaultValue.get
       }
       session.clearPlanCache()
+      key
 
-    case SQLConf.WHOLESTAGE_CODEGEN_ENABLED.key => session.clearPlanCache()
+    case SQLConf.WHOLESTAGE_CODEGEN_ENABLED.key => session.clearPlanCache(); key
 
     case Constant.TRIGGER_AUTHENTICATION => value match {
       case Some(boolVal) if boolVal.toString.toBoolean =>
@@ -865,10 +873,23 @@ class SnappyConf(@transient val session: SnappySession)
               throw Util.generateCsSQLException(SQLState.NET_CONNECT_AUTH_FAILED, failure)
           }
         }
-      case _ =>
+        key
+      case _ => key
     }
 
-    case _ => // ignore others
+    case _ =>
+      // search case-insensitively for other keys if required
+      if (search) {
+        getAllDefinedConfs.collectFirst {
+          case (k, _, _) if k.equalsIgnoreCase(key) => k
+        } match {
+          case None => key
+          case Some(k) =>
+            // execute keyUpdateActions again since it might be one of the pre-defined ones
+            keyUpdateActions(k, value, doSet, search = false)
+            k
+        }
+      } else key
   }
 
   private[sql] def refreshNumShufflePartitions(): Unit = synchronized {
@@ -900,12 +921,12 @@ class SnappyConf(@transient val session: SnappySession)
   def activeSchedulerPool: String = schedulerPool
 
   override def setConfString(key: String, value: String): Unit = {
-    keyUpdateActions(key, Some(value), doSet = true)
-    super.setConfString(key, value)
+    val rkey = keyUpdateActions(key, Some(value), doSet = true)
+    super.setConfString(rkey, value)
   }
 
   override def setConf[T](entry: ConfigEntry[T], value: T): Unit = {
-    keyUpdateActions(entry.key, Some(value), doSet = true)
+    keyUpdateActions(entry.key, Some(value), doSet = true, search = false)
     require(entry != null, "entry cannot be null")
     require(value != null, s"value cannot be null for key: ${entry.key}")
     entry.defaultValue match {
@@ -915,12 +936,12 @@ class SnappyConf(@transient val session: SnappySession)
   }
 
   override def unsetConf(key: String): Unit = {
-    keyUpdateActions(key, None, doSet = false)
-    super.unsetConf(key)
+    val rkey = keyUpdateActions(key, None, doSet = false)
+    super.unsetConf(rkey)
   }
 
   override def unsetConf(entry: ConfigEntry[_]): Unit = {
-    keyUpdateActions(entry.key, None, doSet = false)
+    keyUpdateActions(entry.key, None, doSet = false, search = false)
     super.unsetConf(entry)
   }
 }

--- a/core/src/test/scala/org/apache/spark/sql/store/TokenizationTest.scala
+++ b/core/src/test/scala/org/apache/spark/sql/store/TokenizationTest.scala
@@ -447,8 +447,9 @@ class TokenizationTest
       cacheMap.clear()
 
       val newSession3 = new SnappySession(snc.sparkSession.sparkContext)
-      newSession3.sql(s"set snappydata.sql.tokenize=false").collect()
-      Property.PlanCaching.set(newSession3.sessionState.conf, true)
+      newSession3.sql(s"set snappydata.sql.tokenize=false")
+      // check that SQLConf property names are case-insensitive
+      newSession3.sql(s"set snappydata.sql.plancaching=true")
       assert(cacheMap.size() == 0)
 
       q.zipWithIndex.foreach { case (x, i) =>


### PR DESCRIPTION

## Changes proposed in this pull request

- search through all pre-defined key names case-insensitively for set/unset of SQLConf properties
- added check for planCaching property for the same

## Patch testing

precheckin

## ReleaseNotes.txt changes

mention that SQLConf property names are case-insensitive

## Other PRs 

NA