### PR TITLE
Snap 2631

### DIFF
--- a/cluster/sbin/check-dir-option.sh
+++ b/cluster/sbin/check-dir-option.sh
@@ -22,39 +22,29 @@
 
 noOfInputsArgs=$#
 
-if [ $noOfInputsArgs -eq 0 ]
-  then  #if no arguments passed
-	echo "ERROR : No arguments has been provided. Please provide required arguments"
-	#echo $usage
-  	exit 1
+if [ $noOfInputsArgs -eq 0 ];then  #if no arguments passed
+  echo "ERROR: No arguments have been provided. Please provide required arguments"
+  exit 1
 else
 
-    # there could be two scenario if arguments are not equal to zero
-	# - script get triggerd from snappy-start-all.sh--then argument provided by this snappy-nodes.sh
-	# - user executing individual component script,in this case this script: snappy-locator.sh
-   # Need to check in both case -dir option is provided or not
-	isPresent=0      
-	for argument in "$@"
-	 do	
-		#echo "argument value: $argument"	
-        	if [[ "$argument" == -dir=*  ]]
-		 then
-			isPresent=1 #  present
-			if [ -z $(echo $argument | cut -d'=' -f 2) ] #present but empty i.e "-dir="
-			 then
-			  isPresent=0
-			#else #present but should be a directory but do not need to check here, as getting check in launcher			
-			fi			
-		fi
-	done
+  # there could be two scenario if arguments are not equal to zero
+    # - script get triggerd from snappy-start-all.sh--then argument provided by this snappy-nodes.sh
+    # - user executing individual component script,in this case this script: snappy-locator.sh
+  # Need to check in both case -dir option is provided or not
+  isPresent=0      
+  for argument in "$@"; do	
+    if [[ "$argument" == -dir=*  ]]; then
+      isPresent=1 #  present
+      if [ -z $(echo $argument | cut -d'=' -f 2) ]; then #present but empty i.e "-dir="
+        isPresent=0
+      #else #present but should be a directory but do not need to check here, as getting check in launcher			
+      fi			
+    fi
+  done
 	
-	if [ $isPresent -eq 0 ]
-	 then
-	  echo "ERROR: Please provide -dir option"
-	 # echo $usage
- 	  exit 1
-	fi
-  	
-   exit 0
-  
+  if [ $isPresent -eq 0 ]; then
+    echo "ERROR: Please provide -dir argument"
+    exit 1
+  fi
+  exit 0  
 fi

--- a/cluster/sbin/check-dir-option.sh
+++ b/cluster/sbin/check-dir-option.sh
@@ -33,14 +33,13 @@ else
 	# - script get triggerd from snappy-start-all.sh--then argument provided by this snappy-nodes.sh
 	# - user executing individual component script,in this case this script: snappy-locator.sh
    # Need to check in both case -dir option is provided or not
-	isPresent=1      
+	isPresent=0      
 	for argument in "$@"
-	 do		
-        	if [ "$argument" = *-dir= ]
+	 do	
+		#echo "argument value: $argument"	
+        	if [[ "$argument" == -dir=*  ]]
 		 then
-		 	 isPresent=0 # not present
-		else #present
-			
+			isPresent=1 #  present
 			if [ -z $(echo $argument | cut -d'=' -f 2) ] #present but empty i.e "-dir="
 			 then
 			  isPresent=0
@@ -51,8 +50,7 @@ else
 	
 	if [ $isPresent -eq 0 ]
 	 then
-		
-	  echo "Error: Please provide -dir option"
+	  echo "ERROR: Please provide -dir option"
 	 # echo $usage
  	  exit 1
 	fi

