### PR TITLE
[SNAP-3123] encapsulate any jobs in RDD evaluation under same executionId

### DIFF
--- a/cluster/src/dunit/scala/io/snappydata/externalstore/JDBCPreparedStatementDUnitTest.scala
+++ b/cluster/src/dunit/scala/io/snappydata/externalstore/JDBCPreparedStatementDUnitTest.scala
@@ -17,6 +17,7 @@
 package io.snappydata.externalstore
 
 import java.sql.PreparedStatement
+import java.util.concurrent.atomic.AtomicInteger
 
 import io.snappydata.cluster.ClusterManagerTestBase
 import io.snappydata.test.dunit.AvailablePortHelper
@@ -363,12 +364,12 @@ class JDBCPreparedStatementDUnitTest(s: String) extends ClusterManagerTestBase(s
     }
 
     var thrCount6: Integer = 0
-    var deletedRecords = 0
+    val deletedRecords = new AtomicInteger(0)
     val colThread6 = new Thread(new Runnable {def run() {
       (1 to 5) foreach (i => {
-        var result = deleteRecords(1, 20)
+        val result = deleteRecords(1, 20)
         thrCount6 += result._1
-        deletedRecords += result._2
+        deletedRecords.getAndAdd(result._2)
       })
     }
     })
@@ -377,9 +378,9 @@ class JDBCPreparedStatementDUnitTest(s: String) extends ClusterManagerTestBase(s
     var thrCount7: Integer = 0
     val colThread7 = new Thread(new Runnable {def run() {
       (1 to 5) foreach (i => {
-        var result = deleteRecords(11, 20)
+        val result = deleteRecords(11, 20)
         thrCount7 += result._1
-        deletedRecords += result._2
+        deletedRecords.getAndAdd(result._2)
       })
     }
     })
@@ -388,9 +389,9 @@ class JDBCPreparedStatementDUnitTest(s: String) extends ClusterManagerTestBase(s
     var thrCount8: Integer = 0
     val colThread8 = new Thread(new Runnable {def run() {
       (1 to 5) foreach (i => {
-        var result = deleteRecords(21, 30)
+        val result = deleteRecords(21, 30)
         thrCount8 += result._1
-        deletedRecords += result._2
+        deletedRecords.getAndAdd(result._2)
       })
     }
     })
@@ -403,6 +404,6 @@ class JDBCPreparedStatementDUnitTest(s: String) extends ClusterManagerTestBase(s
     rscnt = stmt.executeQuery("select count(*) from t3")
     rscnt.next()
     assertEquals(0, rscnt.getInt(1))
-    assertEquals(100, deletedRecords)
+    assertEquals(100, deletedRecords.get)
   }
 }

--- a/cluster/src/main/scala/io/snappydata/gemxd/SparkSQLExecuteImpl.scala
+++ b/cluster/src/main/scala/io/snappydata/gemxd/SparkSQLExecuteImpl.scala
@@ -75,7 +75,7 @@ class SparkSQLExecuteImpl(val sql: String,
     session.conf.set(Attribute.PASSWORD_ATTR, ctx.getAuthToken)
   }
 
-  session.setCurrentSchema(schema, createIfNotExists = true)
+  Utils.setCurrentSchema(session, schema, createIfNotExists = true)
 
   session.setPreparedQuery(preparePhase = false, pvs)
 

--- a/cluster/src/main/scala/io/snappydata/gemxd/SparkSQLPrepareImpl.scala
+++ b/cluster/src/main/scala/io/snappydata/gemxd/SparkSQLPrepareImpl.scala
@@ -34,6 +34,7 @@ import com.pivotal.gemfirexd.internal.snappy.{LeadNodeExecutionContext, SparkSQL
 import org.apache.spark.sql.catalyst.expressions
 import org.apache.spark.sql.catalyst.expressions.{BinaryComparison, CaseWhen, Cast, Exists, Expression, Like, ListQuery, ParamLiteral, PredicateSubquery, ScalarSubquery, SubqueryExpression}
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
+import org.apache.spark.sql.collection.Utils
 import org.apache.spark.sql.execution.PutIntoValuesColumnTable
 import org.apache.spark.sql.hive.QuestionMark
 import org.apache.spark.sql.types._
@@ -59,7 +60,7 @@ class SparkSQLPrepareImpl(val sql: String,
     session.conf.set(Attribute.PASSWORD_ATTR, ctx.getAuthToken)
   }
 
-  session.setCurrentSchema(schema, createIfNotExists = true)
+  Utils.setCurrentSchema(session, schema, createIfNotExists = true)
 
   session.setPreparedQuery(preparePhase = true, None)
 

--- a/cluster/src/test/scala/io/snappydata/cluster/PreparedQueryRoutingSingleNodeSuite.scala
+++ b/cluster/src/test/scala/io/snappydata/cluster/PreparedQueryRoutingSingleNodeSuite.scala
@@ -21,7 +21,7 @@ import java.sql.{Connection, DriverManager, PreparedStatement, ResultSet, SQLExc
 import com.pivotal.gemfirexd.TestUtil
 import com.pivotal.gemfirexd.internal.engine.distributed.utils.GemFireXDUtils
 import io.snappydata.{SnappyFunSuite, SnappyTableStatsProviderService}
-import org.scalatest.BeforeAndAfterAll
+import org.scalatest.{Assertions, BeforeAndAfterAll}
 
 import org.apache.spark.sql.{SnappyContext, SnappySession}
 import org.apache.spark.{Logging, SparkConf}
@@ -336,13 +336,13 @@ class PreparedQueryRoutingSingleNodeSuite extends SnappyFunSuite with BeforeAndA
       prepStatement.setInt(2, 300)
       prepStatement.setInt(3, 200)
       PreparedQueryRoutingSingleNodeSuite.verifyResults("query2-1", prepStatement.executeQuery,
-        Array(400, 200, 300), 2)
+        Array(400, 200, 300), 1)
 
       prepStatement.setInt(1, 600)
       prepStatement.setInt(2, 800)
       prepStatement.setInt(3, 700)
       PreparedQueryRoutingSingleNodeSuite.verifyResults("query2-2", prepStatement.executeQuery,
-        Array(600, 700, 800), 2)
+        Array(600, 700, 800), 1)
 
       // Thread.sleep(1000000)
     } finally {
@@ -372,14 +372,14 @@ class PreparedQueryRoutingSingleNodeSuite extends SnappyFunSuite with BeforeAndA
       prepStatement.setInt(3, 200)
       prepStatement.setInt(4, 400)
       PreparedQueryRoutingSingleNodeSuite.verifyResults("query3-1", prepStatement.executeQuery,
-        Array(200, 400), 3)
+        Array(200, 400), 1)
 
       prepStatement.setInt(1, 900)
       prepStatement.setInt(2, 700)
       prepStatement.setInt(3, 600)
       prepStatement.setInt(4, 800)
       PreparedQueryRoutingSingleNodeSuite.verifyResults("query3-2", prepStatement.executeQuery,
-        Array(600, 800), 3)
+        Array(600, 800), 1)
 
       // Thread.sleep(1000000)
     } finally {
@@ -410,14 +410,14 @@ class PreparedQueryRoutingSingleNodeSuite extends SnappyFunSuite with BeforeAndA
       prepStatement.setInt(3, 200)
       prepStatement.setInt(4, 400)
       PreparedQueryRoutingSingleNodeSuite.verifyResults("query4-1", prepStatement.executeQuery,
-        Array(100, 200, 300, 400), 4)
+        Array(100, 200, 300, 400), 1)
 
       prepStatement.setInt(1, 900)
       prepStatement.setInt(2, 600)
       prepStatement.setInt(3, 700)
       prepStatement.setInt(4, 800)
       PreparedQueryRoutingSingleNodeSuite.verifyResults("query4-2", prepStatement.executeQuery,
-        Array(900, 600, 700, 800), 4)
+        Array(900, 600, 700, 800), 1)
 
       // Thread.sleep(1000000)
     } finally {
@@ -449,14 +449,14 @@ class PreparedQueryRoutingSingleNodeSuite extends SnappyFunSuite with BeforeAndA
       prepStatement.setInt(3, 200)
       prepStatement.setInt(4, 300)
       PreparedQueryRoutingSingleNodeSuite.verifyResults("query5-1", prepStatement.executeQuery,
-        Array(100, 200, 300), 4)
+        Array(100, 200, 300), 0)
 
       prepStatement.setInt(1, 900)
       prepStatement.setInt(2, 600)
       prepStatement.setInt(3, 700)
       prepStatement.setInt(4, 800)
       PreparedQueryRoutingSingleNodeSuite.verifyResults("query5-2", prepStatement.executeQuery,
-        Array(600, 700, 800), 4)
+        Array(600, 700, 800), 0)
 
       // Thread.sleep(1000000)
     } finally {
@@ -1119,7 +1119,7 @@ class PreparedQueryRoutingSingleNodeSuite extends SnappyFunSuite with BeforeAndA
   }
 }
 
