### PR TITLE
SNAP-3090: normalize schema when reading from catalog

### DIFF
--- a/cluster/src/dunit/scala/io/snappydata/cluster/QueryRoutingDUnitSecurityTest.scala
+++ b/cluster/src/dunit/scala/io/snappydata/cluster/QueryRoutingDUnitSecurityTest.scala
@@ -130,7 +130,7 @@ class QueryRoutingDUnitSecurityTest(val s: String)
   }
 
   // Test if SNAPPY_HIVE_METASTORE tables can be accessed by admin user only.
-  def testMetastoreAccessAdminOnly: Unit = {
+  def testMetastoreAccessAdminOnly(): Unit = {
     val adminUser = ClusterManagerLDAPTestBase.admin
     val jdbcUser4 = "gemfire3"
 
@@ -270,22 +270,22 @@ object QueryRoutingDUnitSecurityTest {
 
   def checkMetastoreAccess(adminUser: String, nonAdminUser: String, netPort: Int): Unit = {
     val schema = "SNAPPY_HIVE_METASTORE"
-    val adminConn = netConnection(netPort, adminUser, adminUser, false)
+    val adminConn = netConnection(netPort, adminUser, adminUser, routeQuery = false)
     val adminStmt = adminConn.createStatement()
     import org.scalatest.Assertions._
     try {
       adminStmt.execute(s"insert into $schema.version values (2, '1.2.1', 'dummy comment v2')")
       adminStmt.execute(s"update $schema.version set version_comment =" +
           s" 'comment changed' where ver_id = 2")
-     var res = adminStmt.executeQuery(s"select * from $schema.version order by ver_id")
+      var res = adminStmt.executeQuery(s"select * from $schema.version order by ver_id")
       res.next()
-        assert(res.getInt(1) === 1)
+      assert(res.getInt(1) === 1)
       res.next()
       assert(res.getInt(1) === 2 && res.getString(3) === "comment changed")
 
       adminStmt.execute(s"delete from $schema.version where ver_id = 2")
       res = adminStmt.executeQuery(s"select * from $schema.version")
-      while(res.next()){
+      while (res.next()) {
         assert(res.getInt(1) === 1)
       }
     }
@@ -294,48 +294,49 @@ object QueryRoutingDUnitSecurityTest {
       adminConn.close()
     }
 
-    val conn = netConnection(netPort, nonAdminUser, nonAdminUser, false)
+    val conn = netConnection(netPort, nonAdminUser, nonAdminUser, routeQuery = false)
     val stmt = conn.createStatement()
 
     try {
       var thrown = intercept[SQLException] {
-            stmt.executeQuery(s"select * from $schema.version")
-          }
+        stmt.executeQuery(s"select * from $schema.version")
+      }
       assert(thrown.getMessage.contains("User 'GEMFIRE3' does not have SELECT permission on" +
           " column 'VER_ID' of table 'SNAPPY_HIVE_METASTORE'.'VERSION'"))
 
-          thrown = intercept[SQLException] {
-            stmt.execute(s"insert into $schema.version values (2, '1.2.1', 'dummy comm v2')")
-          }
-          assert(thrown.getMessage.contains("User 'GEMFIRE3' does not have INSERT permission on" +
-              " table 'SNAPPY_HIVE_METASTORE'.'VERSION'"))
+      thrown = intercept[SQLException] {
+        stmt.execute(s"insert into $schema.version values (2, '1.2.1', 'dummy comm v2')")
+      }
+      assert(thrown.getMessage.contains("User 'GEMFIRE3' does not have INSERT permission on" +
+          " table 'SNAPPY_HIVE_METASTORE'.'VERSION'"))
 
-         val  thrown2 = intercept[SQLException] {
-            stmt.execute(s"update $schema.version set version_comment =" +
-                s" 'comment changed ' where ver_id = 2")
-          }
-          println(s"Error msg: ${thrown2.getMessage}")
-          assert(thrown2.getMessage.contains("User 'GEMFIRE3' does not have UPDATE permission on column 'VERSION_COMMENT' of table 'SNAPPY_HIVE_METASTORE'.'VERSION'"))
+      val thrown2 = intercept[SQLException] {
+        stmt.execute(s"update $schema.version set version_comment =" +
+            s" 'comment changed ' where ver_id = 2")
+      }
+      assert(thrown2.getMessage.matches(".*User 'GEMFIRE3' does not have (UPDATE|SELECT) " +
+          "permission on column '(VERSION_COMMENT|VER_ID)' of table " +
+          "'SNAPPY_HIVE_METASTORE'.'VERSION'."))
 
-          thrown = intercept[SQLException] {
-            stmt.execute(s"delete from $schema.version where ver_id = 2")
-          }
-          assert(thrown.getMessage.contains("User 'GEMFIRE3' does not have DELETE permission on" +
-              " table 'SNAPPY_HIVE_METASTORE'.'VERSION'"))
+      thrown = intercept[SQLException] {
+        stmt.execute(s"delete from $schema.version where ver_id = 2")
+      }
+      assert(thrown.getMessage.matches(".*User 'GEMFIRE3' does not have (DELETE|SELECT) " +
+          "permission on( column 'VER_ID' of)? table 'SNAPPY_HIVE_METASTORE'.'VERSION'."))
     }
     finally {
       stmt.close()
       conn.close()
     }
 
-    val conn2 = netConnection(netPort, nonAdminUser, nonAdminUser, true)
+    val conn2 = netConnection(netPort, nonAdminUser, nonAdminUser)
     val stmt2 = conn2.createStatement()
     try {
       var thrown = intercept[SQLException] {
         stmt2.executeQuery(s"select * from $schema.version")
       }
-            assert(thrown.getMessage.contains("Invalid input \"SNAPPY_HIVE_METASTORE.v\"," +
-                " expected ws, test or relations"))
+      assert(thrown.getMessage.contains("Invalid input \"SNAPPY_HIVE_METASTORE.v\"," +
+          " expected ws, test or relations"))
 
       thrown = intercept[SQLException] {
         stmt2.execute(s"insert into $schema.version values (2, '1.2.1', 'dummy comm v2')")
@@ -347,13 +348,15 @@ object QueryRoutingDUnitSecurityTest {
         stmt2.execute(s"update $schema.version set version_comment =" +
             s" 'comment changed ' where ver_id = 2")
       }
-      assert(thrown.getMessage.contains("GEMFIRE3' does not have UPDATE permission on column 'VERSION_COMMENT' of table 'SNAPPY_HIVE_METASTORE'.'VERSION'"))
+      assert(thrown.getMessage.matches(".*User 'GEMFIRE3' does not have (UPDATE|SELECT) " +
+          "permission on column '(VERSION_COMMENT|VER_ID)' of table " +
+          "'SNAPPY_HIVE_METASTORE'.'VERSION'."))
 
       thrown = intercept[SQLException] {
         stmt2.execute(s"delete from $schema.version where ver_id = 2")
       }
-      assert(thrown.getMessage.contains("User 'GEMFIRE3' does not have DELETE permission on table" +
-          " 'SNAPPY_HIVE_METASTORE'.'VERSION'"))
+      assert(thrown.getMessage.matches(".*User 'GEMFIRE3' does not have (DELETE|SELECT) " +
+          "permission on( column 'VER_ID' of)? table 'SNAPPY_HIVE_METASTORE'.'VERSION'."))
     }
     finally {
       stmt2.close()
@@ -366,8 +369,8 @@ object QueryRoutingDUnitSecurityTest {
     val driver = "io.snappydata.jdbc.ClientDriver"
     Utils.classForName(driver).newInstance
     var url: String = null
-    if(routeQuery) {
-    url = "jdbc:snappydata://localhost:" + netPort + "/"
+    if (routeQuery) {
+      url = "jdbc:snappydata://localhost:" + netPort + "/"
     }
     else {
       url = "jdbc:snappydata://localhost:" + netPort + "/route-query=false"

--- a/core/src/main/scala/io/snappydata/sql/catalog/impl/StoreHiveCatalog.scala
+++ b/core/src/main/scala/io/snappydata/sql/catalog/impl/StoreHiveCatalog.scala
@@ -196,8 +196,8 @@ class StoreHiveCatalog extends ExternalCatalog with Logging {
 
   private final class CatalogQuery[R](qType: Int, tableName: String, schemaName: String,
       catalogOperation: Int = 0, getRequest: CatalogMetadataRequest = null,
-      updateRequestOrResult: CatalogMetadataDetails = null, user: String = null, forceDrop: Boolean = false)
-      extends Callable[R] {
+      updateRequestOrResult: CatalogMetadataDetails = null, user: String = null,
+      forceDrop: Boolean = false) extends Callable[R] {
 
     private lazy val formattedTable = toLowerCase(tableName)
     private lazy val formattedSchema = toLowerCase(schemaName)
@@ -464,9 +464,10 @@ class StoreHiveCatalog extends ExternalCatalog with Logging {
 
     // Mask access key and secret access key in case of S3 URI
     private def maskLocationURI(locURI: String): String = {
-      val maskedSrcPath = if (locURI.toLowerCase().startsWith("s3a://") ||
-          locURI.toLowerCase().startsWith("s3://") ||
-          locURI.toLowerCase().startsWith("s3n://") ) {
+      val uri = toLowerCase(locURI)
+      val maskedSrcPath = if (uri.startsWith("s3a://") ||
+          uri.startsWith("s3://") ||
+          uri.startsWith("s3n://")) {
         locURI.replace(locURI.slice(locURI.indexOf("//") + 2,
           locURI.indexOf("@")), "****:****")
       } else maskPassword(locURI)

--- a/core/src/main/scala/org/apache/spark/sql/execution/ddl.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/ddl.scala
@@ -24,6 +24,7 @@ import java.util.Map.Entry
 import java.util.function.Consumer
 
 import scala.collection.mutable.ArrayBuffer
+
 import com.gemstone.gemfire.SystemFailure
 import com.pivotal.gemfirexd.internal.engine.Misc
 import com.pivotal.gemfirexd.internal.engine.store.GemFireStore
@@ -32,8 +33,9 @@ import com.pivotal.gemfirexd.internal.impl.jdbc.Util
 import com.pivotal.gemfirexd.internal.shared.common.reference.SQLState
 import io.snappydata.Property
 import io.snappydata.util.ServiceUtils
+
 import org.apache.spark.SparkContext
-import org.apache.spark.deploy.{SparkSubmit, SparkSubmitUtils}
+import org.apache.spark.deploy.SparkSubmitUtils
 import org.apache.spark.sql._
 import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.catalog.CatalogTypes.TablePartitionSpec
@@ -616,7 +618,7 @@ case class UnDeployCommand(alias: String) extends RunnableCommand {
       cmndsSet.forEach(new Consumer[Entry[String, String]] {
         override def accept(t: Entry[String, String]): Unit = {
           val alias1 = t.getKey
-          if(alias == alias1) {
+          if (alias == alias1) {
             value = t.getValue
           }
         }

--- a/core/src/main/scala/org/apache/spark/sql/hive/SnappyHiveExternalCatalog.scala
+++ b/core/src/main/scala/org/apache/spark/sql/hive/SnappyHiveExternalCatalog.scala
@@ -495,18 +495,16 @@ class SnappyHiveExternalCatalog private[hive](val conf: SparkConf,
     // VIEW text is stored as split text for large view strings,
     // so restore its full text and schema from properties if present
     val newTable = if (table.tableType == CatalogTableType.VIEW) {
-      // update the meta-data from properties
       val viewText = JdbcExtendedUtils.readSplitProperty(SPLIT_VIEW_TEXT_PROPERTY,
         table.properties).orElse(table.viewText)
       val viewOriginalText = JdbcExtendedUtils.readSplitProperty(SPLIT_VIEW_ORIGINAL_TEXT_PROPERTY,
         table.properties).orElse(table.viewOriginalText)
-      // schema is "normalized" to deal with upgrade from previous
-      // releases that store column names in upper-case (SNAP-3090)
+      // update the meta-data from properties
       ExternalStoreUtils.getTableSchema(table.properties, forView = true) match {
-        case Some(s) => table.copy(identifier = tableIdent, schema = normalizeSchema(s),
-          viewText = viewText, viewOriginalText = viewOriginalText)
-        case None => table.copy(identifier = tableIdent, schema = normalizeSchema(table.schema),
-          viewText = viewText, viewOriginalText = viewOriginalText)
+        case Some(s) => table.copy(identifier = tableIdent, schema = s, viewText = viewText,
+          viewOriginalText = viewOriginalText)
+        case None => table.copy(identifier = tableIdent, viewText = viewText,
+          viewOriginalText = viewOriginalText)
       }
     } else if (CatalogObjectType.isPolicy(table)) {
       // explicitly change table name in policy properties to lower-case

--- a/core/src/main/scala/org/apache/spark/sql/hive/SnappyHiveExternalCatalog.scala
+++ b/core/src/main/scala/org/apache/spark/sql/hive/SnappyHiveExternalCatalog.scala
@@ -492,7 +492,7 @@ class SnappyHiveExternalCatalog private[hive](val conf: SparkConf,
    */
   protected def finalizeCatalogTable(table: CatalogTable): CatalogTable = {
     // schema is always "normalized" below to deal with upgrade from previous
-    // releases that stored column names in upper-case (SNAP-3090)
+    // releases that store column names in upper-case (SNAP-3090)
     val tableIdent = table.identifier
     // VIEW text is stored as split text for large view strings,
     // so restore its full text and schema from properties if present
@@ -510,7 +510,7 @@ class SnappyHiveExternalCatalog private[hive](val conf: SparkConf,
       }
     } else if (CatalogObjectType.isPolicy(table)) {
       // explicitly change table name in policy properties to lower-case
-      // to deal with older releases that stored the name in upper-case
+      // to deal with older releases that store the name in upper-case
       table.copy(identifier = tableIdent, schema = normalizeSchema(table.schema),
         properties = table.properties.updated(PolicyProperties.targetTable,
           JdbcExtendedUtils.toLowerCase(table.properties(PolicyProperties.targetTable))))

--- a/core/src/main/scala/org/apache/spark/sql/internal/SnappySessionCatalog.scala
+++ b/core/src/main/scala/org/apache/spark/sql/internal/SnappySessionCatalog.scala
@@ -1035,7 +1035,7 @@ class SnappySessionCatalog(val externalCatalog: SnappyExternalCatalog,
 
     if (isEmbeddedMode) {
       callbacks.setSessionDependencies(snappySession.sparkContext,
-        functionQualifiedName, newClassLoader, true)
+        functionQualifiedName, newClassLoader, addAllJars = true)
     } else {
       newClassLoader.getURLs.foreach(url =>
         snappySession.sparkContext.addJar(url.getFile))


### PR DESCRIPTION
## Changes proposed in this pull request

- older releases have schema with upper-case column names so always
  "normalize" schema to lower-case names when reading from SnappyHiveExternalCatalog
- also change targetTable property in policy to lower-case

## Patch testing

precheckin and manual upgrade testing

## ReleaseNotes.txt changes

NA

## Other PRs 

NA