### PR TITLE
SNAP-3094: change default hive tmp file locations to working directory

### DIFF
--- a/cluster/src/main/scala/io/snappydata/impl/LeadImpl.scala
+++ b/cluster/src/main/scala/io/snappydata/impl/LeadImpl.scala
@@ -187,8 +187,7 @@ class LeadImpl extends ServerImpl with Lead
 
       conf.setAll(bootProperties.asScala)
       // set spark ui port to 5050 that is snappy's default
-      conf.set("spark.ui.port",
-        bootProperties.getProperty("spark.ui.port", LeadImpl.SPARKUI_PORT.toString))
+      conf.setIfMissing("spark.ui.port", LeadImpl.SPARKUI_PORT.toString)
 
       // wait for log service to initialize so that Spark also uses the same
       while (!ClientSharedUtils.isLoggerInitialized && status() != State.RUNNING) {

--- a/core/src/main/scala/io/snappydata/util/ServiceUtils.scala
+++ b/core/src/main/scala/io/snappydata/util/ServiceUtils.scala
@@ -16,6 +16,7 @@
  */
 package io.snappydata.util
 
+import java.nio.file.{Files, Paths}
 import java.util.Properties
 import java.util.regex.Pattern
 
@@ -30,9 +31,10 @@ import _root_.com.pivotal.gemfirexd.internal.engine.distributed.utils.GemFireXDU
 import io.snappydata.{Constant, Property, ServerManager, SnappyTableStatsProviderService}
 
 import org.apache.spark.memory.MemoryMode
+import org.apache.spark.sql.collection.Utils
+import org.apache.spark.sql.hive.HiveClientUtil
 import org.apache.spark.sql.{SnappyContext, SparkSession, ThinClientConnectorMode}
 import org.apache.spark.{SparkContext, SparkEnv}
-import org.apache.spark.sql.collection.Utils
 
 /**
  * Common utility methods for store services.
@@ -42,7 +44,7 @@ object ServiceUtils {
   val LOCATOR_URL_PATTERN: Pattern = Pattern.compile("(.+:[0-9]+)|(.+\\[[0-9]+\\])")
 
   private[snappydata] def getStoreProperties(
-      confProps: Seq[(String, String)]): Properties = {
+      confProps: Seq[(String, String)], forInit: Boolean = false): Properties = {
     val storeProps = new Properties()
     confProps.foreach {
       case (Property.Locators(), v) =>
@@ -62,44 +64,44 @@ object ServiceUtils {
           k.startsWith(Constant.JOBSERVER_PROPERTY_PREFIX) => storeProps.setProperty(k, v)
       case _ => // ignore rest
     }
-    setCommonBootDefaults(storeProps, forLocator = false)
+    setCommonBootDefaults(storeProps, forLocator = false, forInit)
   }
 
   private[snappydata] def setCommonBootDefaults(props: Properties,
-      forLocator: Boolean): Properties = {
+      forLocator: Boolean, forInit: Boolean = true): Properties = {
     val storeProps = if (props ne null) props else new Properties()
     if (!forLocator) {
       // set default recovery delay to 2 minutes (SNAP-1541)
-      if (storeProps.getProperty(GfxdConstants.DEFAULT_STARTUP_RECOVERY_DELAY_PROP) == null) {
-        storeProps.setProperty(GfxdConstants.DEFAULT_STARTUP_RECOVERY_DELAY_PROP, "120000")
-      }
+      storeProps.putIfAbsent(GfxdConstants.DEFAULT_STARTUP_RECOVERY_DELAY_PROP, "120000")
       // try hard to maintain executor and node locality
-      if (storeProps.getProperty("spark.locality.wait.process") == null) {
-        storeProps.setProperty("spark.locality.wait.process", "20s")
-      }
-      if (storeProps.getProperty("spark.locality.wait") == null) {
-        storeProps.setProperty("spark.locality.wait", "10s")
-      }
+      storeProps.putIfAbsent("spark.locality.wait.process", "20s")
+      storeProps.putIfAbsent("spark.locality.wait", "10s")
       // default value for spark.sql.files.maxPartitionBytes in snappy is 32mb
-      if (storeProps.getProperty("spark.sql.files.maxPartitionBytes") == null) {
-        storeProps.setProperty("spark.sql.files.maxPartitionBytes", "33554432")
-      }
+      storeProps.putIfAbsent("spark.sql.files.maxPartitionBytes", "33554432")
 
+      // change hive temporary files location to be inside working directory
+      // to fix issues with concurrent queries trying to access/write same directories
+      if (forInit) {
+        Utils.deletePath(Paths.get(HiveClientUtil.HIVE_TMPDIR))
+        Files.createDirectories(Paths.get(HiveClientUtil.HIVE_TMPDIR))
+      }
+      // set as system properties so that these can be overridden by
+      // hive-site.xml if required
+      val sysProps = System.getProperties
+      for ((hiveVar, dirName) <- HiveClientUtil.HIVE_DEFAULT_SETTINGS) {
+        sysProps.putIfAbsent(hiveVar.varname, dirName)
+      }
     }
     // set default member-timeout higher for GC pauses (SNAP-1777)
-    if (storeProps.getProperty(DistributionConfig.MEMBER_TIMEOUT_NAME) == null) {
-      storeProps.setProperty(DistributionConfig.MEMBER_TIMEOUT_NAME, "30000")
-    }
+    storeProps.putIfAbsent(DistributionConfig.MEMBER_TIMEOUT_NAME, "30000")
     // set network partition detection by default
-    if (storeProps.getProperty(ENABLE_NETWORK_PARTITION_DETECTION_NAME) == null) {
-      storeProps.setProperty(ENABLE_NETWORK_PARTITION_DETECTION_NAME, "true")
-    }
+    storeProps.putIfAbsent(ENABLE_NETWORK_PARTITION_DETECTION_NAME, "true")
     storeProps
   }
 
   def invokeStartFabricServer(sc: SparkContext,
       hostData: Boolean): Unit = {
-    val properties = getStoreProperties(Utils.getInternalSparkConf(sc).getAll)
+    val properties = getStoreProperties(Utils.getInternalSparkConf(sc).getAll, forInit = true)
     // overriding the host-data property based on the provided flag
     if (!hostData) {
       properties.setProperty("host-data", "false")

--- a/core/src/main/scala/org/apache/spark/sql/hive/SnappyHiveExternalCatalog.scala
+++ b/core/src/main/scala/org/apache/spark/sql/hive/SnappyHiveExternalCatalog.scala
@@ -37,7 +37,6 @@ import com.pivotal.gemfirexd.internal.engine.distributed.utils.GemFireXDUtils
 import com.pivotal.gemfirexd.internal.impl.sql.catalog.GfxdDataDictionary
 import io.snappydata.sql.catalog.SnappyExternalCatalog._
 import io.snappydata.sql.catalog.{CatalogObjectType, ConnectorExternalCatalog, RelationInfo, SnappyExternalCatalog}
-import org.apache.commons.io.FileUtils
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.hive.metastore.api.NoSuchObjectException
 import org.apache.hadoop.hive.ql.metadata.Hive
@@ -838,8 +837,6 @@ object SnappyHiveExternalCatalog {
       log4jLogger.setLevel(Level.ERROR)
     }
     try {
-      // delete the hive scratch directory if it exists
-      FileUtils.deleteDirectory(new java.io.File("./hive"))
       instance = new SnappyHiveExternalCatalog(sparkConf, hadoopConf, createTime)
     } finally {
       logger.setLevel(previousLevel)


### PR DESCRIPTION
Five hive properties set the "scratch" and other directories to be inside working directory instead of
/tmp directory so that there is no trouble if multiple instances try to use it (else directory
  created by some instance may be unwritable by another)

## Changes proposed in this pull request

- set SCRATCHDIR, LOCALSCRATCHDIR, DOWNLOADED_RESOURCES_DIR,
  HIVEHISTORYFILELOC and HIVE_SERVER2_LOGGING_OPERATION_LOG_LOCATION
  as subdirectories inside working directory + "/hive"
- set as system properties so that will be used by default by all sessions by default and still can be
  overridden by hive-site.xml; additionally builtin catalog always overrides to the defaults
- use putIfAbsent/setIfMissing methods to overwrite if not present instead of check+set

## Patch testing

precheckin

## ReleaseNotes.txt changes

NA

## Other PRs 

NA