### PR TITLE
Fix for SNAP-3179. Modifying the definition of isPartitioned in Colum…

### DIFF
--- a/core/src/main/scala/org/apache/spark/sql/sources/interfaces.scala
+++ b/core/src/main/scala/org/apache/spark/sql/sources/interfaces.scala
@@ -202,6 +202,8 @@ trait SamplingRelation extends BaseRelation with SchemaInsertableRelation {
    * True if underlying sample table is using a row table as reservoir store.
    */
   def isReservoirAsRegion: Boolean
+
+  def canBeOnBuildSide: Boolean
 }
 
 @DeveloperApi


### PR DESCRIPTION
…nFormatSamplingRelation

## Changes proposed in this pull request

Rectified the definition of isPartitioned function so that the join plan does not treat Sample table as replicated table.
## Patch testing
Precheckin 

## ReleaseNotes.txt changes

(Does this change require an entry in ReleaseNotes.txt? If yes, has it been added to it?)

## Other PRs 

[aqp-pr](https://github.com/SnappyDataInc/snappy-aqp/pull/203)
