### PR TITLE
SNAP-1327: making schemaname empty if it isn't present in plan

### DIFF
--- a/cluster/src/dunit/scala/io/snappydata/cluster/QueryRoutingDUnitTest.scala
+++ b/cluster/src/dunit/scala/io/snappydata/cluster/QueryRoutingDUnitTest.scala
@@ -1297,7 +1297,7 @@ class QueryRoutingDUnitTest(val s: String)
 
     val rs = stmt.executeQuery("select * from db1.t1")
     assert(rs.getMetaData.getSchemaName(1).equalsIgnoreCase(""),
-      s"expected '' but received ${rs.getMetaData.getSchemaName(1)}")
+      s"expected 't1' but received ${rs.getMetaData.getSchemaName(1)}")
     assert(rs.getMetaData.getTableName(1).equalsIgnoreCase("t1"),
       s"expected '' but received ${rs.getMetaData.getTableName(1)}")
     assert(rs.getMetaData.getColumnCount.equals(2))

--- a/cluster/src/dunit/scala/io/snappydata/cluster/QueryRoutingDUnitTest.scala
+++ b/cluster/src/dunit/scala/io/snappydata/cluster/QueryRoutingDUnitTest.scala
@@ -1284,4 +1284,23 @@ class QueryRoutingDUnitTest(val s: String)
       i4 = i4 + 1
     }
   }
+
+  def testSchemaAndTableNames: Unit = {
+    val netPort1 = AvailablePortHelper.getRandomAvailableTCPPort
+    vm2.invoke(classOf[ClusterManagerTestBase], "startNetServer", netPort1)
+    val conn = getANetConnection(netPort1)
+    val stmt = conn.createStatement()
+
+    stmt.executeUpdate("create database db1")
+
+    stmt.executeUpdate("create table db1.t1 (c1 integer, c2 integer)")
+
+    val rs = stmt.executeQuery("select * from db1.t1")
+    assert(rs.getMetaData.getSchemaName(1).equalsIgnoreCase(""),
+      s"expected '' but received ${rs.getMetaData.getSchemaName(1)}")
+    assert(rs.getMetaData.getTableName(1).equalsIgnoreCase("t1"),
+      s"expected '' but received ${rs.getMetaData.getTableName(1)}")
+    assert(rs.getMetaData.getColumnCount.equals(2))
+    rs.close()
+  }
 }

--- a/cluster/src/main/scala/io/snappydata/gemxd/SparkSQLExecuteImpl.scala
+++ b/cluster/src/main/scala/io/snappydata/gemxd/SparkSQLExecuteImpl.scala
@@ -288,7 +288,11 @@ object SparkSQLExecuteImpl {
       if (dotIdx > 0) {
         val tableName = fn.substring(0, dotIdx)
         val fullTableName = if (tableName.indexOf('.') > 0) tableName
-        else session.getCurrentSchema + '.' + tableName
+        else {
+          // JDBC spec allows returning empty string for getSchemaName so the code
+          // should do the same instead of returning current schema which can be incorrect
+          "." + tableName
+        }
         (fullTableName, a.nullable)
       } else {
         ("", a.nullable)


### PR DESCRIPTION
## Changes proposed in this pull request

if schema name of individual attributes within analyzed plan is not present, instead of assigning currentschema we are assigning blank

## Patch testing

ran precheckin

## ReleaseNotes.txt changes

no

## Other PRs 

none
