### PR TITLE
Added a fix and test for SNAP-3024

### DIFF
--- a/cluster/src/dunit/scala/io/snappydata/cluster/SplitSnappyClusterDUnitTest.scala
+++ b/cluster/src/dunit/scala/io/snappydata/cluster/SplitSnappyClusterDUnitTest.scala
@@ -306,6 +306,42 @@ class SplitSnappyClusterDUnitTest(s: String)
       snc.sql("drop table if exists T5")
     }
   }
+
+
+  def testSNAP3024(): Unit = {
+    val snc = SnappyContext(sc)
+    snc.sql(s"CREATE TABLE T5(COL1 STRING, COL2 STRING) USING column OPTIONS" +
+        s" (key_columns 'col1', PARTITION_BY 'COL1', COLUMN_MAX_DELTA_ROWS '1')")
+    snc.sql("insert into t5 values('1', '1')")
+    snc.sql("insert into t5 values('2', '2')")
+    snc.sql("insert into t5 values('3', '3')")
+
+    import scala.concurrent.ExecutionContext.Implicits.global
+    val future = Future {
+      vm3.invoke(getClass, "doTestStaleCatalogForSNAP3024", startArgs :+ Int.box(locatorClientPort))
+    }
+
+    try {
+      // wait till the smart connector job perform at-least one putInto operation
+      var count = 0
+      while (snc.table("T5").count() == 3 && count < 10) {
+        Thread.sleep(4000)
+        count += 1
+      }
+      assert(count != 10, "Smart connector application not performing putInto as expected.")
+
+      // perform DDL
+      snc.sql(s"CREATE TABLE T6(COL1 STRING, COL2 STRING) " +
+          s"USING column OPTIONS (PARTITION_BY 'COL1', COLUMN_MAX_DELTA_ROWS '1')")
+
+      Await.result(future, scala.concurrent.duration.Duration.apply(3, "min"))
+    } finally {
+      snc.sql("drop table if exists T6")
+      snc.sql("drop table if exists T5")
+    }
+
+  }
+
 }
 
 object SplitSnappyClusterDUnitTest
@@ -889,6 +925,33 @@ object SplitSnappyClusterDUnitTest
       case _: CatalogStaleException =>
         // retrying putInto operation and it should pass
         dataFrame.write.putInto("T5")
+    }
+  }
+
+  def doTestStaleCatalogForSNAP3024(locatorPort: Int,
+      prop: Properties,
+      locatorClientPort: Int): Unit = {
+    val snc: SnappyContext = getSnappyContextForConnector(locatorClientPort)
+
+    snc.sql("select * from t5").collect()
+
+    val rdd: RDD[Row] = sc.parallelize(
+      Seq(
+        Row("4", "4"),
+        Row("5", "5")
+      )
+    )
+    val schema = new StructType()
+        .add(StructField("col1", StringType))
+        .add(StructField("col2", StringType))
+    val dataFrame = snc.createDataFrame(rdd, schema)
+    import org.apache.spark.sql.snappy._
+
+    dataFrame.write.insertInto("T5")
+    Thread.sleep(6000)
+    // should not throw an exception
+    for (i <- 1 to 5) {
+      snc.sql("select * from t5").collect()
     }
   }
 }

--- a/core/src/main/scala/org/apache/spark/sql/CachedDataFrame.scala
+++ b/core/src/main/scala/org/apache/spark/sql/CachedDataFrame.scala
@@ -17,6 +17,7 @@
 package org.apache.spark.sql
 
 import java.nio.ByteBuffer
+import java.sql.SQLException
 
 import scala.annotation.tailrec
 import scala.collection.JavaConverters._
@@ -28,10 +29,12 @@ import scala.reflect.ClassTag
 
 import com.esotericsoftware.kryo.io.{Input, Output}
 import com.esotericsoftware.kryo.{Kryo, KryoSerializable}
+import com.gemstone.gemfire.SystemFailure
 import com.gemstone.gemfire.cache.LowMemoryException
 import com.gemstone.gemfire.internal.shared.ClientSharedUtils
 import com.gemstone.gemfire.internal.shared.unsafe.DirectBufferAllocator
 import com.gemstone.gemfire.internal.{ByteArrayDataInput, ByteBufferDataOutput}
