### PR TITLE
* [SNAP-3229] Fix an issue with earlier commit where even non-local members were treated as localhost.

### DIFF
--- a/cluster/bin/snappy
+++ b/cluster/bin/snappy
@@ -106,7 +106,7 @@ elif [ -z "$SNAPPY_NO_QUICK_LAUNCH" -a $# -ge 2 \
         if [ -n "$IMPLICIT_CLIENT_BIND_ADDRESS" ]; then
           IMPLICIT_AWS_CLIENT_BIND_ADDRESS="-client-bind-address=0.0.0.0"
         fi
-      else
+      elif [ -n "$IMPLICIT_CLIENT_BIND_ADDRESS" ]; then
         IMPLICIT_AWS_CLIENT_BIND_ADDRESS="-client-bind-address=${IMPLICIT_CLIENT_BIND_ADDRESS}"
       fi
     fi

--- a/cluster/sbin/snappy-nodes.sh
+++ b/cluster/sbin/snappy-nodes.sh
@@ -243,7 +243,7 @@ function execute() {
       -*) postArgs="$postArgs $arg"
     esac
   done
-  if [ "$host" != "localhost" -a -n "$(echo `hostname -I` | grep -q "$host")" ]; then
+  if [ "$host" != "localhost" -a -z "$(echo `hostname -I` | grep "$host")" ]; then
     if [ "$dirfolder" != "" ]; then
       # Create the directory for the snappy component if the folder is a default folder
       (ssh $SPARK_SSH_OPTS "$host" \


### PR DESCRIPTION
## Changes proposed in this pull request
* [SNAP-3229] Fix an issue with earlier commit where even non-local members were treated as localhost and launch-commands were fired locally instead of via ssh. This was caused by a faulty `if` check in `snappy-nodes.sh` script.

## Patch testing
Manually tested:
1. Single/Multi instance cluster on AWS. Single-instance with/without passwordless ssh setup.
2. Single/Multi node cluster on laptop
3. Multi-node cluster on two physical hosts

## ReleaseNotes.txt changes
NA

## Other PRs 
NA