### PR TITLE
Add support for RESTRICT and CASCADE - Alter table drop column

### DIFF
--- a/core/src/main/scala/org/apache/spark/sql/SnappyContext.scala
+++ b/core/src/main/scala/org/apache/spark/sql/SnappyContext.scala
@@ -156,7 +156,7 @@ class SnappyContext protected[spark](val snappySession: SnappySession)
    * @param tableName
    * @param isAddColumn
    * @param column
-   * @param defaultValue
+   * @param referentialAction value can be either be CASCADE or RESTRICT
    */
   def alterTable(tableName: String, isAddColumn: Boolean,
       column: StructField, referentialAction: String): Unit = {

--- a/core/src/main/scala/org/apache/spark/sql/SnappyContext.scala
+++ b/core/src/main/scala/org/apache/spark/sql/SnappyContext.scala
@@ -146,9 +146,22 @@ class SnappyContext protected[spark](val snappySession: SnappySession)
     */
   def alterTable(tableName: String, isAddColumn: Boolean,
       column: StructField, defaultValue: Option[String] = None): Unit = {
-    snappySession.alterTable(tableName, isAddColumn, column, defaultValue)
+    snappySession.alterTable(tableName, isAddColumn, column, defaultValue, "")
   }
 
+  /**
+   * alter table adds/drops provided column, only supprted for row tables.
+   * For adding a column isAddColumn should be true, else it will be drop column
+   *
+   * @param tableName
+   * @param isAddColumn
+   * @param column
+   * @param defaultValue
+   */
+  def alterTable(tableName: String, isAddColumn: Boolean,
+      column: StructField, referentialAction: String): Unit = {
+    snappySession.alterTable(tableName, isAddColumn, column, None, referentialAction)
+  }
   /**
     * alter table adds/drops provided column, only supprted for row tables.
     * For adding a column isAddColumn should be true, else it will be drop column

--- a/core/src/main/scala/org/apache/spark/sql/SnappyDDLParser.scala
+++ b/core/src/main/scala/org/apache/spark/sql/SnappyDDLParser.scala
@@ -618,7 +618,12 @@ abstract class SnappyDDLParser(session: SparkSession)
   protected def alterTable: Rule1[LogicalPlan] = rule {
     ALTER ~ TABLE ~ tableIdentifier ~ (
         ADD ~ COLUMN.? ~ column ~ defaultVal ~ EOI ~> AlterTableAddColumnCommand |
-        DROP ~ COLUMN.? ~ identifier ~ EOI ~> AlterTableDropColumnCommand |
+        DROP ~ COLUMN.? ~ identifier ~ EOI ~> ((table: TableIdentifier, col: String)
+        => AlterTableDropColumnCommand(table, col)) |
+        DROP ~ COLUMN.? ~ identifier ~ CASCADE ~ EOI ~> ((table: TableIdentifier, col: String)
+        => AlterTableDropColumnCommand(table, col, "cascade")) |
+        DROP ~ COLUMN.? ~ identifier ~ RESTRICT ~ EOI ~> ((table: TableIdentifier, col: String)
+        => AlterTableDropColumnCommand(table, col, "restrict")) |
         capture(ANY. +) ~ EOI ~> ((r: TableIdentifier, s: String) =>
           DMLExternalTable(r, UnresolvedRelation(r), s"ALTER TABLE ${quotedUppercaseId(r)} $s"))
     )

--- a/core/src/main/scala/org/apache/spark/sql/SnappySession.scala
+++ b/core/src/main/scala/org/apache/spark/sql/SnappySession.scala
@@ -1352,19 +1352,19 @@ class SnappySession(_sc: SparkContext) extends SparkSession(_sc) {
   }
 
   def alterTable(tableName: String, isAddColumn: Boolean, column: StructField,
-      defaultValue: Option[String]): Unit = {
+      defaultValue: Option[String], referentialAction: String): Unit = {
     val tableIdent = tableIdentifier(tableName)
-    alterTable(tableIdent, isAddColumn, column, defaultValue)
+    alterTable(tableIdent, isAddColumn, column, defaultValue, referentialAction)
   }
 
   private[sql] def alterTable(tableIdent: TableIdentifier, isAddColumn: Boolean,
-      column: StructField, defaultValue: Option[String]): Unit = {
+      column: StructField, defaultValue: Option[String], referentialAction: String = ""): Unit = {
     if (sessionCatalog.isTemporaryTable(tableIdent)) {
       throw new AnalysisException("ALTER TABLE not supported for temporary tables")
     }
     sessionCatalog.resolveRelation(tableIdent) match {
       case LogicalRelation(ar: AlterableRelation, _, _) =>
-        ar.alterTable(tableIdent, isAddColumn, column, defaultValue)
+        ar.alterTable(tableIdent, isAddColumn, column, defaultValue, referentialAction)
         val metadata = sessionCatalog.getTableMetadata(tableIdent)
         sessionCatalog.alterTable(metadata.copy(schema = ar.schema))
       case _ =>

--- a/core/src/main/scala/org/apache/spark/sql/execution/ddl.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/ddl.scala
@@ -219,13 +219,14 @@ case class AlterTableToggleRowLevelSecurityCommand(tableIdent: TableIdentifier,
 }
 
 case class AlterTableDropColumnCommand(
-    tableIdent: TableIdentifier, column: String) extends RunnableCommand {
+    tableIdent: TableIdentifier, column: String,
+    referentialAction: String = "") extends RunnableCommand {
 
   override def run(session: SparkSession): Seq[Row] = {
     val snc = session.asInstanceOf[SnappySession]
     // drop column doesn't need anything apart from name so fill dummy values
     snc.alterTable(tableIdent, isAddColumn = false,
-      StructField(column, NullType), defaultValue = None)
+      StructField(column, NullType), defaultValue = None, referentialAction)
     Nil
   }
 }

--- a/core/src/main/scala/org/apache/spark/sql/row/JDBCMutableRelation.scala
+++ b/core/src/main/scala/org/apache/spark/sql/row/JDBCMutableRelation.scala
@@ -398,7 +398,8 @@ abstract case class JDBCMutableRelation(
   }
 
   override def alterTable(tableIdent: TableIdentifier,
-      isAddColumn: Boolean, column: StructField, defaultValue: Option[String]): Unit = {
+      isAddColumn: Boolean, column: StructField, defaultValue: Option[String],
+      referentialAction: String): Unit = {
     val conn = connFactory()
     try {
       val columnName = JdbcExtendedUtils.toUpperCase(column.name)
@@ -418,7 +419,7 @@ abstract case class JDBCMutableRelation(
            | add column "$columnName"
            |  ${getDataType(column)}$nullable$defaultColumnValue""".stripMargin
       } else {
-        s"""alter table ${quotedName(table)} drop column "$columnName""""
+        s"""alter table ${quotedName(table)} drop column "$columnName" $referentialAction"""
       }
       if (schema.nonEmpty) {
         JdbcExtendedUtils.executeUpdate(sql, conn)

--- a/core/src/main/scala/org/apache/spark/sql/sources/interfaces.scala
+++ b/core/src/main/scala/org/apache/spark/sql/sources/interfaces.scala
@@ -289,6 +289,8 @@ trait AlterableRelation {
    * @param tableIdent  Table identifier
    * @param isAddColumn True if column is to be added else it is to be dropped
    * @param column      Column to be added or dropped
+   * @param defaultValue Default value in case a value is not provided while inserting
+   * @param referentialAction Referential Action (cascade or restrict)
    */
   def alterTable(tableIdent: TableIdentifier,
       isAddColumn: Boolean, column: StructField, defaultValue: Option[String],

--- a/core/src/main/scala/org/apache/spark/sql/sources/interfaces.scala
+++ b/core/src/main/scala/org/apache/spark/sql/sources/interfaces.scala
@@ -291,7 +291,8 @@ trait AlterableRelation {
    * @param column      Column to be added or dropped
    */
   def alterTable(tableIdent: TableIdentifier,
-      isAddColumn: Boolean, column: StructField, defaultValue: Option[String]): Unit
+      isAddColumn: Boolean, column: StructField, defaultValue: Option[String],
+      referentialAction: String): Unit
 }
 
 trait RowLevelSecurityRelation {

--- a/core/src/test/scala/org/apache/spark/sql/store/RowTableTest.scala
+++ b/core/src/test/scala/org/apache/spark/sql/store/RowTableTest.scala
@@ -470,14 +470,27 @@ class RowTableTest
     snc.sql("insert into tab2 values (3333,true,6.6)")
 
     snc.sql("alter table tab2 drop column c1 cascade")
+    var colsTab2 = snc.sql("select * from tab2").columns
+    assert(colsTab2.mkString(",") === "c2,c3", "Columns don't match after the alter command.")
+
     snc.sql("alter table tab2 drop column c3 cascade")
+    colsTab2 = snc.sql("select * from tab2").columns
+    assert(colsTab2.mkString(",") === "c2", "Columns don't match after the alter command.")
+
     snc.sql("alter table tab1 drop column col2 restrict")
+    var colsTab1 = snc.sql("select * from tab1").columns
+    assert(colsTab1.mkString(",") === "col1,col3,col4", "Columns don't match after the alter command.")
+
     snc.sql("alter table tab1 drop column col4 cascade")
+    colsTab1 = snc.sql("select * from tab1").columns
+    assert(colsTab1.mkString(",") === "col1,col3", "Columns don't match after the alter command.")
 
     val df1 = snc.sql("select * from tab1")
     val df2 = snc.sql("select * from tab2")
-    assert(df1.columns.length === 2 && df2.columns.length === 1)
-    assert(df1.count() === 3 && df2.count() === 2)
+    assert(df1.columns.length === 2, "Number of columns does not match after the drop column command.")
+    assert(df2.columns.length === 1, "Number of columns does not match after the drop column command.")
+    assert(df1.count() === 3 , "Row count mismatch for table: tab1")
+    assert(df2.count() === 2, "Row count mismatch for table: tab2")
 
     try{
       snc.sql("alter table tab1 drop column col3 restrict")


### PR DESCRIPTION
## Changes proposed in this pull request

* Add support for these(cascade/restrict) keywords in the parser code of alter table
* Add new parameter to alterTable method(s).
* Append the keyword(cascade/restrict) to the sql string that is fired on Gemfire layer.

## Patch testing

Ran Precheckin

## ReleaseNotes.txt changes

An optional parameter, named referentialAction, has been added.

## Other PRs 

(Does this change require changes in other projects- store, spark, spark-jobserver, aqp? Add the links of PR of the other subprojects that are related to this change)