--- a/cluster/sbin/check-dir-option.sh
+++ b/cluster/sbin/check-dir-option.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+
+#
+# Copyright (c) 2018 SnappyData, Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you
+# may not use this file except in compliance with the License. You
+# may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing
+# permissions and limitations under the License. See accompanying
+# LICENSE file.
+#
+
+# Check whether "-dir" argument has been provide or not while invoing snappy-locator.sh/snappy-server.sh/snappy-lead.sh
+#
+
+noOfInputsArgs=$#
+
+if [ $noOfInputsArgs -eq 0 ]
+  then  #if no arguments passed
+	echo "ERROR : No arguments has been provided. Please provide required arguments"
+	#echo $usage
+  	exit 1
+else
+
+    # there could be two scenario if arguments are not equal to zero
+	# - script get triggerd from snappy-start-all.sh--then argument provided by this snappy-nodes.sh
+	# - user executing individual component script,in this case this script: snappy-locator.sh
+   # Need to check in both case -dir option is provided or not
+	isPresent=1      
+	for argument in "$@"
+	 do		
+        	if [ "$argument" = *-dir= ]
+		 then
+		 	 isPresent=0 # not present
+		else #present
+			
+			if [ -z $(echo $argument | cut -d'=' -f 2) ] #present but empty i.e "-dir="
+			 then
+			  isPresent=0
+			#else #present but should be a directory but do not need to check here, as getting check in launcher			
+			fi			
+		fi
+	done
+	
+	if [ $isPresent -eq 0 ]
+	 then
+		
+	  echo "Error: Please provide -dir option"
+	 # echo $usage
+ 	  exit 1
+	fi
+  	
+   exit 0
+  
+fi

