### PR TITLE
Throw exception on interpreter getting offending line.

### DIFF
--- a/cluster/src/dunit/scala/io/snappydata/cluster/SplitSnappyClusterDUnitTest.scala
+++ b/cluster/src/dunit/scala/io/snappydata/cluster/SplitSnappyClusterDUnitTest.scala
@@ -1220,7 +1220,7 @@ object SplitSnappyClusterDUnitTest
         .add(StructField("col1", StringType))
         .add(StructField("col2", StringType))
     val dataFrame = snc.createDataFrame(rdd, schema)
-    import org.apache.spark.sql.snappy._
+    import org.apache.spark.sql.snappydata._
     try {
       Thread.sleep(2000)
       for (_ <- 1 to 10) {

--- a/cluster/src/main/scala/io/snappydata/remote/interpreter/RemoteInterpreterStateHolder.scala
+++ b/cluster/src/main/scala/io/snappydata/remote/interpreter/RemoteInterpreterStateHolder.scala
@@ -30,7 +30,7 @@ import io.snappydata.impl.LeadImpl
 import org.apache.commons.io.FileUtils
 import org.apache.spark.{Logging, SparkContext}
 import org.apache.spark.repl.SparkILoop
-import org.apache.spark.sql.{AnalysisException, CachedDataFrame, Dataset}
+import org.apache.spark.sql.{CachedDataFrame, Dataset}
 import org.apache.spark.sql.execution.RefreshMetadata
 
 import scala.collection.mutable
@@ -114,6 +114,17 @@ class RemoteInterpreterStateHolder(
         lastResult = intp.interpret(tmpsb.toString())
         if (!(lastResult == Results.Error) && !replay) {
           allInterpretedLinesForReplay += line
+        } else if (lastResult == Results.Error) {
+          logWarning(s"Got error while interpreting line $line")
+          resultBuffer += pw.toString.stripLineEnd
+          val output = resultBuffer.toArray.flatMap(_.split("\n"))
+          val outputsb = new mutable.StringBuilder()
+          output.foreach(l => {
+            outputsb.append(l)
+            outputsb.append("\n")
+          })
+          throw new RuntimeException(s"Got error while interpreting line $line" +
+            s" and interpreter output = ${outputsb.toString()}")
         }
         if (lastResult == Results.Success) tmpsb.clear()
         resultBuffer += pw.toString.stripLineEnd

--- a/cluster/src/test/scala/io/snappydata/benchmark/TPCHColumnPartitionedTable.scala
+++ b/cluster/src/test/scala/io/snappydata/benchmark/TPCHColumnPartitionedTable.scala
@@ -21,7 +21,7 @@ import java.sql.Statement
 
 import org.apache.spark.SparkContext
 import org.apache.spark.sql.execution.benchmark.ColumnCacheBenchmark
-import org.apache.spark.sql.snappy._
+import org.apache.spark.sql.snappydata._
 import org.apache.spark.sql.{DataFrame, SQLContext, SnappyContext, Column}
 
 

--- a/cluster/src/test/scala/org/apache/spark/sql/IndexTest.scala
+++ b/cluster/src/test/scala/org/apache/spark/sql/IndexTest.scala
@@ -61,7 +61,7 @@ class IndexTest extends SnappyFunSuite with PlanTest with BeforeAndAfterEach {
           StructField("b", IntegerType, false) :: Nil)
 
     val df = snc.createDataFrame(data, struct)
-    import snappy._
+    import snappydata._
     df.write.putInto("APP.CHECKO")
 
     assert(snc.sql("select * from checko").count() == 6)

--- a/cluster/src/test/scala/org/apache/spark/sql/execution/SnappyTableMutableAPISuite.scala
+++ b/cluster/src/test/scala/org/apache/spark/sql/execution/SnappyTableMutableAPISuite.scala
@@ -23,7 +23,7 @@ import io.snappydata.SnappyFunSuite
 import io.snappydata.core.Data
 import org.scalatest.{BeforeAndAfter, BeforeAndAfterAll}
 import org.apache.spark.Logging
-import org.apache.spark.sql.snappy._
+import org.apache.spark.sql.snappydata._
 import org.apache.spark.sql.types._
 import org.apache.spark.sql._
 

--- a/cluster/src/test/scala/org/apache/spark/sql/execution/benchmark/ColumnCacheBenchmark.scala
+++ b/cluster/src/test/scala/org/apache/spark/sql/execution/benchmark/ColumnCacheBenchmark.scala
@@ -233,7 +233,7 @@ class ColumnCacheBenchmark extends SnappyFunSuite {
     val benchmark = new Benchmark("PutInto Vs Insert", size)
     val sparkSession = this.sparkSession
     val snappySession = this.snappySession
-    import org.apache.spark.sql.snappy._
+    import org.apache.spark.sql.snappydata._
     if (GemFireCacheImpl.getCurrentBufferAllocator.isDirect) {
       logInfo("ColumnCacheBenchmark: using off-heap for performance comparison")
     } else {
@@ -397,7 +397,7 @@ class ColumnCacheBenchmark extends SnappyFunSuite {
   private def createAndTestPutIntoInBigTable(): Unit = {
     snappySession.sql("drop table if exists wide_table")
     snappySession.sql("drop table if exists wide_table1")
-    import org.apache.spark.sql.snappy._
+    import org.apache.spark.sql.snappydata._
     val size = 100
     val num_col = 300
     val str = (1 to num_col).map(i => s" '$i' as C$i")

--- a/cluster/src/test/scala/org/apache/spark/sql/kafka010/SnappyStructuredKafkaSuite.scala
+++ b/cluster/src/test/scala/org/apache/spark/sql/kafka010/SnappyStructuredKafkaSuite.scala
@@ -254,7 +254,7 @@ class SnappyStructuredKafkaSuite extends SnappyFunSuite with Eventually
     // create a SnappyData table
     snc.createTable("blacklist", "row", dfBlackList.schema, Map.empty[String, String])
 
-    import org.apache.spark.sql.snappy._
+    import org.apache.spark.sql.snappydata._
     dfBlackList.write.putInto("blacklist") // populate the table 'blacklist'.
 
     val topic = newTopic()

--- a/core/src/main/scala/org/apache/spark/RDDJavaFunctions.scala
+++ b/core/src/main/scala/org/apache/spark/RDDJavaFunctions.scala
@@ -23,7 +23,7 @@ import org.apache.spark.api.java.JavaPairRDD._
 import org.apache.spark.api.java.JavaRDD
 import org.apache.spark.api.java.JavaSparkContext.fakeClassTag
 import org.apache.spark.api.java.function.{FlatMapFunction, Function => JFunction}
-import org.apache.spark.sql.snappy._
+import org.apache.spark.sql.snappydata._
 
 
 class RDDJavaFunctions[U](val javaRDD: JavaRDD[U]) {

--- a/core/src/main/scala/org/apache/spark/sql/DataFrameJavaFunctions.scala
+++ b/core/src/main/scala/org/apache/spark/sql/DataFrameJavaFunctions.scala
@@ -34,7 +34,7 @@ class DataFrameJavaFunctions(val df: DataFrame) {
    * }}}
    */
   def stratifiedSample(options: java.util.Map[String, Object]): SampleDataFrame = {
-    snappy.snappyOperationsOnDataFrame(df).stratifiedSample(options.toMap)
+    snappydata.snappyOperationsOnDataFrame(df).stratifiedSample(options.toMap)
   }
 
   /**
@@ -45,14 +45,14 @@ class DataFrameJavaFunctions(val df: DataFrame) {
    * @return
    */
   def withTime(time: java.lang.Long): DataFrameWithTime =
-    snappy.snappyOperationsOnDataFrame(df).withTime(time)
+    snappydata.snappyOperationsOnDataFrame(df).withTime(time)
 
   /**
    * Append to an existing cache table.
    * Automatically uses #cacheQuery if not done already.
    */
   def appendToTempTableCache(tableName: String): Unit =
-    snappy.snappyOperationsOnDataFrame(df).appendToTempTableCache(tableName)
+    snappydata.snappyOperationsOnDataFrame(df).appendToTempTableCache(tableName)
 
 
  /* def errorStats(columnName: String,
@@ -67,7 +67,7 @@ class DataFrameJavaFunctions(val df: DataFrame) {
        else
          groupByColumns
 
-    val result = snappy.samplingOperationsOnDataFrame(df)
+    val result = snappydata.samplingOperationsOnDataFrame(df)
         .errorEstimateAverage(columnName, confidence, groupedColumns.toSet)
 
     result.mapValues(toJDouble(_))
@@ -76,7 +76,7 @@ class DataFrameJavaFunctions(val df: DataFrame) {
 
   def withError(error: JDouble,
       confidence: JDouble = Constant.DEFAULT_CONFIDENCE): DataFrame =
-    snappy.convertToAQPFrame(df).withError(error, confidence)
+    snappydata.convertToAQPFrame(df).withError(error, confidence)
 
 }
 

--- a/core/src/main/scala/org/apache/spark/sql/DataFrameWriterJavaFunctions.scala
+++ b/core/src/main/scala/org/apache/spark/sql/DataFrameWriterJavaFunctions.scala
@@ -16,7 +16,7 @@
  */
 package org.apache.spark.sql
 
-import org.apache.spark.sql.snappy.DataFrameWriterExtensions
+import org.apache.spark.sql.snappydata.DataFrameWriterExtensions
 
 
 class DataFrameWriterJavaFunctions(val dfWriter: DataFrameWriter[_]) {

--- a/core/src/main/scala/org/apache/spark/sql/SnappyImplicits.scala
+++ b/core/src/main/scala/org/apache/spark/sql/SnappyImplicits.scala
@@ -29,7 +29,7 @@ import org.apache.spark.{Partition, TaskContext}
  * Implicit conversions used by Snappy.
  */
 // scalastyle:off
-object snappy extends Serializable {
+object snappydata extends Serializable {
 // scalastyle:on
 
   implicit def snappyOperationsOnDataFrame(df: DataFrame): SnappyDataFrameOperations = {
@@ -43,7 +43,7 @@ object snappy extends Serializable {
   implicit def samplingOperationsOnDataFrame(df: DataFrame): SampleDataFrame = {
     df.sparkSession match {
       case sc: SnappySession =>
-        val plan = snappy.unwrapSubquery(df.logicalPlan)
+        val plan = snappydata.unwrapSubquery(df.logicalPlan)
         if (sc.snappyContextFunctions.isStratifiedSample(plan)) {
           new SampleDataFrame(sc, plan)
         } else {

--- a/core/src/main/scala/org/apache/spark/sql/execution/SnappySortExec.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/SnappySortExec.scala
@@ -51,7 +51,7 @@ case class SnappySortExec(sortPlan: SortExec, child: SparkPlan)
     val spillSize = longMetric("spillSize")
     val sortTime = longMetric("sortTime")
 
-    import org.apache.spark.sql.snappy._
+    import org.apache.spark.sql.snappydata._
 
     child.execute().mapPartitionsPreserveInternal(itr =>
 

--- a/core/src/main/scala/org/apache/spark/sql/execution/ddl.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/ddl.scala
@@ -754,7 +754,7 @@ case class PutIntoValuesColumnTable(db: String, tableName: String,
     }
     val schema = sparkSession.sharedState
         .externalCatalog.getTable(db, tableName).schema
-    import snappy._
+    import snappydata._
     var rowRdd = List.empty[Any]
     val valuesList = v1.toList
     if (colNames.isEmpty) {

--- a/core/src/main/scala/org/apache/spark/sql/streaming/SnappySinkCallback.scala
+++ b/core/src/main/scala/org/apache/spark/sql/streaming/SnappySinkCallback.scala
@@ -230,7 +230,7 @@ case class SnappyStoreSink(snappySession: SnappySession,
   }
 }
 
-import org.apache.spark.sql.snappy._
+import org.apache.spark.sql.snappydata._
 
 class DefaultSnappySinkCallback extends SnappySinkCallback with Logging {
   def process(snappySession: SnappySession, parameters: Map[String, String],

--- a/core/src/test/scala/io/snappydata/CommandLineToolsSuite.scala
+++ b/core/src/test/scala/io/snappydata/CommandLineToolsSuite.scala
@@ -137,8 +137,7 @@ class CommandLineToolsSuite extends SnappyTestRunner {
       "case class TestData(c1: Int, c2: String)",
       "val x = TestData(1, \"1\")",
       "snappy.sql(\"create table tmptable(c1 int not null, c2 string)\")",
-      "snappy.sql(\"insert into tmptable values(1, \'1\')\")",
-      ":qu"
+      "snappy.sql(\"insert into tmptable values(1, \'1\')\")"
     )
     val conn = getJdbcConnection(1527)
     var stmnt = conn.createStatement()
@@ -157,8 +156,7 @@ class CommandLineToolsSuite extends SnappyTestRunner {
         "var rdd = sc.parallelize((1 to 10).map(i => new NewClass(i, i.toString)))",
         "rdd.count",
         "println(\"Just before calling rdd.collect\")",
-        "rdd.collect.foreach(println(_))",
-        ":quit"
+        "rdd.collect.foreach(println(_))"
       )
       stmnt = conn.createStatement()
       cmdOutput = "snappyscala-output1.txt"
@@ -173,18 +171,15 @@ class CommandLineToolsSuite extends SnappyTestRunner {
   test("snappy scala run") {
     val scala_code1 = Seq(
       "snappy.sql(\"create table tmptable(c1 int not null, c2 string)\")",
-      "snappy.sql(\"insert into tmptable values(1, \'1\')\")",
-      ":qu"
+      "snappy.sql(\"insert into tmptable values(1, \'1\')\")"
     )
     val scala_code2 = Seq(
       "snappy.sql(\"create table tmptable2(c1 int not null, c2 string)\")",
-      "snappy.sql(\"insert into tmptable2 values(1, \'1\')\")",
-      ":qu"
+      "snappy.sql(\"insert into tmptable2 values(1, \'1\')\")"
     )
     val scala_code3 = Seq(
       "snappy.sql(\"create table tmptable3(c1 int not null, c2 string)\")",
-      "snappy.sql(\"insert into tmptable3 values(1, \'1\')\")",
-      ":qu"
+      "snappy.sql(\"insert into tmptable3 values(1, \'1\')\")"
     )
     val conn = getJdbcConnection(1527)
     val stmnt = conn.createStatement()

--- a/core/src/test/scala/io/snappydata/CommandLineToolsSuite.scala
+++ b/core/src/test/scala/io/snappydata/CommandLineToolsSuite.scala
@@ -199,7 +199,7 @@ class CommandLineToolsSuite extends SnappyTestRunner {
         printWriter.close()
       })
 
-      SnappyScalaShell("scala_code", scala_code1, cmdOutput,
+      SnappyScalaShell("scala_code", Seq.empty, cmdOutput,
         s"$snappyscalaShell -r $scalaFileToRun1")
       stmnt.execute("create table testtable as select * from tmptable")
       assert(stmnt.execute("select count(*) from testtable"))
@@ -208,7 +208,7 @@ class CommandLineToolsSuite extends SnappyTestRunner {
       assert(rs.getInt(1) == 1)
 
       // Two files
-      SnappyScalaShell("scala_code", scala_code1, cmdOutput,
+      SnappyScalaShell("scala_code", Seq.empty, cmdOutput,
         s"$snappyscalaShell -r $scalaFileToRun2,$scalaFileToRun3")
       assert(stmnt.execute("select count(*) from tmptable2"))
       rs = stmnt.getResultSet

--- a/core/src/test/scala/io/snappydata/ConcurrentOpsTests.scala
+++ b/core/src/test/scala/io/snappydata/ConcurrentOpsTests.scala
@@ -53,7 +53,7 @@ object ConcurrentOpsTests extends Assertions with Logging {
           (1 to 2000).map(i => TestData(i, i.toString)))
 
         val dataDF = snc.createDataFrame(rdd)
-        import org.apache.spark.sql.snappy._
+        import org.apache.spark.sql.snappydata._
         dataDF.write.insertInto(tableName)
         dataDF.write.putInto(tableName)
         dataDF.write.deleteFrom(tableName)
@@ -110,7 +110,7 @@ object ConcurrentOpsTests extends Assertions with Logging {
     val rdd = session.sparkContext.parallelize(
       (1 to 2000).map(i => TestData(i, i.toString)))
     val dataDF = session.createDataFrame(rdd)
-    import org.apache.spark.sql.snappy._
+    import org.apache.spark.sql.snappydata._
     dataDF.write.putInto(tableName)
     dataDF.write.deleteFrom(tableName)
 
@@ -122,7 +122,7 @@ object ConcurrentOpsTests extends Assertions with Logging {
           (1 to 2000).map(i => TestData(i, i.toString)))
 
         val dataDF = snc.createDataFrame(rdd)
-        import org.apache.spark.sql.snappy._
+        import org.apache.spark.sql.snappydata._
         dataDF.write.putInto(tableName)
         dataDF.write.deleteFrom(tableName)
       }
@@ -145,7 +145,7 @@ object ConcurrentOpsTests extends Assertions with Logging {
     val rdd = session.sparkContext.parallelize(
       (1 to 2000).map(i => TestData(i, i.toString)))
     val dataDF = session.createDataFrame(rdd)
-    import org.apache.spark.sql.snappy._
+    import org.apache.spark.sql.snappydata._
     dataDF.write.putInto(tableName)
 
     val t = new Thread(new Runnable {
@@ -155,7 +155,7 @@ object ConcurrentOpsTests extends Assertions with Logging {
           (1 to 2000).map(i => TestData(i, i.toString)))
 
         val dataDF = snc.createDataFrame(rdd)
-        import org.apache.spark.sql.snappy._
+        import org.apache.spark.sql.snappydata._
         dataDF.write.putInto(tableName)
         dataDF.write.deleteFrom(tableName)
       }
@@ -182,7 +182,7 @@ object ConcurrentOpsTests extends Assertions with Logging {
         (1 to 2000).map(i => TestData(i, i.toString)))
 
       val dataDF = newSnc.createDataFrame(rdd)
-      import org.apache.spark.sql.snappy._
+      import org.apache.spark.sql.snappydata._
       dataDF.write.putInto(tableName)
       val result = newSnc.sql("SELECT * FROM " + tableName)
       val r2 = result.collect
@@ -298,7 +298,7 @@ object ConcurrentOpsTests extends Assertions with Logging {
         (1 to 2000).map(i => TestData(i, i.toString)))
       logInfo(s"SKKS The total parallelism is ${rdd.getNumPartitions}")
       val dataDF = snc.createDataFrame(rdd)
-      import org.apache.spark.sql.snappy._
+      import org.apache.spark.sql.snappydata._
       dataDF.write.putInto(tableName)
       val result = snc.sql("SELECT * FROM " + tableName)
       val r2 = result.collect
@@ -341,7 +341,7 @@ object ConcurrentOpsTests extends Assertions with Logging {
       val rdd = snc.sparkContext.parallelize(
         (1 to 2000).map(i => TestData(i, i.toString)))
       val dataDF = snc.createDataFrame(rdd)
-      import org.apache.spark.sql.snappy._
+      import org.apache.spark.sql.snappydata._
       dataDF.write.putInto(tableName)
       val result = snc.sql("SELECT * FROM " + tableName)
       val r2 = result.collect
@@ -353,7 +353,7 @@ object ConcurrentOpsTests extends Assertions with Logging {
       val rdd = snc.sparkContext.parallelize(
         (1 to 2000).map(i => TestData(i, i.toString)))
       val dataDF = snc.createDataFrame(rdd)
-      import org.apache.spark.sql.snappy._
+      import org.apache.spark.sql.snappydata._
       dataDF.write.putInto(tableName)
       val result = snc.sql("SELECT * FROM " + tableName)
       val r2 = result.collect
@@ -442,7 +442,7 @@ object ConcurrentOpsTests extends Assertions with Logging {
       val rdd = snc.sparkContext.parallelize(
         (1 to 2000).map(i => TestData(i, i.toString)))
       val dataDF = snc.createDataFrame(rdd)
-      import org.apache.spark.sql.snappy._
+      import org.apache.spark.sql.snappydata._
       dataDF.write.putInto(table)
     }
 
@@ -513,7 +513,7 @@ object ConcurrentOpsTests extends Assertions with Logging {
       val rdd = session.sparkContext.parallelize(
         (1 to 2000).map(i => TestData(i, i.toString)))
       val dataDF = snc.createDataFrame(rdd)
-      import org.apache.spark.sql.snappy._
+      import org.apache.spark.sql.snappydata._
       dataDF.write.putInto(table)
       val result = snc.sql("SELECT * FROM " + table)
       val r2 = result.collect
@@ -529,7 +529,7 @@ object ConcurrentOpsTests extends Assertions with Logging {
       val rdd = session.sparkContext.parallelize(
         (1 to 2000).map(i => TestData(i, i.toString)))
       val dataDF = snc.createDataFrame(rdd)
-      import org.apache.spark.sql.snappy._
+      import org.apache.spark.sql.snappydata._
       logInfo(s"SKSK for table $table the count is " + dataDF.filter(s"key1 <= $maxKey").count())
       dataDF.filter(s"key1 <= $maxKey").write.deleteFrom(table)
 

--- a/core/src/test/scala/org/apache/spark/sql/store/RowTableTest.scala
+++ b/core/src/test/scala/org/apache/spark/sql/store/RowTableTest.scala
@@ -25,7 +25,7 @@ import io.snappydata.core.{Data, TRIPDATA}
 import org.scalatest.{BeforeAndAfter, BeforeAndAfterAll}
 
 import org.apache.spark.sql._
-import org.apache.spark.sql.snappy._
+import org.apache.spark.sql.snappydata._
 import org.apache.spark.sql.types.{DateType, FloatType, IntegerType, StringType, StructField, StructType, TimestampType}
 
 /**

--- a/dtests/src/test/scala/io/snappydata/hydra/concurrency/StreamingActivity.scala
+++ b/dtests/src/test/scala/io/snappydata/hydra/concurrency/StreamingActivity.scala
@@ -103,7 +103,7 @@ object StreamingActivity extends SnappyStreamingJob {
         df.cache()
         // inserts
         df.write.insertInto(tableName)
-        import org.apache.spark.sql.snappy._
+        import org.apache.spark.sql.snappydata._
         df.write.putInto(tableName)
         df.unpersist()
       } else {

--- a/dtests/src/test/scala/io/snappydata/hydra/ct/CTTestUtil.scala
+++ b/dtests/src/test/scala/io/snappydata/hydra/ct/CTTestUtil.scala
@@ -21,7 +21,7 @@ import java.io.PrintWriter
 
 import io.snappydata.hydra.TestUtil
 
-import org.apache.spark.sql.snappy._
+import org.apache.spark.sql.snappydata._
 import org.apache.spark.sql.{SQLContext, SnappyContext}
 
 object CTTestUtil {

--- a/dtests/src/test/scala/io/snappydata/hydra/putInto/ConcPutIntoWith30Columns.scala
+++ b/dtests/src/test/scala/io/snappydata/hydra/putInto/ConcPutIntoWith30Columns.scala
@@ -27,7 +27,7 @@ import scala.concurrent.duration.Duration
 import scala.concurrent.{Await, Future}
 import scala.util.{Failure, Success, Try}
 import scala.concurrent.ExecutionContext.Implicits.global
-import org.apache.spark.sql.snappy._
+import org.apache.spark.sql.snappydata._
 import scala.util.Random
 
 object ConcPutIntoWith30Columns extends SnappySQLJob {

--- a/dtests/src/test/scala/io/snappydata/hydra/putInto/InsertFromJsonFile.scala
+++ b/dtests/src/test/scala/io/snappydata/hydra/putInto/InsertFromJsonFile.scala
@@ -25,7 +25,7 @@ import io.snappydata.hydra.northwind.NWTestJob
 import org.apache.spark.sql.{SnappyJobValid, SnappyJobValidation, SnappySQLJob, SnappySession}
 import scala.util.{Failure, Success, Try}
 
-import org.apache.spark.sql.snappy._
+import org.apache.spark.sql.snappydata._
 import scala.util.Random
 
 object InsertFromJsonFile extends SnappySQLJob {

--- a/examples/src/main/scala/io/snappydata/examples/AirlineDataJob.scala
+++ b/examples/src/main/scala/io/snappydata/examples/AirlineDataJob.scala
@@ -23,7 +23,7 @@ import scala.util.{Failure, Success, Try}
 
 import com.typesafe.config.Config
 
-import org.apache.spark.sql.snappy._
+import org.apache.spark.sql.snappydata._
 import org.apache.spark.sql.{SnappySession, SnappyJobValid, DataFrame, SnappyContext, SnappyJobValidation, SnappySQLJob}
 
 /**


### PR DESCRIPTION

## Changes proposed in this pull request

Changed the name of the object 'snappy' having implicits to 'snappydata' to avoid clash with 'snappy'variable defined in snappy repl.

Throw run time error if interpretation of a line cannot be done.

## Patch testing

Manual

## ReleaseNotes.txt changes

No

## Other PRs 

No.