### PR TITLE
* [SNAP-3282] SYS.REFRESH_LDAP_GROUP now updates metadata region also.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -168,6 +168,13 @@ allprojects {
     osVersion = System.getProperty('os.version')
     buildDate = new Date().format('yyyy-MM-dd HH:mm:ss Z')
     buildDateShort = ''
+    if (rootProject.hasProperty('withDate')) {
+      buildDateShort = "${new Date().format('yyyyMMdd')}_"
+    }
+    devEdition = ''
+    if (rootProject.hasProperty('dev')) {
+      devEdition = "-dev"
+    }
     buildNumber = new Date().format('MMddyy')
     jdkVersion = System.getProperty('java.version')
     sparkJobServerVersion = '0.6.2.11'
@@ -1238,10 +1245,7 @@ buildDeb {
 distTar {
   // archiveName = 'TIB_compute-ce_' + version + '_' + osFamilyName + '.tar.gz'
   if (isEnterpriseProduct) {
-    if (rootProject.hasProperty('withDate')) {
-      buildDateShort = "${new Date().format('yyyyMMdd')}_"
-    }
-    archiveName = 'TIB_compute_' + version + '_' + buildDateShort + osFamilyName + '.tar.gz'
+    archiveName = 'TIB_compute' + devEdition + '_' + version + '_' + buildDateShort + osFamilyName + '.tar.gz'
   } else {
     classifier 'bin'
   }
@@ -1259,10 +1263,7 @@ distTar {
 distZip {
   // archiveName = 'TIB_compute-ce_' + version + '_' + osFamilyName + '.zip'
   if (isEnterpriseProduct) {
-    if (rootProject.hasProperty('withDate')) {
-      buildDateShort = "${new Date().format('yyyyMMdd')}_"
-    }
-    archiveName = 'TIB_compute_' + version + '_' + buildDateShort + osFamilyName + '.zip'
+    archiveName = 'TIB_compute' + devEdition + '_' + version + '_' + buildDateShort + osFamilyName + '.zip'
   } else {
     classifier 'bin'
   }

--- a/cluster/src/main/scala/io/snappydata/ToolsCallbackImpl.scala
+++ b/cluster/src/main/scala/io/snappydata/ToolsCallbackImpl.scala
@@ -286,7 +286,7 @@ object ToolsCallbackImpl extends ToolsCallback with Logging {
     }
 
     val fqtn: String = if (td.identifier.indexOf('.') > 0) td.identifier
-    else grantor + "." + td.identifier
+    else tableOwner + "." + td.identifier
     val key = GrantRevokeOnExternalTable.getMetaRegionKey(fqtn)
     PermissionChecker.addRemoveUserForKey(key, isGrant, users)
   }

--- a/cluster/src/main/scala/io/snappydata/remote/interpreter/SnappyInterpreterExecute.scala
+++ b/cluster/src/main/scala/io/snappydata/remote/interpreter/SnappyInterpreterExecute.scala
@@ -142,6 +142,7 @@ object SnappyInterpreterExecute {
     } finally {
       if (lockTaken) intpRWLock.writeLock().unlock()
     }
+    // TODO (Optimization) Reuse the grantees list retrieved above in below method.
     updateMetaRegion(group)
   }
 

--- a/core/src/dunit/scala/io/snappydata/cluster/SplitClusterDUnitSecurityTest.scala
+++ b/core/src/dunit/scala/io/snappydata/cluster/SplitClusterDUnitSecurityTest.scala
@@ -556,6 +556,18 @@ class SplitClusterDUnitSecurityTest(s: String)
       getConn(jdbcUser1, true).close() // Just initialize snc.
       group3.foreach(u => doSimpleStuffOnExtTable(u, fqtn, ss(u)))
       doSimpleStuffOnExtTable(jdbcUser9, fqtn, ss(jdbcUser9), true)
+
+      // Verify admin can grant permissions on external tables of other users.
+      val aConn = getConn(adminUser1, false)
+      try {
+        val aSt = aConn.createStatement()
+        aSt.execute(s"grant all on $fqtn to gemfire9")
+        doSimpleStuffOnExtTable(jdbcUser9, fqtn, ss(jdbcUser9))
+        aSt.execute(s"revoke all on $fqtn from gemfire9")
+        doSimpleStuffOnExtTable(jdbcUser9, fqtn, ss(jdbcUser9), true)
+      } finally {
+        aConn.close()
+      }
     } else {
       // This is admin connection. Test REFRESH_LDAP_GROUP works fine (SNAP-3281)
       st.execute("call SYS.REFRESH_LDAP_GROUP('gemGroup1')")


### PR DESCRIPTION
## Changes proposed in this pull request
* [SNAP-3282] Procedure SYS.REFRESH_LDAP_GROUP now updates the entries in metadata region which are used in authorization of external tables.
* Also fixed an issue where system user could not grant permission on external table of another user.

## Patch testing
- Tested manually.
- Added a testcase for second issue.
- precheckin is fine.

## ReleaseNotes.txt changes
NA

## Other PRs 
NA