### PR TITLE
[SNAP-3023] Handle CatalogStaleException with retries in snappy sink

### DIFF
--- a/cluster/src/dunit/scala/io/snappydata/cluster/SplitSnappyClusterDUnitTest.scala
+++ b/cluster/src/dunit/scala/io/snappydata/cluster/SplitSnappyClusterDUnitTest.scala
@@ -16,15 +16,19 @@
  */
 package io.snappydata.cluster
 
+import java.io.{File, PrintWriter}
 import java.net.InetAddress
+import java.nio.file.{Files, Paths}
 import java.util.Properties
 
+import scala.concurrent.duration.Duration
 import scala.concurrent.{Await, Future}
 import scala.language.postfixOps
+import scala.reflect.io.Path
+import scala.util.Try
 
 import com.gemstone.gemfire.internal.cache.PartitionedRegion
 import com.pivotal.gemfirexd.internal.engine.Misc
-import io.snappydata.cluster.SplitSnappyClusterDUnitTest.sc
 import io.snappydata.core.{TestData, TestData2}
 import io.snappydata.test.dunit.{AvailablePortHelper, SerializableRunnable}
 import io.snappydata.util.TestUtils
@@ -33,12 +37,23 @@ import org.junit.Assert
 
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql._
+import org.apache.spark.sql.catalyst.encoders.RowEncoder
 import org.apache.spark.sql.execution.CatalogStaleException
 import org.apache.spark.sql.execution.columnar.impl.ColumnFormatRelation
+import org.apache.spark.sql.kafka010.KafkaTestUtils
 import org.apache.spark.sql.store.{SnappyJoinSuite, StoreUtils}
-import org.apache.spark.sql.types.{DateType, StringType, StructField, StructType}
+import org.apache.spark.sql.streaming.{ProcessingTime, SnappyStoreSinkProvider}
 import org.apache.spark.sql.udf.UserDefinedFunctionsDUnitTest
 import org.apache.spark.{Logging, SparkConf, SparkContext}
