### PR TITLE
SNAP-3247; Disable/skip table count on UI in recovery mode.

### DIFF
--- a/cluster/src/main/scala/io/snappydata/impl/LeadImpl.scala
+++ b/cluster/src/main/scala/io/snappydata/impl/LeadImpl.scala
@@ -94,6 +94,10 @@ class LeadImpl extends ServerImpl with Lead
 
     isTestSetup = bootProperties.getProperty("isTest", "false").toBoolean
     bootProperties.remove("isTest")
+    val enableTableCountInUI =
+      bootProperties.getProperty("snappydata.recovery.enableTableCountInUI", "false")
+    bootProperties.remove("snappydata.recovery.enableTableCountInUI")
+
     val authSpecified = Misc.checkLDAPAuthProvider(bootProperties)
 
     ServiceUtils.setCommonBootDefaults(bootProperties, forLocator = false)
@@ -329,8 +333,11 @@ class LeadImpl extends ServerImpl with Lead
       }
 
       // If recovery mode then initialize the recovery service
-      if(Misc.getGemFireCache.isSnappyRecoveryMode) {
-        RecoveryService.collectViewsAndPrepareCatalog()
+      if (Misc.getGemFireCache.isSnappyRecoveryMode) {
+        if (enableTableCountInUI.equalsIgnoreCase("true"))
+          RecoveryService.collectViewsAndPrepareCatalog(true)
+        else
+          RecoveryService.collectViewsAndPrepareCatalog(false)
       }
 
       if (jobServerWait) {

--- a/core/src/main/scala/io/snappydata/recovery/RecoveryService.scala
+++ b/core/src/main/scala/io/snappydata/recovery/RecoveryService.scala
@@ -20,14 +20,18 @@ package io.snappydata.recovery
 
 import java.util.function.BiConsumer
 
-import com.pivotal.gemfirexd.internal.engine.ui.{SnappyExternalTableStats, SnappyIndexStats,
-  SnappyRegionStats}
+import com.pivotal.gemfirexd.internal.engine.ui.{
+  SnappyExternalTableStats, SnappyIndexStats,
+  SnappyRegionStats
+}
 import com.gemstone.gemfire.distributed.internal.membership.InternalDistributedMember
 import com.gemstone.gemfire.internal.cache.PartitionedRegionHelper
 import com.gemstone.gemfire.internal.shared.SystemProperties
 import com.pivotal.gemfirexd.Attribute
-import com.pivotal.gemfirexd.internal.engine.ddl.{DDLConflatable, GfxdDDLQueueEntry,
-  GfxdDDLRegionQueue}
+import com.pivotal.gemfirexd.internal.engine.ddl.{
+  DDLConflatable, GfxdDDLQueueEntry,
+  GfxdDDLRegionQueue
+}
 import com.pivotal.gemfirexd.internal.engine.distributed.RecoveryModeResultCollector
 import com.pivotal.gemfirexd.internal.engine.distributed.message.PersistentStateInRecoveryMode
 import com.pivotal.gemfirexd.internal.engine.distributed.message.PersistentStateInRecoveryMode
@@ -45,8 +49,10 @@ import io.snappydata.Constant
 
 import org.apache.spark.sql.{SnappyContext, SnappyParser, SnappySession}
 import io.snappydata.sql.catalog.ConnectorExternalCatalog
-import io.snappydata.thrift.{CatalogFunctionObject, CatalogMetadataDetails, CatalogSchemaObject,
-  CatalogTableObject}
+import io.snappydata.thrift.{
+  CatalogFunctionObject, CatalogMetadataDetails, CatalogSchemaObject,
+  CatalogTableObject
+}
 
 import org.apache.spark.sql.catalyst.catalog.{CatalogDatabase, CatalogFunction, CatalogTable}
 import org.apache.spark.sql.types.{DataType, MetadataBuilder, StructField, StructType}
@@ -60,6 +66,7 @@ object RecoveryService extends Logging {
   var catalogTableCount = 0
   val snappyHiveExternalCatalog = HiveClientUtil
       .getOrCreateExternalCatalog(SnappyContext().sparkContext, SnappyContext().sparkContext.getConf)
+  var enableTableCountInUI: Boolean = _
 
   private def isGrantRevokeStatement(conflatable: DDLConflatable) = {
     val sqlText = conflatable.getValueToConflate
@@ -82,22 +89,34 @@ object RecoveryService extends Logging {
       var tblCounts: Seq[SnappyRegionStats] = Seq()
       catalogTableCount = allTables.length
       allTables.foreach(table => {
-        table.storage.locationUri match {
-          case Some(_) => // external tables can be seen in show tables but filtered out in UI
-          case None =>
-            if (recoveryStats == null ||
-                !recoveryStats._1.map(_.getTableName).contains(table.qualifiedName))
-              logDebug(s"Querying table: $table for count")
-            val recCount = snappySession.sql(s"SELECT count(1) FROM ${table.qualifiedName}")
+        try {
+          table.storage.locationUri match {
+            case Some(_) => // external tables can be seen in show tables but filtered out in UI
+            case None =>
+              if (recoveryStats == null ||
+                  !recoveryStats._1.map(_.getTableName).contains(table.qualifiedName))
+                logDebug(s"Querying table: $table for count")
+              val recCount = if (enableTableCountInUI) {
+                snappySession.sql(s"SELECT count(1) FROM ${table.qualifiedName}")
                 .collect()(0).getLong(0)
-            val (numBuckets, isReplicated) = RecoveryService
-                .getNumBuckets(table.qualifiedName.split('.')(0).toUpperCase(),
-                  table.qualifiedName.split('.')(1).toUpperCase())
+              } else -1L
+              val (numBuckets, isReplicatedTable) = RecoveryService
+                  .getNumBuckets(table.qualifiedName.split('.')(0).toUpperCase(),
+                    table.qualifiedName.split('.')(1).toUpperCase())
+              val regionStats = new SnappyRegionStats()
+              regionStats.setRowCount(recCount)
+              regionStats.setTableName(table.qualifiedName)
+              regionStats.setReplicatedTable(isReplicatedTable)
+              regionStats.setBucketCount(numBuckets)
+              regionStats.setColumnTable(getProvider(table.qualifiedName).equalsIgnoreCase
+              ("column"))
+              tblCounts :+= regionStats
+          }
+        } catch {
+          case e: Exception => logError(s"Error querying table $table.\n$e")
             val regionStats = new SnappyRegionStats()
-            regionStats.setRowCount(recCount)
+            regionStats.setRowCount(-1L)
             regionStats.setTableName(table.qualifiedName)
-            regionStats.setReplicatedTable(isReplicated)
-            regionStats.setBucketCount(numBuckets)
             regionStats.setColumnTable(getProvider(table.qualifiedName).equalsIgnoreCase("column"))
             tblCounts :+= regionStats
         }
@@ -371,7 +390,7 @@ object RecoveryService extends Logging {
           s"Schema name not found for the table ${table.identifier.table}")
       }
       var schema: StructType = StructType(DataType.fromJson(schemaJsonStr).asInstanceOf[StructType]
-              .map(f => f.copy(name = f.name.toLowerCase)))
+          .map(f => f.copy(name = f.name.toLowerCase)))
 
       assert(schema != null, s"schemaJson read from catalog table is null " +
           s"for ${table.identifier.table}")
@@ -460,10 +479,11 @@ object RecoveryService extends Logging {
   def isReplicated(schemaName: String, tableName: String): Boolean =
     memberObject.getReplicatedRegions.contains(s"/$schemaName/$tableName")
 
-  def collectViewsAndPrepareCatalog(): Unit = {
+  def collectViewsAndPrepareCatalog(enableTableCountInUI: Boolean): Unit = {
     // Send a message to all the servers and locators to send back their
     // respective persistent state information.
     logDebug("Start collecting PersistentStateInRecoveryMode from all the servers/locators.")
+    this.enableTableCountInUI = enableTableCountInUI
     val collector = new RecoveryModeResultCollector()
     val msg = new RecoveredMetadataRequestMessage(collector)
     msg.executeFunction()

--- a/core/src/main/scala/org/apache/spark/sql/execution/oplog/impl/OpLogRdd.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/oplog/impl/OpLogRdd.scala
@@ -543,8 +543,8 @@ class OpLogRdd(
       if(expectedHost != currentHost) {
         throw new IllegalStateException(s"Expected compute to launch at $expectedHost," +
             s" but was launched at $currentHost. Try increasing value of " +
-            s"spark.locality.wait.process higher than current value in recovery mode." +
-            s"Refer troubleshooting section under Data Extractor Tool for more explanation.")
+            s"spark.locality.wait.process higher than current value(default 1800s) in recovery " +
+            s"mode. Refer troubleshooting section under Data Extractor Tool for more explanation.")
       }
 
       val diskStores = Misc.getGemFireCache.listDiskStores()


### PR DESCRIPTION
## Changes proposed in this pull request

* Add property to enable table count on UI in recovery mode
* Show count as -1, when error while in table scan

Ui will appear as is Recovery Mode, expect the table counts.To see table counts user need to set the property snappydata.recovery.enableTableCountInUI to true. By default the property is set to false and the table count will be shown as -1.
When the table counts is enabled, if there is an error while reading a particular table, it's count will be -1.

## Patch testing

Manual testing

## ReleaseNotes.txt changes

(Does this change require an entry in ReleaseNotes.txt? If yes, has it been added to it?)

## Other PRs 

(Does this change require changes in other projects- store, spark, spark-jobserver, aqp? Add the links of PR of the other subprojects that are related to this change)
