### PR TITLE
Fixes for SNAP-3280 and SNAP-3284

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -72,7 +72,7 @@ allprojects {
   apply plugin: "build-time-tracker"
 
   group = 'io.snappydata'
-  version = '1.2-SNAPSHOT'
+  version = '1.2.0'
 
   // apply compiler options
   tasks.withType(JavaCompile) {
@@ -108,7 +108,7 @@ allprojects {
     scalaBinaryVersion = '2.11'
     scalaVersion = scalaBinaryVersion + '.8'
     sparkVersion = '2.1.1'
-    snappySparkVersion = '2.1.1.7'
+    snappySparkVersion = '2.1.1.8'
     sparkDistName = "spark-${sparkVersion}-bin-hadoop2.7"
     sparkCurrentVersion = '2.3.2'
     sparkCurrentDistName = "spark-${sparkCurrentVersion}-bin-hadoop2.7"
@@ -155,7 +155,7 @@ allprojects {
     antlr2Version = '2.7.7'
 
     pegdownVersion = '1.6.0'
-    snappyStoreVersion = '1.6.5-SNAPSHOT'
+    snappyStoreVersion = '1.6.5'
     snappydataVersion = version
     pulseVersion = '1.5.1'
     zeppelinInterpreterVersion = '0.7.3.6'
@@ -167,9 +167,10 @@ allprojects {
     osFamilyName = osName.getFamilyName().replace(' ', '').toLowerCase()
     osVersion = System.getProperty('os.version')
     buildDate = new Date().format('yyyy-MM-dd HH:mm:ss Z')
+    buildDateShort = ''
     buildNumber = new Date().format('MMddyy')
     jdkVersion = System.getProperty('java.version')
-    sparkJobServerVersion = '0.6.2.10'
+    sparkJobServerVersion = '0.6.2.11'
     eclipseCollectionsVersion = '9.2.0'
     fastutilVersion = '8.2.2'
     snappySparkMetricsLibVersion = '2.0.0.1'
@@ -572,7 +573,7 @@ subprojects {
 
   // apply default manifest
   if (rootProject.hasProperty('enablePublish')) {
-    createdBy = 'TIBCO Software Inc.'
+    createdBy = vendorName
   }
   jar {
     manifest {
@@ -1237,12 +1238,14 @@ buildDeb {
 distTar {
   // archiveName = 'TIB_compute-ce_' + version + '_' + osFamilyName + '.tar.gz'
   if (isEnterpriseProduct) {
-    archiveName = 'TIB_compute_' + version + '_' + osFamilyName + '.tar.gz'
+    if (rootProject.hasProperty('withDate')) {
+      buildDateShort = "${new Date().format('yyyyMMdd')}_"
+    }
+    archiveName = 'TIB_compute_' + version + '_' + buildDateShort + osFamilyName + '.tar.gz'
   } else {
     classifier 'bin'
   }
   dependsOn product
-  // also package VSD
   if (rootProject.hasProperty('enablePublish')) {
     dependsOn ':packageZeppelinInterpreter'
   }
@@ -1256,12 +1259,14 @@ distTar {
 distZip {
   // archiveName = 'TIB_compute-ce_' + version + '_' + osFamilyName + '.zip'
   if (isEnterpriseProduct) {
-    archiveName = 'TIB_compute_' + version + '_' + osFamilyName + '.zip'
+    if (rootProject.hasProperty('withDate')) {
+      buildDateShort = "${new Date().format('yyyyMMdd')}_"
+    }
+    archiveName = 'TIB_compute_' + version + '_' + buildDateShort + osFamilyName + '.zip'
   } else {
     classifier 'bin'
   }
   dependsOn product
-  // also package VSD
   if (rootProject.hasProperty('enablePublish')) {
     dependsOn ':packageZeppelinInterpreter'
   }

--- a/cluster/src/main/scala/io/snappydata/ToolsCallbackImpl.scala
+++ b/cluster/src/main/scala/io/snappydata/ToolsCallbackImpl.scala
@@ -277,7 +277,7 @@ object ToolsCallbackImpl extends ToolsCallback with Logging {
     td: TableIdentifier, users: String, catalogTable: CatalogTable): Unit = {
 
     // this can be issued by only dbOwner or table owner
-    val tableOwner = catalogTable.database  // catalog database should be table owner too. Owner was found to be OS username !!
+    val tableOwner = catalogTable.database  // catalogTable.owner returns an OS user
     val dbOwner = SnappyInterpreterExecute.dbOwner
     if (!(grantor.equalsIgnoreCase(tableOwner) || grantor.equalsIgnoreCase(dbOwner))) {
       throw StandardException.newException(
@@ -298,7 +298,7 @@ object ToolsCallbackImpl extends ToolsCallback with Logging {
     if (metastoreTableIdentifier.isDefined) {
       val identifier = metastoreTableIdentifier.get.identifier
       val database = metastoreTableIdentifier.get.database.getOrElse(null)
-      val schema = if (identifier.indexOf('.') > 0) identifier.substring(identifier.indexOf('.'))
+      val schema = if (identifier.indexOf('.') > 0) identifier.substring(0, identifier.indexOf('.'))
       else if (database != null) {
         database
       } else {

--- a/cluster/src/main/scala/io/snappydata/ToolsCallbackImpl.scala
+++ b/cluster/src/main/scala/io/snappydata/ToolsCallbackImpl.scala
@@ -277,7 +277,7 @@ object ToolsCallbackImpl extends ToolsCallback with Logging {
     td: TableIdentifier, users: String, catalogTable: CatalogTable): Unit = {
 
     // this can be issued by only dbOwner or table owner
-    val tableOwner = catalogTable.owner
+    val tableOwner = catalogTable.database  // catalog database should be table owner too. Owner was found to be OS username !!
     val dbOwner = SnappyInterpreterExecute.dbOwner
     if (!(grantor.equalsIgnoreCase(tableOwner) || grantor.equalsIgnoreCase(dbOwner))) {
       throw StandardException.newException(
@@ -296,11 +296,8 @@ object ToolsCallbackImpl extends ToolsCallback with Logging {
     metastoreTableIdentifier: Option[TableIdentifier]): Exception = {
     if (!Misc.isSecurityEnabled) return null
     if (metastoreTableIdentifier.isDefined) {
-      val dbOwner = SnappyInterpreterExecute.dbOwner
       val identifier = metastoreTableIdentifier.get.identifier
-      val database = if (metastoreTableIdentifier.get.database.isDefined)
-        metastoreTableIdentifier.get.database.get
-      else null
+      val database = metastoreTableIdentifier.get.database.getOrElse(null)
       val schema = if (identifier.indexOf('.') > 0) identifier.substring(identifier.indexOf('.'))
       else if (database != null) {
         database

--- a/cluster/src/main/scala/io/snappydata/remote/interpreter/SnappyInterpreterExecute.scala
+++ b/cluster/src/main/scala/io/snappydata/remote/interpreter/SnappyInterpreterExecute.scala
@@ -251,13 +251,13 @@ object SnappyInterpreterExecute {
         val commaSepVals = users.split(",")
         commaSepVals.foreach(u => {
           if (isGrant) {
-            if (u.startsWith(Constants.LDAP_GROUP_PREFIX))
+            if (u.toUpperCase.startsWith(Constants.LDAP_GROUP_PREFIX)) {
               permissions.addLdapGroup(u)
-            else permissions.addUser(u)
+            } else permissions.addUser(u)
           } else {
-            if (u.startsWith(Constants.LDAP_GROUP_PREFIX))
+            if (u.toUpperCase.startsWith(Constants.LDAP_GROUP_PREFIX)) {
               permissions.removeLdapGroup(u)
-            else permissions.removeUser(u)
+            } else permissions.removeUser(u)
           }
         })
         logger.debug(s"Putting permission obj = $permissions against key = $key")

--- a/cluster/src/main/scala/io/snappydata/remote/interpreter/SnappyInterpreterExecute.scala
+++ b/cluster/src/main/scala/io/snappydata/remote/interpreter/SnappyInterpreterExecute.scala
@@ -219,7 +219,7 @@ object SnappyInterpreterExecute {
     def refreshOnLdapGroupRefresh(group: String): Unit = {
       val groupUC = group.toUpperCase
       val groupstr = if (!groupUC.startsWith(Constants.LDAP_GROUP_PREFIX)) {
-        s"${Constants.LDAP_GROUP_PREFIX}:$group"
+        s"${Constants.LDAP_GROUP_PREFIX}$group"
       } else {
         group
       }

--- a/cluster/src/main/scala/io/snappydata/remote/interpreter/SnappyInterpreterExecute.scala
+++ b/cluster/src/main/scala/io/snappydata/remote/interpreter/SnappyInterpreterExecute.scala
@@ -252,13 +252,11 @@ object SnappyInterpreterExecute {
         commaSepVals.foreach(u => {
           val uUC = u.toUpperCase
           if (isGrant) {
-            if (u.toUpperCase.startsWith(Constants.LDAP_GROUP_PREFIX)) {
-              permissions.addLdapGroup(uUC)
-            } else permissions.addUser(u)
+            if (uUC.startsWith(Constants.LDAP_GROUP_PREFIX)) permissions.addLdapGroup(uUC)
+            else permissions.addUser(u)
           } else {
-            if (u.toUpperCase.startsWith(Constants.LDAP_GROUP_PREFIX)) {
-              permissions.removeLdapGroup(uUC)
-            } else permissions.removeUser(u)
+            if (uUC.startsWith(Constants.LDAP_GROUP_PREFIX)) permissions.removeLdapGroup(uUC)
+            else permissions.removeUser(u)
           }
         })
         logger.debug(s"Putting permission obj = $permissions against key = $key")

--- a/cluster/src/main/scala/io/snappydata/remote/interpreter/SnappyInterpreterExecute.scala
+++ b/cluster/src/main/scala/io/snappydata/remote/interpreter/SnappyInterpreterExecute.scala
@@ -27,14 +27,16 @@ import com.pivotal.gemfirexd.internal.iapi.error.StandardException
 import com.pivotal.gemfirexd.internal.shared.common.reference.SQLState
 import com.pivotal.gemfirexd.internal.snappy.InterpreterExecute
 import io.snappydata.Constant
-import io.snappydata.ToolsCallbackImpl.logInfo
 import io.snappydata.gemxd.SnappySessionPerConnection
 import org.apache.log4j.Logger
+
 import org.apache.spark.Logging
 import org.apache.spark.sql.execution.InterpretCodeCommand
 import org.apache.spark.sql.execution.columnar.ExternalStoreUtils
-
 import scala.collection.mutable
+
+import com.pivotal.gemfirexd.internal.iapi.util.StringUtil
+
 
 class SnappyInterpreterExecute(sql: String, connId: Long) extends InterpreterExecute with Logging {
 
@@ -44,13 +46,14 @@ class SnappyInterpreterExecute(sql: String, connId: Long) extends InterpreterExe
     if (Misc.isSecurityEnabled && !user.equalsIgnoreCase(SnappyInterpreterExecute.dbOwner)) {
       if (!allowed) {
         // throw exception
-        throw StandardException.newException(
-          SQLState.AUTH_NO_EXECUTE_PERMISSION, user, "scala code execution", "", "ComputeDB", "Cluster")
+        throw StandardException.newException(SQLState.AUTH_NO_EXECUTE_PERMISSION, user,
+          "scala code execution", "", "ComputeDB", "Cluster")
       }
     }
     val session = SnappySessionPerConnection.getSnappySessionForConnection(connId)
     val lp = session.sessionState.sqlParser.parseExec(sql).asInstanceOf[InterpretCodeCommand]
-    val interpreterHelper = SnappyInterpreterExecute.getOrCreateStateHolder(connId, user, authToken, group)
+    val interpreterHelper = SnappyInterpreterExecute.getOrCreateStateHolder(connId, user,
+      authToken, group)
     try {
       interpreterHelper.interpret(lp.code.split("\n"), lp.options)
     } finally {
@@ -94,14 +97,12 @@ object SnappyInterpreterExecute {
       }
       val commaSepVals = users.split(",")
       commaSepVals.foreach(u => {
-        val uUC = u.toUpperCase
+        val uUC = StringUtil.SQLToUpperCase(u)
         if (isGrant) {
-          if (uUC.startsWith(Constants.LDAP_GROUP_PREFIX))
-            permissions.addLdapGroup(uUC)
+          if (uUC.startsWith(Constants.LDAP_GROUP_PREFIX)) permissions.addLdapGroup(uUC)
           else permissions.addUser(u)
         } else {
-          if (uUC.startsWith(Constants.LDAP_GROUP_PREFIX))
-            removeAGroupAndCleanup(uUC)
+          if (uUC.startsWith(Constants.LDAP_GROUP_PREFIX)) removeAGroupAndCleanup(uUC)
           else removeAUserAndCleanup(u)
         }
       })
@@ -217,7 +218,7 @@ object SnappyInterpreterExecute {
     }
 
     def refreshOnLdapGroupRefresh(group: String): Unit = {
-      val groupUC = group.toUpperCase
+      val groupUC = StringUtil.SQLToUpperCase(group)
       val groupstr = if (!groupUC.startsWith(Constants.LDAP_GROUP_PREFIX)) {
         s"${Constants.LDAP_GROUP_PREFIX}$group"
       } else {
@@ -234,8 +235,9 @@ object SnappyInterpreterExecute {
       "io.snappydata.remote.interpreter.SnappyInterpreterExecute")
 
     def isAllowed(key: String, currentUser: String, tableSchema: String): Boolean = {
-      if (currentUser.equalsIgnoreCase(tableSchema) ||
-        currentUser.equalsIgnoreCase(dbOwner)) return true
+      if (currentUser.equalsIgnoreCase(tableSchema) || currentUser.equalsIgnoreCase(dbOwner)) {
+        return true
+      }
 
       val permissionsObj = Misc.getMemStore.getMetadataCmdRgn.get(key)
       if (permissionsObj == null) return false
@@ -250,7 +252,7 @@ object SnappyInterpreterExecute {
         // expand the users list. Can be a mix of normal user and ldap group
         val commaSepVals = users.split(",")
         commaSepVals.foreach(u => {
-          val uUC = u.toUpperCase
+          val uUC = StringUtil.SQLToUpperCase(u)
           if (isGrant) {
             if (uUC.startsWith(Constants.LDAP_GROUP_PREFIX)) permissions.addLdapGroup(uUC)
             else permissions.addUser(u)

--- a/cluster/src/main/scala/io/snappydata/remote/interpreter/SnappyInterpreterExecute.scala
+++ b/cluster/src/main/scala/io/snappydata/remote/interpreter/SnappyInterpreterExecute.scala
@@ -250,13 +250,14 @@ object SnappyInterpreterExecute {
         // expand the users list. Can be a mix of normal user and ldap group
         val commaSepVals = users.split(",")
         commaSepVals.foreach(u => {
+          val uUC = u.toUpperCase
           if (isGrant) {
             if (u.toUpperCase.startsWith(Constants.LDAP_GROUP_PREFIX)) {
-              permissions.addLdapGroup(u)
+              permissions.addLdapGroup(uUC)
             } else permissions.addUser(u)
           } else {
             if (u.toUpperCase.startsWith(Constants.LDAP_GROUP_PREFIX)) {
-              permissions.removeLdapGroup(u)
+              permissions.removeLdapGroup(uUC)
             } else permissions.removeUser(u)
           }
         })

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -222,7 +222,7 @@ shadowJar {
   exclude 'log4j.properties'
 
   if (rootProject.hasProperty('enablePublish')) {
-    createdBy = 'SnappyData Build Team'
+    createdBy = vendorName
   } else {
     createdBy = System.getProperty('user.name')
   }

--- a/core/src/dunit/scala/io/snappydata/cluster/SplitClusterDUnitSecurityTest.scala
+++ b/core/src/dunit/scala/io/snappydata/cluster/SplitClusterDUnitSecurityTest.scala
@@ -447,6 +447,8 @@ class SplitClusterDUnitSecurityTest(s: String)
   private def doSimpleStuffOnExtTable(user: String,
       fqtn: String, session: SnappySession, expectException: Boolean = false): Unit = {
     val sql = s"select count(*) from $fqtn"
+
+    // Verify in smart connector mode
     try {
       session.sql(sql)
       if (expectException) assert(false, "Expected an exception but none found!")
@@ -465,6 +467,7 @@ class SplitClusterDUnitSecurityTest(s: String)
       session.close()
     }
 
+    // Verify in embedded mode
     val conn = getConn(user, false)
     try {
       conn.createStatement().execute(sql)

--- a/core/src/dunit/scala/io/snappydata/cluster/SplitClusterDUnitSecurityTest.scala
+++ b/core/src/dunit/scala/io/snappydata/cluster/SplitClusterDUnitSecurityTest.scala
@@ -495,8 +495,11 @@ class SplitClusterDUnitSecurityTest(s: String)
       if (adminConn == null) adminConn = getConn(adminUser1, true)
       doTest(adminConn.createStatement(), t1, s"$adminUser1.$t1", adminUser1)
       val jdbc5Conn = getConn(jdbcUser5)
-      doTest(jdbc5Conn.createStatement(), t1, s"$jdbcUser5.$t1", jdbcUser5)
-      jdbc5Conn.close()
+      try {
+        doTest(jdbc5Conn.createStatement(), t1, s"$jdbcUser5.$t1", jdbcUser5)
+      } finally {
+        jdbc5Conn.close()
+      }
     } finally {
       System.setProperty("CHECK_EXTERNAL_TABLE_AUTHZ", "false")
     }
@@ -553,6 +556,9 @@ class SplitClusterDUnitSecurityTest(s: String)
       getConn(jdbcUser1, true).close() // Just initialize snc.
       group3.foreach(u => doSimpleStuffOnExtTable(u, fqtn, ss(u)))
       doSimpleStuffOnExtTable(jdbcUser9, fqtn, ss(jdbcUser9), true)
+    } else {
+      // This is admin connection. Test REFRESH_LDAP_GROUP works fine (SNAP-3281)
+      st.execute("call SYS.REFRESH_LDAP_GROUP('gemGroup1')")
     }
   }
 

--- a/core/src/main/scala/org/apache/spark/sql/SnappySession.scala
+++ b/core/src/main/scala/org/apache/spark/sql/SnappySession.scala
@@ -2474,7 +2474,7 @@ object SnappySession extends Logging {
 
   private def checkCurrentUserAllowed(session: SnappySession, scanNodes: Seq[SparkPlan]): Unit = {
     val currentUser = session.conf.get(Attribute.USERNAME_ATTR, default = null)
-    if (currentUser eq null) return
+    if (currentUser eq null) return // Why not throw error instead?
     if (ToolsCallbackInit.toolsCallback != null) {
       scanNodes.foreach(n => {
         val dse = n.asInstanceOf[DataSourceScanExec]

--- a/core/src/main/scala/org/apache/spark/sql/SnappySession.scala
+++ b/core/src/main/scala/org/apache/spark/sql/SnappySession.scala
@@ -2473,14 +2473,12 @@ object SnappySession extends Logging {
   }
 
   private def checkCurrentUserAllowed(session: SnappySession, scanNodes: Seq[SparkPlan]): Unit = {
-    val currentUser = SnappyContext.getClusterMode(session.sparkContext) match {
+    var currentUser = SnappyContext.getClusterMode(session.sparkContext) match {
       case ThinClientConnectorMode(_, _) =>
         session.conf.get(Constant.SPARK_STORE_PREFIX + Attribute.USERNAME_ATTR, null)
       case _ => session.conf.get(Attribute.USERNAME_ATTR, default = null)
     }
-    if ((currentUser eq null) || currentUser.isEmpty) {
-      throw new AnalysisException("Username not provided.")
-    }
+    if (currentUser eq null) currentUser = ""
     if (ToolsCallbackInit.toolsCallback != null) {
       scanNodes.foreach(n => {
         val dse = n.asInstanceOf[DataSourceScanExec]

--- a/jdbc/build.gradle
+++ b/jdbc/build.gradle
@@ -86,7 +86,7 @@ shadowJar {
   exclude 'log4j.properties'
 
   if (rootProject.hasProperty('enablePublish')) {
-    createdBy = 'SnappyData Build Team'
+    createdBy = vendorName
   } else {
     createdBy = System.getProperty('user.name')
   }


### PR DESCRIPTION
## Changes proposed in this pull request
- Used `catalogTable.database` instead of `catalogTable.owner` to get the table owner (schema).
- Fixed the issue in extracting the schema name from identifier.
- Used capitalized form of LDAP group name in `PermissionChecker.addRemoveUserForKey()` . This fixed an issue where if a user specified non-capitalized LDAP group name in GRANT/REVOKE DDL for external tables, it failed.
- If a username is found to be null during checking authz for external tables, set it to empty string and proceed to authz instead of returning without authz.
- Added several new testcases in the dunit test.

## Patch testing
Added new testcases.
Precheckin is clear.

## ReleaseNotes.txt changes
NA

## Other PRs 
NA