### PR TITLE
* Skip the "hostname -I" check in snappy-nodes.sh for Mac OS.

### DIFF
--- a/cluster/sbin/snappy-nodes.sh
+++ b/cluster/sbin/snappy-nodes.sh
@@ -243,7 +243,11 @@ function execute() {
       -*) postArgs="$postArgs $arg"
     esac
   done
-  if [ "$host" != "localhost" -a -z "$(echo `hostname -I` | grep "$host")" ]; then
+  THIS_HOST_IP=
+  if [ "$(echo `uname -s`)" == "Linux" ]; then
+    THIS_HOST_IP="$(echo `hostname -I` | grep "$host")"
+  fi
+  if [ "$host" != "localhost" -a -z "$THIS_HOST_IP" ]; then
     if [ "$dirfolder" != "" ]; then
       # Create the directory for the snappy component if the folder is a default folder
       (ssh $SPARK_SSH_OPTS "$host" \


### PR DESCRIPTION
## Changes proposed in this pull request
* Skip the "hostname -I" check in snappy-nodes.sh for Mac OS.

## Patch testing
Manual testing:
1. Single node cluster with/without passwordless ssh on Mac OS
2. Single/Multi node cluster on laptop/different physical hosts for sanity

## ReleaseNotes.txt changes
NA
## Other PRs 
NA