### PR TITLE
Snap 3215

### DIFF
--- a/cluster/src/test/scala/org/apache/spark/sql/store/BugTest.scala
+++ b/cluster/src/test/scala/org/apache/spark/sql/store/BugTest.scala
@@ -23,7 +23,9 @@ import java.util.Properties
 
 import scala.collection.mutable.ArrayBuffer
 
+import com.gemstone.gemfire.internal.cache.PartitionedRegion
 import com.pivotal.gemfirexd.TestUtil
+import com.pivotal.gemfirexd.internal.engine.Misc
 import io.snappydata.SnappyFunSuite.resultSetToDataset
 import io.snappydata.{Property, SnappyFunSuite}
 import org.junit.Assert._
@@ -1381,30 +1383,30 @@ class BugTest extends SnappyFunSuite with BeforeAndAfterAll {
     snc.sql("CREATE TABLE xy.ORDERS(O_ORDERKEY INTEGER NOT NULL," +
       " O_NAME VARCHAR(25) NOT NULL, C_CUSTKEY INTEGER NOT NULL)" +
       " USING COLUMN OPTIONS (BUCKETS '10', PARTITION_BY 'C_CUSTKEY')")
-    snc.sql("INSERT INTO xy.ORDERS VALUES (1, 'order1', 1)")
-    snc.sql("INSERT INTO xy.ORDERS VALUES (2, 'order2', 1)")
+    //snc.sql("INSERT INTO xy.ORDERS VALUES (1, 'order1', 1)")
+   /* snc.sql("INSERT INTO xy.ORDERS VALUES (2, 'order2', 1)")
     snc.sql("INSERT INTO xy.ORDERS VALUES (3, 'order3', 1)")
     snc.sql("INSERT INTO xy.ORDERS VALUES (4, 'order4', 1)")
-    snc.sql("INSERT INTO xy.ORDERS VALUES (5, 'order5', 1)")
+    snc.sql("INSERT INTO xy.ORDERS VALUES (5, 'order5', 1)") */
     snc.sql("INSERT INTO xy.ORDERS VALUES (6, 'order6', 2)")
-    snc.sql("INSERT INTO xy.ORDERS VALUES (7, 'order7', 2)")
+  /*  snc.sql("INSERT INTO xy.ORDERS VALUES (7, 'order7', 2)")
     snc.sql("INSERT INTO xy.ORDERS VALUES (8, 'order8', 2)")
-    snc.sql("INSERT INTO xy.ORDERS VALUES (9, 'order9', 2)")
-    snc.sql("INSERT INTO xy.ORDERS VALUES (10, 'order10', 3)")
-    snc.sql("INSERT INTO xy.ORDERS VALUES (11, 'order11', 3)")
-    snc.sql("INSERT INTO xy.ORDERS VALUES (12, 'order12', 3)")
-    snc.sql("INSERT INTO xy.ORDERS VALUES (13, 'order13', 4)")
-    snc.sql("INSERT INTO xy.ORDERS VALUES (14, 'order14', 4)")
-    snc.sql("INSERT INTO xy.ORDERS VALUES (15, 'order15', 5)")
+    snc.sql("INSERT INTO xy.ORDERS VALUES (9, 'order9', 2)") */
+   // snc.sql("INSERT INTO xy.ORDERS VALUES (10, 'order10', 3)")
+ /*   snc.sql("INSERT INTO xy.ORDERS VALUES (11, 'order11', 3)")
+    snc.sql("INSERT INTO xy.ORDERS VALUES (12, 'order12', 3)") */
+  //  snc.sql("INSERT INTO xy.ORDERS VALUES (13, 'order13', 4)")
+ /*   snc.sql("INSERT INTO xy.ORDERS VALUES (14, 'order14', 4)") */
+  //  snc.sql("INSERT INTO xy.ORDERS VALUES (15, 'order15', 5)")
     snc.sql("DROP TABLE IF EXISTS xy.CUSTOMER")
     snc.sql("CREATE TABLE xy.CUSTOMER (C_CUSTKEY     INTEGER NOT NULL," +
       " C_NAME VARCHAR(25) NOT NULL) USING COLUMN " +
       "OPTIONS (BUCKETS '10', PARTITION_BY 'C_CUSTKEY')")
-    snc.sql("INSERT INTO xy.CUSTOMER  VALUES (1, 'user1')")
+  //  snc.sql("INSERT INTO xy.CUSTOMER  VALUES (1, 'user1')")
     snc.sql("INSERT INTO xy.CUSTOMER  VALUES (2, 'user2')")
-    snc.sql("INSERT INTO xy.CUSTOMER  VALUES (3, 'user3')")
-    snc.sql("INSERT INTO xy.CUSTOMER  VALUES (4, 'user4')")
-    snc.sql("INSERT INTO xy.CUSTOMER  VALUES (5, 'user5')")
+ //   snc.sql("INSERT INTO xy.CUSTOMER  VALUES (3, 'user3')")
+ //   snc.sql("INSERT INTO xy.CUSTOMER  VALUES (4, 'user4')")
+ //   snc.sql("INSERT INTO xy.CUSTOMER  VALUES (5, 'user5')")
 
     val sorter = (row1: Row, row2: Row) => {
       if (row1.getInt(0) == row2.getInt(0)) {
@@ -1421,13 +1423,125 @@ class BugTest extends SnappyFunSuite with BeforeAndAfterAll {
         row1.getInt(0) < row2.getInt(0)
       }
     }
+
+    val rgn1 = Misc.getRegionForTable("XY.CUSTOMER", true).asInstanceOf[PartitionedRegion]
+    val rgn2 = Misc.getRegionForTable("XY.ORDERS", true).asInstanceOf[PartitionedRegion]
+    import collection.JavaConverters._
+    val buckets1 = rgn1.getSortedBuckets
+    val buckets2 = rgn2.getSortedBuckets
+    println ("cutomer region distribution")
+    for(buk <- buckets1.asScala) {
+      println (s"bucket id = ${buk.getId}. count = ${buk.size()}")
+    }
+
+    println ("order region distribution")
+    for(buk <- buckets2.asScala) {
+      println (s"bucket id = ${buk.getId}. count = ${buk.size()}")
+    }
     val q = "SELECT * FROM xy.CUSTOMER AS c  LEFT JOIN " +
       "xy.ORDERS AS o ON c.C_CUSTKEY=o.C_CUSTKEY WHERE c.c_custkey=2"
     val snc1 = snc.newSession()
-    val rs1 = snc1.sql(q).collect().sortWith(sorter)
+    val results1 = snc1.sql(q)
+    //results1.show()
+    val rs1 = results1.collect().sortWith(sorter)
+    println("result1")
+    for(row <- rs1) {
+      println(row)
+    }
+ /*   val snc2 = snc.newSession()
+    snc2.setConf("snappydata.sql.disableHashJoin", "true")
+    val results2 = snc2.sql(q)
+    results2.show()
+    val rs2 = results2.collect().sortWith(sorter)
+    println("result2")
+    for(row <- rs2) {
+      println(row)
+    }
+    assertEquals(rs1.length, rs2.length)
+    assertTrue(rs1.zip(rs2).forall(tup => tup._1.equals(tup._2))) */
+  }
+
+  test("Bug SNAP-3215 Left join yields wrong result with filter condition on colocated tables") {
+    snc.sql("CREATE SCHEMA IF NOT EXISTS xy")
+    snc.sql("DROP TABLE IF EXISTS xy.ORDERS")
+    snc.sql("CREATE TABLE xy.ORDERS(O_ORDERKEY INTEGER NOT NULL," +
+      " O_NAME VARCHAR(25) NOT NULL, C_CUSTKEY INTEGER NOT NULL)" +
+      " USING COLUMN OPTIONS (BUCKETS '10', PARTITION_BY 'C_CUSTKEY')")
+    //snc.sql("INSERT INTO xy.ORDERS VALUES (1, 'order1', 1)")
+    /* snc.sql("INSERT INTO xy.ORDERS VALUES (2, 'order2', 1)")
+     snc.sql("INSERT INTO xy.ORDERS VALUES (3, 'order3', 1)")
+     snc.sql("INSERT INTO xy.ORDERS VALUES (4, 'order4', 1)")
+     snc.sql("INSERT INTO xy.ORDERS VALUES (5, 'order5', 1)") */
+    snc.sql("INSERT INTO xy.ORDERS VALUES (6, 'order6', 2)")
+    /*  snc.sql("INSERT INTO xy.ORDERS VALUES (7, 'order7', 2)")
+      snc.sql("INSERT INTO xy.ORDERS VALUES (8, 'order8', 2)")
+      snc.sql("INSERT INTO xy.ORDERS VALUES (9, 'order9', 2)") */
+    // snc.sql("INSERT INTO xy.ORDERS VALUES (10, 'order10', 3)")
+    /*   snc.sql("INSERT INTO xy.ORDERS VALUES (11, 'order11', 3)")
+       snc.sql("INSERT INTO xy.ORDERS VALUES (12, 'order12', 3)") */
+    //  snc.sql("INSERT INTO xy.ORDERS VALUES (13, 'order13', 4)")
+    /*   snc.sql("INSERT INTO xy.ORDERS VALUES (14, 'order14', 4)") */
+    //  snc.sql("INSERT INTO xy.ORDERS VALUES (15, 'order15', 5)")
+    snc.sql("DROP TABLE IF EXISTS xy.CUSTOMER")
+    snc.sql("CREATE TABLE xy.CUSTOMER (C_CUSTKEY     INTEGER NOT NULL," +
+      " C_NAME VARCHAR(25) NOT NULL) USING COLUMN " +
+      "OPTIONS (BUCKETS '10', PARTITION_BY 'C_CUSTKEY', COLOCATE_WITH 'xy.ORDERS')")
+    //  snc.sql("INSERT INTO xy.CUSTOMER  VALUES (1, 'user1')")
+    snc.sql("INSERT INTO xy.CUSTOMER  VALUES (2, 'user2')")
+    //   snc.sql("INSERT INTO xy.CUSTOMER  VALUES (3, 'user3')")
+    //   snc.sql("INSERT INTO xy.CUSTOMER  VALUES (4, 'user4')")
+    //   snc.sql("INSERT INTO xy.CUSTOMER  VALUES (5, 'user5')")
+
+    val sorter = (row1: Row, row2: Row) => {
+      if (row1.getInt(0) == row2.getInt(0)) {
+        if (row1.isNullAt(2) && row2.isNullAt(2)) {
+          true
+        } else if (!row1.isNullAt(2) && !row2.isNullAt(2)) {
+          row1.getInt(2) < row2.getInt(2)
+        } else if (row1.isNullAt(2)) {
+          true
+        } else {
+          false
+        }
+      } else {
+        row1.getInt(0) < row2.getInt(0)
+      }
+    }
+
+    val rgn1 = Misc.getRegionForTable("XY.CUSTOMER", true).asInstanceOf[PartitionedRegion]
+    val rgn2 = Misc.getRegionForTable("XY.ORDERS", true).asInstanceOf[PartitionedRegion]
+    import collection.JavaConverters._
+    val buckets1 = rgn1.getSortedBuckets
+    val buckets2 = rgn2.getSortedBuckets
+    println ("cutomer region distribution")
+    for(buk <- buckets1.asScala) {
+      println (s"bucket id = ${buk.getId}. count = ${buk.size()}")
+    }
+
+    println ("order region distribution")
+    for(buk <- buckets2.asScala) {
+      println (s"bucket id = ${buk.getId}. count = ${buk.size()}")
+    }
+    val q = "SELECT * FROM xy.CUSTOMER AS c  LEFT JOIN " +
+      "xy.ORDERS AS o ON c.C_CUSTKEY=o.C_CUSTKEY WHERE c.c_custkey=2"
+    val snc1 = snc.newSession()
+    val results1 = snc1.sql(q)
+    results1.show()
+    val rs1 = results1.collect().sortWith(sorter)
+    println("result1")
+    for(row <- rs1) {
+      println(row)
+    }
     val snc2 = snc.newSession()
     snc2.setConf("snappydata.sql.disableHashJoin", "true")
-    val rs2 = snc2.sql(q).collect().sortWith(sorter)
+    val results2 = snc2.sql(q)
+    results2.show()
+    val rs2 = results2.collect().sortWith(sorter)
+    println("result2")
+    for(row <- rs2) {
+      println(row)
+    }
+    assertEquals(rs1.length, rs2.length)
     assertTrue(rs1.zip(rs2).forall(tup => tup._1.equals(tup._2)))
   }
 }