--- a/cluster/sbin/snappy-lead.sh
+++ b/cluster/sbin/snappy-lead.sh
@@ -28,6 +28,7 @@ function absPath() {
 sbin="$(dirname "$(absPath "$0")")"
 
 mode=$1
+dir=
 shift
 
 . "$sbin/snappy-config.sh" lead
@@ -36,12 +37,25 @@ shift
 . "$SNAPPY_HOME/bin/load-spark-env.sh"
 . "$SNAPPY_HOME/bin/load-snappy-env.sh"
 
-
+noOfInputsArgs=$#
 
 # Start up  the lead instance
 function start_instance {
   "$SNAPPY_HOME"/bin/snappy leader "$mode" "$@"
 }
 
+if [ $noOfInputsArgs -le 1 ]
+then
+  if [ $noOfInputsArgs -eq 0 ]
+  then  #if no arguments passed
+   echo "Please provide -dir argument"
+  elif [[ "$1" = -dir=* && -n $(echo $1 | cut -d'=' -f 2) ]] #check -dir is not empty  
+  then  
+   start_instance "$1"
+  else #agrument is given,but not -dir.
+   echo "Invalid argument"
+  fi
+else # when start by snappy-start-all.sh
 start_instance "$@"
+fi
 

--- a/cluster/sbin/snappy-lead.sh
+++ b/cluster/sbin/snappy-lead.sh
@@ -46,14 +46,32 @@ function start_instance {
 
 if [ $noOfInputsArgs -le 1 ]
 then
-  if [ $noOfInputsArgs -eq 0 ]
-  then  #if no arguments passed
-   echo "Please provide -dir argument"
-  elif [[ "$1" = -dir=* && -n $(echo $1 | cut -d'=' -f 2) ]] #check -dir is not empty  
+  if [ $noOfInputsArgs -eq 0 ] #if no arguments passed
+  then 
+   hostIp=$(ip addr | grep 'state UP' -A2 | tail -n1 | awk '{print $2}' | cut -f1  -d'/')
+   dirfolder="$SNAPPY_HOME"/work/"$hostIp"-lead-1
+   if [ ! -d "$dirfolder" ]
+   then  
+	if [ ! -d "$SNAPPY_HOME/work" ]; then 
+	 mkdir work 
+	fi
+	mkdir $dirfolder
+   fi
+   dir="-dir=${dirfolder}"
+   start_instance "$dir"
+  elif [[ "$1" = -dir=* && -n $(echo $1 | cut -d'=' -f 2) ]] #check -dir is not empty or valid 
   then  
+     if [ ! -d "$1" ]
+     then
+     	echo "ERROR : $1 is not a directory"
+	echo $usage
+    	exit 1
+     fi
    start_instance "$1"
   else #agrument is given,but not -dir.
    echo "Invalid argument"
+   echo $usage
+   exit 1
   fi
 else # when start by snappy-start-all.sh
 start_instance "$@"

--- a/cluster/sbin/snappy-lead.sh
+++ b/cluster/sbin/snappy-lead.sh
@@ -61,7 +61,7 @@ then
    start_instance "$dir"
   elif [[ "$1" = -dir=* && -n $(echo $1 | cut -d'=' -f 2) ]] #check -dir is not empty or valid 
   then  
-     if [ ! -d "$1" ]
+     if [ ! -d $(echo $1 | cut -d'=' -f 2) ]
      then
      	echo "ERROR : $1 is not a directory"
 	echo $usage

--- a/cluster/sbin/snappy-lead.sh
+++ b/cluster/sbin/snappy-lead.sh
@@ -43,8 +43,8 @@ function start_instance {
 }
 
 #Since want to test whether the result is zero, don't need to treat it as an return value using $? . Just treat the command itself as a conditional.
-if "$sbin/check-dir-option.sh" "$@" ; then	
-   start_instance "$@"
+if "$sbin/check-dir-option.sh" "$@"; then	
+  start_instance "$@"
 else
   echo $usage
 fi

--- a/cluster/sbin/snappy-lead.sh
+++ b/cluster/sbin/snappy-lead.sh
@@ -28,7 +28,7 @@ function absPath() {
 sbin="$(dirname "$(absPath "$0")")"
 
 mode=$1
-dir=
+
 shift
 
 . "$sbin/snappy-config.sh" lead
@@ -37,43 +37,15 @@ shift
 . "$SNAPPY_HOME/bin/load-spark-env.sh"
 . "$SNAPPY_HOME/bin/load-snappy-env.sh"
 
-noOfInputsArgs=$#
-
 # Start up  the lead instance
 function start_instance {
   "$SNAPPY_HOME"/bin/snappy leader "$mode" "$@"
 }
 
-if [ $noOfInputsArgs -le 1 ]
-then
-  if [ $noOfInputsArgs -eq 0 ] #if no arguments passed
-  then 
-   hostIp=$(ip addr | grep 'state UP' -A2 | tail -n1 | awk '{print $2}' | cut -f1  -d'/')
-   dirfolder="$SNAPPY_HOME"/work/"$hostIp"-lead-1
-   if [ ! -d "$dirfolder" ]
-   then  
-	if [ ! -d "$SNAPPY_HOME/work" ]; then 
-	 mkdir work 
-	fi
-	mkdir $dirfolder
-   fi
-   dir="-dir=${dirfolder}"
-   start_instance "$dir"
-  elif [[ "$1" = -dir=* && -n $(echo $1 | cut -d'=' -f 2) ]] #check -dir is not empty or valid 
-  then  
-     if [ ! -d $(echo $1 | cut -d'=' -f 2) ]
-     then
-     	echo "ERROR : $1 is not a directory"
-	echo $usage
-    	exit 1
-     fi
-   start_instance "$1"
-  else #agrument is given,but not -dir.
-   echo "Invalid argument"
-   echo $usage
-   exit 1
-  fi
-else # when start by snappy-start-all.sh
-start_instance "$@"
+#Since want to test whether the result is zero, don't need to treat it as an return value using $? . Just treat the command itself as a conditional.
+if "$sbin/check-dir-option.sh" "$@" ; then	
+   start_instance "$@"
+else
+  echo $usage
 fi
 

--- a/cluster/sbin/snappy-locator.sh
+++ b/cluster/sbin/snappy-locator.sh
@@ -28,6 +28,7 @@ function absPath() {
 sbin="$(dirname "$(absPath "$0")")"
 
 mode=$1
+dir=
 shift
 
 . "$sbin/snappy-config.sh"
@@ -37,12 +38,25 @@ shift
 . "$SNAPPY_HOME/bin/load-spark-env.sh"
 . "$SNAPPY_HOME/bin/load-snappy-env.sh"
 
-
+noOfInputsArgs=$#
 
 # Start up  the locator instance
 function start_instance {
   "$SNAPPY_HOME"/bin/snappy locator "$mode" "$@"
 }
 
+if [ $noOfInputsArgs -le 1 ]
+then
+  if [ $noOfInputsArgs -eq 0 ]
+  then  #if no arguments passed
+   echo "Please provide -dir argument"
+  elif [[ "$1" = -dir=* && -n $(echo $1 | cut -d'=' -f 2) ]] #check -dir is not empty  
+  then  
+   start_instance "$1"
+  else #agrument is given,but not -dir.
+   echo "Invalid argument"
+  fi
+else # when start by snappy-start-all.sh
 start_instance "$@"
+fi
 

--- a/cluster/sbin/snappy-locator.sh
+++ b/cluster/sbin/snappy-locator.sh
@@ -28,7 +28,7 @@ function absPath() {
 sbin="$(dirname "$(absPath "$0")")"
 
 mode=$1
-dir=
+
 shift
 
 . "$sbin/snappy-config.sh"
@@ -38,43 +38,15 @@ shift
 . "$SNAPPY_HOME/bin/load-spark-env.sh"
 . "$SNAPPY_HOME/bin/load-snappy-env.sh"
 
-noOfInputsArgs=$#
-
 # Start up  the locator instance
 function start_instance {
  "$SNAPPY_HOME"/bin/snappy locator "$mode" "$@"
 }
 
-if [ $noOfInputsArgs -le 1 ]
-then
-  if [ $noOfInputsArgs -eq 0 ] #if no arguments passed
-  then 
-   hostIp=$(ip addr | grep 'state UP' -A2 | tail -n1 | awk '{print $2}' | cut -f1  -d'/')
-   dirfolder="$SNAPPY_HOME"/work/"$hostIp"-locator-1
-   if [ ! -d "$dirfolder" ]
-   then  
-	if [ ! -d "$SNAPPY_HOME/work" ]; then 
-	 mkdir work 
-	fi
-	mkdir $dirfolder
-   fi
-   dir="-dir=${dirfolder}"
-   start_instance "$dir"
-  elif [[ "$1" = -dir=* && -n $(echo $1 | cut -d'=' -f 2) ]] #check -dir is not empty or valid 
-  then  
-     if [ ! -d $(echo $1 | cut -d'=' -f 2) ]
-     then
-     	echo "ERROR : $1 is not a directory"
-	echo $usage
-    	exit 1
-     fi
-   start_instance "$1"
-  else #agrument is given,but not -dir.
-   echo "Invalid argument"
-   echo $usage
-   exit 1
-  fi
-else # when start by snappy-start-all.sh
-start_instance "$@"
+#Since want to test whether the result is zero, don't need to treat it as an return value using $? . Just treat the command itself as a conditional.
+if "$sbin/check-dir-option.sh" "$@" ; then	
+   start_instance "$@"
+else
+  echo $usage
 fi
 

--- a/cluster/sbin/snappy-locator.sh
+++ b/cluster/sbin/snappy-locator.sh
@@ -44,8 +44,8 @@ function start_instance {
 }
 
 #Since want to test whether the result is zero, don't need to treat it as an return value using $? . Just treat the command itself as a conditional.
-if "$sbin/check-dir-option.sh" "$@" ; then	
-   start_instance "$@"
+if "$sbin/check-dir-option.sh" "$@"; then	
+  start_instance "$@"
 else
   echo $usage
 fi

--- a/cluster/sbin/snappy-locator.sh
+++ b/cluster/sbin/snappy-locator.sh
@@ -42,19 +42,37 @@ noOfInputsArgs=$#
 
 # Start up  the locator instance
 function start_instance {
-  "$SNAPPY_HOME"/bin/snappy locator "$mode" "$@"
+ "$SNAPPY_HOME"/bin/snappy locator "$mode" "$@"
 }
 
 if [ $noOfInputsArgs -le 1 ]
 then
-  if [ $noOfInputsArgs -eq 0 ]
-  then  #if no arguments passed
-   echo "Please provide -dir argument"
-  elif [[ "$1" = -dir=* && -n $(echo $1 | cut -d'=' -f 2) ]] #check -dir is not empty  
+  if [ $noOfInputsArgs -eq 0 ] #if no arguments passed
+  then 
+   hostIp=$(ip addr | grep 'state UP' -A2 | tail -n1 | awk '{print $2}' | cut -f1  -d'/')
+   dirfolder="$SNAPPY_HOME"/work/"$hostIp"-locator-1
+   if [ ! -d "$dirfolder" ]
+   then  
+	if [ ! -d "$SNAPPY_HOME/work" ]; then 
+	 mkdir work 
+	fi
+	mkdir $dirfolder
+   fi
+   dir="-dir=${dirfolder}"
+   start_instance "$dir"
+  elif [[ "$1" = -dir=* && -n $(echo $1 | cut -d'=' -f 2) ]] #check -dir is not empty or valid 
   then  
+     if [ ! -d "$1" ]
+     then
+     	echo "ERROR : $1 is not a directory"
+	echo $usage
+    	exit 1
+     fi
    start_instance "$1"
   else #agrument is given,but not -dir.
    echo "Invalid argument"
+   echo $usage
+   exit 1
   fi
 else # when start by snappy-start-all.sh
 start_instance "$@"

--- a/cluster/sbin/snappy-locator.sh
+++ b/cluster/sbin/snappy-locator.sh
@@ -62,7 +62,7 @@ then
    start_instance "$dir"
   elif [[ "$1" = -dir=* && -n $(echo $1 | cut -d'=' -f 2) ]] #check -dir is not empty or valid 
   then  
-     if [ ! -d "$1" ]
+     if [ ! -d $(echo $1 | cut -d'=' -f 2) ]
      then
      	echo "ERROR : $1 is not a directory"
 	echo $usage

--- a/cluster/sbin/snappy-server.sh
+++ b/cluster/sbin/snappy-server.sh
@@ -28,6 +28,7 @@ function absPath() {
 sbin="$(dirname "$(absPath "$0")")"
 
 mode=$1
+dir=
 shift
 
 . "$sbin/snappy-config.sh"
@@ -36,11 +37,25 @@ shift
 . "$SNAPPY_HOME/bin/load-spark-env.sh"
 . "$SNAPPY_HOME/bin/load-snappy-env.sh"
 
-
+noOfInputsArgs=$#
 
 # Start up  the server instance
 function start_instance {
   "$SNAPPY_HOME"/bin/snappy server "$mode" "$@"
 }
 
+if [ $noOfInputsArgs -le 1 ]
+then
+  if [ $noOfInputsArgs -eq 0 ]
+  then  #if no arguments passed
+   echo "Please provide -dir argument"
+  elif [[ "$1" = -dir=* && -n $(echo $1 | cut -d'=' -f 2) ]] #check -dir is not empty  
+  then  
+   start_instance "$1"
+  else #agrument is given,but not -dir.
+   echo "Invalid argument"
+  fi
+else # when start by snappy-start-all.sh
 start_instance "$@"
+fi
+

--- a/cluster/sbin/snappy-server.sh
+++ b/cluster/sbin/snappy-server.sh
@@ -61,7 +61,7 @@ then
    start_instance "$dir"
   elif [[ "$1" = -dir=* && -n $(echo $1 | cut -d'=' -f 2) ]] #check -dir is not empty or valid 
   then  
-     if [ ! -d "$1" ]
+     if [ ! -d $(echo $1 | cut -d'=' -f 2) ]
      then
      	echo "ERROR : $1 is not a directory"
 	echo $usage

--- a/cluster/sbin/snappy-server.sh
+++ b/cluster/sbin/snappy-server.sh
@@ -43,8 +43,8 @@ function start_instance {
 }
 
 #Since want to test whether the result is zero, don't need to treat it as an return value using $? . Just treat the command itself as a conditional.
-if "$sbin/check-dir-option.sh" "$@" ; then	
-   start_instance "$@"
+if "$sbin/check-dir-option.sh" "$@"; then	
+  start_instance "$@"
 else
   echo $usage
 fi

--- a/cluster/sbin/snappy-server.sh
+++ b/cluster/sbin/snappy-server.sh
@@ -28,7 +28,7 @@ function absPath() {
 sbin="$(dirname "$(absPath "$0")")"
 
 mode=$1
-dir=
+
 shift
 
 . "$sbin/snappy-config.sh"
@@ -37,43 +37,15 @@ shift
 . "$SNAPPY_HOME/bin/load-spark-env.sh"
 . "$SNAPPY_HOME/bin/load-snappy-env.sh"
 
-noOfInputsArgs=$#
-
 # Start up  the server instance
 function start_instance {
   "$SNAPPY_HOME"/bin/snappy server "$mode" "$@"
 }
 
-if [ $noOfInputsArgs -le 1 ]
-then
-  if [ $noOfInputsArgs -eq 0 ] #if no arguments passed
-  then 
-   hostIp=$(ip addr | grep 'state UP' -A2 | tail -n1 | awk '{print $2}' | cut -f1  -d'/')
-   dirfolder="$SNAPPY_HOME"/work/"$hostIp"-server-1
-   if [ ! -d "$dirfolder" ]
-   then  
-	if [ ! -d "$SNAPPY_HOME/work" ]; then 
-	 mkdir work 
-	fi
-	mkdir $dirfolder
-   fi
-   dir="-dir=${dirfolder}"
-   start_instance "$dir"
-  elif [[ "$1" = -dir=* && -n $(echo $1 | cut -d'=' -f 2) ]] #check -dir is not empty or valid 
-  then  
-     if [ ! -d $(echo $1 | cut -d'=' -f 2) ]
-     then
-     	echo "ERROR : $1 is not a directory"
-	echo $usage
-    	exit 1
-     fi
-   start_instance "$1"
-  else #agrument is given,but not -dir.
-   echo "Invalid argument"
-   echo $usage
-   exit 1
-  fi
-else # when start by snappy-start-all.sh
-start_instance "$@"
+#Since want to test whether the result is zero, don't need to treat it as an return value using $? . Just treat the command itself as a conditional.
+if "$sbin/check-dir-option.sh" "$@" ; then	
+   start_instance "$@"
+else
+  echo $usage
 fi
 

--- a/cluster/sbin/snappy-server.sh
+++ b/cluster/sbin/snappy-server.sh
@@ -46,14 +46,32 @@ function start_instance {
 
 if [ $noOfInputsArgs -le 1 ]
 then
-  if [ $noOfInputsArgs -eq 0 ]
-  then  #if no arguments passed
-   echo "Please provide -dir argument"
-  elif [[ "$1" = -dir=* && -n $(echo $1 | cut -d'=' -f 2) ]] #check -dir is not empty  
+  if [ $noOfInputsArgs -eq 0 ] #if no arguments passed
+  then 
+   hostIp=$(ip addr | grep 'state UP' -A2 | tail -n1 | awk '{print $2}' | cut -f1  -d'/')
+   dirfolder="$SNAPPY_HOME"/work/"$hostIp"-server-1
+   if [ ! -d "$dirfolder" ]
+   then  
+	if [ ! -d "$SNAPPY_HOME/work" ]; then 
+	 mkdir work 
+	fi
+	mkdir $dirfolder
+   fi
+   dir="-dir=${dirfolder}"
+   start_instance "$dir"
+  elif [[ "$1" = -dir=* && -n $(echo $1 | cut -d'=' -f 2) ]] #check -dir is not empty or valid 
   then  
+     if [ ! -d "$1" ]
+     then
+     	echo "ERROR : $1 is not a directory"
+	echo $usage
+    	exit 1
+     fi
    start_instance "$1"
   else #agrument is given,but not -dir.
    echo "Invalid argument"
+   echo $usage
+   exit 1
   fi
 else # when start by snappy-start-all.sh
 start_instance "$@"

--- a/core/src/test/scala/io/snappydata/CommandLineToolsSuite.scala
+++ b/core/src/test/scala/io/snappydata/CommandLineToolsSuite.scala
@@ -206,6 +206,7 @@ class CommandLineToolsSuite extends SnappyTestRunner {
           "/sbin/snappy-locator.sh stop -dir=./SNAP-2631-work-locator").!!
     } finally {
       (snappyProductDir + "/sbin/snappy-locator.sh stop ").!!
+      ("rm -r ./SNAP-2631-work-locator").!!
     }
   }
   test("-dir option with old server launch script") {
@@ -235,6 +236,7 @@ class CommandLineToolsSuite extends SnappyTestRunner {
           "/sbin/snappy-server.sh stop -dir=./SNAP-2631-work-server").!!
     } finally {
       (snappyProductDir + "/sbin/snappy-server.sh stop").!!
+      ("rm -r ./SNAP-2631-work-server").!!
     }
   }
   test("-dir option with old lead launch script") {
@@ -268,6 +270,7 @@ class CommandLineToolsSuite extends SnappyTestRunner {
           "/sbin/snappy-lead.sh stop -dir=./SNAP-2631-work-lead").!!
     } finally {
       (snappyProductDir + "/sbin/snappy-lead.sh stop").!!
+      ("rm -r ./SNAP-2631-work-lead").!!
     }
   }
 }

--- a/core/src/test/scala/io/snappydata/CommandLineToolsSuite.scala
+++ b/core/src/test/scala/io/snappydata/CommandLineToolsSuite.scala
@@ -192,8 +192,8 @@ class CommandLineToolsSuite extends SnappyTestRunner {
         "Option -dir not specified with a value")
 
       consoleOutput = (snappyProductDir +
-          "/sbin/snappy-locator.sh start -peer-discovery-port=10443 -client-port=2000" +
-          "-dir=/does/not/exist").!!
+          "/sbin/snappy-locator.sh start -peer-discovery-port=10443 -client-port=2000 -dir= " +
+          "/does/not/exist").!!
       assert(consoleOutput.contains("ERROR"),
         s"Option -dir does not exist $consoleOutput")
 
@@ -202,10 +202,10 @@ class CommandLineToolsSuite extends SnappyTestRunner {
           "/sbin/snappy-locator.sh start -peer-discovery-port=10443 -client-port=2000 " +
           "-dir=./SNAP-2631-work-locator").!!
       assert(consoleOutput.contains("running"), s"Locator launch failed: $consoleOutput")
-      consoleOutput = (snappyProductDir +
-          "/sbin/snappy-locator.sh stop -dir=./SNAP-2631-work-locator").!!
+
     } finally {
-      (snappyProductDir + "/sbin/snappy-locator.sh stop ").!!
+      (snappyProductDir +
+          "/sbin/snappy-locator.sh stop -dir=./SNAP-2631-work-locator").!!
       ("rm -r ./SNAP-2631-work-locator").!!
     }
   }
