### PR TITLE
Fixes for SNAP-3264:

### DIFF
--- a/core/src/main/scala/org/apache/spark/sql/SnappySession.scala
+++ b/core/src/main/scala/org/apache/spark/sql/SnappySession.scala
@@ -2186,7 +2186,7 @@ class SnappySession(_sc: SparkContext) extends SparkSession(_sc) {
     }
   }
   // Call to update Structured Streaming UI Tab
-  // updateStructuredStreamingUITab()
+  updateStructuredStreamingUITab()
 
 }
 

--- a/core/src/main/scala/org/apache/spark/sql/hive/SnappySessionState.scala
+++ b/core/src/main/scala/org/apache/spark/sql/hive/SnappySessionState.scala
@@ -24,7 +24,6 @@ import scala.collection.mutable.ArrayBuffer
 import com.gemstone.gemfire.internal.cache.{CacheDistributionAdvisee, ColocationHelper, PartitionedRegion}
 import com.pivotal.gemfirexd.internal.engine.store.GemFireStore
 import io.snappydata.Property
-import io.snappydata.Property.HashAggregateSize
 
 import org.apache.spark.Partition
 import org.apache.spark.sql.catalyst.analysis
@@ -70,12 +69,6 @@ class SnappySessionState(val snappySession: SnappySession)
   }
 
   override lazy val streamingQueryManager: StreamingQueryManager = {
-    // Disabling `SnappyAggregateStrategy` for streaming queries as it clashes with
-    // `StatefulAggregationStrategy` which is applied by spark for streaming queries. This
-    // implies that Snappydata aggregation optimisation will be turned off for any usage of
-    // this session including non-streaming queries.
-
-    HashAggregateSize.set(conf, "-1")
     new SnappyStreamingQueryManager(snappySession)
   }
 

--- a/core/src/main/scala/org/apache/spark/sql/streaming/SnappyStreamingQueryManager.scala
+++ b/core/src/main/scala/org/apache/spark/sql/streaming/SnappyStreamingQueryManager.scala
@@ -16,6 +16,7 @@
  */
 package org.apache.spark.sql.streaming
 
+import io.snappydata.Property.HashAggregateSize
 import org.apache.spark.sql.execution.streaming.{Sink, StreamingQueryWrapper}
 import org.apache.spark.sql.{AnalysisException, DataFrame, SnappySession}
 import org.apache.spark.util.{Clock, SystemClock}
@@ -41,6 +42,12 @@ class SnappyStreamingQueryManager(snappySession: SnappySession)
     }
 
     def startQuery = {
+      // Disabling `SnappyAggregateStrategy` for streaming queries as it clashes with
+      // `StatefulAggregationStrategy` which is applied by spark for streaming queries. This
+      // implies that Snappydata aggregation optimisation will be turned off for any usage of
+      // this session including non-streaming queries.
+
+      HashAggregateSize.set(snappySession.sessionState.conf, "-1")
       super.startQuery(userSpecifiedName, userSpecifiedCheckpointLocation, df, sink, outputMode,
         useTempCheckpointLocation, recoverFromCheckpointLocation, trigger, triggerClock)
     }


### PR DESCRIPTION


## Changes proposed in this pull request

 - call HashAggregateSize.set(conf, "-1") has been shifted from
   SnappySessionState.streamingQueryManager to SnappyStreamingQueryManager.

## Patch testing

 - Ran failing tests again and verified that those are not failing again.

## ReleaseNotes.txt changes

 - None

## Other PRs 

 - None