### PR TITLE
Adding dunit test for SNAP-3010

### DIFF
--- a/core/src/dunit/scala/io/snappydata/cluster/CassandraSnappyDUnitTest.scala
+++ b/core/src/dunit/scala/io/snappydata/cluster/CassandraSnappyDUnitTest.scala
@@ -36,7 +36,15 @@ class CassandraSnappyDUnitTest(val s: String)
 
   val scriptPath = s"$snappyProductDir/../../../cluster/src/test/resources/scripts"
 
-  val downloadLoc = s"$snappyProductDir/../distributions"
+  lazy val downloadLoc = {
+    val path = if (System.getenv().containsKey("GRADLE_USER_HOME")) {
+      Paths.get(System.getenv("GRADLE_USER_HOME"), "cassandraDist")
+    } else {
+      Paths.get(System.getenv("HOME"), ".gradle", "cassandraDist")
+    }
+    Files.createDirectories(path)
+    path.toString
+  }
 
   val userHome = System.getProperty("user.home")
 


### PR DESCRIPTION
## Changes proposed in this pull request

- Adding dunit test for SNAP-3010
- updating the cassandra dunit test to download Cassandra distribution in
`$GRADLE_USER_HOME/cassandraDist` or `$HOME/.gradle/cassandraDist`
 directory instead of downloading in distributions directory. The
 distribution directory gets cleaned up every time precheckin or
 clean build is run causing the download of complete Cassandra distribution
 every time.

## Patch testing

This PR contains changes in tests itself. Affected tests are passing.

## Other PRs 
https://github.com/SnappyDataInc/spark/pull/158