-object PreparedQueryRoutingSingleNodeSuite extends Logging {
+object PreparedQueryRoutingSingleNodeSuite extends Assertions with Logging {
 
   def insertRows(tableName: String, numRows: Int, serverHostPort: String): Unit = {
 
@@ -1154,7 +1154,6 @@ object PreparedQueryRoutingSingleNodeSuite extends Logging {
   def verifyResults(qry: String, rs: ResultSet, results: Array[Int],
       cacheMapSize: Int): Unit = {
     val cacheMap = SnappySession.getPlanCache.asMap()
-
     var index = 0
     while (rs.next()) {
       val i = rs.getInt(1)
@@ -1169,8 +1168,12 @@ object PreparedQueryRoutingSingleNodeSuite extends Logging {
     assert(index == results.length)
     rs.close()
 
+    // for dunit tests, connection close will happen in background so need to retry this
+    for (i <- 0 until 100 if cacheMap.size() != cacheMapSize && -1 != cacheMapSize) {
+      Thread.sleep(100)
+    }
     logInfo(s"cachemapsize = $cacheMapSize and .size = ${cacheMap.size()}")
-    assert( cacheMap.size() == cacheMapSize || -1 == cacheMapSize)
+    assert(cacheMap.size() == cacheMapSize || -1 == cacheMapSize)
   }
 
   def update_delete_query1(tableName1: String, cacheMapSize: Int, serverHostPort: String): Unit = {
@@ -1316,9 +1319,9 @@ object PreparedQueryRoutingSingleNodeSuite extends Logging {
       insertRows(tableName1, 1000, serverHostPort)
       insertRows(tableName2, 1000, serverHostPort)
       update_delete_query1(tableName1, 1, serverHostPort)
-      update_delete_query1(tableName2, 3, serverHostPort)
-      update_delete_query2(tableName1, 5, serverHostPort)
-      update_delete_query2(tableName2, 6, serverHostPort)
+      update_delete_query1(tableName2, 1, serverHostPort)
+      update_delete_query2(tableName1, 1, serverHostPort)
+      update_delete_query2(tableName2, 1, serverHostPort)
     } finally {
       SnappyTableStatsProviderService.TEST_SUSPEND_CACHE_INVALIDATION = false
     }
@@ -1405,7 +1408,7 @@ object PreparedQueryRoutingSingleNodeSuite extends Logging {
       insertRows(tableName1, 1000, serverHostPort)
       insertRows(tableName2, 1000, serverHostPort)
       equalityOnStringColumn_query1(tableName1, 1, serverHostPort)
-      equalityOnStringColumn_query1(tableName2, 4, serverHostPort)
+      equalityOnStringColumn_query1(tableName2, 1, serverHostPort)
     } finally {
       SnappyTableStatsProviderService.TEST_SUSPEND_CACHE_INVALIDATION = false
     }

--- a/cluster/src/test/scala/io/snappydata/cluster/QueryRoutingSingleNodeSuite.scala
+++ b/cluster/src/test/scala/io/snappydata/cluster/QueryRoutingSingleNodeSuite.scala
@@ -584,12 +584,12 @@ class QueryRoutingSingleNodeSuite extends SnappyFunSuite with BeforeAndAfterAll 
       insertRows(tableName1, 1000)
       insertRows(tableName2, 1000)
       update_delete_query1(tableName1, 1)
-      update_delete_query2(tableName1, 2)
-      update_delete_query3(tableName1, 3, 2)
+      update_delete_query2(tableName1, 1)
+      update_delete_query3(tableName1, 1, 2)
 
-      update_delete_query1(tableName2, 4)
-      update_delete_query2(tableName2, 5)
-      update_delete_query3(tableName2, 6, 1)
+      update_delete_query1(tableName2, 1)
+      update_delete_query2(tableName2, 1)
+      update_delete_query3(tableName2, 1, 1)
     } finally {
       SnappyTableStatsProviderService.TEST_SUSPEND_CACHE_INVALIDATION = false
     }

--- a/cluster/src/test/scala/org/apache/spark/sql/store/BugTest.scala
+++ b/cluster/src/test/scala/org/apache/spark/sql/store/BugTest.scala
@@ -32,6 +32,8 @@ import org.scalatest.BeforeAndAfterAll
 import org.apache.spark.scheduler.{SparkListener, SparkListenerTaskEnd}
 import org.apache.spark.sql.catalog.Column
 import org.apache.spark.sql.collection.Utils
+import org.apache.spark.sql.execution.columnar.ExternalStoreUtils
+import org.apache.spark.sql.execution.metric.SQLMetrics
 import org.apache.spark.sql.types.{StringType, StructField, StructType}
 import org.apache.spark.sql.{Row, SaveMode, SparkSession}
 
@@ -1167,5 +1169,37 @@ class BugTest extends SnappyFunSuite with BeforeAndAfterAll {
       "results of prepared and unprepared statements do not match")
     // scalastyle:on println
 
+  }
+
+  test("SNAP-3123: check for GUI plans") {
+    // TODO: [Asif] new SHA code generation fails for query below
+    val session = snc.snappySession.newSession()
+    session.sql(s"set ${Property.UseOptimzedHashAggregate} = false")
+    session.sql(s"set ${Property.UseOptimizedHashAggregateForSingleKey} = false")
+
+    val numRows = 1000000
+    val sleepTime = 7000L
+    session.sql("create table test1 (id long, data string) using column " +
+        s"options (buckets '8') as select id, 'data_' || id from range($numRows)")
+    val ds = session.sql(
+      "select avg(id) average, id % 10 from test1 group by id % 10 order by average")
+    Thread.sleep(sleepTime)
+    ds.collect()
+
+    // check UI timings and plan details
+    val listener = ExternalStoreUtils.getSQLListener.get
+    // last one should be the query above
+    val queryUIData = listener.getCompletedExecutions.last
+    val duration = queryUIData.completionTime.get - queryUIData.submissionTime
+    // never expect the query above to take more than 7 secs
+    assert(duration > 0L)
+    assert(duration < sleepTime)
+    assert(queryUIData.succeededJobs.length === 2)
+
+    val metrics = listener.getExecutionMetrics(queryUIData.executionId)
+    val scanNode = queryUIData.physicalPlanGraph.allNodes.find(_.name == "ColumnTableScan").get
+    val numRowsMetric = scanNode.metrics.find(_.name == "number of output rows").get
+    assert(metrics(numRowsMetric.accumulatorId) ===
+        SQLMetrics.stringValue(numRowsMetric.metricType, numRows :: Nil))
   }
 }

--- a/cluster/src/test/scala/org/apache/spark/sql/store/BugTest.scala
+++ b/cluster/src/test/scala/org/apache/spark/sql/store/BugTest.scala
@@ -1172,10 +1172,10 @@ class BugTest extends SnappyFunSuite with BeforeAndAfterAll {
   }
 
   test("SNAP-3123: check for GUI plans") {
-    // TODO: [Asif] new SHA code generation fails for query below
+    // TODO: new SHA code generation fails for query below
     val session = snc.snappySession.newSession()
-    session.sql(s"set ${Property.UseOptimzedHashAggregate} = false")
-    session.sql(s"set ${Property.UseOptimizedHashAggregateForSingleKey} = false")
+    session.sql(s"set ${Property.UseOptimzedHashAggregate.name} = false")
+    session.sql(s"set ${Property.UseOptimizedHashAggregateForSingleKey.name} = false")
 
     val numRows = 1000000
     val sleepTime = 7000L

--- a/core/src/main/scala/org/apache/spark/sql/SnappyContext.scala
+++ b/core/src/main/scala/org/apache/spark/sql/SnappyContext.scala
@@ -609,11 +609,10 @@ class SnappyContext protected[spark](val snappySession: SnappySession)
   /**
    * Set current database/schema.
    *
-   * @param schemaName        schema name which goes in the catalog
-   * @param createIfNotExists create the schema if it does not exist
+   * @param schemaName schema name which goes in the catalog
    */
-  def setCurrentSchema(schemaName: String, createIfNotExists: Boolean = false): Unit = {
-    snappySession.setCurrentSchema(schemaName, createIfNotExists)
+  def setCurrentSchema(schemaName: String): Unit = {
+    snappySession.setCurrentSchema(schemaName)
   }
 
   /**

--- a/core/src/main/scala/org/apache/spark/sql/SnappySession.scala
+++ b/core/src/main/scala/org/apache/spark/sql/SnappySession.scala
@@ -1499,10 +1499,17 @@ class SnappySession(_sc: SparkContext) extends SparkSession(_sc) {
   /**
    * Set current schema for the session.
    *
+   * @param schema schema name which goes in the catalog
+   */
+  def setCurrentSchema(schema: String): Unit = setCurrentSchema(schema, createIfNotExists = false)
+
+  /**
+   * Set current schema for the session.
+   *
    * @param schema            schema name which goes in the catalog
    * @param createIfNotExists create the schema if it does not exist
    */
-  def setCurrentSchema(schema: String, createIfNotExists: Boolean = false): Unit = {
+  private[sql] def setCurrentSchema(schema: String, createIfNotExists: Boolean): Unit = {
     val schemaName = sessionCatalog.formatDatabaseName(schema)
     if (createIfNotExists) {
       sessionCatalog.createSchema(schemaName, ignoreIfExists = true, createInStore = false)

--- a/core/src/main/scala/org/apache/spark/sql/SnappySession.scala
+++ b/core/src/main/scala/org/apache/spark/sql/SnappySession.scala
@@ -2096,9 +2096,9 @@ object SnappySession extends Logging {
       context.listenerBus.post(SparkListenerSQLPlanExecutionStart(
         executionId, CachedDataFrame.queryStringShortForm(sqlText),
         sqlText, postQueryExecutionStr, postQueryPlanInfo, start))
+      val rdd = f
       clearExecutionProperties(localProperties)
       propertiesSet = false
-      val rdd = f
       (rdd, queryExecutionStr, queryPlanInfo, postQueryExecutionStr, postQueryPlanInfo,
           executionId, start, System.currentTimeMillis())
     } finally {

--- a/core/src/main/scala/org/apache/spark/sql/collection/Utils.scala
+++ b/core/src/main/scala/org/apache/spark/sql/collection/Utils.scala
@@ -567,6 +567,9 @@ object Utils extends Logging {
     }
   }
 
+  def setCurrentSchema(session: SnappySession, schema: String, createIfNotExists: Boolean): Unit =
+    session.setCurrentSchema(schema, createIfNotExists)
+
   def getDriverClassName(url: String): String = DriverManager.getDriver(url) match {
     case wrapper: DriverWrapper => wrapper.wrapped.getClass.getCanonicalName
     case driver => driver.getClass.getCanonicalName

--- a/core/src/main/scala/org/apache/spark/sql/execution/aggregate/CollectAggregateExec.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/aggregate/CollectAggregateExec.scala
@@ -72,33 +72,52 @@ case class CollectAggregateExec(child: SparkPlan)(
     val numPartitions = childRDD.getNumPartitions
     val partitionBlocks = new Array[Any](numPartitions)
     val rddId = childRDD.id
+    var success = false
 
-    sc.runJob(childRDD, CachedDataFrame, 0 until numPartitions,
-      (index: Int, r: (Array[Byte], Int)) =>
-        // store the partition results in BlockManager for large results
-        partitionBlocks(index) = CachedDataFrame.localBlockStoreResultHandler(
-          rddId, bm)(index, r._1))
+    try {
+      sc.runJob(childRDD, CachedDataFrame, 0 until numPartitions,
+        (index: Int, r: (Array[Byte], Int)) =>
+          // store the partition results in BlockManager for large results
+          partitionBlocks(index) = CachedDataFrame.localBlockStoreResultHandler(
+            rddId, bm)(index, r._1))
+      success = true
 
-    partitionBlocks
+      partitionBlocks
+    } finally {
+      if (!success) {
+        // remove any cached results from block manager
+        bm.removeRdd(rddId)
+      }
+    }
   }
 
   override def executeCollect(): Array[InternalRow] = {
     val sc = sqlContext.sparkContext
     val bm = sc.env.blockManager
+    var success = false
 
-    val partitionBlocks = executeCollectData()
-    // create an iterator over the blocks and pass to generated iterator
-    val numFields = child.schema.length
-    val results = partitionBlocks.iterator.flatMap(
-      CachedDataFrame.localBlockStoreDecoder(numFields, bm))
-    val buffer = generatedClass.generate(generatedReferences)
-        .asInstanceOf[BufferedRowIterator]
-    buffer.init(0, Array(results))
-    val processedResults = new ArrayBuffer[InternalRow]
-    while (buffer.hasNext) {
-      processedResults += buffer.next().copy()
+    try {
+      val partitionBlocks = executeCollectData()
+      // create an iterator over the blocks and pass to generated iterator
+      val numFields = child.schema.length
+      val results = partitionBlocks.iterator.flatMap(
+        CachedDataFrame.localBlockStoreDecoder(numFields, bm))
+      val buffer = generatedClass.generate(generatedReferences)
+          .asInstanceOf[BufferedRowIterator]
+      buffer.init(0, Array(results))
+      val processedResults = new ArrayBuffer[InternalRow]
+      while (buffer.hasNext) {
+        processedResults += buffer.next().copy()
+      }
+      val result = processedResults.toArray
+      success = true
+      result
+    } finally {
+      if (!success) {
+        // remove any cached results from block manager
+        bm.removeRdd(this.childRDD.id)
+      }
     }
-    processedResults.toArray
   }
 
   override def doExecute(): RDD[InternalRow] = {

--- a/core/src/main/scala/org/apache/spark/sql/execution/aggregate/CollectAggregateExec.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/aggregate/CollectAggregateExec.scala
@@ -96,8 +96,8 @@ case class CollectAggregateExec(child: SparkPlan)(
     val bm = sc.env.blockManager
     var success = false
 
+    val partitionBlocks = executeCollectData()
     try {
-      val partitionBlocks = executeCollectData()
       // create an iterator over the blocks and pass to generated iterator
       val numFields = child.schema.length
       val results = partitionBlocks.iterator.flatMap(

--- a/core/src/main/scala/org/apache/spark/sql/execution/ui/SnappySQLListener.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/ui/SnappySQLListener.scala
@@ -27,13 +27,13 @@ import org.apache.spark.{JobExecutionStatus, SparkConf}
  * A new event that is fired when a plan is executed to get an RDD.
  */
 case class SparkListenerSQLPlanExecutionStart(
-   executionId: Long,
-   description: String,
-   details: String,
-   physicalPlanDescription: String,
-   sparkPlanInfo: SparkPlanInfo,
-   time: Long)
-  extends SparkListenerEvent
+    executionId: Long,
+    description: String,
+    details: String,
+    physicalPlanDescription: String,
+    sparkPlanInfo: SparkPlanInfo,
+    time: Long)
+    extends SparkListenerEvent
 
 /**
  * Snappy's SQL Listener.
@@ -41,21 +41,22 @@ case class SparkListenerSQLPlanExecutionStart(
  * @param conf SparkConf of active SparkContext
  */
 class SnappySQLListener(conf: SparkConf) extends SQLListener(conf) {
+
   // base class variables that are private
-  private val baseStageIdToStageMetrics = {
+  private[this] val baseStageIdToStageMetrics = {
     getInternalField("org$apache$spark$sql$execution$ui$SQLListener$$_stageIdToStageMetrics").
-      asInstanceOf[mutable.HashMap[Long, SQLStageMetrics]]
+        asInstanceOf[mutable.HashMap[Long, SQLStageMetrics]]
   }
-  private val baseJobIdToExecutionId = {
+  private[this] val baseJobIdToExecutionId = {
     getInternalField("org$apache$spark$sql$execution$ui$SQLListener$$_jobIdToExecutionId").
-      asInstanceOf[mutable.HashMap[Long, Long]]
+        asInstanceOf[mutable.HashMap[Long, Long]]
   }
-  private val baseActiveExecutions = {
+  private[this] val baseActiveExecutions = {
     getInternalField("activeExecutions").asInstanceOf[mutable.HashMap[Long, SQLExecutionUIData]]
   }
-  private val baseExecutionIdToData = {
+  private[this] val baseExecutionIdToData = {
     getInternalField("org$apache$spark$sql$execution$ui$SQLListener$$_executionIdToData").
-      asInstanceOf[mutable.HashMap[Long, SQLExecutionUIData]]
+        asInstanceOf[mutable.HashMap[Long, SQLExecutionUIData]]
   }
 
   def getInternalField(fieldName: String): Any = {
@@ -80,7 +81,7 @@ class SnappySQLListener(conf: SparkConf) extends SQLListener(conf) {
       // in the active executions. For such cases, we need to
       // look up the executionUIToData as well.
       val executionData = baseActiveExecutions.get(executionId).
-        orElse(baseExecutionIdToData.get(executionId))
+          orElse(baseExecutionIdToData.get(executionId))
       executionData.foreach { executionUIData =>
         executionUIData.jobs(jobId) = JobExecutionStatus.RUNNING
         executionUIData.stages ++= stageIds
@@ -89,6 +90,28 @@ class SnappySQLListener(conf: SparkConf) extends SQLListener(conf) {
         baseJobIdToExecutionId(jobId) = executionId
       }
     }
+  }
+
+  private def newExecutionUIData(executionId: Long, description: String, details: String,
+      physicalPlanDescription: String, sparkPlanInfo: SparkPlanInfo,
+      time: Long): SQLExecutionUIData = {
+    val physicalPlanGraph = SparkPlanGraph(sparkPlanInfo)
+    val sqlPlanMetrics = physicalPlanGraph.allNodes.flatMap { node =>
+      node.metrics.map(metric => metric.accumulatorId -> metric)
+    }
+    // description and details strings being reference equals means
+    // trim off former here
+    val desc = if (description eq details) {
+      CachedDataFrame.queryStringShortForm(details)
+    } else description
+    new SQLExecutionUIData(
+      executionId,
+      desc,
+      details,
+      physicalPlanDescription,
+      physicalPlanGraph,
+      sqlPlanMetrics.toMap,
+      time)
   }
 
   /**
@@ -110,46 +133,26 @@ class SnappySQLListener(conf: SparkConf) extends SQLListener(conf) {
 
       case SparkListenerSQLExecutionStart(executionId, description, details,
       physicalPlanDescription, sparkPlanInfo, time) => synchronized {
-        val executionUIData = baseExecutionIdToData.getOrElseUpdate(executionId, {
-        val physicalPlanGraph = SparkPlanGraph(sparkPlanInfo)
-        val sqlPlanMetrics = physicalPlanGraph.allNodes.flatMap { node =>
-          node.metrics.map(metric => metric.accumulatorId -> metric)
+        baseExecutionIdToData.get(executionId) match {
+          case None =>
+            val executionUIData = newExecutionUIData(executionId, description, details,
+              physicalPlanDescription, sparkPlanInfo, time)
+            baseExecutionIdToData(executionId) = executionUIData
+            baseActiveExecutions(executionId) = executionUIData
+          case _ =>
         }
-        // description and details strings being reference equals means
-        // trim off former here
-        val desc = if (description eq details) {
-          CachedDataFrame.queryStringShortForm(details)
-        } else description
-        new SQLExecutionUIData(
-          executionId,
-          desc,
-          details,
-          physicalPlanDescription,
-          physicalPlanGraph,
-          sqlPlanMetrics.toMap,
-          time)
-        })
-        baseActiveExecutions(executionId) = executionUIData
       }
+
       case SparkListenerSQLPlanExecutionStart(executionId, description, details,
       physicalPlanDescription, sparkPlanInfo, time) =>
-        val physicalPlanGraph = SparkPlanGraph(sparkPlanInfo)
-        val sqlPlanMetrics = physicalPlanGraph.allNodes.flatMap { node =>
-          node.metrics.map(metric => metric.accumulatorId -> metric)
-        }
-        val executionUIData = new SQLExecutionUIData(
-          executionId,
-          description,
-          details,
-          physicalPlanDescription,
-          physicalPlanGraph,
-          sqlPlanMetrics.toMap,
-          time)
+        val executionUIData = newExecutionUIData(executionId, description, details,
+          physicalPlanDescription, sparkPlanInfo, time)
         synchronized {
           baseExecutionIdToData(executionId) = executionUIData
+          baseActiveExecutions(executionId) = executionUIData
         }
+
       case _ => super.onOtherEvent(event)
     }
-
   }
 }


### PR DESCRIPTION
## Changes proposed in this pull request

- moved executionId clear after RDD evaluation
- use common method to create SQLExecutionUIData for SparkListenerSQLPlanExecutionStart
  and SparkListenerSQLExecutionStart
- add to activeExecutions in SparkListenerSQLPlanExecutionStart too so that it shows up in GUI
  in case RDD evaluation takes long (e.g. for ORDER BY or subqueries)
- handle case of Union(commands) and treat like other ExecuteCommandExec/ExecutePlans are
- handle exception cases in CollectAggregateExec to clear any blocks in BlockManager
- clear plan cache for session when connection is closed; updated tests to expect the same

## Patch testing

precheckin

## ReleaseNotes.txt changes

NA

## Other PRs 

NA