+import com.pivotal.gemfirexd.internal.shared.common.reference.SQLState
 import io.snappydata.Constant
 
 import org.apache.spark._
@@ -401,13 +404,32 @@ class CachedDataFrame(snappySession: SnappySession, queryExecution: QueryExecuti
             // no processing required
             executeCollect().iterator.asInstanceOf[Iterator[R]]
           } else {
-            val rdd = getExecRDD
-            val numPartitions = rdd.getNumPartitions
-            val results = new Array[R](numPartitions)
-            sc.runJob(rdd, processPartition, 0 until numPartitions,
-              (index: Int, r: (U, Int)) =>
-                results(index) = resultHandler(index, r._1))
-            results.iterator
+            try {
+              val execRDD = getExecRDD
+              runAsJob(execRDD, processPartition, resultHandler, sc)
+            } catch {
+              case t: Throwable
+                if CachedDataFrame.isConnectorCatalogStaleException(t, snappySession) =>
+                snappySession.externalCatalog.invalidateAll()
+                SnappySession.clearAllCache()
+                try {
+                  val execution =
+                    snappySession.getContextObject[() => QueryExecution](SnappySession.ExecutionKey)
+                  execution match {
+                    case Some(exec) =>
+                      val execRDD = exec().executedPlan.execute()
+                      runAsJob(execRDD, processPartition, resultHandler, sc)
+                    case _ => throw t
+                  }
+                } catch {
+                  case t: Throwable
+                    if CachedDataFrame.isConnectorCatalogStaleException(t, snappySession) =>
+                    snappySession.externalCatalog.invalidateAll()
+                    SnappySession.clearAllCache()
+                    throw CachedDataFrame.catalogStaleFailure(t, snappySession)
+                }
+            }
+
           }
       }
     }
@@ -419,6 +441,18 @@ class CachedDataFrame(snappySession: SnappySession, queryExecution: QueryExecuti
         sc.clearCallSite()
       }
     }
+  }
+
+  private def runAsJob[R: ClassTag, U: ClassTag](
+      execRdd: RDD[InternalRow],
+      processPartition: (TaskContext, Iterator[InternalRow]) => (U, Int),
+      resultHandler: (Int, U) => R, sc: SparkContext) = {
+    val numPartitions = execRdd.getNumPartitions
+    val results = new Array[R](numPartitions)
+    sc.runJob(execRdd, processPartition, 0 until numPartitions,
+      (index: Int, r: (U, Int)) =>
+        results(index) = resultHandler(index, r._1))
+    results.iterator
   }
 }
 
@@ -793,6 +827,43 @@ object CachedDataFrame
         session.listenerManager.onFailure(name, queryExecution, e)
         throw e
     }
