### PR TITLE
suggested fix for SDENT-171

### DIFF
--- a/cluster/src/test/scala/org/apache/spark/sql/store/BugTest.scala
+++ b/cluster/src/test/scala/org/apache/spark/sql/store/BugTest.scala
@@ -1605,6 +1605,20 @@ class BugTest extends SnappyFunSuite with BeforeAndAfterAll {
     snc.sql("drop schema xy")
   }
 
+  test("SDENT-171") {
+    snc.sql("drop table if exists t1")
+    snc.sql("create table t1 using column as (select id, concat('sym', id%1000) " +
+      "as sym from range(1000))")
+
+    snc.sql("select * from (select id, sym from (select id, sym, " +
+      "rand() as some_rand from t1) t2  where t2.some_rand < 0.6 ) t3 limit 10")
+
+    val rs = snc.sql("select * from (select id, sym from (select id, sym, " +
+      "rand() as some_rand from t1) t2  where t2.some_rand < 0.6 and  " +
+      "t2.some_rand > 0.9) t3 limit 10")
+    assertEquals(0, rs.collect().length)
+  }
+
   test("SDENT-75-GetTypeInfo-Boolean-Test") {
     snc
     val serverHostPort = TestUtil.startNetServer()

--- a/core/src/main/scala/org/apache/spark/sql/execution/sources/StoreDataSourceStrategy.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/sources/StoreDataSourceStrategy.scala
@@ -36,8 +36,9 @@
 package org.apache.spark.sql.execution.sources
 
 import scala.collection.mutable
+
 import org.apache.spark.rdd.RDD
-import org.apache.spark.sql.catalyst.expressions.{Alias, Attribute, AttributeReference, AttributeSet, EmptyRow, Expression, NamedExpression, ParamLiteral, PredicateHelper, TokenLiteral}
+import org.apache.spark.sql.catalyst.expressions.{Alias, Attribute, AttributeMap, AttributeReference, AttributeSet, EmptyRow, Expression, NamedExpression, ParamLiteral, PredicateHelper, TokenLiteral}
 import org.apache.spark.sql.catalyst.plans.logical.{BroadcastHint, LogicalPlan, Project, Filter => LFilter}
 import org.apache.spark.sql.catalyst.plans.physical.UnknownPartitioning
 import org.apache.spark.sql.catalyst.{CatalystTypeConverters, InternalRow, analysis, expressions}
@@ -364,8 +365,15 @@ object PhysicalScan extends PredicateHelper {
     plan match {
       case Project(fields, child) =>
         val (_, filters, other, aliases) = collectProjectsAndFilters(child)
-        val substitutedFields = fields.map(substitute(aliases)).asInstanceOf[Seq[NamedExpression]]
-        (Some(substitutedFields), filters, other, collectAliases(substitutedFields))
+        val deterministicFields = fields.filter(_.deterministic)
+        val nonDeterministicFields = fields.filter(!_.deterministic)
+        val substitutedFields = deterministicFields.
+          map(substitute(aliases)).asInstanceOf[Seq[NamedExpression]]
+        (Some(substitutedFields ++ nonDeterministicFields),
+          filters, if (nonDeterministicFields.isEmpty) {other}
+        else {
+          Project(substitutedFields ++ nonDeterministicFields, other)
+        }, collectAliases(substitutedFields))
 
       case LFilter(condition, child) =>
         val (fields, filters, other, aliases) = collectProjectsAndFilters(child)
@@ -377,9 +385,10 @@ object PhysicalScan extends PredicateHelper {
       case other => (None, Nil, other, Map.empty)
     }
 
-  private def collectAliases(fields: Seq[Expression]): Map[Attribute, Expression] = fields.collect {
-    case a@Alias(child, _) => a.toAttribute -> child
-  }.toMap
+  private def collectAliases(fields: Seq[Expression]): Map[Attribute, Expression] =
+    AttributeMap[Expression](fields.collect {
+      case a@Alias(child, _) => a.toAttribute -> child
+    })
 
   private def substitute(aliases: Map[Attribute, Expression])(expr: Expression): Expression = {
     expr.transform {

--- a/core/src/main/scala/org/apache/spark/sql/execution/sources/StoreDataSourceStrategy.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/sources/StoreDataSourceStrategy.scala
@@ -365,8 +365,7 @@ object PhysicalScan extends PredicateHelper {
     plan match {
       case Project(fields, child) =>
         val (_, filters, other, aliases) = collectProjectsAndFilters(child)
-        val deterministicFields = fields.filter(_.deterministic)
-        val nonDeterministicFields = fields.filter(!_.deterministic)
+        val (deterministicFields, nonDeterministicFields) = fields.span(_.deterministic)
         val substitutedFields = deterministicFields.
           map(substitute(aliases)).asInstanceOf[Seq[NamedExpression]]
         (Some(substitutedFields ++ nonDeterministicFields),

--- a/core/src/main/scala/org/apache/spark/sql/execution/sources/StoreDataSourceStrategy.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/sources/StoreDataSourceStrategy.scala
@@ -366,13 +366,15 @@ object PhysicalScan extends PredicateHelper {
       case Project(fields, child) =>
         val (_, filters, other, aliases) = collectProjectsAndFilters(child)
         val (deterministicFields, nonDeterministicFields) = fields.span(_.deterministic)
-        val substitutedFields = deterministicFields.
+        val substitutedDeterministicFields = deterministicFields.
           map(substitute(aliases)).asInstanceOf[Seq[NamedExpression]]
-        (Some(substitutedFields ++ nonDeterministicFields),
+        val substitutedNonDeterministicFields = nonDeterministicFields.
+          map(substitute(aliases)).asInstanceOf[Seq[NamedExpression]]
+        (Some(substitutedDeterministicFields ++ substitutedNonDeterministicFields),
           filters, if (nonDeterministicFields.isEmpty) {other}
         else {
-          Project(nonDeterministicFields, other)
-        }, collectAliases(substitutedFields))
+          Project(substitutedNonDeterministicFields, other)
+        }, collectAliases(substitutedDeterministicFields))
 
       case LFilter(condition, child) =>
         val (fields, filters, other, aliases) = collectProjectsAndFilters(child)

--- a/core/src/main/scala/org/apache/spark/sql/execution/sources/StoreDataSourceStrategy.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/sources/StoreDataSourceStrategy.scala
@@ -372,7 +372,7 @@ object PhysicalScan extends PredicateHelper {
         (Some(substitutedFields ++ nonDeterministicFields),
           filters, if (nonDeterministicFields.isEmpty) {other}
         else {
-          Project(substitutedFields ++ nonDeterministicFields, other)
+          Project(nonDeterministicFields, other)
         }, collectAliases(substitutedFields))
 
       case LFilter(condition, child) =>


### PR DESCRIPTION
## Changes proposed in this pull request
The purpose of the function collectProjectsAndFilters is to flatten the intermediate Project Nodes.
for eg. if the the tree is  project1 -> filter1 -> project2  -> filter2 -> project-3 -> BaseTable
and if the aim is to have a flattened structure like
project1 -> filters -> base table.
and given that final projected columns in project1 ( the output) may be less  than project2 , project3, the filter2,  may be refering to an attribute which is no longer present in project1. This is resoleved in the function by substituting attribute reference in filter with the Expression present in aliases map with the guarantee that expression in aliases map is for sure part of final projection.
The fix is that while identifying substitutable fields, we only use those fields which are deterministic. And if a project node contains an indeterministic field, we ensure that a new ProjectNode containing  that indeterministic field stays, so that a filter above it gets satisfied.


## Patch testing

(Fill in the details about how this patch was tested)

## ReleaseNotes.txt changes

(Does this change require an entry in ReleaseNotes.txt? If yes, has it been added to it?)

## Other PRs 

(Does this change require changes in other projects- store, spark, spark-jobserver, aqp? Add the links of PR of the other subprojects that are related to this change)
