### PR TITLE
Adding a system property flag to make reserve configurable.

### DIFF
--- a/cluster/src/dunit/scala/io/snappydata/cluster/ClusterManagerTestBase.scala
+++ b/cluster/src/dunit/scala/io/snappydata/cluster/ClusterManagerTestBase.scala
@@ -85,6 +85,8 @@ abstract class ClusterManagerTestBase(s: String)
 
   sysProps.setProperty("gemfire.DISALLOW_CLUSTER_RESTART_CHECK", "true")
 
+  sysProps.setProperty("gemfire.DISALLOW_RESERVE_SPACE", "true")
+
   var host: Host = _
   var vm0: VM = _
   var vm1: VM = _

--- a/dunit/src/main/java/io/snappydata/test/dunit/DistributedTestBase.java
+++ b/dunit/src/main/java/io/snappydata/test/dunit/DistributedTestBase.java
@@ -122,6 +122,8 @@ public abstract class DistributedTestBase extends TestCase implements java.io.Se
 
     public static void setUp() {
       // nothing; actual setup done in static initializer
+      // May be just use this to set certain system properties in tests, like below.
+      System.setProperty("gemfire.DISALLOW_RESERVE_SPACE", "true");
     }
 
     public static String getBaseDir() {


### PR DESCRIPTION
By default it is ON but tests have an option to ignore it. Similarly users
can ignore it too.

## Changes proposed in this pull request

(Fill in the changes here)

## Patch testing

Running precheckin
## ReleaseNotes.txt changes

(Does this change require an entry in ReleaseNotes.txt? If yes, has it been added to it?)

## Other PRs 

https://github.com/SnappyDataInc/snappy-store/pull/502