### PR TITLE
Snap 3135

### DIFF
--- a/cluster/sbin/cluster-util.sh
+++ b/cluster/sbin/cluster-util.sh
@@ -35,7 +35,7 @@ bold=$(tput bold)
 normal=$(tput sgr0)
 space=
 usage() {
-  echo "${bold}Usage: ${normal}cluster-util.sh --on-locators|--on-servers|--on-leads|--on-all [-y] --copy-conf | --run '<cmd-to-run-on-selected-nodes>'"
+  echo "${bold}Usage: ${normal}cluster-util.sh (--on-locators|--on-servers|--on-leads|--on-all) [-y] (--copy-conf | --run \"<cmd-to-run-on-selected-nodes>\")"
   echo
   echo "${bold}Description${normal}"
   echo
@@ -43,19 +43,19 @@ usage() {
   echo -e ' \t '"The script relies on the entries you specify in locators, servers and leads files in conf directory to identify the members of the cluster."
   echo 
   echo -e ' \t '"--on-locators"   
-  echo -e ' \t ''\t'"Indicates the given command would be executed on locators."
+  echo -e ' \t ''\t'"If specified, the given command would be executed on locators."
   echo
   echo 
   echo -e ' \t '"--on-servers"   
-  echo -e ' \t ''\t'"Indicates the given command would be executed on servers."
+  echo -e ' \t ''\t'"If specified, the given command would be executed on servers."
   echo
   echo 
   echo -e ' \t '"--on-leads"   
-  echo -e ' \t ''\t'"Indicates the given command would be executed on leads."
+  echo -e ' \t ''\t'"If specified, the given command would be executed on leads."
   echo
   echo 
   echo -e ' \t '"--on-all"   
-  echo -e ' \t ''\t'"Indicates the given command would be executed on all members of cluster."
+  echo -e ' \t ''\t'"If specified, the given command would be executed on all member of the cluster."
   echo
   echo -e ' \t '"-y"
   echo -e ' \t ''\t'"If specified, the script doesn't ask for confirmation for execution of the command on each member node."
@@ -66,7 +66,7 @@ usage() {
   echo -e ' \t ''\t'"These files are copied only if a) these are absent in the destination member or b) their content is different. In "
   echo -e ' \t ''\t'"latter case, a backup of the file is taken in conf/backup directory on destination member, before copy."
   echo -e ' \t '"--run '<cmd-to-run-on-selected-nodes>'"
-  echo -e ' \t ''\t'"Will execute the given command on specified member type. Any argument after --run will be consider as command, its not getting validated."
+  echo -e ' \t ''\t'"Will execute the given command(s) on specified members. Command to be executed specified after --run must be in double-quotes."
   echo
   exit 1
 }
@@ -130,6 +130,7 @@ while [ "$1" != "" ]; do
     --on-all)
       MEMBER_LIST="all"
       MEMBER_TYPE="all"
+      rm /tmp/snappy-nodes.txt
       LOCATOR_LIST=$(sed ':loop /^[^#].*[^\\]\\$/N; s/\\\n//; t loop' $SNAPPY_HOME/conf/locators | awk '!/^ *#/ && !/^[[:space:]]*$/ { print$1; }' | awk '!seen[$0]++')
       echo $LOCATOR_LIST >> /tmp/snappy-nodes.txt
       SERVER_LIST=$(sed ':loop /^[^#].*[^\\]\\$/N; s/\\\n//; t loop' $SNAPPY_HOME/conf/servers | awk '!/^ *#/ && !/^[[:space:]]*$/ { print$1; }' | awk '!seen[$0]++')
@@ -154,7 +155,7 @@ done
 
 if [[ $COPY_CONF == 1 && $RUN == "true" ]]; then
   echo
-  echo "Invalid operation: Either execute --copy-conf or --run '<command>'"
+  echo "Invalid operation: Specify either '--copy-conf' or '--run \"<command>\"'"
   echo 
   usage
   exit
@@ -172,8 +173,6 @@ function copyConf() {
 	else
 	  backupDir="backup_"${START_ALL_TIMESTAMP}
 	  if [[ ! -z $(ssh $node "cat $entry" | diff - "$entry") ]] ; then
-	    #backupFileName=${fileName}_${START_ALL_TIMESTAMP}
-            echo "backup directory name: $backupDir"
 	    ssh "$node" "mkdir -p \"${SPARK_CONF_DIR}/$backupDir\" "
 	    ssh $node "mv ${SPARK_CONF_DIR}/$fileName ${SPARK_CONF_DIR}/$backupDir/$fileName"
             echo "INFO:Copying $filename from this host to $node. Moved the original $filename on $node to $backupDir/$fileName."    

--- a/cluster/sbin/cluster-util.sh
+++ b/cluster/sbin/cluster-util.sh
@@ -31,23 +31,24 @@ bold=$(tput bold)
 normal=$(tput sgr0)
 space=
 usage() {
-  echo "${bold}Usage: ${normal}cluster-util.sh -onlocator|-onserver|-onlead|-onall [-f|--force] --run  -copyconf | <cmd-to-run-on-selected-nodes>"
+  echo "${bold}Usage: ${normal}cluster-util.sh -on-locators|-on-servers|-on-leads|-on-all [-y] --run  -copyconf | <cmd-to-run-on-selected-nodes>"
   echo
   echo "${bold}Discription${normal}"
   echo
-  echo -e ' \t '"This is exprimental utility for basically syncup cluster's member configuration files and along with this "
-  echo -e ' \t '"execute user command on selected member type"
+  echo -e ' \t '"This is an experimental utility to execute a given command on selected members of the cluster."
+  echo -e ' \t '"The script relies on the entries you specify in locators, servers and leads files in conf directory to identify the members of the cluster."
   echo 
-  echo -e ' \t '"-onlocator|-onserver|-onlead|-onall"   
-  echo -e ' \t ''\t'"Member type on which command will get execute"
+  echo -e ' \t '"-on-locators|-on-servers|-on-leads|-on-all"   
+  echo -e ' \t ''\t'"Indicates which members of the cluster the given command would be executed on."
   echo
-  echo -e ' \t '"-f|--force"
-  echo -e ' \t ''\t'"For skiping the confirmation before executing the input command"
+  echo -e ' \t '"-y"
+  echo -e ' \t ''\t'"If specified, the script doesn't ask for confirmation for execution of the command on each member node."
   echo
   echo -e ' \t '"-copyconf"
-  echo -e ' \t ''\t'"Copy log4j.properties, snappy-env.sh, spark-env.sh configuration files on the selected member type of cluster."
-  echo -e ' \t ''\t'"If these file already present in selected member then will only copy if there are some diff between these files"
-  echo -e ' \t ''\t'"but create the backup file before copy"
+  echo -e ' \t ''\t'"This is a shortcut command with --run option which when specified copies log4j.properties, snappy-env.sh and "
+  echo -e ' \t ''\t'"spark-env.sh configuration files from local machine to all the members."
+  echo -e ' \t ''\t'"These files are copied only if a) these are absent in the destination member or b) their content is different. In "
+  echo -e ' \t ''\t'"latter case, a backup of the file is taken in conf/backup directory on destination member, before copy."
   echo -e ' \t '"<cmd-to-run-on-selected-nodes>"
   echo -e ' \t ''\t'"Command"
   echo
@@ -59,7 +60,7 @@ shift
 
 # Whether to apply the operation forcefully.
 ISFORCE=0
-if [ "$1" = "-f" -o "$1" = "--force" ]; then
+if [ "$1" = "-y" ]; then
   ISFORCE=1
   shift
 fi
@@ -116,45 +117,35 @@ if [[ ! -e $SNAPPY_DIR/conf/locators ]]; then
   exit 2
 fi
 
-SERVER_LIST=`awk '!/^ *#/ && !/^[[:space:]]*$/ { print$1; }' $SNAPPY_DIR/conf/servers`
+SERVER_LIST=`awk '!/^ *#/ && !/^[[:space:]]*$/ && !/^ *-/ { print$1; }' $SNAPPY_DIR/conf/servers`
 
-LEAD_LIST=`awk '!/^ *#/ && !/^[[:space:]]*$/ { print$1; }' $SNAPPY_DIR/conf/leads`
+LEAD_LIST=`awk '!/^ *#/ && !/^[[:space:]]*$/ && !/^ *-/ { print$1; }' $SNAPPY_DIR/conf/leads`
 
-LOCATOR_LIST=`awk '!/^ *#/ && !/^[[:space:]]*$/ { print$1; }' $SNAPPY_DIR/conf/locators`
+LOCATOR_LIST=`awk '!/^ *#/ && !/^[[:space:]]*$/ && !/^ *-/ { print$1; }' $SNAPPY_DIR/conf/locators`
 
 MEMBER_LIST=
 MEMBER_TYPE=
 case $COMPONENT_TYPE in
 
-  (-onlocator)
+  (-on-locators)
     MEMBER_LIST=$LOCATOR_LIST
     MEMBER_TYPE="locator"
     ;;
 
-  (-onserver)
+  (-on-servers)
     MEMBER_LIST=$SERVER_LIST
     MEMBER_TYPE="server"
     ;;
-  (-onlead)
+  (-on-leads)
     MEMBER_LIST=$LEAD_LIST
     MEMBER_TYPE="lead"
     ;;
-  (-onall)
+  (-on-all)
     MEMBER_LIST="all"
     MEMBER_TYPE="all"
     ;;
 esac
 
-function execute() {
-  echo
-  echo "--------- Executing $@ on $MEMBER_TYPE $node ----------"
-  echo 
-  if [[ $COPY_CONF = 1 ]]; then
-    executeCopyCommand "$@"
-  else
-    executeCommand "$@"
-  fi
-}
 
 START_ALL_TIMESTAMP="$(date +"%Y_%m_%d_%H_%M_%S")"
 
@@ -162,70 +153,64 @@ function copyConf() {
   for entry in "${SPARK_CONF_DIR}"/*; do
       if [ -f "$entry" ];then
 	fileName=$(basename $entry)
- 	template=".template"
-	#skip file with .template extension
-	if [[ ! "$fileName" = @(*.template) ]]; then
-	  if [[ $fileName == "log4j.properties" || $fileName == "snappy-env.sh" || $fileName == "spark-env.sh" ]];then 	       	
-	    if ! ssh $node "test -e $entry"; then #"File does not exist."	  
-	      scp ${SPARK_CONF_DIR}/$fileName  $node:${SPARK_CONF_DIR}
-	    else
-	      backupDir="backup"
-	      if [[ ! -z $(ssh $node "cat $entry" | diff - "$entry") ]] ; then
-		backupFileName=${fileName}_${START_ALL_TIMESTAMP}
-		echo "INFO: Copied $filename from this host to $node. Moved the original $filename on $node to $backupFileName."
-		(ssh "$node" "{ if [ ! -d \"${SPARK_CONF_DIR}/$backupDir\" ]; then  mkdir \"${SPARK_CONF_DIR}/$backupDir\"; fi; } ")
-		ssh $node "mv ${SPARK_CONF_DIR}/$fileName ${SPARK_CONF_DIR}/$backupDir/$backupFileName"		    
-		scp ${SPARK_CONF_DIR}/$fileName  $node:${SPARK_CONF_DIR} 
-	      fi
+        if [[ $fileName == "log4j.properties" || $fileName == "snappy-env.sh" || $fileName == "spark-env.sh" ]];then 	       	
+	  if ! ssh $node "test -e $entry"; then #"File does not exist."	  
+	    scp ${SPARK_CONF_DIR}/$fileName  $node:${SPARK_CONF_DIR}
+	  else
+	    backupDir="backup"
+	    if [[ ! -z $(ssh $node "cat $entry" | diff - "$entry") ]] ; then
+	      backupFileName=${fileName}_${START_ALL_TIMESTAMP}
+	      (ssh "$node" "mkdir -p \"${SPARK_CONF_DIR}/$backupDir\" ")
+	      ssh $node "mv ${SPARK_CONF_DIR}/$fileName ${SPARK_CONF_DIR}/$backupDir/$backupFileName"		    
+	      scp ${SPARK_CONF_DIR}/$fileName  $node:${SPARK_CONF_DIR} 
+              echo "INFO: Copying $filename from this host to $node. Moved the original $filename on $node to $backupFileName."
 	    fi
-	  fi # end of if, check the conf file name      				
-	fi # end of if, check extension
+	  fi
+	fi # end of if, check the conf file name      					
       fi # end of if to get each file
   done  #end of for loop
 }
 
-function executeCopyCommand() {
-  if [[ $ISFORCE -eq 0 ]];then
-    read -p "Are you sure to run $@ on $MEMBER_TYPE $node (y/n)?" userinput
-    echo 
-    if [[ $userinput == "y" || $userinput == "yes" || $userinput == "Y" || $userinput == "YES" ]]; then
-      copyConf "$@"
-    fi
-  else
-    copyConf "$@"
-  fi
-}
-
 function executeCommand() {
-  
+  echo
+  echo "--------- Executing $@ on $MEMBER_TYPE $node ----------"
+  echo 
   if [[ $ISFORCE -eq 0 ]];then
     read -p "Are you sure to run $@ on $MEMBER_TYPE $node (y/n)?" userinput
     echo 
     if [[ $userinput == "y" || $userinput == "yes" || $userinput == "Y" || $userinput == "YES" ]]; then
-      ssh $node "$@ | column"
+      if [[ $COPY_CONF = 1 ]]; then
+        copyConf "$@"
+      else
+        ssh $node "$@ | column"
+      fi     
     fi
   else
-    ssh $node "$@ | column"
+    if [[ $COPY_CONF = 1 ]]; then
+      copyConf "$@"
+    else
+      ssh $node "$@ | column"
+    fi  
   fi
 }
 
 if [[ $RUN = "true" ]]; then
   if [[ $MEMBER_LIST != "all" ]]; then
     for node in $MEMBER_LIST; do
-      execute "$@"
+      executeCommand "$@"
     done
   else
     for node in $SERVER_LIST; do
       MEMBER_TYPE="server"
-      execute "$@"
+      executeCommand "$@"
     done
     for node in $LEAD_LIST; do
       MEMBER_TYPE="lead"
-      execute "$@"
+      executeCommand "$@"
     done
     for node in $LOCATOR_LIST; do
       MEMBER_TYPE="locator"
-      execute "$@"
+      executeCommand "$@"
     done
   fi
 fi

--- a/cluster/sbin/cluster-util.sh
+++ b/cluster/sbin/cluster-util.sh
@@ -117,11 +117,11 @@ if [[ ! -e $SNAPPY_DIR/conf/locators ]]; then
   exit 2
 fi
 
-SERVER_LIST=`awk '!/^ *#/ && !/^[[:space:]]*$/ && !/^ *-/ { print$1; }' $SNAPPY_DIR/conf/servers`
+SERVER_LIST=$(sed ':loop /^[^#].*[^\\]\\$/N; s/\\\n//; t loop' $SNAPPY_DIR/conf/servers | awk '!/^ *#/ && !/^[[:space:]]*$/ { print$1; }')
 
-LEAD_LIST=`awk '!/^ *#/ && !/^[[:space:]]*$/ && !/^ *-/ { print$1; }' $SNAPPY_DIR/conf/leads`
+LEAD_LIST=$(sed ':loop /^[^#].*[^\\]\\$/N; s/\\\n//; t loop' $SNAPPY_DIR/conf/leads | awk '!/^ *#/ && !/^[[:space:]]*$/ { print$1; }')
 
-LOCATOR_LIST=`awk '!/^ *#/ && !/^[[:space:]]*$/ && !/^ *-/ { print$1; }' $SNAPPY_DIR/conf/locators`
+LOCATOR_LIST=$(sed ':loop /^[^#].*[^\\]\\$/N; s/\\\n//; t loop' $SNAPPY_DIR/conf/locators | awk '!/^ *#/ && !/^[[:space:]]*$/ { print$1; }')
 
 MEMBER_LIST=
 MEMBER_TYPE=

--- a/cluster/sbin/cluster-util.sh
+++ b/cluster/sbin/cluster-util.sh
@@ -33,7 +33,7 @@ space=
 usage() {
   echo "${bold}Usage: ${normal}cluster-util.sh -on-locators|-on-servers|-on-leads|-on-all [-y] --run  -copyconf | <cmd-to-run-on-selected-nodes>"
   echo
-  echo "${bold}Discription${normal}"
+  echo "${bold}Description${normal}"
   echo
   echo -e ' \t '"This is an experimental utility to execute a given command on selected members of the cluster."
   echo -e ' \t '"The script relies on the entries you specify in locators, servers and leads files in conf directory to identify the members of the cluster."

--- a/cluster/sbin/cluster-util.sh
+++ b/cluster/sbin/cluster-util.sh
@@ -1,0 +1,139 @@
+#!/bin/bash
+#
+# Copyright (c) 2018 SnappyData, Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you
+# may not use this file except in compliance with the License. You
+# may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing
+# permissions and limitations under the License. See accompanying
+# LICENSE file.
+#
+
+
+function absPath() {
+  perl -MCwd -le 'print Cwd::abs_path(shift)' "$1"
+}
+sbin="$(dirname "$(absPath "$0")")"
+
+# Load the Spark configuration
+. "$sbin/snappy-config.sh"
+. "$sbin/spark-config.sh"
+
+SNAPPY_DIR="$SNAPPY_HOME"
+echo "SNAPPY_HOME= $SNAPPY_HOME"
+usage() {
+  # echo "Usage: cluster-util.sh [--snappydir <path-of-snappy-product>] [--run <cmd-to-run-on-all-servers>]"
+  echo "Usage: cluster-util.sh [locator|server|lead|all] [--run <cmd-to-run-on-all-servers>]"
+  exit 1
+}
+
+componentType=$1
+shift
+
+echo "Input component type: $componentType"
+
+if [[ "$#" < "2" ]]; then
+  usage
+fi
+
+while :
+do
+  case $1 in
+    --run)
+      RUN="true"
+      shift
+      ;;
+    -*)
+      echo "ERROR: Unknown option: $1" >&2
+      usage
+      ;;
+    *) # End of options
+      break
+      ;;
+  esac
+done
+
+if [[ ! -d ${SNAPPY_DIR} ]]; then
+  echo "${SNAPPY_DIR} does not exist. Exiting ..."
+  exit 1
+fi
+
+if [[ ! -e $SNAPPY_DIR/conf/servers ]]; then
+  echo "${SNAPPY_DIR}/conf/servers does not exist. Exiting ..."
+  exit 2
+fi
+
+if [[ ! -e $SNAPPY_DIR/conf/leads ]]; then
+  echo "${SNAPPY_DIR}/conf/leads does not exist. Exiting ..."
+  exit 3
+fi
+
+if [[ ! -e $SNAPPY_DIR/conf/locators ]]; then
+  echo "${SNAPPY_DIR}/conf/locators does not exist. Exiting ..."
+  exit 2
+fi
+
+SERVER_LIST=`awk '!/^ *#/ && !/^[[:space:]]*$/ { print$1; }' $SNAPPY_DIR/conf/servers`
+
+LEAD_LIST=`awk '!/^ *#/ && !/^[[:space:]]*$/ { print$1; }' $SNAPPY_DIR/conf/leads`
+
+LOCATOR_LIST=`awk '!/^ *#/ && !/^[[:space:]]*$/ { print$1; }' $SNAPPY_DIR/conf/locators`
+
+MEMBER_LIST=
+MEMBER_TYPE=
+case $componentType in
+
+  (locator)
+    MEMBER_LIST=$LOCATOR_LIST
+    MEMBER_TYPE="locator"
+    ;;
+
+  (server)
+    MEMBER_LIST=$SERVER_LIST
+    MEMBER_TYPE="server"
+    ;;
+  (lead)
+    MEMBER_LIST=$LEAD_LIST
+    MEMBER_TYPE="lead"
+    ;;
+  (all)
+    MEMBER_LIST="all"
+    ;;
+esac
+
+function executeCommand() {
+  echo "################### Executing $@ on $node ###################"
+  read -p "Are you sure to run $@ on $MEMBER_TYPE $node (y/n)?" userinput
+  if [[ $userinput == "y" || $userinput == "yes" || $userinput == "Y" || $userinput == "YES" ]]; then
+    ssh $node $@
+  fi
+}
+
+if [[ $RUN = "true" ]]; then
+  if [[ $MEMBER_LIST != "all" ]]; then
+    for node in $MEMBER_LIST; do
+      executeCommand "$@"
+    done
+  else
+    for node in $SERVER_LIST; do
+      MEMBER_TYPE="server"
+      executeCommand "$@"
+    done
+    for node in $LEAD_LIST; do
+      MEMBER_TYPE="lead"
+      executeCommand "$@"
+    done
+    for node in $LOCATOR_LIST; do
+      MEMBER_TYPE="locator"
+      executeCommand "$@"
+    done
+  fi
+fi
+

--- a/cluster/sbin/cluster-util.sh
+++ b/cluster/sbin/cluster-util.sh
@@ -165,7 +165,7 @@ function copyConf() {
             echo "INFO:Copying $filename from this host to $node. Moved the original $filename on $node to $backupFileName."    
 	    scp ${SPARK_CONF_DIR}/$fileName  $node:${SPARK_CONF_DIR}
 	  fi
-	fi
+        fi
       fi # end of if, check the conf file name		
     fi # end of if to get each file
   done  #end of for loop


### PR DESCRIPTION
## Changes proposed in this pull request
This is an experimental utility to execute a given command on selected members of the cluster. The script relies on the entries you specify in locators, servers and leads files in conf directory to identify the members of the cluster. "-copyconf"
This is a shortcut command which when specified copies log4j.properties, snappy-env.sh and spark-env.sh configuration files from local machine to all the members.

## Patch testing
Manually test with multinode cluster

## ReleaseNotes.txt changes
Yes, will hand over the document after the merge into the master 

## Other PRs 
NA
