### PR TITLE
SNAP-2947 : Hide internal sink state table from UI

### DIFF
--- a/core/src/main/scala/io/snappydata/TableStatsProviderService.scala
+++ b/core/src/main/scala/io/snappydata/TableStatsProviderService.scala
@@ -193,12 +193,14 @@ trait TableStatsProviderService extends Logging {
     if (!doRun) return (Map.empty, Map.empty, Map.empty)
     // val samples = getSampleTableList(snc)
     tableStats.foreach { stat =>
-      aggregatedStats.get(stat.getTableName) match {
-        case Some(oldRecord) =>
-          aggregatedStats.put(stat.getTableName, oldRecord.getCombinedStats(stat))
-        case None =>
-          aggregatedStats.put(stat.getTableName, stat)
-      }
+        if (!stat.getTableName.contains("SNAPPYSYS_INTERNAL____SINK_STATE_TABLE")) {
+          aggregatedStats.get(stat.getTableName) match {
+            case Some(oldRecord) =>
+              aggregatedStats.put(stat.getTableName, oldRecord.getCombinedStats(stat))
+            case None =>
+              aggregatedStats.put(stat.getTableName, stat)
+          }
+        }
     }
 
     indexStats.foreach { stat =>


### PR DESCRIPTION
## Changes proposed in this pull request

 - Hiding internal sink state table "SNAPPYSYS_INTERNAL____SINK_STATE_TABLE" from UI.

## Patch testing

 - Tested manually

## ReleaseNotes.txt changes

 - NA

## Other PRs 

 - None