+import io.snappydata.cluster.SplitSnappyClusterDUnitTest.sc
+import io.snappydata.test.dunit.DistributedTestBase.WaitCriterion
+import org.apache.commons.io.FileUtils
+
+import org.apache.spark.sql.catalyst.encoders.RowEncoder
+import org.apache.spark.sql.kafka010.KafkaTestUtils
+import org.apache.spark.sql.streaming.ProcessingTime
+import org.apache.spark.sql.streaming.SnappySinkProviderDUnitTest.{TestSinkCallback, checkpointDirectory, kafkaTestUtils, ldapGroup, snc, tableName, waitTillTheBatchIsPickedForProcessing}
+import org.apache.spark.sql.types.{DateType, IntegerType, LongType, StringType, StructField, StructType}
 
 /**
  * Basic tests for non-embedded mode connections to an embedded cluster.
@@ -343,6 +358,33 @@ class SplitSnappyClusterDUnitTest(s: String)
     }
   }
 
+  def testStaleCatalogRetryForStreamingSink(): Unit = {
+    val snc = SnappyContext(sc)
+    import scala.concurrent.ExecutionContext.Implicits.global
+    val testTempDirectory = "/tmp/SplitSnappyClusterDUnitTest"
+
+    val future = Future {
+      vm3.invoke(getClass, "doTestStaleCatalogRetryForStreamingSink",
+        startArgs :+ Int.box(locatorClientPort) :+ testTempDirectory)
+    }
+    try {
+      var attempts = 0
+      while (!Files.exists(Paths.get(testTempDirectory, "file0")) && attempts < 15) {
+        Thread.sleep(4000)
+        attempts += 1
+      }
+      assert(attempts < 14, "No data ingested by streaming application.")
+
+      // perform DDL leading to stale catalog in smart connector application
+      snc.sql(s"CREATE TABLE SYNC_TABLE(COL1 STRING) " + s"USING column")
+
+      new PrintWriter(s"$testTempDirectory/file1") { write("dummydata"); close() }
+      Await.result(future, Duration(2, "min"))
+    } finally {
+      snc.sql("drop table if exists T6")
+      snc.sql("drop table if exists T5")
+    }
+  }
 
   def testSNAP3024(): Unit = {
     val snc = SnappyContext(sc)
@@ -1219,6 +1261,92 @@ object SplitSnappyClusterDUnitTest
         retryOperation(5) {
           snc.sql("update t7 set col2 = '22' where col1 = '2'")
         }
+    }
+  }
+
+  def doTestStaleCatalogRetryForStreamingSink(locatorPort: Int,
+      prop: Properties, locatorClientPort: Int, testTempDir: String): Unit = {
+    val tableName = "users"
+    val kafkaTestUtils = new KafkaTestUtils
+    kafkaTestUtils.setup()
+    kafkaTestUtils.createTopic(tableName, partitions = 3)
+    val checkpointDirectory = "/tmp/SplitSnappyClusterDUnitTest"
+
+    val snc: SnappyContext = getSnappyContextForConnector(locatorClientPort)
+    snc.sql(s"drop table if exists $tableName")
+    snc.sql(
+      s"""create table $tableName (id long , name varchar(40), age int)
+         | using column options(key_columns 'id')""".stripMargin)
+
+    val streamingDF = snc
+        .readStream
+        .format("kafka")
+        .option("kafka.bootstrap.servers", kafkaTestUtils.brokerAddress)
+        .option("subscribe", tableName)
+        .option("startingOffsets", "earliest")
+        .load()
+
+    implicit val encoder = RowEncoder(snc.table(tableName).schema)
+    val session = snc.sparkSession
+    import session.implicits._
+    val streamingQuery = streamingDF.selectExpr("CAST(value AS STRING)")
+        .as[String]
+        .map(_.split(","))
+        .map(r => Row(r(0).toLong, r(1), r(2).toInt))
+        .writeStream
+        .format("snappysink")
+        .queryName(tableName)
+        .trigger(ProcessingTime("1 seconds"))
+        .option("tableName", tableName)
+        .option("checkpointLocation", checkpointDirectory)
+        .start()
+
+    // produce first batch of data
+    val dataBatch1 = Seq(Seq(1, "name1", 20), Seq(2, "name2", 20))
+    kafkaTestUtils.sendMessages(tableName, dataBatch1.map(r => r.mkString(",")).toArray)
+
+    waitTillTheBatchIsPickedForProcessing(snc, 0, tableName)
+
+    new PrintWriter(s"$testTempDir/file0") { write("dummyData"); close() }
+
+    // wait till DDL is fired on snappy cluster which will lead to stale smart-connector catalog
+    var attempts = 0
+    while ( !Files.exists(Paths.get(testTempDir, "file1")) && attempts < 15) {
+      Thread.sleep(4000)
+      attempts += 1
+    }
+
+    assert(attempts < 14, "Waiting for stale catalog timed out")
+
+    // produce second batch of data
+    val dataBatch2 = Seq(Seq(3, "name3", 20))
+    kafkaTestUtils.sendMessages(tableName, dataBatch2.map(r => r.mkString(",")).toArray)
+
+    streamingQuery.processAllAvailable()
+
+    assertData(Array(Row(1, "name1", 20), Row(2, "name2", 20), Row(3, "name3", 20)))
+
+    def assertData(expectedData: Array[Row]): Unit = {
+      val actualData = snc.sql(s"select * from $tableName" +
+          s" order by id, name, age")
+          .collect()
+
+      assert(expectedData sameElements actualData, "actual data:" +
+          actualData.map(a => a.toString()).mkString(","))
+    }
+  }
+
+  private def waitTillTheBatchIsPickedForProcessing(snc: SnappyContext, batchId: Int,
+      queryName: String, retries: Int = 15): Unit = {
+    if (retries == 0) {
+      throw new RuntimeException(s"Batch id $batchId not found in sink status table")
+    }
+    val sql = s"select batch_id from snappysys_internal____sink_state_table " +
+        s"where stream_query_id = '$queryName'"
+    val batchIdFromTable = snc.sql(sql).collect()
+    if (batchIdFromTable.isEmpty || batchIdFromTable(0)(0) != batchId) {
+      Thread.sleep(1000)
+      waitTillTheBatchIsPickedForProcessing(snc, batchId, queryName, retries - 1)
     }
   }
 }

--- a/cluster/src/dunit/scala/io/snappydata/cluster/SplitSnappyClusterDUnitTest.scala
+++ b/cluster/src/dunit/scala/io/snappydata/cluster/SplitSnappyClusterDUnitTest.scala
@@ -378,7 +378,9 @@ class SplitSnappyClusterDUnitTest(s: String)
       // perform DDL leading to stale catalog in smart connector application
       snc.sql(s"CREATE TABLE SYNC_TABLE(COL1 STRING) " + s"USING column")
 
-      new PrintWriter(s"$testTempDirectory/file1") { write("dummydata"); close() }
+      new PrintWriter(s"$testTempDirectory/file1") {
+        write("dummydata"); close()
+      }
       Await.result(future, Duration(2, "min"))
     } finally {
       snc.sql("drop table if exists T6")
@@ -1307,7 +1309,7 @@ object SplitSnappyClusterDUnitTest
       waitTillTheBatchIsPickedForProcessing(snc, 0, tableName)
 
       new PrintWriter(s"$testTempDir/file0") {
-        write("dummyData");
+        write("dummyData")
         close()
       }
 

--- a/core/src/main/scala/org/apache/spark/sql/streaming/SnappySinkCallback.scala
+++ b/core/src/main/scala/org/apache/spark/sql/streaming/SnappySinkCallback.scala
@@ -161,15 +161,15 @@ case class SnappyStoreSink(snappySession: SnappySession,
   }
 
   private def processBatchWithRetries(batchId: Long, data: Dataset[Row], possibleDuplicate: Boolean,
-      totalAttempts: Int = 10, attempt: Int = 0) : Unit = {
+      totalAttempts: Int = 10, attempt: Int = 0): Unit = {
     try {
       sinkCallback.process(snappySession, parameters, batchId, convert(data), possibleDuplicate)
     } catch {
-      case ex: Exception if attempt >= totalAttempts - 1  || !isRetriableException(ex) => throw ex
+      case ex: Exception if attempt >= totalAttempts - 1 || !isRetriableException(ex) => throw ex
       case ex: Exception =>
         val sleepTime = attempt * 100
         logWarning(s"Encountered a retriable exception. Will retry processing batch after" +
-            s" $sleepTime millis. Attempts left: ${totalAttempts - (attempt + 1)}" , ex)
+            s" $sleepTime millis. Attempts left: ${totalAttempts - (attempt + 1)}", ex)
         Thread.sleep(sleepTime)
         processBatchWithRetries(batchId, data, possibleDuplicate = true, totalAttempts, attempt + 1)
     }

--- a/core/src/test/scala/org/apache/spark/sql/streaming/SnappyStoreSinkProviderSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/streaming/SnappyStoreSinkProviderSuite.scala
@@ -378,7 +378,7 @@ class SnappyStoreSinkProviderSuite extends SnappyFunSuite
     val streamingQuery = createAndStartStreamingQuery(topic, testId,
       options = Map("withQueryName" -> "false",
         "sinkCallback" -> "org.apache.spark.sql.streaming.TestSinkCallback",
-        "attempts" -> "7"))
+        "internal___attempts" -> "3", "attempts" -> "4"))
 
     try {
       streamingQuery.processAllAvailable()
@@ -397,7 +397,7 @@ class SnappyStoreSinkProviderSuite extends SnappyFunSuite
     val streamingQuery = createAndStartStreamingQuery(topic, testId,
       options = Map("withQueryName" -> "false",
         "sinkCallback" -> "org.apache.spark.sql.streaming.TestSinkCallback",
-        "attempts" -> "5"))
+        "internal___attempts" -> "3", "attempts" -> "3"))
     streamingQuery.processAllAvailable()
   }
 

--- a/core/src/test/scala/org/apache/spark/sql/streaming/SnappyStoreSinkProviderSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/streaming/SnappyStoreSinkProviderSuite.scala
@@ -17,15 +17,18 @@
 
 package org.apache.spark.sql.streaming
 
+import java.sql.SQLException
 import java.util.concurrent.atomic.AtomicInteger
 
 import scala.reflect.io.Path
 
+import com.pivotal.gemfirexd.internal.shared.common.reference.SQLState.SNAPPY_CATALOG_SCHEMA_VERSION_MISMATCH
 import io.snappydata.SnappyFunSuite
 import org.scalatest.{BeforeAndAfter, BeforeAndAfterAll}
 
-import org.apache.spark.sql.{Row, SnappyContext}
+import org.apache.spark.sql.{Dataset, Row, SnappyContext, SnappySession}
 import org.apache.spark.sql.catalyst.encoders.RowEncoder
+import org.apache.spark.sql.execution.CatalogStaleException
 import org.apache.spark.sql.kafka010.KafkaTestUtils
 import org.apache.spark.sql.types._
 
@@ -214,14 +217,14 @@ class SnappyStoreSinkProviderSuite extends SnappyFunSuite
 
     val dataBatch = Seq(Seq(1, "name1", 20, "lname1", 0), Seq(2, "name2", 10, "lname2", 0))
     kafkaTestUtils.sendMessages(topic, dataBatch.map(r => r.mkString(",")).toArray)
-
+    val streamingQuery = createAndStartStreamingQuery(topic, testId)
     val thrown = intercept[StreamingQueryException] {
-      val streamingQuery = createAndStartStreamingQuery(topic, testId)
       streamingQuery.processAllAvailable()
     }
 
     val errorMessage = "_eventType is present in data but key columns are not defined on table."
     assert(thrown.getCause.getMessage == errorMessage)
+    streamingQuery.stop()
   }
 
   test("test idempotency") {
@@ -237,10 +240,11 @@ class SnappyStoreSinkProviderSuite extends SnappyFunSuite
     streamingQuery.stop()
 
     val streamingQuery1: StreamingQuery = createAndStartStreamingQuery(topic, testId
-      , failBatch = true)
+      , options = Map("internal___failBatch" -> "true"))
     kafkaTestUtils.sendMessages(topic, (11 to 20).map(i => s"$i,name$i,$i,lname$i,0").toArray)
     try {
       streamingQuery1.processAllAvailable()
+      fail("StreamingQueryException expected.")
     } catch {
       case ex: StreamingQueryException if ex.cause.getMessage == "dummy failure for test" =>
         streamingQuery1.stop()
@@ -268,7 +272,8 @@ class SnappyStoreSinkProviderSuite extends SnappyFunSuite
     // producing records with keh `1` on multiple partitions. This may not lead to expected result
     // kafkaTestUtils.sendMessages(topic, (0 to 999).map(i => s"1,name$i,$i,${i%3}").toArray)
 
-    val streamingQuery = createAndStartStreamingQuery(topic, testId, conflation = true)
+    val streamingQuery = createAndStartStreamingQuery(topic, testId,
+      options = Map("conflation" -> "true"))
 
     streamingQuery.processAllAvailable()
 
@@ -284,8 +289,8 @@ class SnappyStoreSinkProviderSuite extends SnappyFunSuite
     val batch2 = Seq(Seq(1, "name2", 30, "lname1"), Seq(1, "name3", 30, "lname1"))
     kafkaTestUtils.sendMessages(topic, batch2.map(r => r.mkString(",")).toArray)
 
-    val streamingQuery = createAndStartStreamingQuery(topic, testId, conflation = true,
-      withEventTypeColumn = false)
+    val streamingQuery = createAndStartStreamingQuery(topic, testId,
+      withEventTypeColumn = false, options = Map("conflation" -> "true"))
 
     streamingQuery.processAllAvailable()
 
@@ -302,8 +307,8 @@ class SnappyStoreSinkProviderSuite extends SnappyFunSuite
     kafkaTestUtils.sendMessages(topic, batch2.map(r => r.mkString(",")).toArray)
 
     val thrown = intercept[StreamingQueryException] {
-      val streamingQuery = createAndStartStreamingQuery(topic, testId, conflation = true,
-        withEventTypeColumn = false)
+      val streamingQuery = createAndStartStreamingQuery(topic, testId,
+        withEventTypeColumn = false , options = Map("conflation" -> "true"))
       streamingQuery.processAllAvailable()
     }
     val errorMessage = "Key column(s) or primary key must be defined on table in order " +
@@ -320,7 +325,8 @@ class SnappyStoreSinkProviderSuite extends SnappyFunSuite
 
     val batch1 = Seq(Seq(1, "name1", 30, "lname1", 0))
     kafkaTestUtils.sendMessages(topic, batch1.map(r => r.mkString(",")).toArray)
-    val streamingQuery = createAndStartStreamingQuery(topic, testId, conflation = true)
+    val streamingQuery = createAndStartStreamingQuery(topic, testId,
+      options = Map("conflation" -> "true"))
 
     waitTillTheBatchIsPickedForProcessing(0, testId)
     val batch2 = Seq(Seq(1, "name1", 30, "lname1", 2), Seq(1, "name1", 30, "lname1", 0))
@@ -365,6 +371,56 @@ class SnappyStoreSinkProviderSuite extends SnappyFunSuite
     }
   }
 
+  test("Streaming query fails after attempts exhausted") {
+    val testId = testIdGenerator.getAndIncrement()
+    createTable()()
+    val topic = getTopic(testId)
+    val streamingQuery = createAndStartStreamingQuery(topic, testId,
+      options = Map("withQueryName" -> "false",
+        "sinkCallback" -> "org.apache.spark.sql.streaming.TestSinkCallback",
+        "attempts" -> "7"))
+
+    try {
+      streamingQuery.processAllAvailable()
+      fail("StreamingQueryException expected.")
+    } catch {
+      case x: StreamingQueryException =>
+        assert(x.getCause.getCause.isInstanceOf[SQLException] ||
+            x.getCause.getCause.isInstanceOf[CatalogStaleException])
+    }
+  }
+
+  test("Streaming query passes is attempts are not exhausted") {
+    val testId = testIdGenerator.getAndIncrement()
+    createTable()()
+    val topic = getTopic(testId)
+    val streamingQuery = createAndStartStreamingQuery(topic, testId,
+      options = Map("withQueryName" -> "false",
+        "sinkCallback" -> "org.apache.spark.sql.streaming.TestSinkCallback",
+        "attempts" -> "5"))
+    streamingQuery.processAllAvailable()
+  }
+
+  test("Streaming query fails on the first attempt itself when failure is not due" +
+      " to stale catalog") {
+    val testId = testIdGenerator.getAndIncrement()
+    createTable()()
+    val topic = getTopic(testId)
+    val streamingQuery = createAndStartStreamingQuery(topic, testId,
+      options = Map("withQueryName" -> "false",
+        "sinkCallback" -> "org.apache.spark.sql.streaming.TestSinkCallback",
+        "attempts" -> "1", "catalogNotStale" -> ""))
+
+    try {
+      streamingQuery.processAllAvailable()
+      fail("StreamingQueryException expected.")
+    } catch {
+      case x: StreamingQueryException =>
+        assert(x.getCause.isInstanceOf[RuntimeException]
+            && x.getCause.getMessage.equals("catalogNotStale"))
+    }
+  }
+
   private def waitTillTheBatchIsPickedForProcessing(batchId: Int, testId: Int,
       retries: Int = 15): Unit = {
     if (retries == 0) {
@@ -399,8 +455,8 @@ class SnappyStoreSinkProviderSuite extends SnappyFunSuite
   }
 
   private def createAndStartStreamingQuery(topic: String, testId: Int,
-      withEventTypeColumn: Boolean = true, failBatch: Boolean = false,
-      conflation: Boolean = false, withQueryName: Boolean = true) = {
+      withEventTypeColumn: Boolean = true, withQueryName: Boolean = true,
+      options: Map[String, String] = Map.empty) = {
     val streamingDF = session
         .readStream
         .format("kafka")
@@ -445,17 +501,33 @@ class SnappyStoreSinkProviderSuite extends SnappyFunSuite
     streamWriter.trigger(ProcessingTime("1 seconds"))
         .option("tableName", tableName)
         .option("checkpointLocation", checkpointDirectory)
-    if (failBatch) {
-      streamWriter = streamWriter.option("internal___failBatch", "true")
-    }
-    if (conflation) {
-      streamWriter = streamWriter.option("conflation", conflation)
-    }
-
+    streamWriter.options(options)
     streamWriter.start()
   }
 
   private def streamName(testId: Int) = {
     s"users_$testId"
+  }
+}
+
+class TestSinkCallback extends SnappySinkCallback {
+
+  private var attempt = -1
+  override def process(snappySession: SnappySession, sinkProps: Map[String, String], batchId: Long,
+      df: Dataset[Row], possibleDuplicate: Boolean): Unit = {
+    if (attempt == -1) attempt = sinkProps("attempts").toInt
+    if (attempt < sinkProps("attempts").toInt) {
+      assert(possibleDuplicate, "Value of possibleDuplicate should be true for retry attempts")
+    }
+    attempt -= 1
+    if (sinkProps.contains("catalogNotStale")) {
+      throw new RuntimeException("catalogNotStale")
+    }
+    if (attempt == 0){
+    } else if (attempt % 2 == 0) {
+      throw new RuntimeException(new CatalogStaleException("dummy", null))
+    } else {
+      throw new RuntimeException(new SQLException("dummy", SNAPPY_CATALOG_SCHEMA_VERSION_MISMATCH))
+    }
   }
 }

--- a/core/src/test/scala/org/apache/spark/sql/streaming/SnappyStoreSinkProviderSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/streaming/SnappyStoreSinkProviderSuite.scala
@@ -308,7 +308,7 @@ class SnappyStoreSinkProviderSuite extends SnappyFunSuite
 
     val thrown = intercept[StreamingQueryException] {
       val streamingQuery = createAndStartStreamingQuery(topic, testId,
-        withEventTypeColumn = false , options = Map("conflation" -> "true"))
+        withEventTypeColumn = false, options = Map("conflation" -> "true"))
       streamingQuery.processAllAvailable()
     }
     val errorMessage = "Key column(s) or primary key must be defined on table in order " +
@@ -513,6 +513,7 @@ class SnappyStoreSinkProviderSuite extends SnappyFunSuite
 class TestSinkCallback extends SnappySinkCallback {
 
   private var attempt = -1
+
   override def process(snappySession: SnappySession, sinkProps: Map[String, String], batchId: Long,
       df: Dataset[Row], possibleDuplicate: Boolean): Unit = {
     if (attempt == -1) attempt = sinkProps("attempts").toInt
@@ -523,7 +524,7 @@ class TestSinkCallback extends SnappySinkCallback {
     if (sinkProps.contains("catalogNotStale")) {
       throw new RuntimeException("catalogNotStale")
     }
-    if (attempt == 0){
+    if (attempt == 0) {
     } else if (attempt % 2 == 0) {
       throw new RuntimeException(new CatalogStaleException("dummy", null))
     } else {


### PR DESCRIPTION
## Changes proposed in this pull request

Retrying streaming batch processing for the snappy sink when `CatalogStaleException` is encountered.  
Currently, number of attempts are set to 10 wtih backoff interval of `100 * attempt_number` millis.   
Also exposed an internal property (`internal___attempts`) to overwrite this for tests.

## Patch testing

Added a Dunit test, added scala tests