@@ -222,8 +222,8 @@ class CommandLineToolsSuite extends SnappyTestRunner {
         "Option -dir not specified with a value")
 
       consoleOutput = (snappyProductDir +
-          "/sbin/snappy-server.sh start -locators=localhost:10334 -client-port=2001" +
-          "-dir=/does/not/exist").!!
+          "/sbin/snappy-server.sh start -locators=localhost:10334 -client-port=2001 -dir= " +
+          "/does/not/exist").!!
       assert(consoleOutput.contains("ERROR"),
         s"Option -dir does not exist $consoleOutput")
 
@@ -232,10 +232,10 @@ class CommandLineToolsSuite extends SnappyTestRunner {
           "/sbin/snappy-server.sh start -locators=localhost:10334 -client-port=2001  " +
           "-dir=./SNAP-2631-work-server").!!
       assert(consoleOutput.contains("running"), s"Server launch failed: $consoleOutput")
-      consoleOutput = (snappyProductDir +
-          "/sbin/snappy-server.sh stop -dir=./SNAP-2631-work-server").!!
+
     } finally {
-      (snappyProductDir + "/sbin/snappy-server.sh stop").!!
+      (snappyProductDir +
+          "/sbin/snappy-server.sh stop -dir=./SNAP-2631-work-server").!!
       ("rm -r ./SNAP-2631-work-server").!!
     }
   }
