### PR TITLE
temporary fix for HashJoin on sample table with non sample table not …

### DIFF
--- a/core/src/main/scala/org/apache/spark/sql/SnappyStrategies.scala
+++ b/core/src/main/scala/org/apache/spark/sql/SnappyStrategies.scala
@@ -396,7 +396,10 @@ private[sql] object JoinStrategy {
   def allowsReplicatedJoin(plan: LogicalPlan): Boolean = {
     plan match {
       case PhysicalScan(_, _, child) => child match {
-        case LogicalRelation(t: PartitionedDataSourceScan, _, _) => !t.isPartitioned
+        case LogicalRelation(t: PartitionedDataSourceScan, _, _) => !t.isPartitioned && (t match {
+          case _: SamplingRelation => false
+          case _ => true
+        })
         case _: Filter | _: Project | _: LocalLimit => allowsReplicatedJoin(child.children.head)
         case ExtractEquiJoinKeys(joinType, _, _, _, left, right) =>
           allowsReplicatedJoin(left) && allowsReplicatedJoin(right) &&

--- a/core/src/main/scala/org/apache/spark/sql/collection/Utils.scala
+++ b/core/src/main/scala/org/apache/spark/sql/collection/Utils.scala
@@ -525,7 +525,7 @@ object Utils extends Logging {
           // if both baseTable and schema have been specified, then both
           // should have matching schema
           try {
-            val tablePlan = catalog.lookupRelation(
+            val tablePlan = catalog.resolveRelation(
               catalog.snappySession.tableIdentifier(baseTableName))
             val tableSchema = tablePlan.schema
             if (catalog.compatibleSchema(tableSchema, s)) {
@@ -552,7 +552,7 @@ object Utils extends Logging {
           try {
             // parquet and other such external tables may have different
             // schema representation so normalize the schema
-            val tablePlan = catalog.lookupRelation(
+            val tablePlan = catalog.resolveRelation(
               catalog.snappySession.tableIdentifier(baseTable))
             (tablePlan.schema, Some(tablePlan))
           } catch {


### PR DESCRIPTION
…working.  There is  still a bug where by if the sample table is broadcasted for Hash Join , in my test I see 1 row missing. I suspect the reservoir region is not being broadcasted or something . so if the relation involves sample table in join it wont be broadcasted but will continue to be used in hashjoin.

## Changes proposed in this pull request

(Fill in the changes here)

## Patch testing

(Fill in the details about how this patch was tested)

## ReleaseNotes.txt changes

(Does this change require an entry in ReleaseNotes.txt? If yes, has it been added to it?)

## Other PRs 

(Does this change require changes in other projects- store, spark, spark-jobserver, aqp? Add the links of PR of the other subprojects that are related to this change)
