### PR TITLE
Avoid error being thrown when PreparedStatement.setDouble is used for comparison with decimal column

### DIFF
--- a/cluster/src/main/scala/io/snappydata/gemxd/SparkSQLPrepareImpl.scala
+++ b/cluster/src/main/scala/io/snappydata/gemxd/SparkSQLPrepareImpl.scala
@@ -125,6 +125,7 @@ class SparkSQLPrepareImpl(val sql: String,
         types(index + 2) = sqlType._3
         types(index + 3) = if (paramLiteralsAtPrepare(i).value.asInstanceOf[Boolean]) 1 else 0
       })
+      session.setPreparedParamsTypeInfo(types)
       DataSerializer.writeIntArray(types, hdos)
     } else {
       DataSerializer.writeIntArray(Array[Int](0), hdos)

--- a/cluster/src/test/scala/org/apache/spark/sql/store/BugTest.scala
+++ b/cluster/src/test/scala/org/apache/spark/sql/store/BugTest.scala
@@ -962,11 +962,13 @@ class BugTest extends SnappyFunSuite with BeforeAndAfterAll {
     insertDataAndTestSNAP3082(conn, stmt, "STRING")
     insertDataAndTestSNAP3082(conn, stmt, "FLOAT")
     insertDataAndTestSNAP3082(conn, stmt, "DECIMAL")
+    // scalastyle:on println
 
   }
 
   private def insertDataAndTestSNAP3082(conn: Connection, stmt: Statement,
       dataTypeForSetParams: String): Unit = {
+    // scalastyle:off println
     println(s"Setting prepared statement parameters as $dataTypeForSetParams")
     stmt.execute("drop table if exists column_table")
     stmt.execute("create table column_table (col1 int, col2 decimal," +
@@ -1059,5 +1061,6 @@ class BugTest extends SnappyFunSuite with BeforeAndAfterAll {
 
     assert(result1.sameElements(result2),
       "results of prepared and unprepared statements do not match")
+    // scalastyle:on println
   }
 }

--- a/cluster/src/test/scala/org/apache/spark/sql/store/BugTest.scala
+++ b/cluster/src/test/scala/org/apache/spark/sql/store/BugTest.scala
@@ -17,7 +17,8 @@
 package org.apache.spark.sql.store
 
 import java.io.{BufferedReader, FileReader}
-import java.sql.{DriverManager, SQLException}
+import java.lang
+import java.sql.{Connection, DriverManager, SQLException, Statement}
 import java.util.Properties
 
 import com.pivotal.gemfirexd.TestUtil
@@ -944,5 +945,119 @@ class BugTest extends SnappyFunSuite with BeforeAndAfterAll {
     }
     assert(se4.getSQLState.equals("42X04"))
 
+  }
+
+
+  test("SNAP3082") {
+    val session = snc.snappySession
+    val serverHostPort = TestUtil.startNetServer()
+    val conn = DriverManager.getConnection(
+      "jdbc:snappydata://" + serverHostPort)
+
+
+    // scalastyle:off println
+    println(s"SNAP3082: Connected to $serverHostPort")
+    val stmt = conn.createStatement()
+    insertDataAndTestSNAP3082(conn, stmt, "DOUBLE")
+    insertDataAndTestSNAP3082(conn, stmt, "STRING")
+    insertDataAndTestSNAP3082(conn, stmt, "FLOAT")
+    insertDataAndTestSNAP3082(conn, stmt, "DECIMAL")
+
+  }
+
+  private def insertDataAndTestSNAP3082(conn: Connection, stmt: Statement,
+      dataTypeForSetParams: String): Unit = {
+    println(s"Setting prepared statement parameters as $dataTypeForSetParams")
+    stmt.execute("drop table if exists column_table")
+    stmt.execute("create table column_table (col1 int, col2 decimal," +
+        " col3 decimal(10, 5)) using column")
+    val ps1 = conn.prepareStatement("insert into column_table values (?, ?, ?)")
+    val numRows = 10
+    for (i <- 0 until numRows) {
+      ps1.setInt(1, i)
+      dataTypeForSetParams match {
+        case "DOUBLE" =>
+          ps1.setDouble(2, java.lang.Double.valueOf(i * 0.1))
+          ps1.setDouble(3, java.lang.Double.valueOf(i * 0.1))
+        case "STRING" =>
+          ps1.setString(2, s"$i" + 0.1)
+          ps1.setString(3, s"$i" + 0.1)
+        case "FLOAT" =>
+          ps1.setFloat(2, java.lang.Float.valueOf(new lang.Float(i*0.1)))
+          ps1.setFloat(3, java.lang.Float.valueOf(new lang.Float(i*0.1)))
+        case "DECIMAL" =>
+          ps1.setBigDecimal(2, new java.math.BigDecimal(s"$i" + 0.1))
+          ps1.setBigDecimal(3, new java.math.BigDecimal(s"$i" + 0.1))
+      }
+      ps1.executeUpdate()
+    }
+
+    println("executing prepared select statement")
+    var result1: Array[(java.math.BigDecimal, java.math.BigDecimal)] = new Array(numRows)
+    val ps2 = conn.prepareStatement("select * from column_table where col2 = ? order by col1")
+    for (j <- 0 until numRows) {
+      dataTypeForSetParams match {
+        case "DOUBLE" =>
+          ps2.setDouble(1, java.lang.Double.valueOf(j * 0.1))
+        case "STRING" =>
+          ps2.setString(1, s"$j" + 0.1)
+        case "FLOAT" =>
+          ps2.setFloat(1, java.lang.Float.valueOf(new lang.Float(j * 0.1)))
+        case "DECIMAL" =>
+          ps2.setBigDecimal(1, new java.math.BigDecimal(s"$j" + 0.1))
+      }
+
+      val rs2 = ps2.executeQuery()
+
+      while (rs2.next()) {
+        val columnValue1 = rs2.getBigDecimal(2)
+        val columnValue2 = rs2.getBigDecimal(3)
+        result1(j) = (columnValue1, columnValue2)
+        // debug statement
+//        println(s"rowNumber = $j (columnVale1, columnVale2) = ($columnValue1, $columnValue2) " +
+//            s" columnVale1 precision = ${columnValue1.precision()} " +
+//            s" columnVale1 scale =  ${columnValue1.scale ()} " +
+//            s" columnVale2 precision = ${columnValue2.precision()} " +
+//            s" columnVale2 scale =  ${columnValue2.scale ()}")
+      }
+    }
+
+    println("executing unprepared select statement")
+    var result2: Array[(java.math.BigDecimal, java.math.BigDecimal)] = new Array(numRows)
+    for (j <- 0 until numRows) {
+      var rs3: java.sql.ResultSet = null
+      dataTypeForSetParams match {
+        case "DOUBLE" =>
+          val v = j * 0.1
+          rs3 = stmt.executeQuery(s"select * from column_table" +
+              s" where col2 = cast($v as double) order by col1")
+        case "STRING" =>
+          val v = s"$j" + 0.1
+          rs3 = stmt.executeQuery(s"select * from column_table" +
+              s" where col2 = cast($v as string) order by col1")
+        case "FLOAT" =>
+          val v = j * 0.1
+          rs3 = stmt.executeQuery(s"select * from column_table" +
+              s" where col2 = cast($v as float) order by col1")
+        case "DECIMAL" =>
+          val v = new java.math.BigDecimal(s"$j" + 0.1)
+          rs3 = stmt.executeQuery(s"select * from column_table" +
+              s" where col2 = cast($v as decimal) order by col1")
+      }
+      while (rs3.next()) {
+        val columnValue1 = rs3.getBigDecimal(2)
+        val columnValue2 = rs3.getBigDecimal(3)
+        result2(j) = (columnValue1, columnValue2)
+        // debug statement
+//        println(s"rowNumber = $j (columnVale1, columnVale2) = ($columnValue1, $columnValue2) " +
+//            s" columnVale1 precision = ${columnValue1.precision()} " +
+//            s" columnVale1 scale =  ${columnValue1.scale ()} " +
+//            s" columnVale2 precision = ${columnValue2.precision()} " +
+//            s" columnVale2 scale =  ${columnValue2.scale ()}")
+      }
+    }
+
+    assert(result1.sameElements(result2),
+      "results of prepared and unprepared statements do not match")
   }
 }