@@ -253,8 +253,8 @@ class CommandLineToolsSuite extends SnappyTestRunner {
         "Option -dir not specified with a value")
 
       consoleOutput = (snappyProductDir +
-          "/sbin/snappy-lead.sh start -locators=localhost:10334 -client-port=2002" +
-          "-dir=/does/not/exist").!!
+          "/sbin/snappy-lead.sh start -locators=localhost:10334 -client-port=2002 -dir= " +
+          "/does/not/exist").!!
       assert(consoleOutput.contains("ERROR"),
         s"Option -dir does not exist $consoleOutput")
 
@@ -266,10 +266,10 @@ class CommandLineToolsSuite extends SnappyTestRunner {
 
       assert(consoleOutput.contains("standby"),
         s"lead launch failed: $consoleOutput")
-      consoleOutput = (snappyProductDir +
-          "/sbin/snappy-lead.sh stop -dir=./SNAP-2631-work-lead").!!
+
     } finally {
-      (snappyProductDir + "/sbin/snappy-lead.sh stop").!!
+      (snappyProductDir +
+          "/sbin/snappy-lead.sh stop -dir=./SNAP-2631-work-lead").!!
       ("rm -r ./SNAP-2631-work-lead").!!
     }
   }


### PR DESCRIPTION
## Changes proposed in this pull request
Added code to resolve the issue: While trying to start a snappydata cluster by launching the processes individually (using snappy-lead.sh/snappy-locator.sh/snappy-server.sh), it fails with NullPointerException if "-dir" argument is not provided.
1- If no arguments provided, exit and ask the user to provide arguments and to help out the user showing "usage" of the script. 
2- If no "-dir" option provided, then exit and ask the user to provide -dir argument and to help out the user showing "usage" of the script. 
3- If the user provides empty "-dir" argument i.e. -dir=, then exit and ask the user to provide -dir argument and to help out the user showing "usage"

## Patch testing
Added automated test in CommandLineToolsSuite

## ReleaseNotes.txt changes
NA

## Other PRs 
NA