### PR TITLE
Provide option to not retry Insert operation

### DIFF
--- a/core/src/main/scala/io/snappydata/Literals.scala
+++ b/core/src/main/scala/io/snappydata/Literals.scala
@@ -322,6 +322,12 @@ object Property extends Enumeration {
     s"${Constant.PROPERTY_PREFIX}sql.codeSplitFunctionParamsSizeInSHA",
     s"The number of group by keys or aggregates which should be used as parameters at a time" +
       s" for code splitting function", Some(5))
+
+  // By default it will be same as MAX_TASK_FAILURES
+  // User should set it to 0, if they want insert to fail on any failure.
+  val MaxRetryAttemptsForWrite: SQLValue[Int] = SQLVal[Int](
+    s"${Constant.PROPERTY_PREFIX}maxRetryAttemptsForWrite",
+    s"The number of times a write task should be retried before all tasks failing." , Some(4))
 }
 
 // extractors for properties

--- a/core/src/main/scala/io/snappydata/Literals.scala
+++ b/core/src/main/scala/io/snappydata/Literals.scala
@@ -325,6 +325,8 @@ object Property extends Enumeration {
 
   // By default it will be same as MAX_TASK_FAILURES
   // User should set it to 0, if they want insert to fail on any failure.
+  // this is used in TaskSchedulerImpl.SNAPPY_WRITE_RETRY_PROP Any change here
+  // should be done reflected there too.
   val MaxRetryAttemptsForWrite: SQLValue[Int] = SQLVal[Int](
     s"${Constant.PROPERTY_PREFIX}maxRetryAttemptsForWrite",
     s"The number of times a write task should be retried before all tasks failing." , Some(4))

--- a/core/src/main/scala/org/apache/spark/sql/execution/ExistingPlans.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/ExistingPlans.scala
@@ -17,7 +17,6 @@
 package org.apache.spark.sql.execution
 
 import scala.collection.mutable.ArrayBuffer
-
 import com.gemstone.gemfire.internal.cache.LocalRegion
 import org.apache.spark.SparkContext
 import org.apache.spark.rdd.{RDD, ZippedPartitionsBaseRDD}
@@ -29,10 +28,10 @@ import org.apache.spark.sql.catalyst.util.{ArrayData, MapData}
 import org.apache.spark.sql.catalyst.{CatalystTypeConverters, InternalRow, TableIdentifier}
 import org.apache.spark.sql.collection.Utils
 import org.apache.spark.sql.execution.columnar.impl.{BaseColumnFormatRelation, ColumnarStorePartitionedRDD, IndexColumnFormatRelation, SmartConnectorColumnRDD}
-import org.apache.spark.sql.execution.columnar.{ColumnTableScan, ConnectionType}
+import org.apache.spark.sql.execution.columnar.{ColumnInsertExec, ColumnTableScan, ConnectionType}
 import org.apache.spark.sql.execution.exchange.{ReusedExchangeExec, ShuffleExchange}
 import org.apache.spark.sql.execution.metric.{SQLMetric, SQLMetricInfo, SQLMetrics}
-import org.apache.spark.sql.execution.row.{RowFormatRelation, RowFormatScanRDD, RowTableScan}
+import org.apache.spark.sql.execution.row.{RowFormatRelation, RowFormatScanRDD, RowInsertExec, RowTableScan}
 import org.apache.spark.sql.sources.{BaseRelation, PrunedUnsafeFilteredScan, SamplingRelation}
 import org.apache.spark.sql.types._
 import org.apache.spark.sql.{AnalysisException, CachedDataFrame, SnappySession}
@@ -262,8 +261,16 @@ case class ExecutePlan(child: SparkPlan, preAction: () => Unit = () => ())
 
   protected[sql] lazy val sideEffectResult: Array[InternalRow] = {
     val session = sqlContext.sparkSession.asInstanceOf[SnappySession]
+    val sc = session.sparkContext
+    // Insert operations shouldn't retry.
+    child.collectFirst {
+      case _: ColumnInsertExec | _: RowInsertExec => {
+        sc.setLocalProperty(io.snappydata.Property.MaxRetryAttemptsForWrite.name
+          , io.snappydata.Property.MaxRetryAttemptsForWrite.get(session.sessionState.conf).toString)
+      }
+    }
+
     try {
-      val sc = session.sparkContext
       val key = session.currentKey
       val oldExecutionId = sc.getLocalProperty(SQLExecution.EXECUTION_ID_KEY)
       val (result, shuffleIds) = if (oldExecutionId eq null) {
@@ -302,6 +309,7 @@ case class ExecutePlan(child: SparkPlan, preAction: () => Unit = () => ())
     finally {
       logDebug(s" Unlocking the table in execute of ExecutePlan:" +
         s" ${child.treeString(false)}")
+      sc.setLocalProperty(io.snappydata.Property.MaxRetryAttemptsForWrite.name, null)
       session.clearWriteLockOnTable()
     }
   }


### PR DESCRIPTION
 Default retry of spark tasks on failure can cause duplicate in case of insert operations.
  Provided a user property snappydata..maxRetryAttemptsForWrite, which user can set to 0 to avoid this scenario.

  Other, operations as usual will retry without causing any consistency issue.

## Changes proposed in this pull request

(Fill in the changes here)

## Patch testing

(Fill in the details about how this patch was tested)

## ReleaseNotes.txt changes

(Does this change require an entry in ReleaseNotes.txt? If yes, has it been added to it?)

## Other PRs 

(Does this change require changes in other projects- store, spark, spark-jobserver, aqp? Add the links of PR of the other subprojects that are related to this change)
