### PR TITLE
Cleanup function registration using ExpressionDescription tags

### DIFF
--- a/core/src/main/scala/io/snappydata/functions.scala
+++ b/core/src/main/scala/io/snappydata/functions.scala
@@ -22,13 +22,14 @@ import io.snappydata.sql.catalog.SnappyExternalCatalog
 
 import org.apache.spark.jdbc.{ConnectionConf, ConnectionUtil}
 import org.apache.spark.sql.catalyst.InternalRow
-import org.apache.spark.sql.catalyst.analysis.FunctionRegistry
+import org.apache.spark.sql.catalyst.analysis.FunctionRegistry.FunctionBuilder
 import org.apache.spark.sql.catalyst.expressions.codegen.{CodegenContext, ExprCode}
-import org.apache.spark.sql.catalyst.expressions.{ExpressionDescription, ExpressionInfo, LeafExpression, Nondeterministic}
+import org.apache.spark.sql.catalyst.expressions.{CurrentDatabase, Expression, ExpressionDescription, ExpressionInfo, LeafExpression, Nondeterministic}
 import org.apache.spark.sql.collection.Utils
 import org.apache.spark.sql.execution.columnar.ExternalStoreUtils
+import org.apache.spark.sql.policy.{CurrentUser, LdapGroupsOfCurrentUser}
 import org.apache.spark.sql.sources.ConnectionProperties
-import org.apache.spark.sql.types.{DataType, StringType}
+import org.apache.spark.sql.types.{ArrayType, DataType, StringType}
 import org.apache.spark.sql.{SnappyContext, ThinClientConnectorMode}
 import org.apache.spark.unsafe.types.UTF8String
 
