### PR TITLE
Snap 3275 - incrementing the index variable for null values for reference type

### DIFF
--- a/cluster/src/main/scala/io/snappydata/gemxd/SparkSQLExecuteImpl.scala
+++ b/cluster/src/main/scala/io/snappydata/gemxd/SparkSQLExecuteImpl.scala
@@ -411,10 +411,10 @@ object SparkSQLExecuteImpl {
         val dvd = dvds(index)
         if (row.isNullAt(index)) {
           dvd.setToNull()
-          index += 1
           if (types(index) == StoredFormatIds.REF_TYPE_ID) {
             refTypeIndex += 1
           }
+          index += 1
         } else {
           types(index) match {
             case StoredFormatIds.SQL_VARCHAR_ID |

--- a/cluster/src/main/scala/io/snappydata/gemxd/SparkSQLExecuteImpl.scala
+++ b/cluster/src/main/scala/io/snappydata/gemxd/SparkSQLExecuteImpl.scala
@@ -406,12 +406,15 @@ object SparkSQLExecuteImpl {
       input.array(), input.position(), input.available())
     unsafeRows.map { row =>
       var index = 0
-      var writeIndex = 0
+      var refTypeIndex = 0
       while (index < numFields) {
         val dvd = dvds(index)
         if (row.isNullAt(index)) {
           dvd.setToNull()
           index += 1
+          if (types(index) == StoredFormatIds.REF_TYPE_ID) {
+            refTypeIndex += 1
+          }
         } else {
           types(index) match {
             case StoredFormatIds.SQL_VARCHAR_ID |
@@ -464,14 +467,14 @@ object SparkSQLExecuteImpl {
               dvd.setValue(row.getDouble(index))
             case StoredFormatIds.REF_TYPE_ID =>
               // convert to Json using JacksonGenerator
-              val writer = writers(writeIndex)
-              val generator = generators(writeIndex)
+              val writer = writers(refTypeIndex)
+              val generator = generators(refTypeIndex)
               Utils.generateJson(generator, row, index,
                 dataTypes(index).asInstanceOf[DataType])
               val json = writer.toString
               writer.reset()
               dvd.setValue(json)
-              writeIndex += 1
+              refTypeIndex += 1
             case StoredFormatIds.SQL_BLOB_ID =>
               // all complex types too work with below because all of
               // Array, Map, Struct (as well as Binary itself) transport


### PR DESCRIPTION
## Changes proposed in this pull request

Index variable tracking reference type fields was not getting incremented
when a reference type column is set to null. Fixing this behavior by
incrementing the index variable at the correct place.

Note that this issue was affecting JDBC connection mode only. Queries run
using `SnappySession#sql` were not affected.

## Patch testing

- added dunit test
