### PR TITLE
[SNAP-3137] use "SampleTableScan" in GUI for sample table scan

### DIFF
--- a/core/src/main/scala/org/apache/spark/sql/execution/columnar/ColumnTableScan.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/columnar/ColumnTableScan.scala
@@ -81,7 +81,10 @@ private[sql] final case class ColumnTableScan(
       partitionColumns, partitionColumnAliases,
       baseRelation.asInstanceOf[BaseRelation]) with CodegenSupport {
 
-  override val nodeName: String = "ColumnTableScan"
+  override val nodeName: String = {
+    if (baseRelation != null && baseRelation.getClass.getName.contains("Sampl")) "SampleTableScan"
+    else "ColumnTableScan"
+  }
 
   override def sameResult(plan: SparkPlan): Boolean = plan match {
     case r: ColumnTableScan => r.baseRelation.table == baseRelation.table &&

--- a/core/src/main/scala/org/apache/spark/sql/execution/ddl.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/ddl.scala
@@ -345,7 +345,8 @@ case class SnappyCacheTableCommand(tableIdent: TableIdentifier, queryString: Str
             // Dummy op to materialize the cache. This does the minimal job of count on
             // the actual cached data (RDD[CachedBatch]) to force materialization of cache
             // while avoiding creation of any new SparkPlan.
-            (memoryPlan.cachedColumnBuffers.count(), System.nanoTime() - start)
+            val count = memoryPlan.cachedColumnBuffers.count()
+            (count, System.nanoTime() - start)
           }))._1) :: Nil
       } finally {
         if (previousJobDescription ne null) {

--- a/core/src/main/scala/org/apache/spark/sql/internal/session.scala
+++ b/core/src/main/scala/org/apache/spark/sql/internal/session.scala
@@ -111,6 +111,7 @@ class SnappyConf(@transient val session: SnappySession)
          Property.TestExplodeComplexDataTypeInSHA.name =>
       session.clearPlanCache()
       key
+
     case SQLConf.SHUFFLE_PARTITIONS.key =>
       // stop dynamic determination of shuffle partitions
       if (doSet) {
@@ -121,6 +122,7 @@ class SnappyConf(@transient val session: SnappySession)
       }
       session.clearPlanCache()
       key
+
     case Property.SchedulerPool.name =>
       schedulerPool = value match {
         case None => Property.SchedulerPool.defaultValue.get
@@ -140,10 +142,11 @@ class SnappyConf(@transient val session: SnappySession)
     case Property.PlanCaching.name =>
       value match {
         case Some(boolVal) =>
-          if (boolVal.toString.toBoolean) {
+          val b = boolVal.toString.toBoolean
+          if (b) {
             session.clearPlanCache()
           }
-          session.planCaching = boolVal.toString.toBoolean
+          session.planCaching = b
         case None => session.planCaching = Property.PlanCaching.defaultValue.get
       }
       key


### PR DESCRIPTION
## Changes proposed in this pull request

- change nodeName to "SampleTableScan" instead of ColumnTableScan for sample table scans
- also fixed CTAS for sample table to show up in GUI by posting separate GUI
  plan for the same

## Patch testing

precheckin

## ReleaseNotes.txt changes

NA

## Other PRs 

NA