### PR TITLE
Added code to copy the configuration files into other member of cluster

### DIFF
--- a/cluster/sbin/snappy-nodes.sh
+++ b/cluster/sbin/snappy-nodes.sh
@@ -244,7 +244,7 @@ function execute() {
     esac
   done
   #copy the conf files into other node before starting the launch processs
-  if [[ -n "$isStart" && $NO_COPYCONF -eq 0 ]]; then
+  if [[ -n "$isStart" && $SKIP_CONF_COPY -eq 0 ]]; then
     copyConf "$@"    
   fi
   if [ "$host" != "localhost" ]; then
@@ -360,7 +360,7 @@ function copyConf() {
 	  else
 	      backupDir="backup"
 	      if [[ ! -z $(ssh $host "cat $entry" | diff - "$entry") ]] ; then
-		backupFileName=${fileName}_${TIME_STAMP_OF_START}
+		backupFileName=${fileName}_${START_ALL_TIMESTAMP}
 		echo "INFO: Copied $filename from this host to $host. Moved the original $filename on $host to $backupFileName."
                 (ssh "$host" "{ if [ ! -d \"${SPARK_CONF_DIR}/$backupDir\" ]; then  mkdir \"${SPARK_CONF_DIR}/$backupDir\"; fi; } ")
 		ssh $host "mv ${SPARK_CONF_DIR}/$fileName ${SPARK_CONF_DIR}/$backupDir/$backupFileName"		    

--- a/cluster/sbin/snappy-nodes.sh
+++ b/cluster/sbin/snappy-nodes.sh
@@ -339,8 +339,11 @@ function getNumLeadsOnHost() {
 }
 
 function scpConf() {
- var=$(ip addr | grep 'state UP' -A2 | tail -n1 | awk '{print $2}' | cut -f1  -d'/')
- if [[ "$host" != "$var" && "$host" != "localhost" ]] ; then
+ 
+ currentNodeIpAddr=$(ip addr | grep 'state UP' -A2 | head -n3 | tail -n1 | awk '{print $2}' | cut -f1  -d'/')
+ currentNodeHostName=$(uname -n)
+
+ if [[ "$host" != "$currentNodeIpAddr" && "$host" != "localhost" && "$host" != $currentNodeHostName ]] ; then
   	#loop to get the all the files avaliable in Conf directory
 	for entry in "${SPARK_CONF_DIR}"/*
 	do
@@ -351,14 +354,21 @@ function scpConf() {
    	    template=".template"
 	    #check the extension, interested in files those doesn't have template extension
 	    if [[ ! "$fileName" = @(*.template) ]]; then	       	
-		if ! ssh $host "test -e $entry"; then #"File does not exist." 		  
-		  scp -i ~/.ssh/id_rsa.pub ${SPARK_CONF_DIR}/$fileName  $host:${SPARK_CONF_DIR}
+		if ! ssh $host "test -e $entry"; then #"File does not exist."	  
+		  scp ${SPARK_CONF_DIR}/$fileName  $host:${SPARK_CONF_DIR}
 		else
-		  #file exits but do not override/copy..since user might have different configuration setting for different node.
-      		  # except			 
-		  if [[ "$fileName" == "locators" || "$fileName" == "servers" || "$fileName" == "leads"  ]]; then		 
-		  scp -i ~/.ssh/id_rsa.pub ${SPARK_CONF_DIR}/$fileName  $host:${SPARK_CONF_DIR}   
-	          fi								
+		  #file exits but before replacing with new one, create a backup file and warn user about it then replace
+      		  # except locators,leads and servers file has to replace all the time			 
+		  if [[ "$fileName" == "locators" || "$fileName" == "servers" || "$fileName" == "leads"  ]]; then
+		    scp ${SPARK_CONF_DIR}/$fileName  $host:${SPARK_CONF_DIR} 
+		  else
+	          	if [[ ! -z $(ssh $host "cat $entry" | diff - "$entry") ]] ; then
+				backupFileName=${fileName%.*}_`date +%Y_%m_%d_%H_%M_%S`.${fileName#*.}
+				echo "###### As $fileName differ from the $fileName present on $host, creating a backup file with the name $backupFileName before replacing #######"
+				ssh $host "mv ${SPARK_CONF_DIR}/$fileName ${SPARK_CONF_DIR}/$backupFileName"		    
+		    		scp ${SPARK_CONF_DIR}/$fileName  $host:${SPARK_CONF_DIR} 
+		    	fi  
+          fi												
 		fi        				
 	    fi # end of if, check extension
 	  fi # end of if to get each file
@@ -419,7 +429,11 @@ if [ -n "${HOSTLIST}" ]; then
       execute "$@"
       if [ -n "$isStart" ]; then
     	count=$(echo $MEMBERS_FILE | grep -o -i "$host" "$MEMBERS_FILE" | wc -l)
-	if [ $count -eq 2 ]; then  # 2 ,since in a single line there wiil be two match of ip address
+	# checking count is 2, since in a single line of member.txt, there will be two matches of ip address/hostname of a component.
+	# entry happpens in member file sequentially. So for example, if on some node 1, both server and lead is running, then by that time lead will start,
+	# member file will have already an entry for ipaddress/hostname of that node 1 after starting the server  
+	# it kind of cross checking if component with same ipaddress already present in member file or not.
+	if [ $count -eq 2 ]; then
     	scpConf "$@"
   	fi
       fi

--- a/cluster/sbin/snappy-nodes.sh
+++ b/cluster/sbin/snappy-nodes.sh
@@ -338,12 +338,41 @@ function getNumLeadsOnHost() {
   echo $numLeadsOnHost
 }
 
+function scpConf() {
+ var=$(ip addr | grep 'state UP' -A2 | tail -n1 | awk '{print $2}' | cut -f1  -d'/')
+ if [[ "$host" != "$var" && "$host" != "localhost" ]] ; then
+  	#loop to get the all the files avaliable in Conf directory
+	for entry in "${SPARK_CONF_DIR}"/*
+	do
+	  if [ -f "$entry" ];then
+	    #${file%.*} to get the filename without the extension and ${file##*.} to get the extension alone
+	    fileName=$(basename $entry)
+	    #echo "fileName:  $fileName"
+   	    template=".template"
+	    #check the extension, interested in files those doesn't have template extension
+	    if [[ ! "$fileName" = @(*.template) ]]; then	       	
+		if ! ssh $host "test -e $entry"; then #"File does not exist." 		  
+		  scp -i ~/.ssh/id_rsa.pub ${SPARK_CONF_DIR}/$fileName  $host:${SPARK_CONF_DIR}
+		else
+		  #file exits but do not override/copy..since user might have different configuration setting for different node.
+      		  # except			 
+		  if [[ "$fileName" == "locators" || "$fileName" == "servers" || "$fileName" == "leads"  ]]; then		 
+		  scp -i ~/.ssh/id_rsa.pub ${SPARK_CONF_DIR}/$fileName  $host:${SPARK_CONF_DIR}   
+	          fi								
+		fi        				
+	    fi # end of if, check extension
+	  fi # end of if to get each file
+	done  #end of for loop
+ fi # end of if 	
+}
+
 if [ -n "${HOSTLIST}" ]; then
   declare -a arr
   declare -a hosts
   declare -a counts
   isStartOrStatus=
-
+  isStart=
+  count=0
   while read slave || [[ -n "${slave}" ]]; do
     [[ -z "$(echo $slave | grep ^[^#])" ]] && continue
     arr[${#arr[@]}]="$slave"
@@ -371,6 +400,9 @@ if [ -n "${HOSTLIST}" ]; then
   if echo $"${@// /\\ }" | grep -wq "start\|status"; then
     isStartOrStatus=1
   fi
+  if echo $"${@// /\\ }" | grep -wq "start"; then
+    isStart=1
+  fi
   for slave in "${arr[@]}"; do
     if [ -n "$isStartOrStatus" ]; then
       host="$(echo "$slave "| tr -s ' ' | cut -d ' ' -f1)"
@@ -385,6 +417,12 @@ if [ -n "${HOSTLIST}" ]; then
         args="$args -J-Dsnappydata.numLeadsOnHost=$(getNumLeadsOnHost "$host")"
       fi
       execute "$@"
+      if [ -n "$isStart" ]; then
+    	count=$(echo $MEMBERS_FILE | grep -o -i "$host" "$MEMBERS_FILE" | wc -l)
+	if [ $count -eq 2 ]; then  # 2 ,since in a single line there wiil be two match of ip address
+    	scpConf "$@"
+  	fi
+      fi
     fi
     ((index++))
   done

--- a/cluster/sbin/snappy-nodes.sh
+++ b/cluster/sbin/snappy-nodes.sh
@@ -138,7 +138,7 @@ else
 fi
 
 MEMBERS_FILE="$SNAPPY_HOME/work/members.txt"
-
+isStart=
 
 function execute() {
   dirparam="$(echo $args | sed -n 's/^.*\(-dir=[^ ]*\).*$/\1/p')"
@@ -243,6 +243,14 @@ function execute() {
       -*) postArgs="$postArgs $arg"
     esac
   done
+  #copy the conf files into other node before starting the launch processs
+  if [ -n "$isStart" ]; then
+   #check $host is present in memberArr or not. If not then copy else do not copy
+    if [[ ! " ${memberArray[@]} " =~ " ${host} " ]]; then
+      memberArray+=($host)
+      scpConf "$@"    
+    fi    
+  fi
   if [ "$host" != "localhost" ]; then
     if [ "$dirfolder" != "" ]; then
       # Create the directory for the snappy component if the folder is a default folder
@@ -339,41 +347,35 @@ function getNumLeadsOnHost() {
 }
 
 function scpConf() {
- 
- currentNodeIpAddr=$(ip addr | grep 'state UP' -A2 | head -n3 | tail -n1 | awk '{print $2}' | cut -f1  -d'/')
- currentNodeHostName=$(uname -n)
+  currentNodeIpAddr=$(ip addr | grep 'state UP' -A2 | head -n3 | tail -n1 | awk '{print $2}' | cut -f1  -d'/')
+  currentNodeHostName=$(uname -n)
 
- if [[ "$host" != "$currentNodeIpAddr" && "$host" != "localhost" && "$host" != $currentNodeHostName ]] ; then
-  	#loop to get the all the files avaliable in Conf directory
-	for entry in "${SPARK_CONF_DIR}"/*
-	do
-	  if [ -f "$entry" ];then
-	    #${file%.*} to get the filename without the extension and ${file##*.} to get the extension alone
-	    fileName=$(basename $entry)
-	    #echo "fileName:  $fileName"
-   	    template=".template"
-	    #check the extension, interested in files those doesn't have template extension
-	    if [[ ! "$fileName" = @(*.template) ]]; then	       	
-		if ! ssh $host "test -e $entry"; then #"File does not exist."	  
-		  scp ${SPARK_CONF_DIR}/$fileName  $host:${SPARK_CONF_DIR}
-		else
-		  #file exits but before replacing with new one, create a backup file and warn user about it then replace
-      		  # except locators,leads and servers file has to replace all the time			 
-		  if [[ "$fileName" == "locators" || "$fileName" == "servers" || "$fileName" == "leads"  ]]; then
-		    scp ${SPARK_CONF_DIR}/$fileName  $host:${SPARK_CONF_DIR} 
-		  else
-	          	if [[ ! -z $(ssh $host "cat $entry" | diff - "$entry") ]] ; then
-				backupFileName=${fileName%.*}_`date +%Y_%m_%d_%H_%M_%S`.${fileName#*.}
-				echo "###### As $fileName differ from the $fileName present on $host, creating a backup file with the name $backupFileName before replacing #######"
-				ssh $host "mv ${SPARK_CONF_DIR}/$fileName ${SPARK_CONF_DIR}/$backupFileName"		    
-		    		scp ${SPARK_CONF_DIR}/$fileName  $host:${SPARK_CONF_DIR} 
-		    	fi  
-          fi												
-		fi        				
-	    fi # end of if, check extension
-	  fi # end of if to get each file
-	done  #end of for loop
- fi # end of if 	
+  if [[ "$host" != "$currentNodeIpAddr" && "$host" != "localhost" && "$host" != $currentNodeHostName ]] ; then
+  #loop to get the all the files avaliable in Conf directory
+    for entry in "${SPARK_CONF_DIR}"/*; do
+      if [ -f "$entry" ];then
+        #${file%.*} to get the filename without the extension and ${file##*.} to get the extension alone
+	fileName=$(basename $entry)
+ 	template=".template"
+	#check the extension, interested in files those doesn't have template extension
+	if [[ ! "$fileName" = @(*.template) ]]; then	       	
+	  if ! ssh $host "test -e $entry"; then #"File does not exist."	  
+            scp ${SPARK_CONF_DIR}/$fileName  $host:${SPARK_CONF_DIR}
+	  else
+	      backupDir="backup"
+	      if [[ ! -z $(ssh $host "cat $entry" | diff - "$entry") ]] ; then
+		backupFileName=${fileName}_`date +%Y_%m_%d_%H_%M_%S`
+		echo "INFO: Copied $filename from this host to $host. Moved the original $filename on $host to $backupFileName."
+                (ssh "$host" "{ if [ ! -d \"${SPARK_CONF_DIR}/$backupDir\" ]; then  mkdir \"${SPARK_CONF_DIR}/$backupDir\"; fi; } ")
+		ssh $host "mv ${SPARK_CONF_DIR}/$fileName ${SPARK_CONF_DIR}/$backupDir/$backupFileName"		    
+		scp ${SPARK_CONF_DIR}/$fileName  $host:${SPARK_CONF_DIR} 
+	      fi  
+            #fi												
+	  fi        				
+	fi # end of if, check extension
+      fi # end of if to get each file
+    done  #end of for loop
+  fi # end of if 	
 }
 
 if [ -n "${HOSTLIST}" ]; then
@@ -381,7 +383,6 @@ if [ -n "${HOSTLIST}" ]; then
   declare -a hosts
   declare -a counts
   isStartOrStatus=
-  isStart=
   count=0
   while read slave || [[ -n "${slave}" ]]; do
     [[ -z "$(echo $slave | grep ^[^#])" ]] && continue
@@ -427,16 +428,6 @@ if [ -n "${HOSTLIST}" ]; then
         args="$args -J-Dsnappydata.numLeadsOnHost=$(getNumLeadsOnHost "$host")"
       fi
       execute "$@"
-      if [ -n "$isStart" ]; then
-    	count=$(echo $MEMBERS_FILE | grep -o -i "$host" "$MEMBERS_FILE" | wc -l)
-	# checking count is 2, since in a single line of member.txt, there will be two matches of ip address/hostname of a component.
-	# entry happpens in member file sequentially. So for example, if on some node 1, both server and lead is running, then by that time lead will start,
-	# member file will have already an entry for ipaddress/hostname of that node 1 after starting the server  
-	# it kind of cross checking if component with same ipaddress already present in member file or not.
-	if [ $count -eq 2 ]; then
-    	scpConf "$@"
-  	fi
-      fi
     fi
     ((index++))
   done

--- a/cluster/sbin/snappy-nodes.sh
+++ b/cluster/sbin/snappy-nodes.sh
@@ -244,12 +244,8 @@ function execute() {
     esac
   done
   #copy the conf files into other node before starting the launch processs
-  if [ -n "$isStart" ]; then
-   #check $host is present in memberArr or not. If not then copy else do not copy
-    if [[ ! " ${memberArray[@]} " =~ " ${host} " ]]; then
-      memberArray+=($host)
-      scpConf "$@"    
-    fi    
+  if [[ -n "$isStart" && $NO_COPYCONF -eq 0 ]]; then
+    copyConf "$@"    
   fi
   if [ "$host" != "localhost" ]; then
     if [ "$dirfolder" != "" ]; then
@@ -345,8 +341,8 @@ function getNumLeadsOnHost() {
   fi
   echo $numLeadsOnHost
 }
-
-function scpConf() {
+# function for copying all the configuration files into the other nodes/members of the cluster
+function copyConf() {
   currentNodeIpAddr=$(ip addr | grep 'state UP' -A2 | head -n3 | tail -n1 | awk '{print $2}' | cut -f1  -d'/')
   currentNodeHostName=$(uname -n)
 
@@ -364,7 +360,7 @@ function scpConf() {
 	  else
 	      backupDir="backup"
 	      if [[ ! -z $(ssh $host "cat $entry" | diff - "$entry") ]] ; then
-		backupFileName=${fileName}_`date +%Y_%m_%d_%H_%M_%S`
+		backupFileName=${fileName}_${TIME_STAMP_OF_START}
 		echo "INFO: Copied $filename from this host to $host. Moved the original $filename on $host to $backupFileName."
                 (ssh "$host" "{ if [ ! -d \"${SPARK_CONF_DIR}/$backupDir\" ]; then  mkdir \"${SPARK_CONF_DIR}/$backupDir\"; fi; } ")
 		ssh $host "mv ${SPARK_CONF_DIR}/$fileName ${SPARK_CONF_DIR}/$backupDir/$backupFileName"		    
@@ -383,7 +379,6 @@ if [ -n "${HOSTLIST}" ]; then
   declare -a hosts
   declare -a counts
   isStartOrStatus=
-  count=0
   while read slave || [[ -n "${slave}" ]]; do
     [[ -z "$(echo $slave | grep ^[^#])" ]] && continue
     arr[${#arr[@]}]="$slave"

--- a/cluster/sbin/snappy-start-all.sh
+++ b/cluster/sbin/snappy-start-all.sh
@@ -65,6 +65,7 @@ while (( "$#" )); do
   shift
 done
 
+declare -a memberArray
 
 # Start Locators
 "$sbin"/snappy-locators.sh $CONF_DIR_ARG start $clustermode "$@"

--- a/cluster/sbin/snappy-start-all.sh
+++ b/cluster/sbin/snappy-start-all.sh
@@ -37,6 +37,7 @@ fi
 BACKGROUND=-bg
 clustermode=
 CONF_DIR_ARG=
+NO_COPYCONF=0
 
 while (( "$#" )); do
   param="$1"
@@ -59,13 +60,17 @@ while (( "$#" )); do
     rowstore)
       clustermode="rowstore"
     ;;
+    -nocopyconf | --nocopyconf)
+      NO_COPYCONF=1
+    ;;
     *)
     ;;
   esac
   shift
 done
 
-declare -a memberArray
+export TIME_STAMP_OF_START="$(date +"%Y_%m_%d_%H_%M_%S")"
+export NO_COPYCONF=$NO_COPYCONF
 
 # Start Locators
 "$sbin"/snappy-locators.sh $CONF_DIR_ARG start $clustermode "$@"

--- a/cluster/sbin/snappy-start-all.sh
+++ b/cluster/sbin/snappy-start-all.sh
@@ -37,7 +37,7 @@ fi
 BACKGROUND=-bg
 clustermode=
 CONF_DIR_ARG=
-NO_COPYCONF=0
+SKIP_CONF_COPY=0
 
 while (( "$#" )); do
   param="$1"
@@ -60,8 +60,8 @@ while (( "$#" )); do
     rowstore)
       clustermode="rowstore"
     ;;
-    -nocopyconf | --nocopyconf)
-      NO_COPYCONF=1
+    --skipconfcopy)
+      SKIP_CONF_COPY=1
     ;;
     *)
     ;;
@@ -69,8 +69,8 @@ while (( "$#" )); do
   shift
 done
 
-export TIME_STAMP_OF_START="$(date +"%Y_%m_%d_%H_%M_%S")"
-export NO_COPYCONF=$NO_COPYCONF
+export START_ALL_TIMESTAMP="$(date +"%Y_%m_%d_%H_%M_%S")"
+export SKIP_CONF_COPY
 
 # Start Locators
 "$sbin"/snappy-locators.sh $CONF_DIR_ARG start $clustermode "$@"


### PR DESCRIPTION
## Changes proposed in this pull request
As per requirement, added code in snappy-nodes.sh to copy the configuration files present in "conf" directory into other members of the cluster. Files present in "conf" are log4j.properties, spark-env.sh, spark-defaults.conf,snappy-env.sh, slaves, servers, leads, locators, metrics.properties,fairscheduler.xml, debug.conf.template,docker.properties. Along with these files if the user has its own configuration files, copy those files as well.
Following use case has been taken care:
1- If cluster running in localhost then do not copy, even though the configuration file configured with IP address and host-name.
2- Do not copy files with ".template" extension
3- Replace the leads, locators, servers files, with existing one other member of the cluster but inform the user about it and keep the backup of it.
4- Replace the other configuration files if it exists in other node/member of the cluster but inform the user about it and keep backup of it.

## Patch testing
To test this patch created the Virtual Machine with Ubuntu 16.04. Ran the multinode cluster to test and copy the files from the main machine to VM. Please let me know if there any test suite available for testing scripts.

## ReleaseNotes.txt changes
NA

## Other PRs 
