### PR TITLE
Fixing [SNAP-2653]

### DIFF
--- a/cluster/src/dunit/scala/io/snappydata/cluster/ClusterManagerLDAPTestBase.scala
+++ b/cluster/src/dunit/scala/io/snappydata/cluster/ClusterManagerLDAPTestBase.scala
@@ -31,11 +31,13 @@ import io.snappydata.test.dunit.{AvailablePortHelper, SerializableRunnable}
 object ClusterManagerLDAPTestBase {
   val securityProperties: Properties = new Properties()
   val thriftPort = AvailablePortHelper.getRandomAvailableUDPPort
+  var admin: String = ""
 }
 
 abstract class ClusterManagerLDAPTestBase(s: String, val adminUser: String = "gemfire10")
     extends ClusterManagerTestBase(s) with Serializable {
 
+  ClusterManagerLDAPTestBase.admin = adminUser
   // start embedded thrift server on lead
   bootProps.setProperty("snappydata.hiveServer.enabled", "true")
   bootProps.setProperty("hive.server2.thrift.bind.host", "localhost")

--- a/cluster/src/dunit/scala/io/snappydata/cluster/QueryRoutingDUnitSecurityTest.scala
+++ b/cluster/src/dunit/scala/io/snappydata/cluster/QueryRoutingDUnitSecurityTest.scala
@@ -128,6 +128,20 @@ class QueryRoutingDUnitSecurityTest(val s: String)
     stmt.close()
     conn.close()
   }
+
+  // Test if SNAPPY_HIVE_METASTORE tables can be accessed by admin user only.
+  def testMetastoreAccessAdminOnly: Unit = {
+    val adminUser = ClusterManagerLDAPTestBase.admin
+    val jdbcUser4 = "gemfire3"
+
+    val serverHostPort = AvailablePortHelper.getRandomAvailableTCPPort
+    vm2.invoke(classOf[ClusterManagerTestBase], "startNetServer", serverHostPort)
+    // scalastyle:off println
+    println(s"QueryRoutingDUnitSecureTest.testMetastoreAccessAdminOnly:" +
+        s" network server started at $serverHostPort")
+    // scalastyle:on println
+    QueryRoutingDUnitSecurityTest.checkMetastoreAccess(adminUser, jdbcUser4, serverHostPort)
+  }
 }
 
 object QueryRoutingDUnitSecurityTest {
@@ -254,10 +268,110 @@ object QueryRoutingDUnitSecurityTest {
       tableName, jdbcUser1, jdbcUser1)
   }
 
