### PR TITLE
[SNAP-3262] Fixing createTable API for python

### DIFF
--- a/python/pyspark/sql/snappy/snappysession.py
+++ b/python/pyspark/sql/snappy/snappysession.py
@@ -61,9 +61,9 @@ class SnappySession(SparkSession):
         :return: :class:`DataFrame`
         """
         if provider is None:
-            provider = self.getConf("spark.sql.sources.default", "org.apache.spark.sql.parquet")
+            provider = self.conf.get("spark.sql.sources.default", "org.apache.spark.sql.parquet")
         if schema is None:
-            df = self._jsparkSession.createTable(tableName, provider, allowExisting, options)
+            df = self._jsparkSession.createTable(tableName, provider, options, allowExisting)
         else:
             if isinstance(schema, str):
                 df = self._jsparkSession.createTable(tableName, provider, schema, options, allowExisting)


### PR DESCRIPTION
## Changes proposed in this pull request

`createTable` API was failing when used without passing explicit values for
 provider and schema.
By default API defaults provider parameter to `parquet` and the schema can
also be retrieved from parquet file.

Usage example: snappy.createTable("table1",path ="/path/to/file.parquet")

## Patch testing

Manually tested using `pyspark` shell. Have written unit test but somehow 
`checkPython` target is not picking up the test. Will analyze further and add it
later.