@@ -37,12 +38,49 @@ import org.apache.spark.unsafe.types.UTF8String
  */
 object SnappyDataFunctions {
 
-  val usageStr: String = "_FUNC_() - Returns the unique distributed member" +
-      " ID of the server containing the row."
+  val stringArrayType: DataType = ArrayType(StringType)
 
-  def registerSnappyFunctions(functionRegistry: FunctionRegistry): Unit = {
-    val info = new ExpressionInfo(DSID.getClass.getCanonicalName, null, "DSID", usageStr, "")
-    functionRegistry.registerFunction("DSID", info, _ => DSID())
+  /**
+   * List all the additional builtin functions here.
+   */
+  val builtin: Seq[(String, ExpressionInfo, FunctionBuilder)] = Seq(
+    buildZeroArgExpression("dsid", classOf[DSID], DSID),
+    // add current_schema() as an alias for current_database()
+    buildZeroArgExpression("current_schema", classOf[CurrentDatabase], CurrentDatabase),
+    buildZeroArgExpression("current_user", classOf[CurrentUser], CurrentUser),
+    buildZeroArgExpression("current_user_ldap_groups", classOf[LdapGroupsOfCurrentUser],
+      LdapGroupsOfCurrentUser)
+  )
+
+  def expressionInfo(name: String, fnClass: Class[_]): ExpressionInfo = {
+    val df = fnClass.getAnnotation(classOf[ExpressionDescription])
+    if (df ne null) {
+      new ExpressionInfo(fnClass.getCanonicalName, null, name, df.usage(), df.extended())
+    } else {
+      new ExpressionInfo(fnClass.getCanonicalName, name)
+    }
+  }
+
+  def buildZeroArgExpression(name: String, fnClass: Class[_],
+      fn: () => Expression): (String, ExpressionInfo, FunctionBuilder) = {
+    (name, expressionInfo(name, fnClass), e => {
+      if (e.nonEmpty) {
+        throw Utils.analysisException(s"Argument(s) passed for zero argument function $name")
+      }
+      fn()
+    })
+  }
+
+  def buildOneArgExpression(name: String, fnClass: Class[_],
+      fn: Expression => Expression): (String, ExpressionInfo, FunctionBuilder) = {
+    (name, expressionInfo(name, fnClass), e => {
+      if (e.length == 1) {
+        fn(e.head)
+      } else {
+        throw Utils.analysisException("Invalid number of arguments for function " +
+            s"$name: got ${e.length} but expected 1")
+      }
+    })
   }
 
   lazy val defaultConnectionProps: ConnectionProperties = SnappyContext.getClusterMode(
@@ -76,7 +114,12 @@ object SnappyDataFunctions {
  * Expression that returns the dsid of the server containing the row.
  */
 @ExpressionDescription(
-  usage = "_FUNC_() - Returns the dsid of the server containing the row.")
+  usage = "_FUNC_() - Returns the unique distributed member ID of executor fetching current row.",
+  extended = """
+    Examples:
+      > SELECT _FUNC_();
+       localhost(1831)<v2>:18165
+  """)
 case class DSID() extends LeafExpression with Nondeterministic {
 
   override def nullable: Boolean = false

--- a/core/src/main/scala/org/apache/spark/sql/SnappyContextFunctions.scala
+++ b/core/src/main/scala/org/apache/spark/sql/SnappyContextFunctions.scala
@@ -16,13 +16,12 @@
  */
 package org.apache.spark.sql
 
+import io.snappydata.SnappyDataFunctions
 import io.snappydata.sql.catalog.CatalogObjectType
 
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.InternalRow
-import org.apache.spark.sql.catalyst.expressions.ExpressionInfo
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
-import org.apache.spark.sql.policy.{CurrentUser, LdapGroupsOfCurrentUser}
 import org.apache.spark.sql.sources.BaseRelation
 import org.apache.spark.sql.streaming.StreamBaseRelation
 import org.apache.spark.sql.types.StructType
@@ -37,32 +36,7 @@ class SnappyContextFunctions {
 
   def registerSnappyFunctions(session: SnappySession): Unit = {
     val registry = session.sessionState.functionRegistry
-    val usageStr1 = "_FUNC_() - Returns the User's UserName who is executing the " +
-      "current SQL statement."
-    val info1 = new ExpressionInfo(CurrentUser.getClass.getCanonicalName, null,
-      "CURRENT_USER", usageStr1, "")
-    registry.registerFunction("CURRENT_USER", info1,
-      e => {
-        if (e.nonEmpty) {
-          throw new AnalysisException("Argument(s)  passed for zero arg function " +
-            s"CURRENT_USER")
-        }
-        CurrentUser()
-      })
-
-    val usageStr2 = "_FUNC_() - Returns the ldap groups of, which the user " +
-      "who is executing the current SQL statement, is a member of."
-    val info2 = new ExpressionInfo(LdapGroupsOfCurrentUser.getClass.getCanonicalName,
-      null, "CURRENT_USER_LDAP_GROUPS", usageStr2, "")
-    registry.registerFunction("CURRENT_USER_LDAP_GROUPS", info2,
-      e => {
-        if (e.nonEmpty) {
-          throw new AnalysisException("Incorrect arguments passed for function " +
-            s"CURRENT_USER_LDAP_GROUPS")
-        } else {
-          LdapGroupsOfCurrentUser()
-        }
-      })
+    SnappyDataFunctions.builtin.foreach(fn => registry.registerFunction(fn._1, fn._2, fn._3))
   }
 
   def createTopK(session: SnappySession, tableName: String,

--- a/core/src/main/scala/org/apache/spark/sql/SnappySession.scala
+++ b/core/src/main/scala/org/apache/spark/sql/SnappySession.scala
@@ -38,7 +38,7 @@ import com.pivotal.gemfirexd.internal.iapi.types.TypeId
 import com.pivotal.gemfirexd.internal.iapi.{types => stypes}
 import com.pivotal.gemfirexd.internal.shared.common.{SharedUtils, StoredFormatIds}
 import io.snappydata.sql.catalog.{CatalogObjectType, SnappyExternalCatalog}
-import io.snappydata.{Constant, Property, SnappyDataFunctions, SnappyTableStatsProviderService}
+import io.snappydata.{Constant, Property, SnappyTableStatsProviderService}
 import org.eclipse.collections.impl.map.mutable.UnifiedMap
 
 import org.apache.spark.annotation.{DeveloperApi, Experimental}
@@ -125,7 +125,6 @@ class SnappySession(_sc: SparkContext) extends SparkSession(_sc) {
   private[spark] def snappyContextFunctions = sessionState.contextFunctions
 
   SnappyContext.initGlobalSnappyContext(sparkContext, this)
-  SnappyDataFunctions.registerSnappyFunctions(sessionState.functionRegistry)
   snappyContextFunctions.registerSnappyFunctions(this)
 
   /**


### PR DESCRIPTION
## Changes proposed in this pull request

- added proper ExpressionDescription tags for the extra builtin functions
  for doc generation
- created static list of functions in SnappyDataFunctions filling information
  using the above tags instead of hard-coding in registration code
- centralized function registration to be via SnappyContextFunctions.registerSnappyFunctions

## Patch testing

precheckin buildSqlFuncDocs

## ReleaseNotes.txt changes

NA

## Other PRs 

https://github.com/SnappyDataInc/spark/pull/169
https://github.com/SnappyDataInc/snappy-aqp/pull/192