--- a/cluster/src/test/scala/org/apache/spark/sql/store/BugTest.scala
+++ b/cluster/src/test/scala/org/apache/spark/sql/store/BugTest.scala
@@ -1037,28 +1037,28 @@ class BugTest extends SnappyFunSuite with BeforeAndAfterAll {
       " from samples as s1, samples as s2 where s1.timestamp = s2.timestamp" +
       " and s1.channel = 'vCar' and s2.channel = 'NGears'" +
       "  ")
-    rs.show()
+    // rs.show()
     rs.collect().foreach(row => assertTrue(row.getDouble(1) != row.getDouble(2)))
 
     rs = sncToUse.sql("select s1.timestamp, s1.sample as vCar, s2.sample as NGears" +
       " from samples as s1, samples as s2 where s1.timestamp = s2.timestamp" +
       " and s1.channel = 'vCar' and s2.channel = 'NGears'" +
       "  ")
-    rs.show()
+    // rs.show()
     rs.collect().foreach(row => assertTrue(row.getDouble(1) != row.getDouble(2)))
 
     rs = sncToUse.sql("select s1.timestamp, s1.sample as vCar, s2.sample as NGears" +
       " from samples as s1, samples as s2 where s1.timestamp = s2.timestamp" +
       " and s1.channel = 'vCar' and s2.channel = 'NGears'" +
       " order by s1.timestamp asc limit 10")
