### PR TITLE
Prepared stmt on views gives error [SNAP-2254]

### DIFF
--- a/cluster/src/dunit/scala/io/snappydata/cluster/PreparedQueryRoutingDUnitTest.scala
+++ b/cluster/src/dunit/scala/io/snappydata/cluster/PreparedQueryRoutingDUnitTest.scala
@@ -66,6 +66,9 @@ class PreparedQueryRoutingDUnitTest(val s: String)
 
     // (1 to 5).foreach(d => query())
     query_test1(tableName)
+    // fire queries on views
+    snc.sql(s"create view $tableName" + s"_view as select * from $tableName")
+    query_test1(tableName + "_view")
   }
 
   def insertRows_test1(numRows: Int, tableName: String): Unit = {
@@ -803,5 +806,106 @@ class PreparedQueryRoutingDUnitTest(val s: String)
     for ( t <- 0 until i) allThreads(t).start()
     for ( t <- 0 until i) allThreads(t).join(180000)
     assert(keepRunning.get())
+  }
+
+
+  def testSNAP2254(): Unit = {
+    serverHostPort = AvailablePortHelper.getRandomAvailableTCPPort
+    vm2.invoke(classOf[ClusterManagerTestBase], "startNetServer", serverHostPort)
+    // scalastyle:off println
+    println(s"testSNAP2254: network server started at $serverHostPort")
+    // scalastyle:on println
+    val conn = DriverManager.getConnection(
+      "jdbc:snappydata://localhost:" + serverHostPort)
+
+    // scalastyle:off println
+    println(s"testSNAP2254: Connected to $serverHostPort")
+    val stmt = conn.createStatement()
+
+    viewQueryTest1(conn, stmt)
+    viewQueryTest2(conn, stmt)
+  }
+
+  private def viewQueryTest1(conn: Connection, stmt: Statement): Unit = {
+    stmt.execute("create table t1 (col1 int, col2 string, col3 date) using row")
+    val ps1 = conn.prepareStatement("insert into t1 values (?, ?, ?)")
+    for (i <- 1 to 100) {
+      ps1.setInt(1, i)
+      ps1.setString(2, s"$i")
+      ps1.setString(3, "2019-06-09")
+      ps1.addBatch()
+    }
+    ps1.executeBatch()
+    ps1.close()
+
+    stmt.execute("create view t1view as select col1 as c1, col2 as c2 from t1")
+
+    val ps2 = conn.prepareStatement("select c1, c2 from t1view where c1 = ? and c2 = ?")
+    val parameterMetaData = ps2.getParameterMetaData
+    assert(parameterMetaData.getParameterCount == 2)
+    assert(parameterMetaData.getParameterType(1) == java.sql.Types.INTEGER)
+    assert(parameterMetaData.getParameterType(2) == java.sql.Types.CLOB)
+    ps2.setInt(1, 5)
+    ps2.setString(2, "5")
+
+    val rs1 = ps2.executeQuery()
+    val resultSetMetaData = rs1.getMetaData
+    assert(resultSetMetaData.getColumnCount == 2)
+    assert(resultSetMetaData.getColumnName(1).equalsIgnoreCase("c1"))
+    assert(resultSetMetaData.getColumnName(2).equalsIgnoreCase("c2"))
+    assert(resultSetMetaData.getColumnType(1) == java.sql.Types.INTEGER)
+    assert(resultSetMetaData.getColumnType(2) == java.sql.Types.CLOB)
+    assert(rs1.next())
+    assert(rs1.getInt(1) == 5)
+    assert(rs1.getString(2).equals("5"))
+    rs1.close()
+    ps2.close()
+  }
+
+  private def viewQueryTest2(conn: Connection, stmt: Statement): Unit = {
+    stmt.execute("create table t2 (col21 int, col22 string, col23 timestamp, col24 boolean)")
+    stmt.execute("create table t3 (col31 int, col32 string, col33 timestamp, col34 boolean)")
+    stmt.execute("create view view2 as select t2.col21 as c1, t2.col22 as c2, t2.col23 as" +
+        " c3 from t2 join t3 on t2.col21 = t3.col31")
+
+    def insertData(table: String): Unit = {
+      val ps1 = conn.prepareStatement(s"insert into $table values (?, ?, ?)")
+      for (i <- 1 to 100) {
+        ps1.setInt(1, i)
+        ps1.setString(2, s"$i")
+        ps1.setString(3, "2019-06-09 04:04:10")
+        ps1.addBatch()
+      }
+      ps1.executeBatch()
+      ps1.close()
+    }
+
+    insertData("t2")
+    insertData("t3")
+
+
+    val ps3 = conn.prepareStatement("select * from view2 where c1 = ? and c3 = ?")
+    val parameterMetaData = ps3.getParameterMetaData
+    assert(parameterMetaData.getParameterCount == 2)
+    assert(parameterMetaData.getParameterType(1) == java.sql.Types.INTEGER)
+    assert(parameterMetaData.getParameterType(2) == java.sql.Types.TIMESTAMP)
+    ps3.setInt(1, 5)
+    ps3.setString(2, "2019-06-09 04:04:10.0")
+
+    val rs1 = ps3.executeQuery()
+    val resultSetMetaData = rs1.getMetaData
+    assert(resultSetMetaData.getColumnCount == 3)
+    assert(resultSetMetaData.getColumnName(1).equalsIgnoreCase("c1"))
+    assert(resultSetMetaData.getColumnName(2).equalsIgnoreCase("c2"))
+    assert(resultSetMetaData.getColumnName(3).equalsIgnoreCase("c3"))
+    assert(resultSetMetaData.getColumnType(1) == java.sql.Types.INTEGER)
+    assert(resultSetMetaData.getColumnType(2) == java.sql.Types.CLOB)
+    assert(resultSetMetaData.getColumnType(3) == java.sql.Types.TIMESTAMP)
+    assert(rs1.next())
+    assert(rs1.getInt(1) == 5)
+    assert(rs1.getString(2).equals("5"))
+    assert(rs1.getString(3).equals("2019-06-09 04:04:10.0"))
+    rs1.close()
+    ps3.close()
   }
 }

