### PR TITLE
Snap 2728

### DIFF
--- a/cluster/src/test/scala/org/apache/spark/sql/store/BugTest.scala
+++ b/cluster/src/test/scala/org/apache/spark/sql/store/BugTest.scala
@@ -1203,6 +1203,7 @@ class BugTest extends SnappyFunSuite with BeforeAndAfterAll {
   }
 
   test("Bug SNAP-2728. SQL Built in functions throwing exception") {
+    snc.dropTable("test1", true)
     snc.sql("SELECT sort_array(array('b', 'd', 'c', 'a'), true)").collect()
     snc.sql("SELECT sort_array(array('b', 'd', 'c', 'a'), true)").collect()
     val numRows = 100
@@ -1216,5 +1217,6 @@ class BugTest extends SnappyFunSuite with BeforeAndAfterAll {
     snc.sql("select rand(0)").collect()
     snc.sql("select randn(0)").collect()
     snc.sql("select randn(0)").collect()
+    snc.dropTable("test1")
   }
 }

--- a/cluster/src/test/scala/org/apache/spark/sql/store/BugTest.scala
+++ b/cluster/src/test/scala/org/apache/spark/sql/store/BugTest.scala
@@ -1201,4 +1201,20 @@ class BugTest extends SnappyFunSuite with BeforeAndAfterAll {
     assert(metrics(numRowsMetric.accumulatorId) ===
         SQLMetrics.stringValue(numRowsMetric.metricType, numRows :: Nil))
   }
+
+  test("Bug SNAP-2728. SQL Built in functions throwing exception") {
+    snc.sql("SELECT sort_array(array('b', 'd', 'c', 'a'), true)").collect()
+    snc.sql("SELECT sort_array(array('b', 'd', 'c', 'a'), true)").collect()
+    val numRows = 100
+    snc.sql("create table test1 (id long, data string) using column " +
+      s"options (buckets '8') as select id, 'data_' || id from range($numRows)")
+    snc.sql("select first_value(id, true) from test1").collect()
+    snc.sql("select first_value(id, true) from test1").collect()
+    snc.sql("select last_value(id, true) from test1").collect()
+    snc.sql("select last_value(id, true) from test1").collect()
+    snc.sql("select rand(0)").collect()
+    snc.sql("select rand(0)").collect()
+    snc.sql("select randn(0)").collect()
+    snc.sql("select randn(0)").collect()
+  }
 }

--- a/core/src/main/scala/org/apache/spark/sql/SnappyBaseParser.scala
+++ b/core/src/main/scala/org/apache/spark/sql/SnappyBaseParser.scala
@@ -423,7 +423,8 @@ object SnappyParserConsts {
     // rand() plans are not to be cached since each run should use different seed
     // and the Spark impls create the seed in constructor rather than in generated code
     "rand" -> Array.emptyIntArray, "randn" -> Array.emptyIntArray,
-    "like" -> Array(1), "rlike" -> Array(1), "approx_count_distinct" -> Array(1)))
+    "like" -> Array(1), "rlike" -> Array(1), "first_value" -> Array(1), "last_value" -> Array(1),
+    "sort_array" -> Array(1), "approx_count_distinct" -> Array(1)))
 
   /**
    * Registering a Keyword with this method marks it a reserved keyword,


### PR DESCRIPTION
## Changes proposed in this pull request

Added some missing functions to the mapping of functions whose arguments  (one or more) should 
 not be tokenized. Fixed the bug where Array.Empty mapping value was not transforming all arguments to remove TokenizedLiteral causing bugs in rnd & rndn functions even though they are present in mapping.
## Patch testing

added bug test. precheckin run

## ReleaseNotes.txt changes

(Does this change require an entry in ReleaseNotes.txt? If yes, has it been added to it?)

## Other PRs 

(Does this change require changes in other projects- store, spark, spark-jobserver, aqp? Add the links of PR of the other subprojects that are related to this change)