-  def netConnection(netPort: Int, user: String, pass: String): Connection = {
+  def checkMetastoreAccess(adminUser: String, nonAdminUser: String, netPort: Int): Unit = {
+    val schema = "SNAPPY_HIVE_METASTORE"
+    val adminConn = netConnection(netPort, adminUser, adminUser, false)
+    val adminStmt = adminConn.createStatement()
+    import org.scalatest.Assertions._
+    try {
+      adminStmt.execute(s"insert into $schema.version values (2, '1.2.1', 'dummy comment v2')")
+      adminStmt.execute(s"update $schema.version set version_comment =" +
+          s" 'comment changed' where ver_id = 2")
+     var res = adminStmt.executeQuery(s"select * from $schema.version order by ver_id")
+      res.next()
+        assert(res.getInt(1) === 1)
+      res.next()
+      assert(res.getInt(1) === 2 && res.getString(3) === "comment changed")
+
+      adminStmt.execute(s"delete from $schema.version where ver_id = 2")
+      res = adminStmt.executeQuery(s"select * from $schema.version")
+      while(res.next()){
+        assert(res.getInt(1) === 1)
+      }
+    }
+    finally {
+      adminStmt.close()
+      adminConn.close()
+    }
+
+    val conn = netConnection(netPort, nonAdminUser, nonAdminUser, false)
+    val stmt = conn.createStatement()
+
+    try {
+      var thrown = intercept[SQLException] {
+            stmt.executeQuery(s"select * from $schema.version")
+          }
+      assert(thrown.getMessage.contains("User 'GEMFIRE3' does not have SELECT permission on" +
+          " column 'VER_ID' of table 'SNAPPY_HIVE_METASTORE'.'VERSION'"))
+
+          thrown = intercept[SQLException] {
+            stmt.execute(s"insert into $schema.version values (2, '1.2.1', 'dummy comm v2')")
+          }
+          assert(thrown.getMessage.contains("User 'GEMFIRE3' does not have INSERT permission on" +
+              " table 'SNAPPY_HIVE_METASTORE'.'VERSION'"))
+
+         val  thrown2 = intercept[SQLException] {
+            stmt.execute(s"update $schema.version set version_comment =" +
+                s" 'comment changed ' where ver_id = 2")
+          }
+          println(s"Error msg: ${thrown2.getMessage}")
+          assert(thrown2.getMessage.contains("User 'GEMFIRE3' does not have UPDATE permission on column 'VERSION_COMMENT' of table 'SNAPPY_HIVE_METASTORE'.'VERSION'"))
+
+          thrown = intercept[SQLException] {
+            stmt.execute(s"delete from $schema.version where ver_id = 2")
+          }
+          assert(thrown.getMessage.contains("User 'GEMFIRE3' does not have DELETE permission on" +
+              " table 'SNAPPY_HIVE_METASTORE'.'VERSION'"))
+    }
+    finally {
+      stmt.close()
+      conn.close()
+    }
+
+    val conn2 = netConnection(netPort, nonAdminUser, nonAdminUser, true)
+    val stmt2 = conn2.createStatement()
+    try {
+      var thrown = intercept[SQLException] {
+        stmt2.executeQuery(s"select * from $schema.version")
+      }
+            assert(thrown.getMessage.contains("Invalid input \"SNAPPY_HIVE_METASTORE.v\"," +
+                " expected ws, test or relations"))
+
+      thrown = intercept[SQLException] {
+        stmt2.execute(s"insert into $schema.version values (2, '1.2.1', 'dummy comm v2')")
+      }
+      assert(thrown.getMessage.contains("User 'GEMFIRE3' does not have INSERT permission on" +
+          " table 'SNAPPY_HIVE_METASTORE'.'VERSION'"))
+
+      thrown = intercept[SQLException] {
+        stmt2.execute(s"update $schema.version set version_comment =" +
+            s" 'comment changed ' where ver_id = 2")
+      }
+      assert(thrown.getMessage.contains("GEMFIRE3' does not have UPDATE permission on column 'VERSION_COMMENT' of table 'SNAPPY_HIVE_METASTORE'.'VERSION'"))
+
+      thrown = intercept[SQLException] {
+        stmt2.execute(s"delete from $schema.version where ver_id = 2")
+      }
+      assert(thrown.getMessage.contains("User 'GEMFIRE3' does not have DELETE permission on table" +
+          " 'SNAPPY_HIVE_METASTORE'.'VERSION'"))
+    }
+    finally {
+      stmt2.close()
+      conn2.close()
+    }
+  }
+
+  def netConnection(netPort: Int, user: String, pass: String,
+      routeQuery: Boolean = true): Connection = {
     val driver = "io.snappydata.jdbc.ClientDriver"
     Utils.classForName(driver).newInstance
-    val url: String = "jdbc:snappydata://localhost:" + netPort + "/"
+    var url: String = null
+    if(routeQuery) {
+    url = "jdbc:snappydata://localhost:" + netPort + "/"
+    }
+    else {
+      url = "jdbc:snappydata://localhost:" + netPort + "/route-query=false"
+    }
     DriverManager.getConnection(url, user, pass)
   }
 

--- a/core/src/dunit/scala/io/snappydata/cluster/SplitClusterDUnitSecurityTest.scala
+++ b/core/src/dunit/scala/io/snappydata/cluster/SplitClusterDUnitSecurityTest.scala
@@ -35,7 +35,7 @@ import io.snappydata.util.TestUtils
 import org.apache.commons.io.FileUtils
 
 import org.apache.spark.sql.types.{IntegerType, StructField}
-import org.apache.spark.sql.{Row, SnappyContext, SnappySession, TableNotFoundException}
+import org.apache.spark.sql.{ParseException, Row, SnappyContext, SnappySession, TableNotFoundException}
 
 class SplitClusterDUnitSecurityTest(s: String)
     extends DistributedTestBase(s)
@@ -786,6 +786,49 @@ class SplitClusterDUnitSecurityTest(s: String)
           throw t
         }
     }
