### PR TITLE
Instead of creating a new SparkConf, use existing SparkConf in StoreHiveCatalog.CatalogQuery#initCatalog

### DIFF
--- a/core/src/main/scala/io/snappydata/sql/catalog/impl/StoreHiveCatalog.scala
+++ b/core/src/main/scala/io/snappydata/sql/catalog/impl/StoreHiveCatalog.scala
@@ -51,7 +51,7 @@ import org.apache.spark.sql.policy.PolicyProperties
 import org.apache.spark.sql.sources.JdbcExtendedUtils.{toLowerCase, toUpperCase}
 import org.apache.spark.sql.sources.{DataSourceRegister, JdbcExtendedUtils}
 import org.apache.spark.sql.{AnalysisException, SnappyContext}
-import org.apache.spark.{Logging, SparkConf}
+import org.apache.spark.{Logging, SparkConf, SparkEnv}
 
 class StoreHiveCatalog extends ExternalCatalog with Logging {
 
@@ -419,7 +419,10 @@ class StoreHiveCatalog extends ExternalCatalog with Logging {
       var done = false
       while (!done) {
         try {
-          val conf = new SparkConf
+          val conf = SparkEnv.get match {
+            case null => new SparkConf
+            case env => env.conf.clone()
+          }
           for ((k, v) <- Misc.getMemStoreBooting.getBootProperties.asScala) {
             val key = k.toString
             if ((v ne null) && (key.startsWith(Constant.SPARK_PREFIX) ||

--- a/core/src/main/scala/io/snappydata/sql/catalog/impl/StoreHiveCatalog.scala
+++ b/core/src/main/scala/io/snappydata/sql/catalog/impl/StoreHiveCatalog.scala
@@ -34,7 +34,9 @@ import com.pivotal.gemfirexd.internal.engine.locks.GfxdLockSet
 import com.pivotal.gemfirexd.internal.engine.store.GemFireStore
 import com.pivotal.gemfirexd.internal.impl.sql.catalog.GfxdDataDictionary
 import com.pivotal.gemfirexd.internal.shared.common.reference.SQLState
+import com.pivotal.gemfirexd.Attribute.{USERNAME_ATTR, PASSWORD_ATTR}
 import io.snappydata.Constant
+import io.snappydata.Constant.{SPARK_STORE_PREFIX, STORE_PROPERTY_PREFIX}
 import io.snappydata.sql.catalog.SnappyExternalCatalog.checkSchemaPermission
 import io.snappydata.sql.catalog.{CatalogObjectType, ConnectorExternalCatalog, SnappyExternalCatalog}
 import io.snappydata.thrift._
@@ -421,7 +423,13 @@ class StoreHiveCatalog extends ExternalCatalog with Logging {
         try {
           val conf = SparkEnv.get match {
             case null => new SparkConf
-            case env => env.conf.clone()
+            case env =>
+              val sparkConf = env.conf.clone()
+              sparkConf.remove(SPARK_STORE_PREFIX + USERNAME_ATTR)
+              sparkConf.remove(STORE_PROPERTY_PREFIX + USERNAME_ATTR)
+              sparkConf.remove(SPARK_STORE_PREFIX + PASSWORD_ATTR)
+              sparkConf.remove(STORE_PROPERTY_PREFIX + PASSWORD_ATTR)
+              sparkConf
           }
           for ((k, v) <- Misc.getMemStoreBooting.getBootProperties.asScala) {
             val key = k.toString

--- a/core/src/main/scala/org/apache/spark/sql/hive/HiveClientUtil.scala
+++ b/core/src/main/scala/org/apache/spark/sql/hive/HiveClientUtil.scala
@@ -74,15 +74,9 @@ object HiveClientUtil extends Logging {
       password = sparkConf.getOption(STORE_PROPERTY_PREFIX + PASSWORD_ATTR)
     }
     // check store boot properties
-    if (user.isEmpty) {
-      val bootProperties = Misc.getMemStoreBooting.getBootProperties
-      bootProperties.get(USERNAME_ATTR).asInstanceOf[String] match {
-        case null =>
-        case u =>
-          user = Some(u)
-          password = Option(bootProperties.get(PASSWORD_ATTR).asInstanceOf[String])
-      }
-    }
+    val bootProperties = Misc.getMemStoreBooting.getBootProperties
+    if (user.isEmpty) user = Option(bootProperties.get(USERNAME_ATTR).asInstanceOf[String])
+    if (password.isEmpty) password = Option(bootProperties.get(PASSWORD_ATTR).asInstanceOf[String])
     var logURL = dbURL
     val secureDbURL = if (user.isDefined && password.isDefined) {
       logURL = dbURL + ";user=" + user.get
@@ -160,7 +154,8 @@ object HiveClientUtil extends Logging {
     val propertyNames = props.stringPropertyNames.iterator()
     while (propertyNames.hasNext) {
       val name = propertyNames.next()
-      System.setProperty(name, props.getProperty(name))
+      val value = props.getProperty(name)
+      if (value ne null) System.setProperty(name, value)
     }
 
     // set integer properties after the system properties have been used by

--- a/core/src/main/scala/org/apache/spark/sql/hive/HiveClientUtil.scala
+++ b/core/src/main/scala/org/apache/spark/sql/hive/HiveClientUtil.scala
@@ -74,9 +74,15 @@ object HiveClientUtil extends Logging {
       password = sparkConf.getOption(STORE_PROPERTY_PREFIX + PASSWORD_ATTR)
     }
     // check store boot properties
-    val bootProperties = Misc.getMemStoreBooting.getBootProperties
-    if (user.isEmpty) user = Option(bootProperties.get(USERNAME_ATTR).asInstanceOf[String])
-    if (password.isEmpty) password = Option(bootProperties.get(PASSWORD_ATTR).asInstanceOf[String])
+    if (user.isEmpty) {
+      val bootProperties = Misc.getMemStoreBooting.getBootProperties
+      bootProperties.get(USERNAME_ATTR).asInstanceOf[String] match {
+        case null =>
+        case u =>
+          user = Some(u)
+          password = Option(bootProperties.get(PASSWORD_ATTR).asInstanceOf[String])
+      }
+    }
     var logURL = dbURL
     val secureDbURL = if (user.isDefined && password.isDefined) {
       logURL = dbURL + ";user=" + user.get


### PR DESCRIPTION
# Changes proposed in this pull request

- In StoreHiveCatalog.CatalogQuery#initCatalog, instead of creating a new SparkConf, use existing SparkConf if available in SparkEnv. This avoids properties getting loaded from system properties as in case of new SparkConf object.
- Remove username/password from cloned spark conf as Spark conf does not contain the password. Username/password is later filled in by getOrCreateExternalCatalog() from bootProperties
- In HiveClientUtil added a NULL check for property values

Above changes are done with @sumwale by code inspection as a possible fix for SNAP-3013 (NPE in org.apache.spark.SparkConf.set for maxPartitionBytes) which is not readily reproducible. 

## Patch testing
precheckin 
30 runs of hydra tests mentioned in SNAP-3013

## ReleaseNotes.txt changes
NA

## Other PRs 
