### PR TITLE
Fix for SNAP-3132. The size calculation for DecimalType in a special …

### DIFF
--- a/core/src/main/scala/org/apache/spark/sql/execution/aggregate/SnappyHashAggregateExec.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/aggregate/SnappyHashAggregateExec.scala
@@ -809,18 +809,12 @@ case class SnappyHashAggregateExec(
       val keysToProcessSize = this.groupingAttributes.drop(numToDrop)
       val suffixSize = if (numBytesForNullKeyBits == 0) {
         keysToProcessSize.foldLeft(0) {
-          case (size, attrib) => size + attrib.dataType.defaultSize + (attrib.dataType match {
-            case dec: DecimalType if (dec.precision > Decimal.MAX_LONG_DIGITS) => 1
-            case _ => 0
-          })
+          case (size, attrib) => size + attrib.dataType.defaultSize
         }.toString
       } else {
         keysToProcessSize.zipWithIndex.map {
           case(attrib, i) => {
-            val sizeTerm = attrib.dataType.defaultSize + (attrib.dataType match {
-              case dec: DecimalType if (dec.precision > Decimal.MAX_LONG_DIGITS) => 1
-              case _ => 0
-            })
+            val sizeTerm = attrib.dataType.defaultSize
             s"""(int)(${SHAMapAccessor.getExpressionForNullEvalFromMask(i + numToDrop,
               numBytesForNullKeyBits, nullKeysBitsetTerm)} ? 0 : $sizeTerm)
             """


### PR DESCRIPTION
…case of optimization was incorrect

## Changes proposed in this pull request
Correcting the size of DecimalType with precision > 18.
This should have been changed when the bug related to the size of Decimal with precision > 18 was fixed in the main section of code.
## Patch testing

(Fill in the details about how this patch was tested)

## ReleaseNotes.txt changes

(Does this change require an entry in ReleaseNotes.txt? If yes, has it been added to it?)

## Other PRs 

(Does this change require changes in other projects- store, spark, spark-jobserver, aqp? Add the links of PR of the other subprojects that are related to this change)
