### PR TITLE
Fixes for SNAP-3253:

### DIFF
--- a/core/src/main/scala/org/apache/spark/sql/SnappySession.scala
+++ b/core/src/main/scala/org/apache/spark/sql/SnappySession.scala
@@ -16,8 +16,8 @@
  */
 package org.apache.spark.sql
 
+import java.lang.reflect.Method
 import java.sql.{Connection, SQLException, SQLWarning}
-import java.util.Calendar
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.atomic.AtomicInteger
 import java.util.{Calendar, Properties}
@@ -2154,6 +2154,24 @@ class SnappySession(_sc: SparkContext) extends SparkSession(_sc) {
     }
     (scalaTypeVal, SnappySession.getDataType(storeType, storePrecision, storeScale))
   }
+
+  /*
+     Method to add/update Structured Streaming UI Tab if cluster is running in embedded mode or
+     smart connector mode using SnappyData's Spark distribution
+  */
+  def updateStructuredStreamingUITab: Unit = {
+    try {
+      val updateUIMethod: Method = super.getClass.getMethod("updateUIWithStructuredStreamingTab")
+      updateUIMethod.invoke(this)
+    } catch {
+      case e: NoSuchMethodException =>
+        logWarning("Unable to add Structured Streaming UI Tab because" +
+            " updateUIWithStructuredStreamingTab method is not found in SparkSession class.")
+    }
+  }
+  // Call to update Structured Streaming UI Tab
+  updateStructuredStreamingUITab;
+
 }
 
 private class FinalizeSession(session: SnappySession)

--- a/core/src/main/scala/org/apache/spark/sql/SnappySession.scala
+++ b/core/src/main/scala/org/apache/spark/sql/SnappySession.scala
@@ -2159,18 +2159,19 @@ class SnappySession(_sc: SparkContext) extends SparkSession(_sc) {
      Method to add/update Structured Streaming UI Tab if cluster is running in embedded mode or
      smart connector mode using SnappyData's Spark distribution
   */
-  def updateStructuredStreamingUITab: Unit = {
+  def updateStructuredStreamingUITab(): Unit = {
     try {
       val updateUIMethod: Method = super.getClass.getMethod("updateUIWithStructuredStreamingTab")
       updateUIMethod.invoke(this)
     } catch {
       case e: NoSuchMethodException =>
-        logWarning("Unable to add Structured Streaming UI Tab because" +
-            " updateUIWithStructuredStreamingTab method is not found in SparkSession class.")
+        logWarning("Unable to add Structured Streaming UI Tab because " +
+            "updateUIWithStructuredStreamingTab method is not present in SparkSession class. " +
+            "It seems spark distribution used is not snappy-spark distribution.")
     }
   }
   // Call to update Structured Streaming UI Tab
-  updateStructuredStreamingUITab;
+  updateStructuredStreamingUITab()
 
 }
 


### PR DESCRIPTION
## Changes proposed in this pull request

**Problem:** [SNAP-3253] Few Cluster and AQP tests are failing with InvocationTargetException after introducing structured streaming ui feature

**Cause:** 
  Structured streaming UI tab is created when SparkSession instance is created. But while creating SnappySession (which extends SparkSession class) instance, it requires gemfire cache be created before its instance is created. But SparkSession makes calls to add structured streaming tab before instance is initialised and which becomes bottle neck here.  

**Changes:**
  - Adding method updateStructuredStreamingUITab which calls parent classes method
    updateUIWithStructuredStreamingTab using reflection.
    This method creates or updates Structured Streaming UI Tab.
  - Adding call to updateStructuredStreamingUITab for each SnappySession object creation.



## Patch testing

 - Tested manually. Ran precheckin, no relevant failures.

## ReleaseNotes.txt changes

(Does this change require an entry in ReleaseNotes.txt? If yes, has it been added to it?)

## Other PRs 

**Spark:** https://github.com/SnappyDataInc/spark/pull/187

(Does this change require changes in other projects- store, spark, spark-jobserver, aqp? Add the links of PR of the other subprojects that are related to this change)
