### PR TITLE
masking creds before capturing into catalog

### DIFF
--- a/compatibilityTests/src/test/scala/org/apache/spark/sql/SnappyJDBCSuite.scala
+++ b/compatibilityTests/src/test/scala/org/apache/spark/sql/SnappyJDBCSuite.scala
@@ -16,8 +16,52 @@
  */
 package org.apache.spark.sql
 
+import io.snappydata.util.ServiceUtils
+
 import org.apache.spark.sql.jdbc.JDBCSuite
 import org.apache.spark.sql.test.{SharedSnappySessionContext, SnappySparkTestUtil}
 
 class SnappyJDBCSuite extends JDBCSuite
-    with SharedSnappySessionContext with SnappySparkTestUtil
+    with SharedSnappySessionContext with SnappySparkTestUtil {
+  test("hide credentials in captured ddl string") {
+    // jdbc connection strings from diffreent databases
+    val jdbcUrls = Seq(
+      // jdbc pattern 1
+      "jdbc:mysql://[(host=myhost1,port=1111,user=sandy," +
+          "password=secret),(host=myhost2,port=2222,user=finn,password=secret)]/db",
+      "jdbc:mysql://address=(host=myhost1)(port=1111)(user=sandy)(password=secret)," +
+          "address=(host=myhost2)(port=2222)(user=finn)(password=secret)/db",
+      "jdbc:mysql://localhost/test?user=minty&password=greatsqldb",
+      "jdbc:postgresql://localhost/test?user=fred&password=secret&ssl=true",
+      "jdbc:postgresql://localhost/mydb?user=other&password=secret",
+      "jdbc:h2:file:~/sample;USER=sa;PASSWORD=123",
+      "jdbc:derby://localhost:1527/myDB;create=true;user=me;password=mine",
+      "jdbc:derby:myDB;create=true;user=me;password=mine",
+      // jdbc pattern2
+      "jdbc:mysql://sandy:secret@[myhost1:1111,myhost2:2222]/db",
+      "jdbc:mysql://sandy:secret@[(address=host1:1111,priority=1,key1=value1)," +
+          "(address=host2:2222,priority=2,key2=value2))]/db",
+      // s3 path pattern1
+      "s3a://DUMMYKEY175GDRZIF4QQ:DUMMYKEY2zUkvIS88xrMJ7v5cMmQEWRjqS@" +
+          "ryft-public-sample-data/passengers.txt"
+    )
+    val expectedUrls = Seq("jdbc:mysql://[(host=myhost1,port=1111,user=sandy," +
+        "password=xxxxx),(host=myhost2,port=2222,user=finn,password=xxxxx)]/db",
+      "jdbc:mysql://address=(host=myhost1)(port=1111)(user=sandy)(password=xxxxx)," +
+          "address=(host=myhost2)(port=2222)(user=finn)(password=xxxxx)/db",
+      "jdbc:mysql://localhost/test?user=minty&password=xxxxx",
+      "jdbc:postgresql://localhost/test?user=fred&password=xxxxx&ssl=true",
+      "jdbc:postgresql://localhost/mydb?user=other&password=xxxxx",
+      "jdbc:h2:file:~/sample;USER=sa;PASSWORD=xxxxx",
+      "jdbc:derby://localhost:1527/myDB;create=true;user=me;password=xxxxx",
+      "jdbc:derby:myDB;create=true;user=me;password=xxxxx",
+      "jdbc:mysql://sandy:xxxxx@[myhost1:1111,myhost2:2222]/db",
+      "jdbc:mysql://sandy:xxxxx@[(address=host1:1111,priority=1,key1=value1)," +
+          "(address=host2:2222,priority=2,key2=value2))]/db",
+      "s3a://xxxxx:xxxxx@ryft-public-sample-data/passengers.txt"
+    )
+    val maskedUrls = jdbcUrls.map(url => ServiceUtils.maskPasswordsInString(url))
+    jdbcUrls.indices.foreach(i => assert(maskedUrls(i).equals(expectedUrls(i)),
+      s"password in url not masked. url=${maskedUrls(i)}"))
+  }
+}

--- a/core/src/main/scala/io/snappydata/util/ServiceUtils.scala
+++ b/core/src/main/scala/io/snappydata/util/ServiceUtils.scala
@@ -177,4 +177,34 @@ object ServiceUtils {
         }
     }
   }
+
+  /**
+   * We capture table ddl string and add it to table properties before adding to catalog.
+   * This will also contain passwords in the string such as jdbc connection string or
+   * s3 location etc. This method masks passwords
+   * @param str DDL string that might contain jdbc/s3 passwords
+   * @return similar string with masked passwords
+   */
+  def maskPasswordsInString(str: String): String = {
+    val jdbcPattern1 = ".*jdbc.*(?i)\\bpassword\\b=([^);&]*).*".r
+    val jdbcPattern2 = ".*jdbc.*:(.*)@.*".r
+    val s3Pattern1 = "s3[an]?://([^:]*):([^@]*)@.*".r
+    var maskedStr = ""
+    val mask = "xxxxx"
+
+    str match {
+      case jdbcPattern1(passwd) => maskedStr = str.replace(passwd, mask)
+      case _ =>
+    }
+    str match {
+      case jdbcPattern2(passwd) => maskedStr = str.replace(passwd, mask)
+      case _ =>
+    }
+    str match {
+      case s3Pattern1(passwd3, passwd4) => maskedStr = str.replace(passwd3, mask)
+          .replace(passwd4, mask)
+      case _ =>
+    }
+    maskedStr
+  }
 }


### PR DESCRIPTION
## Changes proposed in this pull request

we are capturing exact ddl string provided and adding it to corresponding catalog table. This is needed so that EXPORT_DDLS procedure can return original ddls.
This PR masks passwords if any provided in ddls

## Patch testing

Precheckin looks fine

## ReleaseNotes.txt changes

no

## Other PRs 

no