+  }
+
+  def testMetastoreAccessAdminOnlySmartConn: Unit = {
+    getConn(adminUser1, true)
+    import org.scalatest.Assertions.intercept
+    var thrown = intercept[ParseException] {
+      snc.sql("select * from SNAPPY_HIVE_METASTORE.version")
+    }
+    assert(thrown.getMessage().startsWith("Invalid input \"SNAPPY_HIVE_METASTORE.v\""))
+
+    thrown = intercept[ParseException] {
+      snc.sql("update SNAPPY_HIVE_METASTORE.version set version_comment = 'comment changed'")
+    }
+    assert(thrown.getMessage().startsWith("Invalid input \"SNAPPY_HIVE_METASTORE.v\""))
+    thrown = intercept[ParseException] {
+      snc.sql("insert into SNAPPY_HIVE_METASTORE.version values (4, '1.2.3', 'dummy comment')")
+    }
+    assert(thrown.getMessage().startsWith("Invalid input \"SNAPPY_HIVE_METASTORE.v\""))
+    thrown = intercept[ParseException] {
+      snc.sql("delete from SNAPPY_HIVE_METASTORE.version where ver_id = 2")
+    }
+    assert(thrown.getMessage().startsWith("Invalid input \"SNAPPY_HIVE_METASTORE.v\""))
+
+
+    getConn(jdbcUser1, true)
+    thrown = intercept[ParseException] {
+      snc.sql("select * from SNAPPY_HIVE_METASTORE.version")
+    }
+    assert(thrown.getMessage().startsWith("Invalid input \"SNAPPY_HIVE_METASTORE.v\""))
+
+    thrown = intercept[ParseException] {
+      snc.sql("update SNAPPY_HIVE_METASTORE.version set version_comment = 'comment changed'")
+    }
+    assert(thrown.getMessage().startsWith("Invalid input \"SNAPPY_HIVE_METASTORE.v\""))
+
+    thrown = intercept[ParseException] {
+      snc.sql("insert into SNAPPY_HIVE_METASTORE.version values (4, '1.2.3', 'dummy comment')")
+    }
+    assert(thrown.getMessage().startsWith("Invalid input \"SNAPPY_HIVE_METASTORE.v\""))
+    thrown = intercept[ParseException] {
+      snc.sql("delete from SNAPPY_HIVE_METASTORE.version where ver_id = 2")
+    }
+    assert(thrown.getMessage().startsWith("Invalid input \"SNAPPY_HIVE_METASTORE.v\""))
   }
 
   def _testLDAPGroupOwnershipSmartConnector(): Unit = {

--- a/core/src/main/scala/io/snappydata/SnappyTableStatsProviderService.scala
+++ b/core/src/main/scala/io/snappydata/SnappyTableStatsProviderService.scala
@@ -209,15 +209,8 @@ object SnappyEmbeddedTableStatsProviderService extends TableStatsProviderService
         // External Tables
         hiveTables.collect {
           case table if table.tableType == CatalogObjectType.External.toString =>
-            val tableSrcPath = table.dataSourcePath
-            val maskedSrcPath = if (tableSrcPath.toLowerCase().startsWith("s3a://") ||
-                tableSrcPath.toLowerCase().startsWith("s3://") ||
-                tableSrcPath.toLowerCase().startsWith("s3n://") ) {
-              tableSrcPath.replace(tableSrcPath.slice(tableSrcPath.indexOf("//") + 2,
-                tableSrcPath.indexOf("@")), "****:****")
-          } else tableSrcPath
             new SnappyExternalTableStats(table.entityName, table.tableType, table.schema,
-              table.shortProvider, table.externalStore, maskedSrcPath, table.driverClass)
+              table.shortProvider, table.externalStore, table.dataSourcePath, table.driverClass)
         }
       }
       catch {

--- a/core/src/main/scala/io/snappydata/SnappyTableStatsProviderService.scala
+++ b/core/src/main/scala/io/snappydata/SnappyTableStatsProviderService.scala
@@ -209,8 +209,15 @@ object SnappyEmbeddedTableStatsProviderService extends TableStatsProviderService
         // External Tables
         hiveTables.collect {
           case table if table.tableType == CatalogObjectType.External.toString =>
+            val tableSrcPath = table.dataSourcePath
+            val maskedSrcPath = if (tableSrcPath.toLowerCase().startsWith("s3a://") ||
+                tableSrcPath.toLowerCase().startsWith("s3://") ||
+                tableSrcPath.toLowerCase().startsWith("s3n://") ) {
+              tableSrcPath.replace(tableSrcPath.slice(tableSrcPath.indexOf("//") + 2,
+                tableSrcPath.indexOf("@")), "****:****")
+          } else tableSrcPath
             new SnappyExternalTableStats(table.entityName, table.tableType, table.schema,
-              table.shortProvider, table.externalStore, table.dataSourcePath, table.driverClass)
+              table.shortProvider, table.externalStore, maskedSrcPath, table.driverClass)
         }
       }
       catch {

--- a/core/src/main/scala/io/snappydata/sql/catalog/SnappyExternalCatalog.scala
+++ b/core/src/main/scala/io/snappydata/sql/catalog/SnappyExternalCatalog.scala
@@ -289,7 +289,7 @@ object SnappyExternalCatalog {
   val INDEXED_TABLE_LOWER: String = Utils.toLowerCase("INDEXED_TABLE")
 
   val EMPTY_SCHEMA: StructType = StructType(Nil)
-  private[sql] val PASSWORD_MATCH = "(?i)(password|passwd).*".r
+  private[sql] val PASSWORD_MATCH = "(?i)(password|passwd|secret).*".r
 
   val currentFunctionIdentifier = new ThreadLocal[FunctionIdentifier]
 

--- a/core/src/main/scala/io/snappydata/sql/catalog/impl/StoreHiveCatalog.scala
+++ b/core/src/main/scala/io/snappydata/sql/catalog/impl/StoreHiveCatalog.scala
@@ -434,16 +434,32 @@ class StoreHiveCatalog extends ExternalCatalog with Logging {
       }
     }
 
+    private def maskPassword(s: String): String = {
+      SnappyExternalCatalog.PASSWORD_MATCH.replaceAllIn(s, "xxx")
+    }
+
+    // Mask access key and secret access key in case of S3 URI
+    private def maskLocationURI(locURI: String): String = {
+      val maskedSrcPath = if (locURI.toLowerCase().startsWith("s3a://") ||
+          locURI.toLowerCase().startsWith("s3://") ||
+          locURI.toLowerCase().startsWith("s3n://") ) {
+        locURI.replace(locURI.slice(locURI.indexOf("//") + 2,
+          locURI.indexOf("@")), "****:****")
+      } else locURI
+      maskedSrcPath
+    }
+
+    // latest change is here - mask it here - include s3 masking here too
     private def getDataSourcePath(properties: scala.collection.Map[String, String],
         storage: CatalogStorageFormat): String = {
       properties.get("path") match {
-        case Some(p) if !p.isEmpty => p
+        case Some(p) if !p.isEmpty => maskPassword(p)
         case _ => properties.get("region.path") match { // for external GemFire connector
-          case Some(p) if !p.isEmpty => p
+          case Some(p) if !p.isEmpty => maskPassword(p)
           case _ => properties.get("url") match { // jdbc
             case Some(p) if !p.isEmpty =>
               // mask the password if present
-              val url = SnappyExternalCatalog.PASSWORD_MATCH.replaceAllIn(p, "xxx")
+              val url = maskPassword(p)
               // add dbtable if present
               properties.get(SnappyExternalCatalog.DBTABLE_PROPERTY) match {
                 case Some(d) if !d.isEmpty => s"$url; ${SnappyExternalCatalog.DBTABLE_PROPERTY}=$d"
@@ -451,7 +467,7 @@ class StoreHiveCatalog extends ExternalCatalog with Logging {
               }
             case _ => storage.locationUri match { // fallback to locationUri
               case None => ""
-              case Some(l) => l
+              case Some(l) => maskLocationURI(l)
             }
           }
         }

--- a/core/src/main/scala/io/snappydata/sql/catalog/impl/StoreHiveCatalog.scala
+++ b/core/src/main/scala/io/snappydata/sql/catalog/impl/StoreHiveCatalog.scala
@@ -445,7 +445,7 @@ class StoreHiveCatalog extends ExternalCatalog with Logging {
           locURI.toLowerCase().startsWith("s3n://") ) {
         locURI.replace(locURI.slice(locURI.indexOf("//") + 2,
           locURI.indexOf("@")), "****:****")
-      } else locURI
+      } else maskPassword(locURI)
       maskedSrcPath
     }
 
@@ -453,13 +453,13 @@ class StoreHiveCatalog extends ExternalCatalog with Logging {
     private def getDataSourcePath(properties: scala.collection.Map[String, String],
         storage: CatalogStorageFormat): String = {
       properties.get("path") match {
-        case Some(p) if !p.isEmpty => maskPassword(p)
+        case Some(p) if !p.isEmpty => maskLocationURI(p)
         case _ => properties.get("region.path") match { // for external GemFire connector
-          case Some(p) if !p.isEmpty => maskPassword(p)
+          case Some(p) if !p.isEmpty => maskLocationURI(p)
           case _ => properties.get("url") match { // jdbc
             case Some(p) if !p.isEmpty =>
               // mask the password if present
-              val url = maskPassword(p)
+              val url = maskLocationURI(p)
               // add dbtable if present
               properties.get(SnappyExternalCatalog.DBTABLE_PROPERTY) match {
                 case Some(d) if !d.isEmpty => s"$url; ${SnappyExternalCatalog.DBTABLE_PROPERTY}=$d"


### PR DESCRIPTION
* Mask credentials (in case of s3 URI) in Describe extended/formatted output.
* Mask credentials in case of s3 on UI for external tables.
* Disallow access non-admin user to the tables in SNAPPY_HIVE_METASTORE.
* Added tests for the fixes.

## Changes proposed in this pull request

(Fill in the changes here)

## Patch testing

Precheckin is in progress

## ReleaseNotes.txt changes

(Does this change require an entry in ReleaseNotes.txt? If yes, has it been added to it?)

## Other PRs 

(Does this change require changes in other projects- store, spark, spark-jobserver, aqp? Add the links of PR of the other subprojects that are related to this change)