--- a/cluster/src/test/scala/org/apache/spark/sql/store/BugTest.scala
+++ b/cluster/src/test/scala/org/apache/spark/sql/store/BugTest.scala
@@ -832,4 +832,43 @@ class BugTest extends SnappyFunSuite with BeforeAndAfterAll {
 
     TestUtil.stopNetServer()
   }
+
+  test("SNAP3007") {
+    val session = snc.snappySession
+    val serverHostPort = TestUtil.startNetServer()
+    val conn = DriverManager.getConnection(
+      "jdbc:snappydata://" + serverHostPort)
+
+    // scalastyle:off println
+    println(s"testSNAP3007: Connected to $serverHostPort")
+    val stmt = conn.createStatement()
+    stmt.execute("CREATE TABLE app.application(application VARCHAR(64), " +
+        "content CLOB, active BOOLEAN, configuration CLOB)")
+    var ps = null
+
+    val sql = "INSERT INTO app.application VALUES (?, ?, ?, ?)"
+    val pstmt1 = conn.prepareStatement(sql)
+    pstmt1.setString(1, "a")
+    pstmt1.setString(2, "b")
+    pstmt1.setBoolean(3, true)
+    pstmt1.setString(4, "c")
+    pstmt1.addBatch()
+    pstmt1.executeBatch
+    pstmt1.close()
+
+    val sql2 = "DELETE FROM app.application"
+    val pstmt2 = conn.prepareStatement(sql2)
+    pstmt2.addBatch()
+    val rows = pstmt2.executeBatch
+    pstmt2.close()
+
+    val sql3 = "select count(*) from app.application"
+    val rs = conn.createStatement().executeQuery(sql3)
+    assert(rs.next())
+    assert(rs.getInt(1) == 0, "Table should not contain any data after delete statement")
+    rs.close()
+
+  }
+
+
 }

--- a/core/src/main/scala/org/apache/spark/sql/internal/SnappySessionCatalog.scala
+++ b/core/src/main/scala/org/apache/spark/sql/internal/SnappySessionCatalog.scala
@@ -613,7 +613,7 @@ class SnappySessionCatalog(val externalCatalog: SnappyExternalCatalog,
             val table = externalCatalog.getTable(schemaName, tableName)
             if (table.tableType == CatalogTableType.VIEW) {
               if (table.viewText.isEmpty) sys.error("Invalid view without text.")
-              snappySession.sessionState.sqlParser.parsePlan(table.viewText.get)
+              new SnappySqlParser(snappySession).parsePlan(table.viewText.get)
             } else if (CatalogObjectType.isPolicy(table)) {
               getPolicyPlan(table)
             } else {


### PR DESCRIPTION
## Changes proposed in this pull request

In case of views, to return LogicalPlan, SnappySessionCatalog#lookupRelation() parses the SQL text for view using sessionState.sqlParser.  For PreparedStatements this resets SnappyParser#_questionMarkCounter thereby causing the inconsistency. Now using a new instance SnappySqlParser to parse the view text.

## Patch testing
Added unit tests for prepared statements on views
Also added a test for SNAP-3007
precheckin

## ReleaseNotes.txt changes
NA

## Other PRs 
