### PR TITLE
Fix for SNAP-3141. This was a case where the input variables were eva…

### DIFF
--- a/cluster/src/test/scala/org/apache/spark/sql/store/BugTest.scala
+++ b/cluster/src/test/scala/org/apache/spark/sql/store/BugTest.scala
@@ -1202,4 +1202,20 @@ class BugTest extends SnappyFunSuite with BeforeAndAfterAll {
     assert(metrics(numRowsMetric.accumulatorId) ===
         SQLMetrics.stringValue(numRowsMetric.metricType, numRows :: Nil))
   }
+
+  test("SNAP-3141: code gen failure") {
+    // TODO: new SHA code generation fails for query below
+    val session = snc.snappySession.newSession()
+    session.sql(s"set ${Property.UseOptimzedHashAggregate.name} = true")
+    session.sql(s"set ${Property.UseOptimizedHashAggregateForSingleKey.name} = true")
+
+    val numRows = 1000000
+
+    session.sql("create table test1 (id long, data string) using column " +
+      s"options (buckets '8') as select id, 'data_' || id from range($numRows)")
+    val ds = session.sql(
+      "select avg(id) average, id % 10 from test1 group by id % 10 order by average")
+
+    ds.collect()
+  }
 }

--- a/cluster/src/test/scala/org/apache/spark/sql/store/BugTest.scala
+++ b/cluster/src/test/scala/org/apache/spark/sql/store/BugTest.scala
@@ -1171,11 +1171,11 @@ class BugTest extends SnappyFunSuite with BeforeAndAfterAll {
 
   }
 
-  test("SNAP-3123: check for GUI plans") {
+  test("SNAP-3123: check for GUI plans and SNAP-3141: code gen failure") {
     // TODO: new SHA code generation fails for query below
     val session = snc.snappySession.newSession()
-    session.sql(s"set ${Property.UseOptimzedHashAggregate.name} = false")
-    session.sql(s"set ${Property.UseOptimizedHashAggregateForSingleKey.name} = false")
+    session.sql(s"set ${Property.UseOptimzedHashAggregate.name} = true")
+    session.sql(s"set ${Property.UseOptimizedHashAggregateForSingleKey.name} = true")
 
     val numRows = 1000000
     val sleepTime = 7000L
@@ -1203,19 +1203,4 @@ class BugTest extends SnappyFunSuite with BeforeAndAfterAll {
         SQLMetrics.stringValue(numRowsMetric.metricType, numRows :: Nil))
   }
 
-  test("SNAP-3141: code gen failure") {
-    // TODO: new SHA code generation fails for query below
-    val session = snc.snappySession.newSession()
-    session.sql(s"set ${Property.UseOptimzedHashAggregate.name} = true")
-    session.sql(s"set ${Property.UseOptimizedHashAggregateForSingleKey.name} = true")
-
-    val numRows = 1000000
-
-    session.sql("create table test1 (id long, data string) using column " +
-      s"options (buckets '8') as select id, 'data_' || id from range($numRows)")
-    val ds = session.sql(
-      "select avg(id) average, id % 10 from test1 group by id % 10 order by average")
-
-    ds.collect()
-  }
 }


### PR DESCRIPTION
…luated inside a block to generate the group by key. However same base input variables were also needed by aggregate function. The fix is to first evaluate the input var code & then generate Key Expression code on the input var.

## Changes proposed in this pull request

Evaluating the input variables code , before generating the KeyExpressions code of group by Key.
This ensures that if aggregate functions refer to variables of input attribute , they are available.
Previously the input variables were getting evaluated inside the code block of key expression generation, making the input variables unavailable inside aggregate function block.

## Patch testing

precheckin being run

## ReleaseNotes.txt changes

(Does this change require an entry in ReleaseNotes.txt? If yes, has it been added to it?)

## Other PRs 

(Does this change require changes in other projects- store, spark, spark-jobserver, aqp? Add the links of PR of the other subprojects that are related to this change)