--- a/core/src/main/scala/org/apache/spark/sql/SnappySession.scala
+++ b/core/src/main/scala/org/apache/spark/sql/SnappySession.scala
@@ -16,6 +16,7 @@
  */
 package org.apache.spark.sql
 
+import java.math.{MathContext, RoundingMode}
 import java.sql.{SQLException, SQLWarning}
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.atomic.AtomicInteger
@@ -33,6 +34,7 @@ import com.gemstone.gemfire.internal.shared.{ClientResolverUtils, FinalizeHolder
 import com.google.common.cache.{Cache, CacheBuilder}
 import com.pivotal.gemfirexd.internal.GemFireXDVersion
 import com.pivotal.gemfirexd.internal.iapi.sql.ParameterValueSet
+import com.pivotal.gemfirexd.internal.iapi.types.{SQLDecimal, TypeId}
 import com.pivotal.gemfirexd.internal.iapi.{types => stypes}
 import com.pivotal.gemfirexd.internal.shared.common.{SharedUtils, StoredFormatIds}
 import io.snappydata.sql.catalog.{CatalogObjectType, SnappyExternalCatalog}
@@ -1816,7 +1818,11 @@ class SnappySession(_sc: SparkContext) extends SparkSession(_sc) {
   def setPreparedQuery(preparePhase: Boolean, paramSet: Option[ParameterValueSet]): Unit =
     snappyParser.setPreparedQuery(preparePhase, paramSet)
 
-  private[sql] def getParameterValue(questionMarkCounter: Int, pvs: Any): (Any, DataType) = {
+  def setPreparedParamsTypeInfo(info: Array[Int]): Unit =
+    snappyParser.setPrepareParamsTypesInfo(info)
+
+  private[sql] def getParameterValue(
+      questionMarkCounter: Int, pvs: Any, preparedParamsTypesInfo: Option[Array[Int]]) = {
     val parameterValueSet = pvs.asInstanceOf[ParameterValueSet]
     if (questionMarkCounter > parameterValueSet.getParameterCount) {
       assert(assertion = false, s"For Prepared Statement, Got more number of" +
@@ -1825,15 +1831,24 @@ class SnappySession(_sc: SparkContext) extends SparkSession(_sc) {
           s" constants = ${parameterValueSet.getParameterCount}")
     }
     val dvd = parameterValueSet.getParameter(questionMarkCounter - 1)
-    val scalaTypeVal = SnappySession.getValue(dvd)
+    var scalaTypeVal = SnappySession.getValue(dvd)
     val storeType = dvd.getTypeFormatId
-    val storePrecision = dvd match {
-      case d: stypes.SQLDecimal => d.getDecimalValuePrecision
-      case _ => -1
-    }
-    val storeScale = dvd match {
-      case d: stypes.SQLDecimal => d.getDecimalValueScale
-      case _ => -1
+    val (storePrecision, storeScale) = dvd match {
+      case d: stypes.SQLDecimal =>
+        // try to normalize parameter value into target column's scale/precision
+        val index = (questionMarkCounter - 1) * 4 + 1
+        // actual scale of the target column
+        val scale = preparedParamsTypesInfo.map(a => a(index + 2)).getOrElse(-1)
+
+        val decimalValue = new com.pivotal.gemfirexd.internal.iapi.types.SQLDecimal()
+        val typeId = TypeId.getBuiltInTypeId(java.sql.Types.DECIMAL)
+        val dtd = new com.pivotal.gemfirexd.internal.iapi.types.DataTypeDescriptor(
+          typeId, DecimalType.MAX_PRECISION, scale, true, typeId.getMaximumMaximumWidth)
+        decimalValue.normalize(dtd, dvd)
+        scalaTypeVal = decimalValue.getBigDecimal
+        (decimalValue.getDecimalValuePrecision, scale)
+
+      case _ => (-1, -1)
     }
     (scalaTypeVal, SnappySession.getDataType(storeType, storePrecision, storeScale))
   }


### PR DESCRIPTION
## Changes proposed in this pull request
Fix for SNAP-3082
Avoid error being thrown when PreparedStatement.setDouble is used for comparison with decimal column.

The issue is seen when for a comparison with decimal column a double parameter is set (using PreparedStatement#setDouble).  The double value 0.9 set in this test actually gets set as 0.90000000000000002220446049250313080847263336181640625  (with precision of 53) and the error is seen as Decimal can not support precision more than 38.
We do allow insert of such a value by normalizing it to target column's precision/scale also for unprepared statements.  Using similar approach in this case as well.

## Patch testing
Added a unit test for the scenario. Comparing results of prepared and unprepared statements to make sure that results are correct.
precheckin

## ReleaseNotes.txt changes
NA

## Other PRs 
NA