### PR TITLE
Fix for SNAP-3069: Executing two UDFs one-after another throws ClassNotFoundException

### DIFF
--- a/cluster/src/main/java/org/apache/spark/streaming/JavaSnappyStreamingJob.java
+++ b/cluster/src/main/java/org/apache/spark/streaming/JavaSnappyStreamingJob.java
@@ -47,7 +47,7 @@ public abstract class JavaSnappyStreamingJob implements SparkJobBase {
     try {
       SnappyUtils.setSessionDependencies(context.snappySession().sparkContext(),
           this.getClass().getCanonicalName(),
-          Thread.currentThread().getContextClassLoader());
+          Thread.currentThread().getContextClassLoader(), false);
       return runSnappyJob(context, SnappySessionFactory.updateCredentials(context.snappySession()
           , jobConfig, true));
     } finally {

--- a/cluster/src/main/scala/io/snappydata/ToolsCallbackImpl.scala
+++ b/cluster/src/main/scala/io/snappydata/ToolsCallbackImpl.scala
@@ -91,8 +91,8 @@ object ToolsCallbackImpl extends ToolsCallback with Logging {
   }
 
   override def setSessionDependencies(sparkContext: SparkContext, appName: String,
-      classLoader: ClassLoader): Unit = {
-    SnappyUtils.setSessionDependencies(sparkContext, appName, classLoader)
+      classLoader: ClassLoader, addAllJars: Boolean): Unit = {
+    SnappyUtils.setSessionDependencies(sparkContext, appName, classLoader, addAllJars)
   }
 
   override def addURIs(alias: String, jars: Array[String],
@@ -140,6 +140,7 @@ object ToolsCallbackImpl extends ToolsCallback with Logging {
       // Remove the file from spark directory
       if (!args(0).isEmpty) { // args(0) = appname-filename
         val appName = args(0).split('-')(0)
+        // This url points to the jar on the file server
         val url = Misc.getMemStore.getGlobalCmdRgn.get(ContextJarUtils.functionKeyPrefix + appName)
         if (url != null && !url.isEmpty) {
           val executor = ExecutorInitiator.snappyExecBackend.executor.asInstanceOf[SnappyExecutor]
@@ -149,8 +150,8 @@ object ToolsCallbackImpl extends ToolsCallback with Logging {
           val lockFile = new File(localDir, lockFileName)
           val lockFileChannel = new RandomAccessFile(lockFile, "rw").getChannel()
           val lock = lockFileChannel.lock()
-          val cachedFile = new File(localDir, cachedFileName)
           try {
+            val cachedFile = new File(localDir, cachedFileName)
             if (cachedFile.exists()) {
               cachedFile.delete()
               logDebug(s"Deleted $cachedFile for UDF ${args(0)}")

--- a/cluster/src/main/scala/org/apache/spark/executor/SnappyExecutor.scala
+++ b/cluster/src/main/scala/org/apache/spark/executor/SnappyExecutor.scala
@@ -96,7 +96,7 @@ class SnappyExecutor(
               env.securityManager, hadoopConf, -1L, useCache = !isLocal)
             val url = new File(SparkFiles.getRootDirectory(), localName).toURI.toURL
             Misc.getMemStore.getGlobalCmdRgn.put(ContextJarUtils.functionKeyPrefix + appName, name)
-            url
+            url // points to the jar in executor's work directory
           })
         }
         val newClassLoader = new SnappyMutableURLClassLoader(urls.toArray, replClassLoader)

--- a/cluster/src/main/scala/org/apache/spark/util/SnappyUtils.scala
+++ b/cluster/src/main/scala/org/apache/spark/util/SnappyUtils.scala
@@ -25,11 +25,12 @@ import _root_.io.snappydata.Constant
 import com.pivotal.gemfirexd.internal.engine.Misc
 import org.joda.time.DateTime
 import spark.jobserver.util.ContextURLClassLoader
+
 import org.apache.spark.deploy.SparkHadoopUtil
 import org.apache.spark.sql.collection.ToolsCallbackInit
+import org.apache.spark.sql.internal.ContextJarUtils
 import org.apache.spark.ui.SparkUI
 import org.apache.spark.{SparkContext, SparkEnv}
-
 import scala.util.Try
 
 object SnappyUtils {
@@ -41,6 +42,7 @@ object SnappyUtils {
     case _ => new SnappyContextLoader(parent)
   }
 
+  // FIXME Unused method, remove.
   def removeJobJar(sc: SparkContext): Unit = {
     def getName(path: String): String = new File(path).getName
 
@@ -57,6 +59,7 @@ object SnappyUtils {
     }
   }
 
+  // FIXME Unused method, remove.
   def removeJobJar(sc: SparkContext, jarName: String): Unit = {
     def getName(path: String): String = new File(path).getName
 
@@ -74,9 +77,13 @@ object SnappyUtils {
 
   def setSessionDependencies(sparkContext: SparkContext,
       appName: String,
-      classLoader: ClassLoader): Unit = {
+      classLoader: ClassLoader, addAllJars: Boolean = false): Unit = {
     assert(classOf[URLClassLoader].isAssignableFrom(classLoader.getClass))
-    val dependentJars = classLoader.asInstanceOf[URLClassLoader].getURLs
+    val dependentJars = if (addAllJars) {
+      ContextJarUtils.getDriverJarURLs()
+    } else {
+      classLoader.asInstanceOf[URLClassLoader].getURLs
+    }
     val sparkJars = dependentJars.map(url => {
       Try(sparkContext.env.rpcEnv.fileServer.addJar(new File(url.toURI))).getOrElse("")
     })

--- a/core/src/dunit/scala/io/snappydata/cluster/SplitClusterDUnitSecurityTest.scala
+++ b/core/src/dunit/scala/io/snappydata/cluster/SplitClusterDUnitSecurityTest.scala
@@ -1106,6 +1106,134 @@ class SplitClusterDUnitSecurityTest(s: String)
     executeSQL(user2Conn.createStatement(), s"drop function if exists myUDF")
   }
 
+  def testUDFWithQueries(): Unit = {
+    // Build a jar with UDF
+    val udf1Source = "public class StringLengthUDF implements " +
+        "org.apache.spark.sql.api.java.UDF1<String,Integer> {" +
+        " @Override public Integer call(String s){ " +
+        "               return (s.length() + 100); " +
+        "} }"
+    var classfile = SparkUtilsAccess.createUDFClass("StringLengthUDF", udf1Source)
+    val jar1 = SparkUtilsAccess.createJarFile(Seq(classfile), "stringlengthudf", true)
+
+    val udf2Source = "public class StringifyIntUDF implements " +
+        "org.apache.spark.sql.api.java.UDF1<Integer,String> {" +
+        " @Override public String call(Integer s){ " +
+        "               return (s + \" stringified\"); " +
+        "} }"
+    classfile = SparkUtilsAccess.createUDFClass("StringifyIntUDF", udf2Source)
+    val jar2 = SparkUtilsAccess.createJarFile(Seq(classfile))
+
+    var user1stmt = getConn(jdbcUser1).createStatement()
+
+    // create table and run some queries
+    val tabName = "udf_coltab"
+    executeSQL(user1stmt, s"create table $tabName (id int, name string, address varchar(100)," +
+        " contact string) using column")
+    for (i <- 1001 to 3000) {
+      executeSQL(user1stmt, s"insert into $tabName values ($i, 'name_$i', 'address_$i'," +
+          s" '98$i-765')")
+    }
+    executeSQL(user1stmt, s"select count(*) from $tabName")
+    executeSQL(user1stmt, s"select id, contact from $tabName where id > 2980")
+    executeSQL(user1stmt, s"select name, address from $tabName where contact = '981500-765'")
+
+    // create and execute udfs
+    executeSQL(user1stmt, s"CREATE FUNCTION strlen AS " +
+        s"StringLengthUDF returns Integer using jar '$jar1'")
+    executeSQL(user1stmt, s"CREATE FUNCTION stringifyInt AS " +
+        s"StringifyIntUDF returns String using jar '$jar2'")
+
+    user1stmt.execute(s"select strlen('11223344')")
+    var rs = user1stmt.getResultSet
+    var rows = 0
+    if (rs ne null) {
+      while (rs.next()) {
+        rows += 1
+        assert(rs.getInt(1) == 108, s"Expected 108, found ${rs.getInt(1)}")
+      }
+      rs.close()
+    }
+    user1stmt.execute(s"select stringifyInt(11223344)")
+    rs = user1stmt.getResultSet
+    rows = 0
+    if (rs ne null) {
+      while (rs.next()) {
+        rows += 1
+        assert(rs.getString(1).equals("11223344 stringified"), s"Expected" +
+            s" '11223344 stringified', found '${rs.getString(1)}'")
+      }
+      rs.close()
+    }
+
+    executeSQL(user1stmt, s"drop function if exists strlen")
+    executeSQL(user1stmt, s"drop function if exists stringifyInt")
+
+    // Now execute old queries again with new constants
+    user1stmt.execute(s"select count(*) from $tabName")
+    rs = user1stmt.getResultSet
+    rows = 0
+    if (rs ne null) {
+      while (rs.next()) {
+        rows += 1
+        assert(rs.getInt(1) == 2000, s"Expected 2000 rows," +
+            s" found ${rs.getInt(1)}")
+      }
+      rs.close()
+    }
+    user1stmt.execute(s"select id, contact from $tabName where id > 2985")
+    rs = user1stmt.getResultSet
+    rows = 0
+    if (rs ne null) {
+      while (rs.next()) {
+        rows += 1
+        assert(rs.getInt(1) > 2985)
+      }
+      rs.close()
+    }
+    assert(rows == 15)
+    user1stmt.execute(s"select name, address from $tabName where contact = '9812000-765'")
+    rs = user1stmt.getResultSet
+    rows = 0
+    if (rs ne null) {
+      while (rs.next()) {
+        rows += 1
+        assert(rs.getString(1).equalsIgnoreCase("name_2000"))
+        assert(rs.getString(2).equalsIgnoreCase("address_2000"))
+      }
+      rs.close()
+    }
+
+    // Execute some other queries too
+    user1stmt.execute(s"select * from $tabName where id = 2333")
+    rs = user1stmt.getResultSet
+    rows = 0
+    if (rs ne null) {
+      while (rs.next()) {
+        rows += 1
+        assert(rs.getInt(1) == 2333)
+        assert(rs.getString(2).equalsIgnoreCase(s"name_2333"))
+        assert(rs.getString(3).equalsIgnoreCase(s"address_2333"))
+        assert(rs.getString(4).equalsIgnoreCase(s"982333-765"))
+      }
+      rs.close()
+    }
+    user1stmt.execute(s"select id, contact, name from $tabName where id < 2500 " +
+        s"and name like 'name_159%'")
+    rs = user1stmt.getResultSet
+    rows = 0
+    if (rs ne null) {
+      while (rs.next()) {
+        rows += 1
+        assert(rs.getInt(1) < 1600 && rs.getInt(1) > 1589)
+        assert(rs.getString(2).contains(s"98159"))
+        assert(rs.getString(3).contains(s"name_159"))
+      }
+      rs.close()
+    }
+    assert(rows == 10, s"Expected 10 rows found $rows")
+  }
+
 }
 
 object SplitClusterDUnitSecurityTest extends SplitClusterDUnitTestObject {

--- a/core/src/dunit/scala/org/apache/spark/SparkUtilsAccess.scala
+++ b/core/src/dunit/scala/org/apache/spark/SparkUtilsAccess.scala
@@ -46,10 +46,10 @@ object SparkUtilsAccess {
   }
 
   def createJarFile(files: Seq[File], jarName: String, recreate: Boolean = false): String = {
-    var jarFile = new File(destDir, jarName)
+    var jarFile = new File(destDir, s"$jarName.jar")
     if (jarFile.exists() && recreate) {
       jarFile.delete()
-      jarFile = new File(destDir, jarName)
+      jarFile = new File(destDir, s"$jarName.jar")
     }
     TestUtils.createJar(files, jarFile)
     jarFile.getPath

--- a/core/src/main/scala/io/snappydata/ToolsCallback.scala
+++ b/core/src/main/scala/io/snappydata/ToolsCallback.scala
@@ -48,7 +48,7 @@ trait ToolsCallback {
 
   def setSessionDependencies(sparkContext: SparkContext,
       appName: String,
-      classLoader: ClassLoader): Unit = {
+      classLoader: ClassLoader, addAllJars: Boolean): Unit = {
   }
 
   def addURIs(alias: String, jars: Array[String],

--- a/core/src/main/scala/org/apache/spark/sql/internal/JarUtils.scala
+++ b/core/src/main/scala/org/apache/spark/sql/internal/JarUtils.scala
@@ -53,21 +53,14 @@ object ContextJarUtils extends Logging {
     driverJars.putIfAbsent(key, classLoader)
   }
 
-  // FIXME Unused, remove.
-  def addIfNotPresent(key: String, urls: Array[URL], parent: ClassLoader): Unit = {
-    if (driverJars.get(key).isEmpty) {
-      driverJars.putIfAbsent(key, new MutableURLClassLoader(urls, parent))
-    }
-  }
-
   def getDriverJar(key: String): Option[URLClassLoader] = driverJars.get(key)
 
   def removeDriverJar(key: String) : Unit = driverJars.remove(key)
 
   def getDriverJarURLs(): Array[URL] = {
-    var sm = new mutable.HashSet[URL]()
-    driverJars.foreach(_._2.getURLs.foreach(sm += _))
-    sm.toArray
+    var urls = new mutable.HashSet[URL]()
+    driverJars.foreach(_._2.getURLs.foreach(urls += _))
+    urls.toArray
   }
 
   /**

--- a/core/src/main/scala/org/apache/spark/sql/internal/JarUtils.scala
+++ b/core/src/main/scala/org/apache/spark/sql/internal/JarUtils.scala
@@ -67,7 +67,6 @@ object ContextJarUtils extends Logging {
   def getDriverJarURLs(): Array[URL] = {
     var sm = new mutable.HashSet[URL]()
     driverJars.foreach(_._2.getURLs.foreach(sm += _))
-    logInfo(s"ABS returning ${sm.size} driver jars")
     sm.toArray
   }
 

--- a/core/src/main/scala/org/apache/spark/sql/internal/JarUtils.scala
+++ b/core/src/main/scala/org/apache/spark/sql/internal/JarUtils.scala
@@ -22,6 +22,7 @@ import java.net.{URL, URLClassLoader}
 import java.util.concurrent.ConcurrentHashMap
 
 import scala.collection.JavaConverters._
+import scala.collection.mutable
 
 import com.pivotal.gemfirexd.internal.engine.Misc
 
@@ -52,6 +53,7 @@ object ContextJarUtils extends Logging {
     driverJars.putIfAbsent(key, classLoader)
   }
 
+  // FIXME Unused, remove.
   def addIfNotPresent(key: String, urls: Array[URL], parent: ClassLoader): Unit = {
     if (driverJars.get(key).isEmpty) {
       driverJars.putIfAbsent(key, new MutableURLClassLoader(urls, parent))
@@ -61,6 +63,13 @@ object ContextJarUtils extends Logging {
   def getDriverJar(key: String): Option[URLClassLoader] = driverJars.get(key)
 
   def removeDriverJar(key: String) : Unit = driverJars.remove(key)
+
+  def getDriverJarURLs(): Array[URL] = {
+    var sm = new mutable.HashSet[URL]()
+    driverJars.foreach(_._2.getURLs.foreach(sm += _))
+    logInfo(s"ABS returning ${sm.size} driver jars")
+    sm.toArray
+  }
 
   /**
     * This method will copy the given jar to Spark root directory

--- a/core/src/main/scala/org/apache/spark/sql/internal/SnappySessionCatalog.scala
+++ b/core/src/main/scala/org/apache/spark/sql/internal/SnappySessionCatalog.scala
@@ -752,10 +752,10 @@ class SnappySessionCatalog(val externalCatalog: SnappyExternalCatalog,
 
   private def removeFromFuncJars(funcDefinition: CatalogFunction,
       qualifiedName: FunctionIdentifier): Unit = {
+    ContextJarUtils.removeDriverJar(qualifiedName.unquotedString)
     funcDefinition.resources.foreach { r =>
       ContextJarUtils.deleteFile(funcDefinition.identifier.toString(), r.uri, isEmbeddedMode())
     }
-    ContextJarUtils.removeDriverJar(qualifiedName.unquotedString)
   }
 
   override def dropFunction(name: FunctionIdentifier, ignoreIfNotExists: Boolean): Unit = {

--- a/core/src/main/scala/org/apache/spark/sql/internal/SnappySessionCatalog.scala
+++ b/core/src/main/scala/org/apache/spark/sql/internal/SnappySessionCatalog.scala
@@ -743,7 +743,7 @@ class SnappySessionCatalog(val externalCatalog: SnappyExternalCatalog,
     SnappyContext.getClusterMode(snappySession.sparkContext) match {
       case SnappyEmbeddedMode(_, _) =>
         callbacks.setSessionDependencies(snappySession.sparkContext,
-          functionQualifiedName, newClassLoader)
+          functionQualifiedName, newClassLoader, true)
       case _ =>
         newClassLoader.getURLs.foreach(url =>
           snappySession.sparkContext.addJar(url.getFile))


### PR DESCRIPTION
## Changes proposed in this pull request
- Including all the jar urls at the time of sending the list to executors.

## Patch testing
precheckin is clean,
Basic unit test is added,
Manually tested.
Will add more testcases but the source changes are ready to be reviewed.

## ReleaseNotes.txt changes
(Does this change require an entry in ReleaseNotes.txt? If yes, has it been added to it?)

## Other PRs 
NA