### PR TITLE
[SNAP-3033] Validating whether at max one streaming query with snappysink is active in a SnappySession

### DIFF
--- a/cluster/src/test/scala/org/apache/spark/sql/SchedularPoolTest.scala
+++ b/cluster/src/test/scala/org/apache/spark/sql/SchedularPoolTest.scala
@@ -105,12 +105,12 @@ class SchedulerPoolTest extends SnappyFunSuite with BeforeAndAfter with BeforeAn
     val streamingQuery = streamingDF.writeStream.format("snappysink")
         .queryName(queryName)
         .trigger(ProcessingTime("1 seconds"))
-        .option("streamqueryid", queryName)
         .option("sinkcallback", callback)
         .option("checkpointLocation", checkPointDir)
         .start()
 
     streamingQuery.processAllAvailable()
+    streamingQuery.stop()
   }
 }
 

--- a/core/src/dunit/scala/org/apache/spark/sql/streaming/SnappySinkProviderDUnitTest.scala
+++ b/core/src/dunit/scala/org/apache/spark/sql/streaming/SnappySinkProviderDUnitTest.scala
@@ -37,9 +37,10 @@ import io.snappydata.test.dunit.{AvailablePortHelper, DistributedTestBase, Host,
 import io.snappydata.test.util.TestException
 import io.snappydata.util.TestUtils
 
-import org.apache.spark.sql.catalyst.encoders.RowEncoder
+import org.apache.spark.sql.catalyst.encoders.{ExpressionEncoder, RowEncoder}
 import org.apache.spark.sql.kafka010.KafkaTestUtils
 import org.apache.spark.sql.streaming.SnappySinkProviderDUnitTest.{adminUser, getConn, ldapGroup, locatorNetPort}
+import org.apache.spark.sql.streaming.SnappyStoreSinkProvider.TEST_FAILBATCH_OPTION
 import org.apache.spark.sql.types.{IntegerType, LongType, StringType, StructField, StructType}
 import org.apache.spark.sql.{Dataset, Row, SnappyContext, SnappySession, ThinClientConnectorMode}
 import org.apache.spark.{Logging, SparkConf, SparkContext}
@@ -125,8 +126,8 @@ class SnappySinkProviderDUnitTest(s: String)
     try {
       connection = getConn(adminUser)
       val statement = connection.createStatement()
-      statement.execute(s"CREATE SCHEMA ${ldapGroup}" +
-          s" AUTHORIZATION ldapgroup:${ldapGroup};")
+      statement.execute(s"CREATE SCHEMA $ldapGroup" +
+          s" AUTHORIZATION ldapgroup:$ldapGroup;")
       statement.close()
     } finally {
       if (connection ne null) connection.close()
@@ -241,7 +242,7 @@ object SnappySinkProviderDUnitTest extends Logging {
     SplitClusterDUnitTest.getConnection(locatorNetPort, props)
   }
 
-  private def teardown() = {
+  private def teardown(): Unit = {
     Path(checkpointDirectory).deleteRecursively()
 
     kafkaTestUtils.teardown()
@@ -278,7 +279,7 @@ object SnappySinkProviderDUnitTest extends Logging {
       kafkaTestUtils.sendMessages(testId, dataBatch1.map(r => r.mkString(",")).toArray)
 
       val streamingQuery: StreamingQuery = createAndStartStreamingQuery(testId)
-      snc.sql(s"select * from ${ldapGroup}.${SnappyStoreSinkProvider.SINK_STATE_TABLE}").show()
+      snc.sql(s"select * from $ldapGroup.${SnappyStoreSinkProvider.SINK_STATE_TABLE}").show()
       waitTillTheBatchIsPickedForProcessing(0, testId)
 
       val dataBatch2 = Seq(Seq(1, "name11", 30, 1), Seq(2, "name2", 10, 2), Seq(3, "name3", 30, 0))
@@ -304,7 +305,7 @@ object SnappySinkProviderDUnitTest extends Logging {
       waitTillTheBatchIsPickedForProcessing(0, testId)
       streamingQuery.stop()
 
-      val streamingQuery1 = createAndStartStreamingQuery(testId, true, true)
+      val streamingQuery1 = createAndStartStreamingQuery(testId, failBatch = true)
       kafkaTestUtils.sendMessages(testId, (11 to 20).map(i => s"$i,name$i,$i,0").toArray)
       try {
         streamingQuery1.processAllAvailable()
@@ -386,8 +387,8 @@ object SnappySinkProviderDUnitTest extends Logging {
 
     def structFields() = {
       StructField("id", LongType, nullable = false) ::
-          StructField("name", StringType, nullable = true) ::
-          StructField("age", IntegerType, nullable = true) ::
+          StructField("name", StringType) ::
+          StructField("age", IntegerType) ::
           (if (withEventTypeColumn) {
             StructField("_eventType", IntegerType, nullable = false) :: Nil
           }
@@ -398,7 +399,7 @@ object SnappySinkProviderDUnitTest extends Logging {
 
     val schema = StructType(structFields())
 
-    implicit val encoder = RowEncoder(schema)
+    implicit val encoder: ExpressionEncoder[Row] = RowEncoder(schema)
     val session = snc.sparkSession
     import session.implicits._
     val streamWriter = streamingDF.selectExpr("CAST(value AS STRING)")
@@ -421,7 +422,7 @@ object SnappySinkProviderDUnitTest extends Logging {
       streamWriter.option("stateTableSchema", ldapGroup)
     }
     if (failBatch) {
-      streamWriter.option("internal___failBatch", "true")
+      streamWriter.option(TEST_FAILBATCH_OPTION, "true")
     }
     if (withCustomCallback) {
       streamWriter.option("sinkCallback", classOf[TestSinkCallback].getName)
@@ -430,14 +431,14 @@ object SnappySinkProviderDUnitTest extends Logging {
   }
 
   private def createTable() = {
-    snc.sql(s"drop table if exists ${ldapGroup}.$tableName")
+    snc.sql(s"drop table if exists $ldapGroup.$tableName")
     snc.sql(
-      s"""create table ${ldapGroup}.$tableName
+      s"""create table $ldapGroup.$tableName
        (id long , name varchar(40), age int) using column options(key_columns 'id')""")
   }
 
   private def assertData(expectedData: Array[Row]): Unit = {
-    val actualData = snc.sql(s"select * from ${ldapGroup}.$tableName" +
+    val actualData = snc.sql(s"select * from $ldapGroup.$tableName" +
         s" order by id, name, age")
         .collect()
 
@@ -450,7 +451,7 @@ object SnappySinkProviderDUnitTest extends Logging {
     if (retries == 0) {
       throw new RuntimeException(s"Batch id $batchId not found in sink status table")
     }
-    val sql = s"select batch_id from ${ldapGroup}.${SnappyStoreSinkProvider.SINK_STATE_TABLE} " +
+    val sql = s"select batch_id from $ldapGroup.${SnappyStoreSinkProvider.SINK_STATE_TABLE} " +
         s"where stream_query_id = '$testId'"
     val batchIdFromTable = snc.sql(sql).collect()
 

--- a/core/src/main/scala/org/apache/spark/sql/hive/SnappySessionState.scala
+++ b/core/src/main/scala/org/apache/spark/sql/hive/SnappySessionState.scala
@@ -48,7 +48,7 @@ import org.apache.spark.sql.internal._
 import org.apache.spark.sql.policy.PolicyProperties
 import org.apache.spark.sql.sources._
 import org.apache.spark.sql.store.StoreUtils
-import org.apache.spark.sql.streaming.{LogicalDStreamPlan, StreamingQueryManager, WindowLogicalPlan}
+import org.apache.spark.sql.streaming.{LogicalDStreamPlan, SnappyStreamingQueryManager, StreamingQueryManager, WindowLogicalPlan}
 import org.apache.spark.sql.types._
 import org.apache.spark.sql.{Strategy, _}
 import org.apache.spark.streaming.Duration
@@ -76,7 +76,7 @@ class SnappySessionState(val snappySession: SnappySession)
     // this session including non-streaming queries.
 
     HashAggregateSize.set(conf, "-1")
-    new StreamingQueryManager(snappySession)
+    new SnappyStreamingQueryManager(snappySession)
   }
 
   private[sql] lazy val hiveSession: SparkSession = {

--- a/core/src/main/scala/org/apache/spark/sql/streaming/SnappySinkCallback.scala
+++ b/core/src/main/scala/org/apache/spark/sql/streaming/SnappySinkCallback.scala
@@ -115,17 +115,18 @@ class SnappyStoreSinkProvider extends StreamSinkProvider with DataSourceRegister
 private[streaming] object SnappyStoreSinkProvider {
 
   val EVENT_TYPE_COLUMN = "_eventType"
-  val SINK_STATE_TABLE = "snappysys_internal____sink_state_table"
+  private val INTERNAL_SUFFIX = "snappysys_internal____"
+  val SINK_STATE_TABLE = s"${INTERNAL_SUFFIX}sink_state_table"
   val TABLE_NAME = "tableName"
   val QUERY_NAME = "queryName"
   val SINK_CALLBACK = "sinkCallback"
   val STATE_TABLE_SCHEMA = "stateTableSchema"
   val CONFLATION = "conflation"
-  val EVENT_COUNT_COLUMN = "snappysys_internal____event_count"
+  val EVENT_COUNT_COLUMN = s"${INTERNAL_SUFFIX}event_count"
   val QUERY_ID_COLUMN = "stream_query_id"
   val BATCH_ID_COLUMN = "batch_id"
-  val TEST_FAILBATCH_OPTION = "internal___failBatch"
-  val ATTEMPTS = "internal___attempts"
+  val TEST_FAILBATCH_OPTION = s"${INTERNAL_SUFFIX}failBatch"
+  val ATTEMPTS = s"${INTERNAL_SUFFIX}attempts"
 
   object EventType {
     val INSERT = 0

--- a/core/src/main/scala/org/apache/spark/sql/streaming/SnappyStreamingQueryManager.scala
+++ b/core/src/main/scala/org/apache/spark/sql/streaming/SnappyStreamingQueryManager.scala
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2017-2019 TIBCO Software Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License. You
+ * may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License. See accompanying
+ * LICENSE file.
+ */
+package org.apache.spark.sql.streaming
+
+import org.apache.spark.sql.execution.streaming.{Sink, StreamingQueryWrapper}
+import org.apache.spark.sql.{AnalysisException, DataFrame, SnappySession}
+import org.apache.spark.util.{Clock, SystemClock}
+
+class SnappyStreamingQueryManager(snappySession: SnappySession)
+    extends StreamingQueryManager(snappySession) {
+  private val snappySinkQueriesLock = new Object()
+
+  override private[sql] def startQuery(
+      userSpecifiedName: Option[String],
+      userSpecifiedCheckpointLocation: Option[String],
+      df: DataFrame,
+      sink: Sink,
+      outputMode: OutputMode,
+      useTempCheckpointLocation: Boolean = false,
+      recoverFromCheckpointLocation: Boolean = true,
+      trigger: Trigger = ProcessingTime(0),
+      triggerClock: Clock = new SystemClock()): StreamingQuery = {
+
+    def isQueryWithSnappySinkRunning = {
+      super.active.map(_.asInstanceOf[StreamingQueryWrapper].streamingQuery.sink)
+          .exists(_.isInstanceOf[SnappyStoreSink])
+    }
+
+    def startQuery = {
+      super.startQuery(userSpecifiedName, userSpecifiedCheckpointLocation, df, sink, outputMode,
+        useTempCheckpointLocation, recoverFromCheckpointLocation, trigger, triggerClock)
+    }
+
+    if (sink.isInstanceOf[SnappyStoreSink]) {
+      snappySinkQueriesLock.synchronized {
+        if (isQueryWithSnappySinkRunning) {
+          val message = "A streaming query with snappy sink is already running with current" +
+              " session. Please start query with new SnappySession."
+          throw new AnalysisException(message)
+        } else {
+          startQuery
+        }
+      }
+    } else {
+      startQuery
+    }
+  }
+}

--- a/core/src/test/scala/org/apache/spark/sql/streaming/SnappyStoreSinkProviderSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/streaming/SnappyStoreSinkProviderSuite.scala
@@ -24,13 +24,15 @@ import scala.reflect.io.Path
 
 import com.pivotal.gemfirexd.internal.shared.common.reference.SQLState.SNAPPY_CATALOG_SCHEMA_VERSION_MISMATCH
 import io.snappydata.SnappyFunSuite
+import org.junit.Assert
 import org.scalatest.{BeforeAndAfter, BeforeAndAfterAll}
 
-import org.apache.spark.sql.{Dataset, Row, SnappyContext, SnappySession}
-import org.apache.spark.sql.catalyst.encoders.RowEncoder
+import org.apache.spark.sql.catalyst.encoders.{ExpressionEncoder, RowEncoder}
 import org.apache.spark.sql.execution.CatalogStaleException
 import org.apache.spark.sql.kafka010.KafkaTestUtils
+import org.apache.spark.sql.streaming.SnappyStoreSinkProvider.{ATTEMPTS, TEST_FAILBATCH_OPTION}
 import org.apache.spark.sql.types._
+import org.apache.spark.sql.{AnalysisException, Dataset, Row, SnappyContext, SnappySession}
 
 class SnappyStoreSinkProviderSuite extends SnappyFunSuite
     with BeforeAndAfter with BeforeAndAfterAll {
@@ -84,7 +86,7 @@ class SnappyStoreSinkProviderSuite extends SnappyFunSuite
     kafkaTestUtils.sendMessages(topic, dataBatch2.map(r => r.mkString(",")).toArray)
 
     streamingQuery.processAllAvailable()
-
+    streamingQuery.stop()
     val rows = Array(Row(1, "name11", 40, "lname1"), Row(2, "name2", 10, "lname2"),
       Row(3, "name3", 30, "lname3"), Row(4, "name4", 50, "lname4"))
     assertData(rows)
@@ -103,7 +105,7 @@ class SnappyStoreSinkProviderSuite extends SnappyFunSuite
     kafkaTestUtils.sendMessages(topic, dataBatch.map(r => r.mkString(",")).toArray)
 
     streamingQuery.processAllAvailable()
-
+    streamingQuery.stop()
     val rows = Array(Row(1, "name1", 30, "lname1"), Row(1, "name1", 30, "lname1"),
       Row(2, "name2", 10, "lname2"), Row(3, "name3", 30, "lname3"))
     assertData(rows)
@@ -125,7 +127,7 @@ class SnappyStoreSinkProviderSuite extends SnappyFunSuite
       Seq(3, "name3", 30, "lname3", 0), Seq(4, "name4", 10, "lname4", 2))
     kafkaTestUtils.sendMessages(topic, dataBatch2.map(r => r.mkString(",")).toArray)
     streamingQuery.processAllAvailable()
-
+    streamingQuery.stop()
     assertData(Array(Row(1, "name11", 30, "lname1"), Row(3, "name3", 30, "lname3")))
   }
 
@@ -141,6 +143,7 @@ class SnappyStoreSinkProviderSuite extends SnappyFunSuite
     val thrown = intercept[StreamingQueryException] {
       val streamingQuery = createAndStartStreamingQuery(topic, testId)
       streamingQuery.processAllAvailable()
+      streamingQuery.stop()
     }
 
     val errorMessage = "_eventType is present in data but key columns are not defined on table."
@@ -164,7 +167,7 @@ class SnappyStoreSinkProviderSuite extends SnappyFunSuite
     kafkaTestUtils.sendMessages(topic, dataBatch2.map(r => r.mkString(",")).toArray)
 
     streamingQuery.processAllAvailable()
-
+    streamingQuery.stop()
     val rows = Array(Row(1, "name11", 40, "lname1"), Row(2, "name2", 10, "lname2"),
       Row(3, "name3", 30, "lname3"), Row(4, "name4", 50, "lname4"))
     assertData(rows)
@@ -183,7 +186,7 @@ class SnappyStoreSinkProviderSuite extends SnappyFunSuite
     kafkaTestUtils.sendMessages(topic, dataBatch.map(r => r.mkString(",")).toArray)
 
     streamingQuery.processAllAvailable()
-
+    streamingQuery.stop()
     val rows = Array(Row(1, "name1", 30, "lname1"), Row(1, "name1", 30, "lname1"),
       Row(2, "name2", 10, "lname2"), Row(3, "name3", 30, "lname3"))
     assertData(rows)
@@ -205,7 +208,7 @@ class SnappyStoreSinkProviderSuite extends SnappyFunSuite
       Seq(3, "name3", 30, "lname3", 0), Seq(4, "name4", 10, "lname4", 2))
     kafkaTestUtils.sendMessages(topic, dataBatch2.map(r => r.mkString(",")).toArray)
     streamingQuery.processAllAvailable()
-
+    streamingQuery.stop()
     assertData(Array(Row(1, "name11", 30, "lname1"), Row(3, "name3", 30, "lname3")))
   }
 
@@ -227,7 +230,7 @@ class SnappyStoreSinkProviderSuite extends SnappyFunSuite
     streamingQuery.stop()
   }
 
-  test("test idempotency") {
+  test("idempotency") {
     val testId = testIdGenerator.getAndIncrement()
     createTable()()
     val topic = getTopic(testId)
@@ -240,7 +243,7 @@ class SnappyStoreSinkProviderSuite extends SnappyFunSuite
     streamingQuery.stop()
 
     val streamingQuery1: StreamingQuery = createAndStartStreamingQuery(topic, testId
-      , options = Map("internal___failBatch" -> "true"))
+      , options = Map(TEST_FAILBATCH_OPTION -> "true"))
     kafkaTestUtils.sendMessages(topic, (11 to 20).map(i => s"$i,name$i,$i,lname$i,0").toArray)
     try {
       streamingQuery1.processAllAvailable()
@@ -255,11 +258,11 @@ class SnappyStoreSinkProviderSuite extends SnappyFunSuite
     kafkaTestUtils.sendMessages(topic, (21 to 30).map(i => s"$i,name$i,$i,lname$i,0").toArray)
     waitTillTheBatchIsPickedForProcessing(1, testId)
     streamingQuery2.processAllAvailable()
-
+    streamingQuery2.stop()
     assertData((0 to 30).map(i => Row(i, s"name$i", i, s"lname$i")).toArray)
   }
 
-  test("test conflation enabled") {
+  test("conflation enabled") {
     val testId = testIdGenerator.getAndIncrement()
     createTable()()
     val topic = getTopic(testId)
@@ -276,7 +279,7 @@ class SnappyStoreSinkProviderSuite extends SnappyFunSuite
       options = Map("conflation" -> "true"))
 
     streamingQuery.processAllAvailable()
-
+    streamingQuery.stop()
     assertData(Array(Row(1, "name999", 999, "lname1")))
   }
 
@@ -293,7 +296,7 @@ class SnappyStoreSinkProviderSuite extends SnappyFunSuite
       withEventTypeColumn = false, options = Map("conflation" -> "true"))
 
     streamingQuery.processAllAvailable()
-
+    streamingQuery.stop()
     assertData(Array(Row(1, "name3", 30, "lname1")))
   }
 
@@ -310,6 +313,7 @@ class SnappyStoreSinkProviderSuite extends SnappyFunSuite
       val streamingQuery = createAndStartStreamingQuery(topic, testId,
         withEventTypeColumn = false, options = Map("conflation" -> "true"))
       streamingQuery.processAllAvailable()
+      streamingQuery.stop()
     }
     val errorMessage = "Key column(s) or primary key must be defined on table in order " +
         "to perform conflation."
@@ -333,11 +337,11 @@ class SnappyStoreSinkProviderSuite extends SnappyFunSuite
     kafkaTestUtils.sendMessages(topic, batch2.map(r => r.mkString(",")).toArray)
 
     streamingQuery.processAllAvailable()
-
+    streamingQuery.stop()
     assertData(Array(Row(1, "name1", 30, "lname1")))
   }
 
-  test("test conflation disabled") {
+  test("conflation disabled") {
     val testId = testIdGenerator.getAndIncrement()
     createTable()()
     val topic = getTopic(testId)
@@ -349,6 +353,7 @@ class SnappyStoreSinkProviderSuite extends SnappyFunSuite
     val streamingQuery: StreamingQuery = createAndStartStreamingQuery(topic, testId)
 
     streamingQuery.processAllAvailable()
+    streamingQuery.stop()
     // The delete will be processed prior to insert event irrespective of their order or arrival.
     // Hence when conflation is disabled, both the events are processed resulting into one record.
     assertData(Array(Row(1, "name1", 1, "lname1")))
@@ -378,7 +383,7 @@ class SnappyStoreSinkProviderSuite extends SnappyFunSuite
     val streamingQuery = createAndStartStreamingQuery(topic, testId,
       options = Map("withQueryName" -> "false",
         "sinkCallback" -> "org.apache.spark.sql.streaming.TestSinkCallback",
-        "internal___attempts" -> "3", "attempts" -> "4"))
+        ATTEMPTS -> "3", "attempts" -> "4"))
 
     try {
       streamingQuery.processAllAvailable()
@@ -397,8 +402,9 @@ class SnappyStoreSinkProviderSuite extends SnappyFunSuite
     val streamingQuery = createAndStartStreamingQuery(topic, testId,
       options = Map("withQueryName" -> "false",
         "sinkCallback" -> "org.apache.spark.sql.streaming.TestSinkCallback",
-        "internal___attempts" -> "3", "attempts" -> "3"))
+        ATTEMPTS -> "3", "attempts" -> "3"))
     streamingQuery.processAllAvailable()
+    streamingQuery.stop()
   }
 
   test("Streaming query fails on the first attempt itself when failure is not due" +
@@ -421,6 +427,40 @@ class SnappyStoreSinkProviderSuite extends SnappyFunSuite
     }
   }
 
+  test("At max only one streaming query with snappy sink allowed to run in single session") {
+    val testId = testIdGenerator.getAndIncrement()
+    createTable()()
+    val topic = getTopic(testId)
+    val memorySinkQuery = session
+        .readStream
+        .format("kafka")
+        .option("kafka.bootstrap.servers", kafkaTestUtils.brokerAddress)
+        .option("subscribe", topic)
+        .option("startingOffsets", "earliest")
+        .load().writeStream
+        .queryName("memorysink")
+        .option("checkpointLocation", checkpointDirectory + "/memorysink")
+        .format("memory")
+        .start()
+    try {
+      // This query should start successfully as earlier started query is using memory sink
+      val streamingQuery = createAndStartStreamingQuery(topic, testId * 100)
+      try {
+        val streamingQuery2 = createAndStartStreamingQuery(topic, testId * 200)
+        fail("StreamingQueryException expected.")
+      } catch {
+        case x: AnalysisException =>
+          val expectedMessage = "A streaming query with snappy sink is already running with" +
+              " current session. Please start query with new SnappySession.;"
+          Assert.assertEquals(expectedMessage, x.getMessage)
+      } finally {
+        streamingQuery.processAllAvailable()
+      }
+    } finally {
+      memorySinkQuery.processAllAvailable()
+    }
+  }
+
   private def waitTillTheBatchIsPickedForProcessing(batchId: Int, testId: Int,
       retries: Int = 15): Unit = {
     if (retries == 0) {
@@ -429,25 +469,21 @@ class SnappyStoreSinkProviderSuite extends SnappyFunSuite
     val sqlString = s"select batch_id from APP.${SnappyStoreSinkProvider.SINK_STATE_TABLE} " +
         s"where stream_query_id = '${streamName(testId)}'"
     val batchIdFromTable = session.sql(sqlString).collect()
-
     if (batchIdFromTable.isEmpty || batchIdFromTable(0)(0) != batchId) {
       Thread.sleep(1000)
       waitTillTheBatchIsPickedForProcessing(batchId, testId, retries - 1)
     }
   }
 
-  private def assertData(expectedData: Array[Row]) = {
+  private def assertData(expectedData: Array[Row]): Unit = {
     val actualData = session.sql(s"select * from $tableName order by id, last_name").collect()
     assertResult(expectedData)(actualData)
   }
 
   private def createTable(withKeyColumn: Boolean = true)(isRowTable: Boolean = false) = {
     def provider = if (isRowTable) "row" else "column"
-
     def options = if (!isRowTable && withKeyColumn) "options(key_columns 'id,last_name')" else ""
-
     def primaryKey = if (isRowTable && withKeyColumn) ", primary key (id,last_name)" else ""
-
     val s = s"create table IF NOT EXISTS $tableName  (id long , first_name varchar(40), age int, " +
         s"last_name varchar(40) $primaryKey) using $provider $options "
     session.sql(s)
@@ -467,9 +503,9 @@ class SnappyStoreSinkProviderSuite extends SnappyFunSuite
 
     def structFields() = {
       StructField("id", LongType, nullable = false) ::
-          StructField("firstName", StringType, nullable = true) ::
-          StructField("age", IntegerType, nullable = true) ::
-          StructField("last_name", StringType, nullable = true) ::
+          StructField("firstName", StringType) ::
+          StructField("age", IntegerType) ::
+          StructField("last_name", StringType) ::
           (if (withEventTypeColumn) {
             StructField("_eventType", IntegerType, nullable = false) :: Nil
           }
@@ -480,8 +516,7 @@ class SnappyStoreSinkProviderSuite extends SnappyFunSuite
 
     val schema = StructType(structFields())
 
-    implicit val encoder = RowEncoder(schema)
-
+    implicit val encoder: ExpressionEncoder[Row] = RowEncoder(schema)
 
     var streamWriter = streamingDF.selectExpr("CAST(value AS STRING)")
         .as[String]

--- a/core/src/test/scala/org/apache/spark/sql/streaming/SnappyStoreSinkProviderSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/streaming/SnappyStoreSinkProviderSuite.scala
@@ -454,10 +454,10 @@ class SnappyStoreSinkProviderSuite extends SnappyFunSuite
               " current session. Please start query with new SnappySession.;"
           Assert.assertEquals(expectedMessage, x.getMessage)
       } finally {
-        streamingQuery.processAllAvailable()
+        streamingQuery.stop()
       }
     } finally {
-      memorySinkQuery.processAllAvailable()
+      memorySinkQuery.stop()
     }
   }
 


### PR DESCRIPTION
## Changes requested in this PR

SnappySessionState maintained as part of SnappySession is not thread-safe. Hence running multiple streaming queries (which run in separate threads) may lead to issues related to thread safety.

With this change, we are checking whether another streaming query with Snappysink is already running in the SnappySession before starting a streaming query with SnappySink.

## Patch testing

Added scalatest, precheckin
