### PR TITLE
Avoids setting currentDatabase as 'sys' in hive's SessionState.

### DIFF
--- a/core/src/main/scala/org/apache/spark/sql/internal/SnappySessionCatalog.scala
+++ b/core/src/main/scala/org/apache/spark/sql/internal/SnappySessionCatalog.scala
@@ -381,7 +381,10 @@ class SnappySessionCatalog(val externalCatalog: SnappyExternalCatalog,
     val schemaName = formatDatabaseName(schema)
     validateSchemaName(schemaName, checkForDefault = false)
     super.setCurrentDatabase(schemaName)
-    externalCatalog.setCurrentDatabase(schemaName)
+    // since hive metastore doesn't have sys schema.
+    if (schemaName != SnappyExternalCatalog.SYS_SCHEMA) {
+      externalCatalog.setCurrentDatabase(schemaName)
+    }
   }
 
   override def listDatabases(): Seq[String] = synchronized {


### PR DESCRIPTION
This avoids the exception thrown when setting 'sys' as current schema via beeline.[SNAP-2972]

## Changes proposed in this pull request

* Skip setting current database in case of 'sys' schema.

## Patch testing

Tested manually; precheckin running.

## ReleaseNotes.txt changes

(Does this change require an entry in ReleaseNotes.txt? If yes, has it been added to it?)

## Other PRs 

(Does this change require changes in other projects- store, spark, spark-jobserver, aqp? Add the links of PR of the other subprojects that are related to this change)
