### PR TITLE
Change in the exit status if already running is in "waiting"

### DIFF
--- a/cluster/sbin/snappy-nodes.sh
+++ b/cluster/sbin/snappy-nodes.sh
@@ -280,6 +280,7 @@ function execute() {
     fi
   fi
 
+  childPids+=($LAST_PID)
   df=${dirfolder}
   if [ -z "${df}" ]; then
     df=$(echo ${dirparam} | cut -d'=' -f2)
@@ -297,6 +298,8 @@ index=1
 isServerStart=
 declare -a leadHosts
 declare -a leadCounts
+declare -a childPids
+
 if [ "$componentType" = "server" -a -n "$(echo $"${@// /\\ }" | grep -w start)" ]; then
   isServerStart=1
 fi
@@ -448,4 +451,18 @@ else
   fi
   execute "$@"
 fi
-wait
+
+if [ "$isServerStart" ]; then
+  # server status file
+  SERVERS_STATUS_FILE="$SNAPPY_HOME/work/serversstatus"
+  if [ -f $SERVERS_STATUS_FILE ]; then
+    rm $SERVERS_STATUS_FILE
+  fi
+  touch $SERVERS_STATUS_FILE
+  for pid in "${childPids[@]}"; do
+    wait $pid
+    echo $? >> $SERVERS_STATUS_FILE
+  done
+else
+  wait
+fi

--- a/cluster/sbin/snappy-nodes.sh
+++ b/cluster/sbin/snappy-nodes.sh
@@ -280,7 +280,7 @@ function execute() {
     fi
   fi
 
-  childPids+=($LAST_PID)
+  childPids[$LAST_PID]="$host"
   df=${dirfolder}
   if [ -z "${df}" ]; then
     df=$(echo ${dirparam} | cut -d'=' -f2)
@@ -454,14 +454,14 @@ fi
 
 if [ "$isServerStart" ]; then
   # server status file
-  SERVERS_STATUS_FILE="$SNAPPY_HOME/work/serversstatus"
+  SERVERS_STATUS_FILE="$SNAPPY_HOME/work/members-status.txt"
   if [ -f $SERVERS_STATUS_FILE ]; then
     rm $SERVERS_STATUS_FILE
   fi
   touch $SERVERS_STATUS_FILE
-  for pid in "${childPids[@]}"; do
+  for pid in "${!childPids[@]}"; do
     wait $pid
-    echo $? >> $SERVERS_STATUS_FILE
+    echo "$? ${childPids[${pid}]}" >> $SERVERS_STATUS_FILE
   done
 else
   wait

--- a/cluster/sbin/snappy-start-all.sh
+++ b/cluster/sbin/snappy-start-all.sh
@@ -34,7 +34,7 @@ if [ -f "${MEMBERS_FILE}" ]; then
   rm $MEMBERS_FILE
 fi
 
-SERVERS_STATUS_FILE="$SNAPPY_HOME/work/serversstatus"
+SERVERS_STATUS_FILE="$SNAPPY_HOME/work/members-status.txt"
 if [ -f "${SERVERS_STATUS_FILE}" ]; then
   rm $SERVERS_STATUS_FILE
 fi
@@ -42,7 +42,7 @@ fi
 CAN_START_LEAD=0
 function checkIfOkayToStartLeads() {
   while  read -r line || [[ -n "$line" ]]; do
-    read exitstatus <<< $line
+    read exitstatus member <<< $line
     if [ "x$exitstatus" = "x0" -o "x$exitstatus" = "x10" ]; then
       CAN_START_LEAD=1
     fi
@@ -100,8 +100,9 @@ if [ "$clustermode" != "rowstore" ]; then
     "$sbin"/snappy-leads.sh $CONF_DIR_ARG start
   else
     echo "Cannot start lead components. At least one server should be"
-    echo "in running state. Please check server logs."
-    echo "Try running snappy-status-all script to check servers status"
-    echo "Try starting lead once at least one server comes in running state."
+    echo "in running state."
+    echo "Check work/members-status.txt for server status code and try"
+    echo "running snappy-status-all script ..."
+    echo "Try running lead with snappy-start-all once again"
   fi
 fi

--- a/launcher/src/main/java/io/snappydata/tools/QuickLauncher.java
+++ b/launcher/src/main/java/io/snappydata/tools/QuickLauncher.java
@@ -164,7 +164,7 @@ class QuickLauncher extends LauncherBase {
     // Complain if a cache server is already running in the specified working directory.
     // See bug 32574.
     int state = verifyAndClearStatus();
-    if (state != 0) {
+    if (state != Status.SHUTDOWN) {
       // Returning a status of 10 would indicate the startup scripts to know that an
       // instance was already running and in healthy state.
       if (state == Status.RUNNING) {

--- a/launcher/src/main/java/io/snappydata/tools/QuickLauncher.java
+++ b/launcher/src/main/java/io/snappydata/tools/QuickLauncher.java
@@ -28,6 +28,7 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.Properties;
+import java.util.regex.Pattern;
 
 import com.gemstone.gemfire.internal.cache.Status;
 import com.gemstone.gemfire.internal.shared.ClientSharedUtils;
@@ -164,7 +165,16 @@ class QuickLauncher extends LauncherBase {
     // See bug 32574.
     String msg = verifyAndClearStatus();
     if (msg != null) {
+      final Status status = getStatus();
       System.err.println(msg);
+      // Returning a status of 10 would indicate the startup scripts to know that an
+      // instance was already running and in healthy state.
+      if (status.state == Status.RUNNING) {
+        return 10;
+      }
+      // else this will indicate that an instance was there but not in running state.
+      // It can be waiting too ( specially for servers -- for lead it can be standby)
+      // but we can ignore making further differentiation here.
       return 1;
     }
 

--- a/launcher/src/main/java/io/snappydata/tools/QuickLauncher.java
+++ b/launcher/src/main/java/io/snappydata/tools/QuickLauncher.java
@@ -163,13 +163,11 @@ class QuickLauncher extends LauncherBase {
 
     // Complain if a cache server is already running in the specified working directory.
     // See bug 32574.
-    String msg = verifyAndClearStatus();
-    if (msg != null) {
-      final Status status = getStatus();
-      System.err.println(msg);
+    int state = verifyAndClearStatus();
+    if (state != 0) {
       // Returning a status of 10 would indicate the startup scripts to know that an
       // instance was already running and in healthy state.
-      if (status.state == Status.RUNNING) {
+      if (state == Status.RUNNING) {
         return 10;
       }
       // else this will indicate that an instance was there but not in running state.


### PR DESCRIPTION
and if already running is in "running" state. This differentiation is required in start all script for starting lead members.
The start up script carefully decides based on the exit status of the servers
where at least one server is in "running" state and then only starts lead members.

## Changes proposed in this pull request

(Fill in the changes here)

## Patch testing

Manuall testing
## ReleaseNotes.txt changes

(Does this change require an entry in ReleaseNotes.txt? If yes, has it been added to it?)

## Other PRs 

https://github.com/SnappyDataInc/snappy-store/pull/511