+  }
+
+  def isConnectorCatalogStaleException(t: Throwable, session: SnappySession): Boolean = {
+
+    // error check needed in SmartConnector mode only
+    val isSmartConnectorMode = SnappyContext.getClusterMode(session.sparkContext) match {
+      case ThinClientConnectorMode(_, _) => true
+      case _ => false
+    }
+    if (!isSmartConnectorMode) return false
+
+    var cause = t
+    do {
+      cause match {
+        case sqle: SQLException
+          if SQLState.SNAPPY_CATALOG_SCHEMA_VERSION_MISMATCH.equals(sqle.getSQLState) =>
+          return true
+        case e: Error =>
+          if (SystemFailure.isJVMFailureError(e)) {
+            SystemFailure.initiateFailure(e)
+            // If this ever returns, rethrow the error. We're poisoned
+            // now, so don't let this thread continue.
+            throw e
+          }
+        case _ =>
+      }
+      cause = cause.getCause
+    } while (cause ne null)
+    false
+  }
+
+  def catalogStaleFailure(cause: Throwable, session: SnappySession): Exception = {
+    logWarning(s"SmartConnector catalog is not up to date. " +
+        s"Please reconstruct the Dataset and retry the operation")
+    new CatalogStaleException("Smart connector catalog is out of date due to " +
+        "table schema change (DROP/CREATE/ALTER operation). " +
+        "Please reconstruct the Dataset and retry the operation", cause)
   }
 
   private[sql] def clear(): Unit = synchronized {

--- a/core/src/main/scala/org/apache/spark/sql/execution/CodegenSparkFallback.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/CodegenSparkFallback.scala
@@ -30,7 +30,7 @@ import org.apache.spark.sql.catalyst.plans.physical.Partitioning
 import org.apache.spark.sql.execution.command.ExecutedCommandExec
 import org.apache.spark.sql.execution.metric.SQLMetric
 import org.apache.spark.sql.internal.CodeGenerationException
-import org.apache.spark.sql.{SnappyContext, SnappySession, ThinClientConnectorMode}
+import org.apache.spark.sql.{CachedDataFrame, SnappyContext, SnappySession, ThinClientConnectorMode}
 
 /**
  * Catch exceptions in code generation of SnappyData plans and fallback
@@ -72,43 +72,6 @@ case class CodegenSparkFallback(var child: SparkPlan,
     false
   }
 
-  protected def isConnectorCatalogStaleException(t: Throwable, session: SnappySession): Boolean = {
-
-    // error check needed in SmartConnector mode only
-    val isSmartConnectorMode = SnappyContext.getClusterMode(session.sparkContext) match {
-      case ThinClientConnectorMode(_, _) => true
-      case _ => false
-    }
-    if (!isSmartConnectorMode) return false
-
-    var cause = t
-    do {
-      cause match {
-        case sqle: SQLException
-          if SQLState.SNAPPY_CATALOG_SCHEMA_VERSION_MISMATCH.equals(sqle.getSQLState) =>
-          return true
-        case e: Error =>
-          if (SystemFailure.isJVMFailureError(e)) {
-            SystemFailure.initiateFailure(e)
-            // If this ever returns, rethrow the error. We're poisoned
-            // now, so don't let this thread continue.
-            throw e
-          }
-        case _ =>
-      }
-      cause = cause.getCause
-    } while (cause ne null)
-    false
-  }
-
-  private def catalogStaleFailure(cause: Throwable, session: SnappySession): Exception = {
-    logWarning(s"SmartConnector catalog is not up to date. " +
-        s"Please reconstruct the Dataset and retry the operation")
-    new CatalogStaleException("Smart connector catalog is out of date due to " +
-        "table schema change (DROP/CREATE/ALTER operation). " +
-        "Please reconstruct the Dataset and retry the operation", cause)
-  }
-
   private def executeWithFallback[T](f: SparkPlan => T, plan: SparkPlan): T = {
     try {
       f(plan)
@@ -121,7 +84,7 @@ case class CodegenSparkFallback(var child: SparkPlan,
         // is still usable:
         SystemFailure.checkFailure()
 
-        val isCatalogStale = isConnectorCatalogStaleException(t, session)
+        val isCatalogStale = CachedDataFrame.isConnectorCatalogStaleException(t, session)
         if (isCatalogStale) {
           session.externalCatalog.invalidateAll()
           SnappySession.clearAllCache()
@@ -130,7 +93,7 @@ case class CodegenSparkFallback(var child: SparkPlan,
             case _: ExecutePlan | _: ExecutedCommandExec => true
             case _ => false
           }
-          if (action.isDefined) throw catalogStaleFailure(t, session)
+          if (action.isDefined) throw CachedDataFrame.catalogStaleFailure(t, session)
         }
         if (isCatalogStale || isCodeGenerationException(t)) {
           // fallback to Spark plan for code-generation exception
@@ -157,10 +120,10 @@ case class CodegenSparkFallback(var child: SparkPlan,
                 child = plan
                 result
               } catch {
-                case t: Throwable if isConnectorCatalogStaleException(t, session) =>
+                case t: Throwable if CachedDataFrame.isConnectorCatalogStaleException(t, session) =>
                   session.externalCatalog.invalidateAll()
                   SnappySession.clearAllCache()
-                  throw catalogStaleFailure(t, session)
+                  throw CachedDataFrame.catalogStaleFailure(t, session)
               } finally if (!isCatalogStale) {
                 session.sessionState.disableStoreOptimizations = false
               }


### PR DESCRIPTION
## Changes proposed in this pull request
- In CachedDataFrame#collectWithHandler, for one case, query/job is run using sc.runJob(). Here if sc.runJob fails due to stale catalog, there was no code invalidate the cached metadata and retry the query. Added this code.
- Added a dunit test

## Patch testing
New dunit test
precheckin

## ReleaseNotes.txt changes
NA

## Other PRs 
NA