-    rs.show()
+    // rs.show()
     rs.collect().foreach(row => assertTrue(row.getDouble(1) != row.getDouble(2)))
 
     rs = sncToUse.sql("select s1.timestamp, s1.sample as vCar, s2.sample as NGears" +
       " from samples as s1, samples as s2 where s1.timestamp = s2.timestamp" +
       " and s1.channel = 'vCar' and s2.channel = 'NGears'" +
       " order by s1.timestamp asc limit 10")
-    rs.show()
+    // rs.show()
     rs.collect().foreach(row => assertTrue(row.getDouble(1) != row.getDouble(2)))
 
     var serverHostPort2 = TestUtil.startNetServer()
@@ -1417,16 +1417,19 @@ class BugTest extends SnappyFunSuite with BeforeAndAfterAll {
     }.isDefined)
     val rs1 = results1.collect().sortWith(sorter)
 
-       val snc2 = snc.newSession()
-       snc2.setConf("snappydata.sql.disableHashJoin", "true")
-       val results2 = snc2.sql(q)
+    val snc2 = snc.newSession()
+    snc2.setConf("snappydata.sql.disableHashJoin", "true")
+    val results2 = snc2.sql(q)
     assertTrue(results2.queryExecution.executedPlan.collectFirst {
       case x: HashJoinExec => x
     }.isEmpty)
-       val rs2 = results2.collect().sortWith(sorter)
+    val rs2 = results2.collect().sortWith(sorter)
 
-       assertEquals(rs1.length, rs2.length)
-       assertTrue(rs1.zip(rs2).forall(tup => tup._1.equals(tup._2)))
+    assertEquals(rs1.length, rs2.length)
+    assertTrue(rs1.zip(rs2).forall(tup => tup._1.equals(tup._2)))
+    snc.dropTable("xy.customer", true)
+    snc.dropTable("xy.orders", true)
+    snc.sql("drop schema xy")
   }
 
   test("Bug SNAP-3215 Left join yields wrong result with filter condition") {
@@ -1496,6 +1499,9 @@ class BugTest extends SnappyFunSuite with BeforeAndAfterAll {
 
     assertEquals(rs1.length, rs2.length)
     assertTrue(rs1.zip(rs2).forall(tup => tup._1.equals(tup._2)))
+    snc.dropTable("xy.customer", true)
+    snc.dropTable("xy.orders", true)
+    snc.sql("drop schema xy")
   }
 
   test("Bug SNAP-3215") {
@@ -1547,6 +1553,9 @@ class BugTest extends SnappyFunSuite with BeforeAndAfterAll {
 
     assertEquals(rs1.length, rs2.length)
     assertTrue(rs1.zip(rs2).forall(tup => tup._1.equals(tup._2)))
+    snc.dropTable("xy.customer", true)
+    snc.dropTable("xy.orders", true)
+    snc.sql("drop schema xy")
   }
 
 }

--- a/cluster/src/test/scala/org/apache/spark/sql/store/BugTest.scala
+++ b/cluster/src/test/scala/org/apache/spark/sql/store/BugTest.scala
@@ -1498,7 +1498,7 @@ class BugTest extends SnappyFunSuite with BeforeAndAfterAll {
     assertTrue(rs1.zip(rs2).forall(tup => tup._1.equals(tup._2)))
   }
 
-  test("Bug SNAP-3215 non colocated tables equi join should not use local HashJoinExec") {
+  test("Bug SNAP-3215") {
     snc.sql("CREATE SCHEMA IF NOT EXISTS xy")
     snc.sql("DROP TABLE IF EXISTS xy.ORDERS")
     snc.sql("CREATE TABLE xy.ORDERS(O_ORDERKEY INTEGER NOT NULL," +
@@ -1534,7 +1534,7 @@ class BugTest extends SnappyFunSuite with BeforeAndAfterAll {
     val results1 = snc1.sql(q)
     assertTrue(results1.queryExecution.executedPlan.collectFirst {
       case x: HashJoinExec => x
-    }.isEmpty)
+    }.isDefined)
     val rs1 = results1.collect().sortWith(sorter)
 
     val snc2 = snc.newSession()

--- a/core/src/main/scala/org/apache/spark/sql/SnappyStrategies.scala
+++ b/core/src/main/scala/org/apache/spark/sql/SnappyStrategies.scala
@@ -228,6 +228,26 @@ private[sql] trait SnappyStrategies {
         rightPlan: LogicalPlan, rightKeys: Seq[Expression],
         checkBroadcastJoin: Boolean): (Seq[NamedExpression], Seq[Int], Int) = {
 
+      def isColocated(left: LogicalPlan, right: LogicalPlan): Boolean = {
+        val leftPds = left match {
+          case PhysicalScan(_, _, LogicalRelation(scan: PartitionedDataSourceScan, _, _)) =>
+            Some(scan)
+          case _ => None
+        }
+
+        val rightPds = right match {
+          case PhysicalScan(_, _, LogicalRelation(scan: PartitionedDataSourceScan, _, _)) =>
+            Some(scan)
+          case _ => None
+        }
+        leftPds.isEmpty || rightPds.isEmpty ||
+          leftPds.get.getColocatedTable.map(_.equalsIgnoreCase(rightPds.get.table)).
+            getOrElse(false) || rightPds.get.getColocatedTable.
+          map(_.equalsIgnoreCase(leftPds.get.table)).getOrElse(false) ||
+          leftPds.get.table.equalsIgnoreCase(rightPds.get.table)
+
+      }
+
       def getCompatiblePartitioning(plan: LogicalPlan,
           joinKeys: Seq[Expression]): (Seq[NamedExpression], Seq[Int], Int) = plan match {
         case PhysicalScan(_, _, child) => child match {
@@ -273,7 +293,7 @@ private[sql] trait SnappyStrategies {
       val (rightCols, rightKeyOrder, rightNumPartitions) = getCompatiblePartitioning(
         rightPlan, rightKeys)
       if (leftKeyOrder.nonEmpty && leftNumPartitions == rightNumPartitions &&
-          leftKeyOrder == rightKeyOrder) {
+          leftKeyOrder == rightKeyOrder && isColocated(leftPlan, rightPlan)) {
         (leftCols, leftKeyOrder, leftNumPartitions)
       } else if (leftNumPartitions == 1) {
         // replicate table is always collocated (used by recursive call for Join)

--- a/core/src/main/scala/org/apache/spark/sql/SnappyStrategies.scala
+++ b/core/src/main/scala/org/apache/spark/sql/SnappyStrategies.scala
@@ -293,7 +293,7 @@ private[sql] trait SnappyStrategies {
       val (rightCols, rightKeyOrder, rightNumPartitions) = getCompatiblePartitioning(
         rightPlan, rightKeys)
       if (leftKeyOrder.nonEmpty && leftNumPartitions == rightNumPartitions &&
-          leftKeyOrder == rightKeyOrder && isColocated(leftPlan, rightPlan)) {
+          leftKeyOrder == rightKeyOrder /* && isColocated(leftPlan, rightPlan) */) {
         (leftCols, leftKeyOrder, leftNumPartitions)
       } else if (leftNumPartitions == 1) {
         // replicate table is always collocated (used by recursive call for Join)

--- a/core/src/main/scala/org/apache/spark/sql/execution/ExistingPlans.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/ExistingPlans.scala
@@ -331,6 +331,8 @@ trait PartitionedDataSourceScan extends PrunedUnsafeFilteredScan {
   def partitionColumns: Seq[String]
 
   def connectionType: ConnectionType.Value
+
+  def getColocatedTable: Option[String]
 }
 
 /** Combines two SparkPlan or one SparkPlan and another RDD and acts as a LeafExecNode for the

--- a/core/src/main/scala/org/apache/spark/sql/execution/columnar/impl/ColumnFormatRelation.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/columnar/impl/ColumnFormatRelation.scala
@@ -17,7 +17,9 @@
 package org.apache.spark.sql.execution.columnar.impl
 
 import java.sql.{Connection, PreparedStatement}
+import java.util
 
+import scala.collection.AbstractIterator
 import scala.util.control.NonFatal
 
 import com.gemstone.gemfire.internal.cache.{ExternalTableMetaData, LocalRegion, PartitionedRegion}
@@ -35,7 +37,7 @@ import org.apache.spark.sql.execution.columnar.ExternalStoreUtils.CaseInsensitiv
 import org.apache.spark.sql.execution.columnar._
 import org.apache.spark.sql.execution.datasources.LogicalRelation
 import org.apache.spark.sql.execution.row.RowFormatScanRDD
-import org.apache.spark.sql.execution.{ConnectionPool, PartitionedDataSourceScan, RefreshMetadata, SparkPlan}
+import org.apache.spark.sql.execution.{BucketSetIterator, ConnectionPool, PartitionedDataSourceScan, RefreshMetadata, SparkPlan}
 import org.apache.spark.sql.internal.ColumnTableBulkOps
 import org.apache.spark.sql.sources.JdbcExtendedUtils.quotedName
 import org.apache.spark.sql.sources._
@@ -145,7 +147,23 @@ abstract class BaseColumnFormatRelation(
     } else columns
     val zipped = buildRowBufferRDD(partitionEvaluator, rowBufferColumns, filters,
       useResultSet = true, projection).zipPartitions(rdd) { (leftItr, rightItr) =>
-      Iterator[Any](leftItr, rightItr)
+      val x = Iterator[Any](leftItr, rightItr)
+      val bucketSet = (leftItr, rightItr) match {
+        case (x: BucketSetIterator, _) => x.getBucketSet()
+        case (_, x: BucketSetIterator) => x.getBucketSet()
+        case _ => java.util.Collections.emptySet[Integer]()
+      }
+      if (x.isEmpty) {
+        x
+      } else {
+        new AbstractIterator[Any] with BucketSetIterator {
+          override def getBucketSet(): util.Set[Integer] = bucketSet
+
+          override def hasNext: Boolean = x.hasNext
+
+          override def next(): Any = x.next()
+        }
+      }
     }
     (zipped, Nil)
   }

--- a/core/src/main/scala/org/apache/spark/sql/execution/columnar/impl/ColumnFormatRelation.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/columnar/impl/ColumnFormatRelation.scala
@@ -519,7 +519,7 @@ class ColumnFormatRelation(
       _relationInfo) with BulkPutRelation {
 
   val tableOptions = new CaseInsensitiveMutableHashMap(_origOptions)
-
+  def getColocatedTable: Option[String] = tableOptions.get(StoreUtils.COLOCATE_WITH)
   override def withKeyColumns(relation: LogicalRelation,
       keyColumns: Seq[String]): LogicalRelation = {
     // keyColumns should match the key fields required for update/delete
@@ -700,7 +700,7 @@ class IndexColumnFormatRelation(
       _relationInfo) {
 
   def baseTable: Option[String] = Some(baseTableName)
-
+  def getColocatedTable: Option[String] = None
   override def withKeyColumns(relation: LogicalRelation,
       keyColumns: Seq[String]): LogicalRelation = {
     val cr = relation.relation.asInstanceOf[IndexColumnFormatRelation]

--- a/core/src/main/scala/org/apache/spark/sql/execution/columnar/impl/JDBCSourceAsColumnarStore.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/columnar/impl/JDBCSourceAsColumnarStore.scala
@@ -624,7 +624,8 @@ class JDBCSourceAsColumnarStore(private var _connProperties: ConnectionPropertie
       val iter = gen._1.generate(refs).asInstanceOf[BufferedRowIterator]
       // put the single ColumnBatch in the iterator read by generated code
       iter.init(partitionId, Array(Iterator[Any](new ResultSetTraversal(
-        conn = null, stmt = null, rs = null, context = null),
+        conn = null, stmt = null, rs = null, context = null,
+        java.util.Collections.emptySet[Integer]()),
         ColumnBatchIterator(batch)).asInstanceOf[Iterator[InternalRow]]))
       // ignore the result which is the update count
       while (iter.hasNext) {

--- a/core/src/main/scala/org/apache/spark/sql/execution/joins/HashJoinExec.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/joins/HashJoinExec.scala
@@ -374,7 +374,7 @@ case class HashJoinExec(leftKeys: Seq[Expression],
             return pIndex;
           } else {
            for (int j = 0; j < buketsMapping.length; ++j) {
-               if (buketsMapping[j].equals(realBucketSet)) {
+               if (buketsMapping[j].containsAll(realBucketSet)) {
                  return j;
                }
             }

--- a/core/src/main/scala/org/apache/spark/sql/execution/row/RowFormatRelation.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/row/RowFormatRelation.scala
@@ -37,7 +37,7 @@ import org.apache.spark.sql.internal.ColumnTableBulkOps
 import org.apache.spark.sql.row.JDBCMutableRelation
 import org.apache.spark.sql.sources.JdbcExtendedUtils.quotedName
 import org.apache.spark.sql.sources._
-import org.apache.spark.sql.store.CodeGeneration
+import org.apache.spark.sql.store.{CodeGeneration, StoreUtils}
 
 /**
  * A LogicalPlan implementation for an Snappy row table whose contents
@@ -62,7 +62,7 @@ class RowFormatRelation(
     with RowPutRelation {
 
   override def toString: String = s"RowFormatRelation[${Utils.toLowerCase(table)}]"
-
+  def getColocatedTable: Option[String] = origOptions.get(StoreUtils.COLOCATE_WITH)
   override val connectionType: ConnectionType.Value =
     ExternalStoreUtils.getConnectionType(dialect)
 

--- a/core/src/main/scala/org/apache/spark/sql/execution/row/RowFormatScanRDD.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/row/RowFormatScanRDD.scala
@@ -43,7 +43,7 @@ import org.apache.spark.sql.catalyst.expressions.Expression
 import org.apache.spark.sql.collection.{MultiBucketExecutorPartition, Utils}
 import org.apache.spark.sql.execution.columnar.{ExternalStoreUtils, ResultSetIterator}
 import org.apache.spark.sql.execution.sources.StoreDataSourceStrategy.translateToFilter
-import org.apache.spark.sql.execution.{BucketSetIterator, RDDKryo, SecurityUtils}
+import org.apache.spark.sql.execution.{BucketsBasedIterator, RDDKryo, SecurityUtils}
 import org.apache.spark.sql.sources.JdbcExtendedUtils.quotedName
 import org.apache.spark.sql.sources._
 import org.apache.spark.{Partition, TaskContext, TaskContextImpl, TaskKilledException}
@@ -465,7 +465,7 @@ final class CompactExecRowIteratorOnRS(conn: Connection,
 
 abstract class PRValuesIterator[T](container: GemFireContainer, region: LocalRegion,
     bucketIds: java.util.Set[Integer], context: TaskContext) extends Iterator[T]
-with BucketSetIterator {
+with BucketsBasedIterator {
 
   def getBucketSet(): java.util.Set[Integer] = this.bucketIds
   protected type PRIterator = PartitionedRegion#PRLocalScanIterator

--- a/core/src/main/scala/org/apache/spark/sql/execution/row/RowFormatScanRDD.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/row/RowFormatScanRDD.scala
@@ -43,7 +43,7 @@ import org.apache.spark.sql.catalyst.expressions.Expression
 import org.apache.spark.sql.collection.{MultiBucketExecutorPartition, Utils}
 import org.apache.spark.sql.execution.columnar.{ExternalStoreUtils, ResultSetIterator}
 import org.apache.spark.sql.execution.sources.StoreDataSourceStrategy.translateToFilter
-import org.apache.spark.sql.execution.{RDDKryo, SecurityUtils}
+import org.apache.spark.sql.execution.{BucketSetIterator, RDDKryo, SecurityUtils}
 import org.apache.spark.sql.sources.JdbcExtendedUtils.quotedName
 import org.apache.spark.sql.sources._
 import org.apache.spark.{Partition, TaskContext, TaskContextImpl, TaskKilledException}
@@ -269,7 +269,8 @@ class RowFormatScanRDD(@transient val session: SnappySession,
 
     if (pushProjections) {
       val (conn, stmt, rs) = computeResultSet(thePart, context)
-      val itr = new ResultSetTraversal(conn, stmt, rs, context)
+      val itr = new ResultSetTraversal(conn, stmt, rs, context,
+        java.util.Collections.emptySet[Integer]())
       if (commitTx) {
         commitTxBeforeTaskCompletion(Option(conn), context)
       }
@@ -305,7 +306,7 @@ class RowFormatScanRDD(@transient val session: SnappySession,
           val dataItr = itr.map(r =>
             if (r.hasByteArrays) r.getRowByteArrays(null) else r.getRowBytes(null): AnyRef).asJava
           val rs = new RawStoreResultSet(dataItr, container, container.getCurrentRowFormatter)
-          new ResultSetTraversal(conn = null, stmt = null, rs, context)
+          new ResultSetTraversal(conn = null, stmt = null, rs, context, bucketIds)
         } else itr
       } else {
         val (conn, stmt, rs) = computeResultSet(thePart, context)
@@ -442,28 +443,31 @@ class RowFormatScanRDD(@transient val session: SnappySession,
  * This is primarily intended to be used for cleanup.
  */
 final class ResultSetTraversal(conn: Connection,
-    stmt: Statement, val rs: ResultSet, context: TaskContext)
+    stmt: Statement, val rs: ResultSet, context: TaskContext, bucketSet: java.util.Set[Integer])
     extends ResultSetIterator[Void](conn, stmt, rs, context) {
 
   lazy val defaultCal: GregorianCalendar =
     ClientSharedData.getDefaultCleanCalendar
 
   override protected def getCurrentValue: Void = null
+  def getBucketSet(): java.util.Set[Integer] = this.bucketSet
 }
 
 final class CompactExecRowIteratorOnRS(conn: Connection,
     stmt: Statement, ers: EmbedResultSet, context: TaskContext)
     extends ResultSetIterator[AbstractCompactExecRow](conn, stmt,
       ers, context) {
-
+  def getBucketSet(): java.util.Set[Integer] = java.util.Collections.emptySet[Integer]()
   override protected def getCurrentValue: AbstractCompactExecRow = {
     ers.currentRow.asInstanceOf[AbstractCompactExecRow]
   }
 }
 
 abstract class PRValuesIterator[T](container: GemFireContainer, region: LocalRegion,
-    bucketIds: java.util.Set[Integer], context: TaskContext) extends Iterator[T] {
+    bucketIds: java.util.Set[Integer], context: TaskContext) extends Iterator[T]
+with BucketSetIterator {
 
+  def getBucketSet(): java.util.Set[Integer] = this.bucketIds
   protected type PRIterator = PartitionedRegion#PRLocalScanIterator
 
   protected[this] final val taskContext = context.asInstanceOf[TaskContextImpl]

--- a/encoders/src/main/scala/org/apache/spark/sql/execution/BucketSetIterator.scala
+++ b/encoders/src/main/scala/org/apache/spark/sql/execution/BucketSetIterator.scala
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2017-2019 TIBCO Software Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License. You
+ * may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License. See accompanying
+ * LICENSE file.
+ */
+package org.apache.spark.sql.execution
+
+trait BucketSetIterator {
+  def getBucketSet(): java.util.Set[Integer]
+}

--- a/encoders/src/main/scala/org/apache/spark/sql/execution/columnar/ColumnBatch.scala
+++ b/encoders/src/main/scala/org/apache/spark/sql/execution/columnar/ColumnBatch.scala
@@ -30,6 +30,7 @@ import org.eclipse.collections.api.block.procedure.Procedure
 import org.eclipse.collections.impl.map.mutable.primitive.IntObjectHashMap
 
 import org.apache.spark.memory.MemoryManagerCallback.releaseExecutionMemory
+import org.apache.spark.sql.execution.BucketSetIterator
 import org.apache.spark.sql.execution.columnar.encoding.{ColumnDecoder, ColumnDeleteDecoder, ColumnEncoding, UpdatedColumnDecoder, UpdatedColumnDecoderBase}
 import org.apache.spark.sql.execution.columnar.impl.{ColumnDelta, ColumnFormatEntry}
 import org.apache.spark.sql.store.CompressionUtils
@@ -39,7 +40,7 @@ import org.apache.spark.{Logging, TaskContext, TaskContextImpl, TaskKilledExcept
 abstract class ResultSetIterator[A](conn: Connection,
                                     stmt: Statement, rs: ResultSet, context: TaskContext,
                                     closeConnectionOnResultsClose: Boolean = true)
-  extends Iterator[A] with Logging {
+  extends Iterator[A] with Logging with BucketSetIterator {
 
   protected[this] final var doMove = true
 
@@ -124,7 +125,7 @@ final class ColumnBatchIteratorOnRS(conn: Connection,
   private var currentStats: ByteBuffer = _
   private var currentDeltaStats: ByteBuffer = _
   private var rsHasNext: Boolean = rs.next()
-
+  def getBucketSet(): java.util.Set[Integer] = java.util.Collections.singleton(getCurrentBucketId)
   def getCurrentBatchId: Long = currentUUID
 
   def getCurrentBucketId: Int = partitionId

--- a/encoders/src/main/scala/org/apache/spark/sql/execution/columnar/ColumnBatch.scala
+++ b/encoders/src/main/scala/org/apache/spark/sql/execution/columnar/ColumnBatch.scala
@@ -30,7 +30,7 @@ import org.eclipse.collections.api.block.procedure.Procedure
 import org.eclipse.collections.impl.map.mutable.primitive.IntObjectHashMap
 
 import org.apache.spark.memory.MemoryManagerCallback.releaseExecutionMemory
-import org.apache.spark.sql.execution.BucketSetIterator
+import org.apache.spark.sql.execution.BucketsBasedIterator
 import org.apache.spark.sql.execution.columnar.encoding.{ColumnDecoder, ColumnDeleteDecoder, ColumnEncoding, UpdatedColumnDecoder, UpdatedColumnDecoderBase}
 import org.apache.spark.sql.execution.columnar.impl.{ColumnDelta, ColumnFormatEntry}
 import org.apache.spark.sql.store.CompressionUtils
@@ -40,7 +40,7 @@ import org.apache.spark.{Logging, TaskContext, TaskContextImpl, TaskKilledExcept
 abstract class ResultSetIterator[A](conn: Connection,
                                     stmt: Statement, rs: ResultSet, context: TaskContext,
                                     closeConnectionOnResultsClose: Boolean = true)
-  extends Iterator[A] with Logging with BucketSetIterator {
+  extends Iterator[A] with Logging with BucketsBasedIterator {
 
   protected[this] final var doMove = true
 


### PR DESCRIPTION
## Changes proposed in this pull request
The main issue is that the build side partition id no longer maps to the partition index passed, if the stream side partitions have got prunned ( which may be because some partitions (buckets) are empty or a filter condition has caused partition prunning).
In such cases, the real partition id to be used in get build side iterator at execution time, needs to be obtained from the bucketset .  The build side partition id should be the one, whose bucketset matches the stream side partition id.
However since the partition information used to get get stream side iterator is lost when the generated BufferedIterator is initialized, I have added a new interface BucketBasedIterator which is implemented by iterators obtained from PartitionedRegion . This method gives the bucketset for the parition. 
At compile time. a mapping of bucketSet to partition index of the build side Iterators is kept. At execution time, the BucketBasedIterator gives the bucketSet & this is used to obtain the correct partition index of the build side iterators using the mapping.


## Patch testing

precheckin will be run.

## ReleaseNotes.txt changes

(Does this change require an entry in ReleaseNotes.txt? If yes, has it been added to it?)

## Other PRs 

(Does this change require changes in other projects- store, spark, spark-jobserver, aqp? Add the links of PR of the other subprojects that are related to this change)
